### PR TITLE
Expose `failureMode` for extProc

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2246,7 +2246,7 @@ type ExtProc struct {
 	BackendRef *gwv1.BackendObjectReference `json:"backendRef,omitempty"`
 
 	// Behavior when the external processor is unavailable or returns an error.
-	// "FailOpen" allows the request to continue unprocessed.
+	// "FailOpen" allows the request to continue.
 	// "FailClosed" (default) rejects the request.
 	// +optional
 	FailureMode FailureMode `json:"failureMode,omitempty"`

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2244,6 +2244,13 @@ type ExtProc struct {
 	// Supported types: `Service` and `Backend`.
 	// +optional
 	BackendRef *gwv1.BackendObjectReference `json:"backendRef,omitempty"`
+
+	// Behavior when the external processor is unavailable or returns an error.
+	// "FailOpen" allows the request to continue unprocessed.
+	// "FailClosed" (default) rejects the request.
+	// +optional
+	FailureMode FailureMode `json:"failureMode,omitempty"`
+
 	// How request and response phases are sent to ext_proc.
 	// +optional
 	ProcessingOptions *ProcessingOptions `json:"processingOptions,omitempty"`

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2246,8 +2246,10 @@ type ExtProc struct {
 	BackendRef *gwv1.BackendObjectReference `json:"backendRef,omitempty"`
 
 	// Behavior when the external processor is unavailable or returns an error.
-	// "FailOpen" allows the request to continue.
-	// "FailClosed" (default) rejects the request.
+	// "FailOpen" allows the request to continue, as long as the request body has not
+	// been sent (or started streaming) to the ext_proc. Once the request body has
+	// started streaming to the ext_proc, the request will fail closed on error.
+	// "FailClosed" (default) rejects the request on any failure.
 	// +optional
 	FailureMode FailureMode `json:"failureMode,omitempty"`
 

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -11944,6 +11944,15 @@ spec:
                                   - message: Must have port for Service reference
                                     rule: '(size(self.group) == 0 && self.kind ==
                                       ''Service'') ? has(self.port) : true'
+                                failureMode:
+                                  description: |-
+                                    Behavior when the external processor is unavailable or returns an error.
+                                    "FailOpen" allows the request to continue unprocessed.
+                                    "FailClosed" (default) rejects the request.
+                                  enum:
+                                  - FailClosed
+                                  - FailOpen
+                                  type: string
                                 metadataContext:
                                   additionalProperties:
                                     additionalProperties:
@@ -12073,6 +12082,15 @@ spec:
                         - message: conditional entries without condition must be last
                           rule: self.filter(e, !has(e.condition)).size() <= 1 && (!self.exists(e,
                             !has(e.condition)) || !has(self[size(self) - 1].condition))
+                      failureMode:
+                        description: |-
+                          Behavior when the external processor is unavailable or returns an error.
+                          "FailOpen" allows the request to continue unprocessed.
+                          "FailClosed" (default) rejects the request.
+                        enum:
+                        - FailClosed
+                        - FailOpen
+                        type: string
                       metadataContext:
                         additionalProperties:
                           additionalProperties:
@@ -12187,7 +12205,7 @@ spec:
                     type: object
                     x-kubernetes-validations:
                     - message: conditional cannot be set with any other field
-                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.metadataContext),has(self.processingOptions),has(self.requestAttributes),has(self.responseAttributes)].filter(x,x==true).size()
+                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.failureMode),has(self.metadataContext),has(self.processingOptions),has(self.requestAttributes),has(self.responseAttributes)].filter(x,x==true).size()
                         == 0 : true'
                     - message: 'backendRef: Required value'
                       rule: 'has(self.conditional) ? true : has(self.backendRef)'

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -11947,7 +11947,7 @@ spec:
                                 failureMode:
                                   description: |-
                                     Behavior when the external processor is unavailable or returns an error.
-                                    "FailOpen" allows the request to continue unprocessed.
+                                    "FailOpen" allows the request to continue.
                                     "FailClosed" (default) rejects the request.
                                   enum:
                                   - FailClosed
@@ -12085,7 +12085,7 @@ spec:
                       failureMode:
                         description: |-
                           Behavior when the external processor is unavailable or returns an error.
-                          "FailOpen" allows the request to continue unprocessed.
+                          "FailOpen" allows the request to continue.
                           "FailClosed" (default) rejects the request.
                         enum:
                         - FailClosed

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -11947,8 +11947,10 @@ spec:
                                 failureMode:
                                   description: |-
                                     Behavior when the external processor is unavailable or returns an error.
-                                    "FailOpen" allows the request to continue.
-                                    "FailClosed" (default) rejects the request.
+                                    "FailOpen" allows the request to continue, as long as the request body has not
+                                    been sent (or started streaming) to the ext_proc. Once the request body has
+                                    started streaming to the ext_proc, the request will fail closed on error.
+                                    "FailClosed" (default) rejects the request on any failure.
                                   enum:
                                   - FailClosed
                                   - FailOpen
@@ -12085,8 +12087,10 @@ spec:
                       failureMode:
                         description: |-
                           Behavior when the external processor is unavailable or returns an error.
-                          "FailOpen" allows the request to continue.
-                          "FailClosed" (default) rejects the request.
+                          "FailOpen" allows the request to continue, as long as the request body has not
+                          been sent (or started streaming) to the ext_proc. Once the request body has
+                          started streaming to the ext_proc, the request will fail closed on error.
+                          "FailClosed" (default) rejects the request on any failure.
                         enum:
                         - FailClosed
                         - FailOpen

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extproc-fail-open.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extproc-fail-open.yaml
@@ -14,21 +14,6 @@ spec:
         name: extproc-svc
         port: 4444
       failureMode: FailOpen
