### PR TITLE
auth: make crossAppAccess subject token source configurable

### DIFF
--- a/crates/agentgateway/src/http/auth/oauth/cross_app_access.rs
+++ b/crates/agentgateway/src/http/auth/oauth/cross_app_access.rs
@@ -58,6 +58,11 @@ pub(super) struct CrossAppAccessAuthConfig {
 	/// `scope` values for the requested token, sent space-delimited.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub(super) scopes: Vec<String>,
+	/// Overrides where the exchanged `id_token` is read from; defaults to the Authorization
+	/// Bearer header. Set to a CEL `expression` to extract it from a claim of the validated
+	/// inbound token (e.g. `{ expression: "jwt.the_id_token" }`).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub(super) subject_token_source: Option<AuthorizationLocation>,
 	/// Response cache configuration. Defaults to an in-memory cache with 8192 entries and a 300s
 	/// TTL when the token endpoint omits `expires_in`. Set `maxEntries` to 0 to disable.
 	#[serde(
@@ -79,6 +84,7 @@ impl From<CrossAppAccessAuthConfig> for CrossAppAccessAuth {
 			audience,
 			resources,
 			scopes,
+			subject_token_source,
 			cache,
 		} = config;
 		let CrossAppAccessEndpoint {
@@ -92,7 +98,7 @@ impl From<CrossAppAccessAuthConfig> for CrossAppAccessAuth {
 			path,
 			grant_type: OAuthGrantType::TokenExchange,
 			subject_token: TokenSpec {
-				source: AuthorizationLocation::default(),
+				source: subject_token_source.unwrap_or_default(),
 				token_type: OAuthTokenType::IdToken,
 			},
 			actor_token: None,
@@ -174,6 +180,8 @@ impl CrossAppAccessAuth {
 			audience,
 			resources: self.oauth.resources.clone(),
 			scopes: self.oauth.scopes.clone(),
+			// Emitted explicitly, including when it holds the default Bearer-header source.
+			subject_token_source: Some(self.oauth.subject_token.source.clone()),
 			cache: self.oauth.cache.clone(),
 		})
 	}
@@ -208,6 +216,7 @@ impl CrossAppAccessAuth {
 			audience: t.audience,
 			resources: t.resources,
 			scopes: t.scopes,
+			subject_token_source: None,
 			cache: token_cache_from_proto(t.cache)?,
 		};
 		let auth = Self::from(config);

--- a/crates/agentgateway/src/http/auth/oauth/tests.rs
+++ b/crates/agentgateway/src/http/auth/oauth/tests.rs
@@ -108,6 +108,7 @@ fn cross_app_access_config(
 		audience: "https://resource-as.example".into(),
 		resources: vec![],
 		scopes: vec!["read".into()],
+		subject_token_source: None,
 		cache: Some(InMemoryTokenCache::default()),
 	}
 }
@@ -812,6 +813,37 @@ fn deserializes_cross_app_access_local_config_shape() {
 }
 
 #[test]
+fn cross_app_access_subject_token_source_override() {
+	let mut config = cross_app_access_config(
+		Arc::new(SimpleBackendReference::Invalid),
+		Arc::new(SimpleBackendReference::Invalid),
+	);
+
+	// Unset: the id_token is read from the Authorization Bearer header.
+	let auth = CrossAppAccessAuth::from(config.clone());
+	let subject_token = &auth.oauth_token_exchange().subject_token;
+	assert!(matches!(
+		&subject_token.source,
+		AuthorizationLocation::Header { name, .. } if name == ::http::header::AUTHORIZATION
+	));
+	assert_eq!(subject_token.token_type, OAuthTokenType::IdToken);
+
+	// Overridden source; the exchange still declares an id_token subject.
+	config.subject_token_source =
+		Some(serde_json::from_str(r#"{"expression": "jwt.the_id_token"}"#).unwrap());
+	let auth = CrossAppAccessAuth::from(config);
+	let subject_token = &auth.oauth_token_exchange().subject_token;
+	let AuthorizationLocation::Expression(expr) = &subject_token.source else {
+		panic!(
+			"expected an expression source, got {:?}",
+			subject_token.source
+		);
+	};
+	assert_eq!(expr.original_expression, "jwt.the_id_token");
+	assert_eq!(subject_token.token_type, OAuthTokenType::IdToken);
+}
+
+#[test]
 fn serializes_cross_app_access_local_config_shape() {
 	let serialized = serde_json::to_value(cross_app_access_local_config()).unwrap();
 	assert!(serialized.get("identityProvider").is_some());
@@ -833,6 +865,32 @@ fn serializes_cross_app_access_local_config_shape() {
 	);
 	assert!(serialized.get("oauthTokenExchange").is_none());
 	assert!(serialized.get("cache").is_none());
+}
+
+#[test]
+fn serializes_cross_app_access_subject_token_source() {
+	let backend = || {
+		Arc::new(SimpleBackendReference::InlineBackend(Target::Hostname(
+			crate::strng::new("idp.example.com"),
+			443,
+		)))
+	};
+	let mut config = cross_app_access_config(backend(), backend());
+
+	// The derived exchange cannot tell an omitted source from an explicit default, so the
+	// default is spelled out on the way back to config, as `oauthTokenExchange` already does
+	// for `subjectToken.source`.
+	let serialized = serde_json::to_value(CrossAppAccessAuth::from(config.clone())).unwrap();
+	assert!(serialized["subjectTokenSource"]["header"].is_object());
+
+	// A configured source is preserved on the way back to config.
+	config.subject_token_source =
+		Some(serde_json::from_str(r#"{"expression": "jwt.the_id_token"}"#).unwrap());
+	let serialized = serde_json::to_value(CrossAppAccessAuth::from(config)).unwrap();
+	assert_eq!(
+		serialized["subjectTokenSource"],
+		json!({ "expression": "jwt.the_id_token" })
+	);
 }
 
 #[test]

--- a/schema/config.json
+++ b/schema/config.json
@@ -3910,6 +3910,17 @@
             "type": "string"
           }
         },
+        "subjectTokenSource": {
+          "description": "Overrides where the exchanged `id_token` is read from; defaults to the Authorization\nBearer header. Set to a CEL `expression` to extract it from a claim of the validated\ninbound token (e.g. `{ expression: \"jwt.the_id_token\" }`).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AuthorizationLocation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "cache": {
           "description": "Response cache configuration. Defaults to an in-memory cache with 8192 entries and a 300s\nTTL when the token endpoint omits `expires_in`. Set `maxEntries` to 0 to disable.",
           "anyOf": [


### PR DESCRIPTION
The crossAppAccess policy hardcodes the exchanged subject token to an id_token read from the inbound Authorization Bearer header. This assumes the user's ID token arrives as the request's bearer credential, which is usually not the case: a gateway typically authenticates the incoming client with an access token (e.g. MCP OAuth), and the ID token, when present, is carried elsewhere.

Add an optional `subjectToken` override to the policy so the subject token's source and type can be configured, reusing the existing TokenSpec (its source supports a CEL expression over the validated inbound request, e.g. an id_token embedded as a claim). When unset, behavior is unchanged: an id_token taken from the Authorization Bearer header.