### PR TITLE
Add support for Responses→Bedrock images translation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "http-body-util",
  "insta",
  "itertools 0.15.0",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 rstest = "0.26"
 rust_decimal = { version = "1", default-features = false }
 mimalloc = { version = "0.1", features = ["v3", "no_thp"] }
+mime_guess = "2.0"
 rustc_version = "0.4"
 rustls = { version = "0.23", default-features = false, features = ["tls12", "std", "logging"] }
 rustls-native-certs = "0.8"

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -33,6 +33,7 @@ http.workspace = true
 http-body.workspace = true
 http-body-util.workspace = true
 itertools.workspace = true
+mime_guess.workspace = true
 percent-encoding.workspace = true
 pin-project-lite.workspace = true
 rand.workspace = true

--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -1951,6 +1951,98 @@ pub mod from_responses {
 	use crate::types::ResponseType;
 	use crate::{AIError, StreamingUsageGuard, json, logged_response_parsing, parse, types};
 
+	// Bedrock Converse supported document formats:
+	// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html
+	fn media_type_to_doc_format(media_type: &str) -> Option<&'static str> {
+		match media_type {
+			"application/pdf" => Some("pdf"),
+			"text/csv" => Some("csv"),
+			"application/msword" => Some("doc"),
+			"application/vnd.openxmlformats-officedocument.wordprocessingml.document" => Some("docx"),
+			"application/vnd.ms-excel" => Some("xls"),
+			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => Some("xlsx"),
+			"text/html" => Some("html"),
+			"text/plain" => Some("txt"),
+			"text/markdown" | "text/x-markdown" => Some("md"),
+			_ => None,
+		}
+	}
+
+	fn ext_to_doc_format(ext: &str) -> Option<&'static str> {
+		match ext.to_ascii_lowercase().as_str() {
+			"pdf" => Some("pdf"),
+			"csv" => Some("csv"),
+			"doc" => Some("doc"),
+			"docx" => Some("docx"),
+			"xls" => Some("xls"),
+			"xlsx" => Some("xlsx"),
+			"html" | "htm" => Some("html"),
+			"txt" => Some("txt"),
+			"md" | "markdown" => Some("md"),
+			_ => None,
+		}
+	}
+
+	fn derive_doc_format(
+		media_type: Option<&str>,
+		filename: Option<&str>,
+	) -> Result<&'static str, AIError> {
+		if let Some(fmt) = media_type.and_then(media_type_to_doc_format) {
+			return Ok(fmt);
+		}
+		if let Some(fmt) = filename
+			.and_then(|name| name.rsplit_once('.'))
+			.and_then(|(_, ext)| ext_to_doc_format(ext))
+		{
+			return Ok(fmt);
+		}
+		Err(AIError::UnsupportedConversion(strng::literal!(
+			"bedrock document format could not be determined; provide a filename with a supported extension (pdf, csv, doc, docx, xls, xlsx, html, txt, md)"
+		)))
+	}
+
+	// Bedrock document names may only contain alphanumerics, whitespace, hyphens,
+	// parentheses, and square brackets, with no consecutive whitespace. Notably this
+	// excludes periods, so "notes.txt" must be rewritten before sending.
+	fn sanitize_doc_name(filename: Option<&str>) -> String {
+		let Some(name) = filename else {
+			return "document".to_string();
+		};
+		// Drop the extension; format is carried separately in the document block.
+		let stem = name.rsplit_once('.').map(|(s, _)| s).unwrap_or(name);
+		let mut out = String::with_capacity(stem.len());
+		let mut last_was_space = false;
+		for c in stem.chars() {
+			let mapped = if c.is_ascii_alphanumeric() || matches!(c, '-' | '(' | ')' | '[' | ']') {
+				last_was_space = false;
+				c
+			} else if last_was_space {
+				continue;
+			} else {
+				last_was_space = true;
+				' '
+			};
+			out.push(mapped);
+		}
+		let out = out.trim().to_string();
+		if out.is_empty() {
+			"document".to_string()
+		} else {
+			out
+		}
+	}
+
+	/// Parse a `data:` URL into its optional media type and base64 payload.
+	/// Errors if the data URL is not base64-encoded.
+	fn parse_doc_data_url(url: &str) -> Result<(Option<&str>, String), AIError> {
+		let Some((mt, data)) = parse_data_url(url) else {
+			return Err(AIError::UnsupportedConversion(strng::literal!(
+				"bedrock file data URLs must be base64-encoded"
+			)));
+		};
+		Ok((Some(mt), data.to_string()))
+	}
+
 	/// translate an OpenAI responses request to a Bedrock converse request
 	pub fn translate(
 		req: &types::responses::Request,
@@ -2092,6 +2184,9 @@ pub mod from_responses {
 			InputParam::Items(items) => items.clone(),
 		};
 
+		// Bedrock requires document names to be unique within a request; track names
+		// already used so repeated filenames (or missing ones) get a numeric suffix.
+		let used_doc_names = std::cell::RefCell::new(HashSet::<String>::new());
 		let input_parts_to_blocks = |parts: &[InputContent],
 		                             role: bedrock::Role|
 		 -> Result<Vec<bedrock::ContentBlock>, AIError> {
@@ -2140,10 +2235,60 @@ pub mod from_responses {
 							},
 						}));
 					},