-      requestAttributes:
-        source.address: source.address
-      responseAttributes:
-        response.code: response.code
-      metadataContext:
-        envoy.filters.http.jwt_authn:
-          jwt_payload: request.jwt.payload
-      processingOptions:
-        requestBodyMode: BufferedPartial
-        responseBodyMode: FullDuplexStreamed
-        requestHeaderMode: Skip
-        responseHeaderMode: Send
-        requestTrailerMode: Send
-        responseTrailerMode: Skip
-        allowModeOverride: true
 ---
 apiVersion: v1
 kind: Service
@@ -38,6 +23,7 @@ metadata:
 spec:
   ports:
     - port: 4444
+
 ---
 # Output
 output:
@@ -58,22 +44,6 @@ output:
       traffic:
         extProc:
           failureMode: FAIL_OPEN
-          metadataContext:
-            envoy.filters.http.jwt_authn:
-              context:
-                jwt_payload: request.jwt.payload
-          processingOptions:
-            allowModeOverride: true
-            requestBodyMode: BUFFERED_PARTIAL
-            requestHeaderMode: SKIP
-            requestTrailerMode: SEND
-            responseBodyMode: FULL_DUPLEX_STREAMED
-            responseHeaderMode: SEND
-            responseTrailerMode: SKIP
-          requestAttributes:
-            source.address: source.address
-          responseAttributes:
-            response.code: response.code
           target:
             port: 4444
             service:

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extproc-fail-open.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/extproc-fail-open.yaml
@@ -1,0 +1,107 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: http
+  namespace: default
+spec:
+  targetRefs:
+  - kind: Gateway
+    name: test
+    group: gateway.networking.k8s.io
+  traffic:
+    extProc:
+      backendRef:
+        name: extproc-svc
+        port: 4444
+      failureMode: FailOpen
+      requestAttributes:
+        source.address: source.address
+      responseAttributes:
+        response.code: response.code
+      metadataContext:
+        envoy.filters.http.jwt_authn:
+          jwt_payload: request.jwt.payload
+      processingOptions:
+        requestBodyMode: BufferedPartial
+        responseBodyMode: FullDuplexStreamed
+        requestHeaderMode: Skip
+        responseHeaderMode: Send
+        requestTrailerMode: Send
+        responseTrailerMode: Skip
+        allowModeOverride: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: extproc-svc
+  namespace: default
+spec:
+  ports:
+    - port: 4444
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/http:extproc:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: http
+        namespace: default
+      target:
+        gateway:
+          name: test
+          namespace: default
+      traffic:
+        extProc:
+          failureMode: FAIL_OPEN
+          metadataContext:
+            envoy.filters.http.jwt_authn:
+              context:
+                jwt_payload: request.jwt.payload
+          processingOptions:
+            allowModeOverride: true
+            requestBodyMode: BUFFERED_PARTIAL
+            requestHeaderMode: SKIP
+            requestTrailerMode: SEND
+            responseBodyMode: FULL_DUPLEX_STREAMED
+            responseHeaderMode: SEND
+            responseTrailerMode: SKIP
+          requestAttributes:
+            source.address: source.address
+          responseAttributes:
+            response.code: response.code
+          target:
+            port: 4444
+            service:
+              hostname: extproc-svc.default.svc.cluster.local
+              namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: http
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -1312,8 +1312,8 @@ func processExtProcTraffic(
 
 	spec := &api.TrafficPolicySpec_ExtProc{
 		Target: be,
-		// always use FAIL_CLOSED to prevent silent data loss when ExtProc is unavailable.
-		FailureMode: api.TrafficPolicySpec_ExtProc_FAIL_CLOSED,
+		// Defaults to FAIL_CLOSED to prevent silent data loss when ExtProc is unavailable.
+		FailureMode: extProcFailureMode(extProc.FailureMode),
 	}
 	if extProc.ProcessingOptions != nil {
 		spec.ProcessingOptions = &api.TrafficPolicySpec_ExtProc_ProcessingOptions{
@@ -1748,6 +1748,13 @@ func remoteRateLimitFailureMode(mode agentgateway.FailureMode) api.TrafficPolicy
 		return api.TrafficPolicySpec_RemoteRateLimit_FAIL_OPEN
 	}
 	return api.TrafficPolicySpec_RemoteRateLimit_FAIL_CLOSED
+}
+
+func extProcFailureMode(mode agentgateway.FailureMode) api.TrafficPolicySpec_ExtProc_FailureMode {
+	if mode == agentgateway.FailOpen {
+		return api.TrafficPolicySpec_ExtProc_FAIL_OPEN
+	}
+	return api.TrafficPolicySpec_ExtProc_FAIL_CLOSED
 }
 
 // BuildBackendRef constructs an agentgateway backend reference from a Gateway


### PR DESCRIPTION
This PR exposes `failureMode` for extProc. Resolves issue https://github.com/agentgateway/agentgateway/issues/2528

- `FailClosed` (default) - This is unchanged. Will fail on any error.
- `FailOpen` - Allows request through if extProc is unavailable or throws an error. However, once the request body is sent, this will behave as `FailClosed`

### Tests
- Manual Local: Ran gateway against an unreachable ext proc. Verified that it returns 500 when setup as `FailClosed` and 200 when setup as `FailOpen`
- Unit test: new `extproc-fail-open.yaml` ensures `failureMode: FailOpen` translates to `FAIL_OPEN`
- Manual Kubernetes: deployed a kind cluster, applied an agentgatewaypolicy with ext_proc pointing to an endpointless service confirmed 500 with `FailClosed` and 200 with `FailOpen` 

