### PR TITLE
.github: nightly agctl artifacts

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -125,6 +125,12 @@ jobs:
             else
               git log -20 --format='- `%h` %s (%an)'
             fi
+
+            echo
+            echo "## agctl binaries"
+            echo
+            echo "Nightly \`agctl\` binaries (Linux amd64/arm64, Darwin arm64, Windows amd64) are published as the \`release-binary-agctl\` workflow artifact on this run:"
+            echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           } > nightly-changelog.md
 
           cat nightly-changelog.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,7 +599,7 @@ jobs:
           target/${{ matrix.target }}/release/agentgateway.exe
 
   build-agctl:
-    if: ${{ github.event_name != 'workflow_call' && (github.event_name == 'push' || ! github.event.inputs.skip_gh_release) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_call' || ! github.event.inputs.skip_gh_release }}
     needs:
       - setup
     runs-on: ubuntu-24.04


### PR DESCRIPTION
It seems like we probably should have nightly agctl builds.

I considered whether a bit more complexity was worth it to only rebuild the agctl if there were commits that touched on the cli pieces of the repo but that seemed like it could bloat the script if it copied over the old agctl to this action.

I wasnt quite sure how much we wanted workflow_dispatch and workflow_call to be differentiated for in the release action so figured that the smallest touch made sense so only changed the behavior on workflow_call.