-					InputContent::InputFile(_) => {
-						return Err(AIError::UnsupportedConversion(strng::literal!(
-							"file inputs are unsupported for bedrock"
-						)));
+					InputContent::InputFile(input_file) => {
+						if role != bedrock::Role::User {
+							return Err(AIError::UnsupportedConversion(strng::literal!(
+								"bedrock document inputs are only supported on user messages"
+							)));
+						}
+						// Bedrock-side constraints we do NOT pre-validate here (Bedrock enforces them
+						// and they may change; see the Converse API docs):
+						// - a document must be accompanied by a text block in the same message
+						// - at most 5 documents per request, each no larger than 4.5 MB
+						// https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html
+						//
+						// Resolve base64 bytes and optional media type from file_data or file_url.
+						// file_id cannot be resolved without an external API call.
+						let (media_type, bytes) = if let Some(file_data) = &input_file.file_data {
+							if file_data.starts_with("data:") {
+								parse_doc_data_url(file_data)?
+							} else {
+								// Raw base64 without a data URL wrapper; format comes from the filename
+								(None, file_data.clone())
+							}
+						} else if let Some(file_url) = &input_file.file_url {
+							if file_url.starts_with("data:") {
+								parse_doc_data_url(file_url)?
+							} else {
+								return Err(AIError::UnsupportedConversion(strng::literal!(
+									"bedrock file inputs must be base64 data URLs; remote URLs are unsupported"
+								)));
+							}
+						} else {
+							return Err(AIError::UnsupportedConversion(strng::literal!(
+								"bedrock file inputs must supply file_data or a base64 data URL in file_url; file_id is unsupported"
+							)));
+						};
+						let format = derive_doc_format(media_type, input_file.filename.as_deref())?;
+						let mut name = sanitize_doc_name(input_file.filename.as_deref());
+						{
+							let mut used = used_doc_names.borrow_mut();
+							if !used.insert(name.clone()) {
+								let mut i = 2;
+								name = loop {
+									let candidate = format!("{name} [{i}]");
+									if used.insert(candidate.clone()) {
+										break candidate;
+									}
+									i += 1;
+								};
+							}
+						}
+						blocks.push(bedrock::ContentBlock::Document(bedrock::DocumentBlock {
+							format: format.to_string(),
+							name,
+							source: bedrock::DocumentSource { bytes },
+						}));
 					},
 				}
 			}
@@ -2162,7 +2307,7 @@ pub mod from_responses {
 					},
 					InputContent::InputFile(_) => {
 						return Err(AIError::UnsupportedConversion(strng::literal!(
-							"file inputs are unsupported for bedrock"
+							"bedrock document inputs are only supported on user messages"
 						)));
 					},
 				}
@@ -3266,6 +3411,7 @@ impl ConverseResponseAdapter {
 					));
 				},
 				bedrock::ContentBlock::Image(_)
+				| bedrock::ContentBlock::Document(_)
 				| bedrock::ContentBlock::ToolResult(_)
 				| bedrock::ContentBlock::CachePoint(_) => {
 					continue;
@@ -3385,6 +3531,7 @@ impl ConverseResponseAdapter {
 					));
 				},
 				bedrock::ContentBlock::Image(_)
+				| bedrock::ContentBlock::Document(_)
 				| bedrock::ContentBlock::ToolResult(_)
 				| bedrock::ContentBlock::CachePoint(_) => {
 					// Skip these in responses (not part of output)
@@ -3505,6 +3652,7 @@ impl ConverseResponseAdapter {
 					},
 				)),
 				bedrock::ContentBlock::ToolResult(_) => None, // Skip tool results in responses
+				bedrock::ContentBlock::Document(_) => None,   // Input-only; never in a Bedrock response
 				bedrock::ContentBlock::CachePoint(_) => None, // Skip cache points - they're metadata only
 			}
 		}

--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
+use agent_core::strng;
 use http::Response;
 use rand::RngExt;
 use tracing::trace;
