### PR TITLE
examples: tune semantic routing escalation

### DIFF
--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -136,22 +136,22 @@ curl -sS -i "$INGRESS_GW_ADDRESS/v1/chat/completions" \
 The response body `model` field identifies the serving model. vSR response
 headers record the explicit selection when available.
 
-### Require Automatic Routing
+### Force Automatic Routing
 
-To require `model: "auto"` and reject direct model requests, apply the
-optional validation policy:
+To require automatic routing regardless of a client-provided model, apply the
+optional override policy:
 
 ```bash
-kubectl apply -f examples/llm-semantic-routing/k8s/require-auto.yaml
+kubectl apply -f examples/llm-semantic-routing/k8s/force-auto.yaml
 ```
 
 The policy uses an [agentgateway request-body
 transformation](https://agentgateway.dev/docs/kubernetes/latest/traffic-management/transformations/validate/)
-to reject requests whose `model` is missing or is not `auto`. Remove it to
-restore direct model selection:
+to rewrite the request's `model` field to `auto` before vSR selects a model.
+Remove it to restore direct model selection:
 
 ```bash
-kubectl delete -f examples/llm-semantic-routing/k8s/require-auto.yaml
+kubectl delete -f examples/llm-semantic-routing/k8s/force-auto.yaml
 ```
 
 Keep this optional policy disabled when running an evaluation that includes a
@@ -260,9 +260,9 @@ The gateway authenticates to OpenAI with its configured provider credential and
 records the selected model and cost as it does for other OpenAI-compatible
 clients. Agentgateway can [rewrite client-facing model names with model
 aliases](https://agentgateway.dev/docs/kubernetes/latest/llm/alias/). An
-organization can also [validate and reject unsupported request-body model
-values](https://agentgateway.dev/docs/kubernetes/latest/traffic-management/transformations/validate/),
-such as any value other than `auto`. Treat `auto` as the supported client path
+organization can also use a [request-body
+transformation](https://agentgateway.dev/docs/kubernetes/latest/traffic-management/transformations/validate/)
+to rewrite every request to `auto`. Treat `auto` as the supported client path
 when testing this policy.
 
 ## Cleanup

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -115,6 +115,49 @@ the routine request and `x-vsr-selected-model: gpt-5.5` for the advanced
 request. The debug header is for verification only and should not be required
 by application traffic.
 
+### Force a Model Tier
+
+The default configuration allows a client to request either configured model
+directly. This bypasses vSR's automatic model selection, while retaining the
+same agentgateway forwarding, cost tracking, and observability path:
+
+```bash
+curl -sS -i "$INGRESS_GW_ADDRESS/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-5.5",
+    "messages": [
+      {"role": "user", "content": "Use the advanced model for this request."}
+    ],
+    "max_tokens": 64
+  }'
+```
+
+The response body `model` field identifies the serving model. vSR response
+headers record the explicit selection when available.
+
+### Require Automatic Routing
+
+To require `model: "auto"` and reject direct model requests, apply the
+optional validation policy:
+
+```bash
+kubectl apply -f examples/llm-semantic-routing/k8s/require-auto.yaml
+```
+
+The policy uses an [agentgateway request-body
+transformation](https://agentgateway.dev/docs/kubernetes/latest/traffic-management/transformations/validate/)
+to reject requests whose `model` is missing or is not `auto`. Remove it to
+restore direct model selection:
+
+```bash
+kubectl delete -f examples/llm-semantic-routing/k8s/require-auto.yaml
+```
+
+Keep this optional policy disabled when running an evaluation that includes a
+forced-model baseline, such as the cost-based semantic-routing demo's
+`always_expensive` lane.
+
 Agentgateway’s model catalog, metrics, logs, and traces remain the cost and
 observability source of record. Use isolated evaluation traffic with forced
 lower-cost and always-expensive baselines before adopting the policy broadly.

--- a/examples/llm-semantic-routing/k8s/force-auto.yaml
+++ b/examples/llm-semantic-routing/k8s/force-auto.yaml
@@ -1,7 +1,7 @@
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
-  name: semantic-router-require-auto
+  name: semantic-router-force-auto
   namespace: agentgateway-system
   labels:
     app.kubernetes.io/name: llm-semantic-routing
@@ -13,4 +13,4 @@ spec:
   traffic:
     transformation:
       request:
-        body: 'default(json(request.body).model, "") == "auto" ? request.body : fail("model must be auto")'
+        body: 'toJson(json(request.body).merge({"model": "auto"}))'

--- a/examples/llm-semantic-routing/k8s/require-auto.yaml
+++ b/examples/llm-semantic-routing/k8s/require-auto.yaml
@@ -1,0 +1,16 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: semantic-router-require-auto
+  namespace: agentgateway-system
+  labels:
+    app.kubernetes.io/name: llm-semantic-routing
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: openai-semantic-routing
+  traffic:
+    transformation:
+      request:
+        body: 'default(json(request.body).model, "") == "auto" ? request.body : fail("model must be auto")'

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -107,8 +107,10 @@ config:
         - paxos
         - linearizability
         - serializability
+        - serializable isolation
         - formal verification
         - model checking
+        - model checker
         - TLA+
         - Alloy
         - Coq
@@ -129,8 +131,10 @@ config:
         - idempotency boundary
         - fencing token
         - fencing tokens
+        - leader election
         - stale writer
         - regional failover
+        - cross-region failover
         - network partition
         - network partitions
         - replicated state
@@ -145,6 +149,11 @@ config:
         - dual writes
         - durable state transition
         - duplicate business effects
+        - transactional outbox
+        - event log compaction
+        - Kafka rebalance
+        - schema migration
+        - saga compensation
         - configuration replicas
         - eventual-consistency
         - leased message
@@ -152,7 +161,8 @@ config:
         case_sensitive: false
       - name: routine_coding_markers
         operator: OR
-        method: bm25
+        # Use literal matching so broad implementation language in an advanced
+        # request cannot outweigh its correctness or distributed-systems cues.
         keywords:
         - implement
         - refactor
@@ -165,7 +175,6 @@ config:
         - simple bug
         - straightforward
         case_sensitive: false
-        bm25_threshold: 0.1
 
       embeddings:
       - name: routine_coding_intent

--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -158,11 +158,19 @@ config:
         - eventual-consistency
         - leased message
         - delayed, duplicated, and reordered
+        - etcd election
+        - version acknowledgement
+        - duplicate side effects
+        - eventually consistent
+        - durable saga
+        - partition ownership
+        - replayed events
+        - zero-downtime
         case_sensitive: false
       - name: routine_coding_markers
         operator: OR
-        # Use literal matching so broad implementation language in an advanced
-        # request cannot outweigh its correctness or distributed-systems cues.
+        # Use literal matching so common coding vocabulary does not suppress
+        # an advanced operational-design request.
         keywords:
         - implement
         - refactor
@@ -197,6 +205,9 @@ config:
         - Design conflict resolution for replicated state and justify convergence, monotonic growth, and deletion semantics.
         - Compare competing collaboration or consistency approaches and recommend one based on their tradeoffs.
         - Debug a rare production incident involving timing, retries, and consistency.
+        - Design an idempotent workflow resilient to retries, duplicate delivery, leases, and crash recovery.
+        - Design a migration or replay protocol that preserves ordering, consistency, and safe recovery.
+        - Analyze cross-region replication, failover, and reconciliation under partitions.
 
       context:
       - name: long_context
@@ -248,6 +259,8 @@ config:
           - debug a complex distributed production incident
           - synthesize research and produce a technical recommendation
           - analyze consistency, consensus, and failure recovery
+          - design an idempotent workflow with retries, duplicate delivery, and crash recovery
+          - design a migration, replay, or failover protocol that preserves ordering and consistency
         easy:
           candidates:
           - write a small helper function


### PR DESCRIPTION
## Summary
- use literal routine coding markers so broad topic matching does not suppress advanced work
- add high-specificity advanced markers and reasoning examples for distributed systems, formal methods, retries, recovery, migration, replay, and failover
- document direct model-tier requests and add an opt-in policy that forces `model: "auto"`

## Validation
- `kubectl apply --dry-run=server -f examples/llm-semantic-routing/k8s/force-auto.yaml`
- `helm template semantic-router oci://ghcr.io/vllm-project/charts/semantic-router --version 0.0.0-latest --values examples/llm-semantic-routing/k8s/semantic-router-values.yaml`