@@ -128,6 +129,70 @@ fn restore_tool_name(map: Option<&BedrockToolNameMap>, name: &str) -> String {
 	map
 		.map(|m| m.restore(name))
 		.unwrap_or_else(|| name.to_string())
+}
+
+struct CanonicalImage {
+	media_type: String,
+	bytes_base64: String,
+}
+
+impl CanonicalImage {
+	fn image_format(media_type: &str) -> Option<&str> {
+		media_type
+			.strip_prefix("image/")
+			.filter(|format| !format.is_empty())
+	}
+
+	fn from_data_url(url: &str) -> Result<Self, AIError> {
+		if !url.starts_with("data:") {
+			return Err(AIError::UnsupportedConversion(strng::literal!(
+				"bedrock image inputs must be base64 data URLs; remote URLs and file_ids are unsupported"
+			)));
+		}
+		let Some((media_type, data)) = crate::conversion::completions::parse_data_url(url) else {
+			return Err(AIError::UnsupportedConversion(strng::literal!(
+				"bedrock image data URLs must be base64-encoded"
+			)));
+		};
+		let Some(_) = Self::image_format(media_type) else {
+			return Err(AIError::UnsupportedConversion(strng::literal!(
+				"bedrock image data URLs must use a non-empty image/* media type"
+			)));
+		};
+		Ok(Self {
+			media_type: media_type.to_string(),
+			bytes_base64: data.to_string(),
+		})
+	}
+
+	fn from_media_type_and_base64(media_type: &str, bytes_base64: &str) -> Result<Self, AIError> {
+		let Some(_) = Self::image_format(media_type) else {
+			return Err(AIError::UnsupportedConversion(strng::literal!(
+				"bedrock image inputs must use a non-empty image/* media type"
+			)));
+		};
+		Ok(Self {
+			media_type: media_type.to_string(),
+			bytes_base64: bytes_base64.to_string(),
+		})
+	}
+
+	fn into_bedrock_image_block(self) -> bedrock::ImageBlock {
+		bedrock::ImageBlock {
+			format: self
+				.media_type
+				.strip_prefix("image/")
+				.unwrap_or(&self.media_type)
+				.to_string(),
+			source: bedrock::ImageSource {
+				bytes: self.bytes_base64,
+			},
+		}
+	}
+
+	fn into_bedrock_content_block(self) -> bedrock::ContentBlock {
+		bedrock::ContentBlock::Image(self.into_bedrock_image_block())
+	}
 }
 
 fn error_message(bytes: &[u8]) -> String {
@@ -404,14 +469,14 @@ pub mod from_completions {
 
 	use super::helpers;
 	use crate::bedrock::Provider;
-	use crate::conversion::completions::{extract_system_text, parse_data_url};
+	use crate::conversion::completions::extract_system_text;
 	use crate::types::ResponseType;
 	use crate::types::completions::typed::UsagePromptDetails;
 	use crate::{AIError, StreamingUsageGuard, json, logged_response_parsing, parse, types};
 
 	fn text_blocks_from_user_content(
 		content: &completions::RequestUserMessageContent,
-	) -> Vec<bedrock::ContentBlock> {
+	) -> Result<Vec<bedrock::ContentBlock>, AIError> {
 		let mut out = Vec::new();
 		match content {
 			completions::RequestUserMessageContent::Text(text) => {
@@ -428,17 +493,11 @@ pub mod from_completions {
 							}
 						},
 						completions::RequestUserMessageContentPart::ImageUrl(image) => {
-							if let Some((media_type, data)) = parse_data_url(&image.image_url.url) {
-								let format = media_type
-									.strip_prefix("image/")
-									.unwrap_or(media_type)
-									.to_string();
-								out.push(bedrock::ContentBlock::Image(bedrock::ImageBlock {
-									format,
-									source: bedrock::ImageSource {
-										bytes: data.to_string(),
-									},
-								}));
+							if image.image_url.url.starts_with("data:") {
+								out.push(
+									super::CanonicalImage::from_data_url(&image.image_url.url)?
+										.into_bedrock_content_block(),
+								);
 							}
 						},
 						completions::RequestUserMessageContentPart::InputAudio(_)
@@ -447,7 +506,7 @@ pub mod from_completions {
 				}
 			},
 		}
-		out
+		Ok(out)
 	}
 
 	fn assistant_content_to_bedrock(
@@ -565,7 +624,7 @@ pub mod from_completions {
 		let typed = json::convert::<_, completions::Request>(req).map_err(AIError::RequestParsing)?;
 		let model_id = typed.model.clone().unwrap_or_default();
 		let (xlated, tool_name_map) =
-			translate_internal(typed, model_id, provider, headers, prompt_caching);
+			translate_internal(typed, model_id, provider, headers, prompt_caching)?;
 		let body = serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)?;
 		Ok(super::BedrockRequest {
 			body,
@@ -579,7 +638,7 @@ pub mod from_completions {
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
 		prompt_caching: Option<&crate::PromptCachingConfig>,
-	) -> (bedrock::ConverseRequest, super::BedrockToolNameMap) {
+	) -> Result<(bedrock::ConverseRequest, super::BedrockToolNameMap), AIError> {
 		let mut tool_name_map = super::BedrockToolNameMap::default();
 		for tool in req.tools.iter().flatten() {
 			if let completions::Tool::Function(function_tool) = tool {
@@ -668,43 +727,30 @@ pub mod from_completions {
 		});
 		let tool_config = tools.map(|tools| bedrock::ToolConfiguration { tools, tool_choice });
 
-		let messages = req
-			.messages
-			.iter()
-			.filter_map(|msg| match msg {
+		let mut messages = Vec::new();
+		for msg in &req.messages {
+			let msg = match msg {
 				completions::RequestMessage::System(_) | completions::RequestMessage::Developer(_) => None,
 				completions::RequestMessage::User(user) => {
-					let content = text_blocks_from_user_content(&user.content);
-					if content.is_empty() {
-						None
-					} else {
-						Some(bedrock::Message {
-							role: bedrock::Role::User,
-							content,
-						})
-					}
+					let content = text_blocks_from_user_content(&user.content)?;
+					(!content.is_empty()).then_some(bedrock::Message {
+						role: bedrock::Role::User,
+						content,
+					})
 				},
 				completions::RequestMessage::Assistant(assistant) => {
 					let content = assistant_content_to_bedrock(assistant, &mut tool_name_map);
-					if content.is_empty() {
-						None
-					} else {
-						Some(bedrock::Message {
-							role: bedrock::Role::Assistant,
-							content,
-						})
-					}
+					(!content.is_empty()).then_some(bedrock::Message {
+						role: bedrock::Role::Assistant,
+						content,
+					})
 				},
 				completions::RequestMessage::Tool(tool_result) => {
 					let content = tool_content_to_bedrock(tool_result);
-					if content.is_empty() {
-						None
-					} else {
-						Some(bedrock::Message {
-							role: bedrock::Role::User,
-							content,
-						})
-					}
+					(!content.is_empty()).then_some(bedrock::Message {
+						role: bedrock::Role::User,
+						content,
+					})
 				},
 				completions::RequestMessage::Function(function) => function
 					.content
@@ -714,11 +760,11 @@ pub mod from_completions {
 						role: bedrock::Role::User,
 						content: vec![bedrock::ContentBlock::Text(s.clone())],
 					}),
-			})
-			.fold(Vec::new(), |mut msgs, msg| {
-				helpers::push_or_merge_message(&mut msgs, msg);
-				msgs
-			});
+			};
+			if let Some(msg) = msg {
+				helpers::push_or_merge_message(&mut messages, msg);
+			}
+		}
 
 		// Build guardrail configuration if specified
 		let guardrail_config = if let (Some(identifier), Some(version)) =
@@ -824,7 +870,7 @@ pub mod from_completions {
 			}
 		}
 
-		(bedrock_request, tool_name_map)
+		Ok((bedrock_request, tool_name_map))
 	}
 
 	fn reasoning_effort_to_enabled_budget(effort: &completions::ReasoningEffort) -> Option<u64> {
@@ -1371,17 +1417,9 @@ pub mod from_messages {
 						if let Some(media_type) = source.get("media_type").and_then(|v| v.as_str())
 							&& let Some(data) = source.get("data").and_then(|v| v.as_str())
 						{
-							let format = media_type
-								.strip_prefix("image/")
-								.unwrap_or(media_type)
-								.to_string();
 							(
-								bedrock::ContentBlock::Image(bedrock::ImageBlock {
-									format,
-									source: bedrock::ImageSource {
-										bytes: data.to_string(),
-									},
-								}),
+								super::CanonicalImage::from_media_type_and_base64(media_type, data)?
+									.into_bedrock_content_block(),
 								cache_control.is_some(),
 							)
 						} else {
@@ -1423,18 +1461,11 @@ pub mod from_messages {
 										if let Some(media_type) = source.get("media_type").and_then(|v| v.as_str())
 											&& let Some(data) = source.get("data").and_then(|v| v.as_str())
 										{
-											let format = media_type
-												.strip_prefix("image/")
-												.unwrap_or(media_type)
-												.to_string();
-											Some(bedrock::ToolResultContentBlock::Image(
-												bedrock::ImageBlock {
-													format,
-													source: bedrock::ImageSource {
-														bytes: data.to_string(),
-													},
-												},
-											))
+											super::CanonicalImage::from_media_type_and_base64(media_type, data)
+												.ok()
+												.map(|image| {
+													bedrock::ToolResultContentBlock::Image(image.into_bedrock_image_block())
+												})
 										} else {
 											None
 										}
@@ -1968,32 +1999,17 @@ pub mod from_responses {
 		}
 	}
 
-	fn ext_to_doc_format(ext: &str) -> Option<&'static str> {
-		match ext.to_ascii_lowercase().as_str() {
-			"pdf" => Some("pdf"),
-			"csv" => Some("csv"),
-			"doc" => Some("doc"),
-			"docx" => Some("docx"),
-			"xls" => Some("xls"),
-			"xlsx" => Some("xlsx"),
-			"html" | "htm" => Some("html"),
-			"txt" => Some("txt"),
-			"md" | "markdown" => Some("md"),
-			_ => None,
-		}
-	}
-
 	fn derive_doc_format(
 		media_type: Option<&str>,
 		filename: Option<&str>,
 	) -> Result<&'static str, AIError> {
-		if let Some(fmt) = media_type.and_then(media_type_to_doc_format) {
-			return Ok(fmt);
-		}
-		if let Some(fmt) = filename
-			.and_then(|name| name.rsplit_once('.'))
-			.and_then(|(_, ext)| ext_to_doc_format(ext))
-		{
+		if let Some(fmt) = media_type.and_then(media_type_to_doc_format).or_else(|| {
+			filename.and_then(|f| {
+				mime_guess::from_path(f)
+					.iter_raw()
+					.find_map(media_type_to_doc_format)
+			})
+		}) {
 			return Ok(fmt);
 		}
 		Err(AIError::UnsupportedConversion(strng::literal!(
@@ -2215,25 +2231,8 @@ pub mod from_responses {
 								"bedrock image inputs must be base64 data URLs; remote URLs and file_ids are unsupported"
 							)));
 						};
-						let Some((media_type, data)) = parse_data_url(image_url) else {
-							return Err(AIError::UnsupportedConversion(strng::literal!(
-								"bedrock image data URLs must be base64-encoded"
-							)));
-						};
-						let Some(format) = media_type
-							.strip_prefix("image/")
-							.filter(|format| !format.is_empty())
-						else {
-							return Err(AIError::UnsupportedConversion(strng::literal!(
-								"bedrock image data URLs must use a non-empty image/* media type"
-							)));
-						};
-						blocks.push(bedrock::ContentBlock::Image(bedrock::ImageBlock {
-							format: format.to_string(),
-							source: bedrock::ImageSource {
-								bytes: data.to_string(),
-							},
-						}));
+						blocks
+							.push(super::CanonicalImage::from_data_url(image_url)?.into_bedrock_content_block());
 					},
 					InputContent::InputFile(input_file) => {
 						if role != bedrock::Role::User {

--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -17,6 +17,7 @@ mod tests;
 pub const BEDROCK_TOOL_NAME_MAX_LEN: usize = 64;
 
 /// Serialized Bedrock request body plus any tool-name remapping applied for that request.
+#[derive(Debug)]
 pub struct BedrockRequest {
 	pub body: Vec<u8>,
 	pub tool_name_map: BedrockToolNameMap,
@@ -1943,8 +1944,11 @@ pub mod from_responses {
 	use types::bedrock;
 	use types::responses::typed as responses;
 
+	use agent_core::strng;
+
 	use super::helpers;
 	use crate::bedrock::Provider;
+	use crate::conversion::completions::parse_data_url;
 	use crate::types::ResponseType;
 	use crate::{AIError, StreamingUsageGuard, json, logged_response_parsing, parse, types};
 
@@ -1966,7 +1970,7 @@ pub mod from_responses {
 			provider,
 			headers,
 			prompt_caching,
-		);
+		)?;
 		let body = serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)?;
 		Ok(super::BedrockRequest {
 			body,
@@ -1981,7 +1985,7 @@ pub mod from_responses {
 		provider: &Provider,
 		headers: Option<&http::HeaderMap>,
 		prompt_caching: Option<&crate::PromptCachingConfig>,
-	) -> (bedrock::ConverseRequest, super::BedrockToolNameMap) {
+	) -> Result<(bedrock::ConverseRequest, super::BedrockToolNameMap), AIError> {
 		use responses::{
 			CustomToolCallOutput, CustomToolCallOutputOutput, EasyInputContent, FunctionCallOutput,
 			InputContent, InputItem, InputMessage, InputParam, InputRole, InputTextContent, Item,
@@ -2089,7 +2093,9 @@ pub mod from_responses {
 			InputParam::Items(items) => items.clone(),
 		};
 
-		let input_parts_to_blocks = |parts: &[InputContent]| {
+		let input_parts_to_blocks = |parts: &[InputContent],
+		                             role: bedrock::Role|
+		 -> Result<Vec<bedrock::ContentBlock>, AIError> {
 			let mut blocks = Vec::new();
 			tracing::debug!("Processing {} content parts", parts.len());
 			for part in parts {
@@ -2098,19 +2104,59 @@ pub mod from_responses {
 						tracing::debug!("Found InputText with text: {}", input_text.text);
 						blocks.push(bedrock::ContentBlock::Text(input_text.text.clone()));
 					},
-					InputContent::InputImage(_) => {
-						// Image support requires fetching URLs or resolving file_ids
-						tracing::debug!("Image inputs not supported in Responses->Bedrock translation");
-						continue;
+					InputContent::InputImage(input_image) => {
+						if role != bedrock::Role::User {
+							return Err(AIError::UnsupportedConversion(strng::literal!(
+								"bedrock image inputs are only supported on user messages"
+							)));
+						}
+						let Some((media_type, data)) =
+							input_image.image_url.as_deref().and_then(parse_data_url)
+						else {
+							// Remote URLs and file_ids would require the gateway to fetch content itself
+							return Err(AIError::UnsupportedConversion(strng::literal!(
+								"bedrock image inputs must be base64 data URLs; remote URLs and file_ids are unsupported"
+							)));
+						};
+						let format = media_type
+							.strip_prefix("image/")
+							.unwrap_or(media_type)
+							.to_string();
+						blocks.push(bedrock::ContentBlock::Image(bedrock::ImageBlock {
+							format,
+							source: bedrock::ImageSource {
+								bytes: data.to_string(),
+							},
+						}));
 					},
 					InputContent::InputFile(_) => {
-						tracing::debug!("Skipping InputFile");
-						continue;
+						return Err(AIError::UnsupportedConversion(strng::literal!(
+							"file inputs are unsupported for bedrock"
+						)));
 					},
 				}
 			}
 			tracing::debug!("Created {} content blocks", blocks.len());
-			blocks
+			Ok(blocks)
+		};
+		let input_parts_to_system_text = |parts: &[InputContent]| -> Result<String, AIError> {
+			let mut text = Vec::new();
+			for part in parts {
+				match part {
+					InputContent::InputText(input_text) => text.push(input_text.text.clone()),
+					InputContent::InputImage(_) => {
+						return Err(AIError::UnsupportedConversion(strng::literal!(
+							"bedrock image inputs are only supported on user messages"
+						)));
+					},
+					InputContent::InputFile(_) => {
+						return Err(AIError::UnsupportedConversion(strng::literal!(
+							"file inputs are unsupported for bedrock"
+						)));
+					},
+				}
+			}
+			Ok(text.join("\n"))
 		};
 
 		// Process each input item
@@ -2123,14 +2169,7 @@ pub mod from_responses {
 						ResponsesRole::System | ResponsesRole::Developer => {
 							let text = match &msg.content {
 								EasyInputContent::Text(text) => text.clone(),
-								EasyInputContent::ContentList(parts) => parts
-									.iter()
-									.filter_map(|part| match part {
-										InputContent::InputText(input_text) => Some(input_text.text.clone()),
-										_ => None,
-									})
-									.collect::<Vec<_>>()
-									.join("\n"),
+								EasyInputContent::ContentList(parts) => input_parts_to_system_text(parts)?,
 							};
 							system_blocks.push(bedrock::SystemContentBlock::Text { text });
 							continue;
@@ -2141,7 +2180,7 @@ pub mod from_responses {
 						EasyInputContent::Text(text) => {
 							vec![bedrock::ContentBlock::Text(text.clone())]
 						},
-						EasyInputContent::ContentList(parts) => input_parts_to_blocks(parts),
+						EasyInputContent::ContentList(parts) => input_parts_to_blocks(parts, role)?,
 					};
 
 					helpers::push_or_merge_message(&mut messages, bedrock::Message { role, content });
@@ -2150,21 +2189,13 @@ pub mod from_responses {
 					let role = match msg.role {
 						InputRole::User => bedrock::Role::User,
 						InputRole::System | InputRole::Developer => {
-							let text = msg
-								.content
-								.iter()
-								.filter_map(|part| match part {
-									InputContent::InputText(input_text) => Some(input_text.text.clone()),
-									_ => None,
-								})
-								.collect::<Vec<_>>()
-								.join("\n");
+							let text = input_parts_to_system_text(&msg.content)?;
 							system_blocks.push(bedrock::SystemContentBlock::Text { text });
 							continue;
 						},
 					};
 
-					let content = input_parts_to_blocks(&msg.content);
+					let content = input_parts_to_blocks(&msg.content, role)?;
 					helpers::push_or_merge_message(&mut messages, bedrock::Message { role, content });
 				},
 				InputItem::Item(Item::Message(MessageItem::Output(msg))) => {
@@ -2431,7 +2462,7 @@ pub mod from_responses {
 				.and_then(|tc| tc.tool_choice.as_ref())
 		);
 
-		(bedrock_request, tool_name_map)
+		Ok((bedrock_request, tool_name_map))
 	}
 
 	fn extract_responses_thinking_budget_tokens(req: &types::responses::Request) -> Option<u64> {

--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -1929,6 +1929,7 @@ pub mod from_responses {
 	use std::collections::{HashMap, HashSet};
 	use std::time::Instant;
 
+	use agent_core::strng;
 	use axum_core::body::Body;
 	use bytes::Bytes;
 	use helpers::*;
@@ -1943,8 +1944,6 @@ pub mod from_responses {
 	};
 	use types::bedrock;
 	use types::responses::typed as responses;
-
-	use agent_core::strng;
 
 	use super::helpers;
 	use crate::bedrock::Provider;
@@ -2110,20 +2109,32 @@ pub mod from_responses {
 								"bedrock image inputs are only supported on user messages"
 							)));
 						}
-						let Some((media_type, data)) =
-							input_image.image_url.as_deref().and_then(parse_data_url)
-						else {
+						let Some(image_url) = input_image.image_url.as_deref() else {
+							return Err(AIError::UnsupportedConversion(strng::literal!(
+								"bedrock image inputs must be base64 data URLs; remote URLs and file_ids are unsupported"
+							)));
+						};
+						if !image_url.starts_with("data:") {
 							// Remote URLs and file_ids would require the gateway to fetch content itself
 							return Err(AIError::UnsupportedConversion(strng::literal!(
 								"bedrock image inputs must be base64 data URLs; remote URLs and file_ids are unsupported"
 							)));
 						};
-						let format = media_type
+						let Some((media_type, data)) = parse_data_url(image_url) else {
+							return Err(AIError::UnsupportedConversion(strng::literal!(
+								"bedrock image data URLs must be base64-encoded"
+							)));
+						};
+						let Some(format) = media_type
 							.strip_prefix("image/")
-							.unwrap_or(media_type)
-							.to_string();
+							.filter(|format| !format.is_empty())
+						else {
+							return Err(AIError::UnsupportedConversion(strng::literal!(
+								"bedrock image data URLs must use a non-empty image/* media type"
+							)));
+						};
 						blocks.push(bedrock::ContentBlock::Image(bedrock::ImageBlock {
-							format,
+							format: format.to_string(),
 							source: bedrock::ImageSource {
 								bytes: data.to_string(),
 							},

--- a/crates/llm/src/conversion/bedrock_tests.rs
+++ b/crates/llm/src/conversion/bedrock_tests.rs
@@ -1752,6 +1752,102 @@ fn test_responses_input_image_remote_url_is_rejected() {
 }
 
 #[test]
+fn test_responses_input_image_non_base64_data_url_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_image",
+				"image_url": "data:image/png,iVBORw0KGgo=",
+				"detail": "auto"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
+		err
+			.to_string()
+			.contains("image data URLs must be base64-encoded")
+	);
+}
+
+#[test]
+fn test_responses_input_image_non_image_data_url_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_image",
+				"image_url": "data:application/octet-stream;base64,iVBORw0KGgo=",
+				"detail": "auto"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
+		err
+			.to_string()
+			.contains("image data URLs must use a non-empty image/* media type")
+	);
+}
+
+#[test]
+fn test_responses_input_image_empty_media_type_data_url_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_image",
+				"image_url": "data:;base64,iVBORw0KGgo=",
+				"detail": "auto"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
+		err
+			.to_string()
+			.contains("image data URLs must use a non-empty image/* media type")
+	);
+}
+
+#[test]
 fn test_responses_input_image_file_id_is_rejected() {
 	let provider = Provider {
 		model: None,

--- a/crates/llm/src/conversion/bedrock_tests.rs
+++ b/crates/llm/src/conversion/bedrock_tests.rs
@@ -1902,12 +1902,13 @@ fn test_responses_system_input_file_is_rejected() {
 	assert!(
 		err
 			.to_string()
-			.contains("file inputs are unsupported for bedrock")
+			.contains("bedrock document inputs are only supported on user messages"),
+		"unexpected error: {err}"
 	);
 }
 
 #[test]
-fn test_responses_input_file_is_rejected() {
+fn test_responses_input_file_id_is_rejected() {
 	let provider = Provider {
 		model: None,
 		region: strng::new("us-east-1"),
@@ -1931,8 +1932,222 @@ fn test_responses_input_file_is_rejected() {
 	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
 	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
 	assert!(
+		err.to_string().contains("file_id is unsupported"),
+		"unexpected error: {err}"
+	);
+}
+
+#[test]
+fn test_responses_input_file_remote_url_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_file",
+				"file_url": "https://example.com/report.pdf",
+				"filename": "report.pdf"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
+		err.to_string().contains("remote URLs are unsupported"),
+		"unexpected error: {err}"
+	);
+}
+
+#[test]
+fn test_responses_input_file_data_url_maps_to_document_block() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	// PDF via file_data data URL — format derived from MIME type
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [
+				{ "type": "input_text", "text": "Summarize this document." },
+				{
+					"type": "input_file",
+					"file_data": "data:application/pdf;base64,JVBERi0=",
+					"filename": "report.pdf"
+				}
+			]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let bedrock_req = super::from_responses::translate(&req, &provider, None, None)
+		.expect("translation should succeed")
+		.body;
+	let body: serde_json::Value = serde_json::from_slice(&bedrock_req).expect("valid JSON");
+	let content = &body["messages"][0]["content"];
+	assert_eq!(content[0]["text"], json!("Summarize this document."));
+	assert_eq!(content[1]["document"]["format"], json!("pdf"));
+	// Bedrock doc names cannot contain periods, so the extension is stripped
+	assert_eq!(content[1]["document"]["name"], json!("report"));
+	assert_eq!(content[1]["document"]["source"]["bytes"], json!("JVBERi0="));
+}
+
+#[test]
+fn test_responses_input_file_data_url_in_file_url_field_maps_to_document_block() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	// CSV via file_url data URL — format derived from filename extension
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_file",
+				"file_url": "data:text/csv;base64,YSxiLGM=",
+				"filename": "data.csv"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let bedrock_req = super::from_responses::translate(&req, &provider, None, None)
+		.expect("translation should succeed")
+		.body;
+	let body: serde_json::Value = serde_json::from_slice(&bedrock_req).expect("valid JSON");
+	let content = &body["messages"][0]["content"];
+	assert_eq!(content[0]["document"]["format"], json!("csv"));
+	assert_eq!(content[0]["document"]["name"], json!("data"));
+	assert_eq!(content[0]["document"]["source"]["bytes"], json!("YSxiLGM="));
+}
+
+#[test]
+fn test_responses_input_file_format_from_extension_fallback() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	// Unknown MIME type but known extension — format derived from filename
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_file",
+				"file_data": "data:application/octet-stream;base64,dGVzdA==",
+				"filename": "notes.md"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let bedrock_req = super::from_responses::translate(&req, &provider, None, None)
+		.expect("translation should succeed")
+		.body;
+	let body: serde_json::Value = serde_json::from_slice(&bedrock_req).expect("valid JSON");
+	let content = &body["messages"][0]["content"];
+	assert_eq!(content[0]["document"]["format"], json!("md"));
+}
+
+#[test]
+fn test_responses_input_file_unknown_format_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_file",
+				"file_data": "data:application/octet-stream;base64,dGVzdA==",
+				"filename": "archive.zip"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
 		err
 			.to_string()
-			.contains("file inputs are unsupported for bedrock")
+			.contains("document format could not be determined"),
+		"unexpected error: {err}"
 	);
+}
+
+#[test]
+fn test_responses_input_file_duplicate_names_are_deduplicated() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	// Bedrock requires unique document names within a request
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [
+				{ "type": "input_text", "text": "Compare these documents." },
+				{
+					"type": "input_file",
+					"file_data": "data:application/pdf;base64,JVBERi0=",
+					"filename": "report.pdf"
+				},
+				{
+					"type": "input_file",
+					"file_data": "data:application/pdf;base64,JVBERi1=",
+					"filename": "report.pdf"
+				},
+				{
+					"type": "input_file",
+					"file_data": "data:text/plain;base64,dGVzdA=="
+				}
+			]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let bedrock_req = super::from_responses::translate(&req, &provider, None, None)
+		.expect("translation should succeed")
+		.body;
+	let body: serde_json::Value = serde_json::from_slice(&bedrock_req).expect("valid JSON");
+	let content = &body["messages"][0]["content"];
+	assert_eq!(content[1]["document"]["name"], json!("report"));
+	assert_eq!(content[2]["document"]["name"], json!("report [2]"));
+	assert_eq!(content[3]["document"]["name"], json!("document"));
 }

--- a/crates/llm/src/conversion/bedrock_tests.rs
+++ b/crates/llm/src/conversion/bedrock_tests.rs
@@ -636,6 +636,49 @@ fn test_messages_image_url_to_bedrock_returns_error() {
 }
 
 #[test]
+fn test_completions_image_data_url_maps_to_converse_image_block() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::completions::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_tokens": 64,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{ "type": "text", "text": "What is in this image?" },
+				{
+					"type": "image_url",
+					"image_url": {
+						"url": "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
+					}
+				}
+			]
+		}]
+	}))
+	.expect("valid completions request");
+
+	let translated = super::from_completions::translate(&req, &provider, None, None)
+		.unwrap()
+		.body;
+	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
+
+	let content = translated["messages"][0]["content"]
+		.as_array()
+		.expect("user message content");
+	assert_eq!(content[0]["text"], json!("What is in this image?"));
+	assert_eq!(content[1]["image"]["format"], json!("jpeg"));
+	assert_eq!(
+		content[1]["image"]["source"]["bytes"],
+		json!("/9j/4AAQSkZJRg==")
+	);
+}
+
+#[test]
 fn test_completions_request_metadata_only_uses_bedrock_header() {
 	let provider = Provider {
 		model: None,
@@ -705,7 +748,8 @@ fn test_completions_request_metadata_only_uses_bedrock_header() {
 		&provider,
 		Some(&headers),
 		None,
-	);
+	)
+	.unwrap();
 	let md = out.request_metadata.unwrap();
 
 	assert!(!md.contains_key("user_id"));
@@ -794,7 +838,8 @@ fn test_completions_json_schema_response_format_maps_to_converse_output_config()
 		&provider,
 		None,
 		None,
-	);
+	)
+	.unwrap();
 	assert_eq!(
 		out.output_config,
 		Some(types::bedrock::OutputConfig {
@@ -872,7 +917,8 @@ fn test_completions_reasoning_effort_maps_to_enabled_thinking_budget() {
 		&provider,
 		None,
 		None,
-	);
+	)
+	.unwrap();
 
 	assert_eq!(
 		out.additional_model_request_fields,
@@ -948,7 +994,8 @@ fn test_completions_explicit_thinking_budget_forces_enabled_thinking() {
 		&provider,
 		None,
 		None,
-	);
+	)
+	.unwrap();
 
 	assert_eq!(
 		out.additional_model_request_fields,

--- a/crates/llm/src/conversion/bedrock_tests.rs
+++ b/crates/llm/src/conversion/bedrock_tests.rs
@@ -1644,3 +1644,199 @@ fn test_messages_long_tool_name_round_trip_response() {
 
 	assert_eq!(tool_use_name, long_name);
 }
+
+#[test]
+fn test_responses_input_image_data_url_maps_to_converse_image_block() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [
+				{ "type": "input_text", "text": "What is in this image?" },
+				{
+					"type": "input_image",
+					"image_url": "data:image/png;base64,iVBORw0KGgo=",
+					"detail": "auto"
+				}
+			]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let translated = super::from_responses::translate(&req, &provider, None, None)
+		.unwrap()
+		.body;
+	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
+
+	let content = translated["messages"][0]["content"]
+		.as_array()
+		.expect("user message content");
+	assert_eq!(content[0]["text"], json!("What is in this image?"));
+	assert_eq!(content[1]["image"]["format"], json!("png"));
+	assert_eq!(
+		content[1]["image"]["source"]["bytes"],
+		json!("iVBORw0KGgo=")
+	);
+}
+
+#[test]
+fn test_responses_assistant_input_image_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "assistant",
+			"content": [{
+				"type": "input_image",
+				"image_url": "data:image/png;base64,iVBORw0KGgo=",
+				"detail": "auto"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
+		err
+			.to_string()
+			.contains("image inputs are only supported on user messages")
+	);
+}
+
+#[test]
+fn test_responses_input_image_remote_url_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_image",
+				"image_url": "https://example.com/sample.png",
+				"detail": "auto"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
+		err
+			.to_string()
+			.contains("remote URLs and file_ids are unsupported")
+	);
+}
+
+#[test]
+fn test_responses_input_image_file_id_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_image",
+				"file_id": "file-abc123",
+				"detail": "auto"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+}
+
+#[test]
+fn test_responses_system_input_file_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"type": "message",
+			"role": "system",
+			"content": [{
+				"type": "input_file",
+				"file_id": "file-abc123"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
+		err
+			.to_string()
+			.contains("file inputs are unsupported for bedrock")
+	);
+}
+
+#[test]
+fn test_responses_input_file_is_rejected() {
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+
+	let req: types::responses::Request = serde_json::from_value(json!({
+		"model": "gpt-4o",
+		"max_output_tokens": 64,
+		"input": [{
+			"role": "user",
+			"content": [{
+				"type": "input_file",
+				"file_id": "file-abc123"
+			}]
+		}]
+	}))
+	.expect("valid responses request");
+
+	let err = super::from_responses::translate(&req, &provider, None, None).unwrap_err();
+	assert!(matches!(err, crate::AIError::UnsupportedConversion(_)));
+	assert!(
+		err
+			.to_string()
+			.contains("file inputs are unsupported for bedrock")
+	);
+}

--- a/crates/llm/src/types/bedrock.rs
+++ b/crates/llm/src/types/bedrock.rs
@@ -16,6 +16,7 @@ pub enum Role {
 pub enum ContentBlock {
 	Text(String),
 	Image(ImageBlock),
+	Document(DocumentBlock),
 	ToolResult(ToolResultBlock),
 	ToolUse(ToolUseBlock),
 	ReasoningContent(ReasoningContentBlock),
@@ -32,6 +33,20 @@ pub struct ImageBlock {
 #[derive(Clone, Deserialize, Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ImageSource {
+	pub bytes: String,
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentBlock {
+	pub format: String,
+	pub name: String,
+	pub source: DocumentSource,
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentSource {
 	pub bytes: String,
 }
 


### PR DESCRIPTION
Responses API to Bedrock Converse translation to support inline image inputs (`input_image` with `base64 data:image/...` URLs are now converted into Bedrock image content blocks) and adds some errors for unsupported media types. Doesn't support fetching remote URLs and file_ids yet which would require the gateway to fetch content itself.

Fixes https://github.com/agentgateway/agentgateway/issues/2312 

Fun with testing:
```

IMG_URL='https://docs.solo.io/gloo-edge/main/img/Gloo-01.png'
IMG_B64="$(curl -Ls "$IMG_URL" | base64 | tr -d '\n')"

curl -sS http://127.0.0.1:3000/v1/responses \
    -H 'content-type: application/json' \
    -d "{
      \"model\": \"us.anthropic.claude-haiku-4-5-20251001-v1:0\",
      \"max_output_tokens\": 128,
      \"input\": [{
        \"role\": \"user\",
        \"content\": [
          { \"type\": \"input_text\", \"text\": \"What would you name this blue thing?\" },
          {
            \"type\": \"input_image\",
            \"image_url\": \"data:image/png;base64,$IMG_B64\",
            \"detail\": \"auto\"
          }
        ]
      }]
    }"

{"id":"resp_ea94ea7d7387d280","status":"incomplete","output":[{"type":"message","content":[{"type":"output_text","annotations":[],"logprobs":null,"text":"Based on its cheerful, round appearance with antenna-like features and friendly expression, I'd call this blue character **\"Blob\"** or **\"Blobby\"**. \n\nThe character has a cute, amorphous blob-like body shape with a happy demeanor, making it a fitting name. Other options could be:\n- **Bubbles** (given its round, bubble-like form)\n- **Gizmo** (considering the tech/circuit board context with the GlooEdge branding)\n- **Gloo** (a playful shortenedversion"}],"id":"msg_1d4d2f2c256b9a7d","role":"assistant","status":"completed"}],"model":"us.anthropic.claude-haiku-4-5-20251001-v1:0","usage":{"input_tokens":1569,"output_tokens":128,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}%  
```

With the url directly set (`"image_url": "https://docs.solo.io/gloo-edge/main/img/Gloo-01.png"`) you get an error on response:
```
processing failed: unsupported conversion: bedrock image inputs must be base64 data URLs; remote URLs and file_ids are unsupported% 
```

Document support:
```
DOC_B64="$(echo 'Hello world' | base64 | tr -d '\n')"

curl -sS http://127.0.0.1:3000/v1/responses \
    -H 'content-type: application/json' \
    -d "{
      \"model\": \"us.anthropic.claude-haiku-4-5-20251001-v1:0\",
      \"max_output_tokens\": 128,
      \"input\": [{
        \"role\": \"user\",
        \"content\": [
          { \"type\": \"input_text\", \"text\": \"Summarize this document.\" },
          {
            \"type\": \"input_file\",
            \"file_data\": \"data:text/plain;base64,$DOC_B64\",
            \"filename\": \"notes.txt\"
          }
        ]
      }]
    }"

{"id":"resp_8d766c30c292c3e2","status":"completed","output":[{"type":"message","content":[{"type":"output_text","annotations":[],"logprobs":null,"text":"# Summary\n\nThe document is a simple text file containing the phrase \"Hello world\" — a classic greeting often used as the first program or message in programming and computing contexts."}],"id":"msg_3d7342b4e8572801","role":"assistant","status":"completed"}],"model":"us.anthropic.claude-haiku-4-5-20251001-v1:0","usage":{"input_tokens":60,"output_tokens":38,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}%
```