### PR TITLE
examples: expand advanced routing signals

### DIFF
--- a/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
+++ b/examples/llm-semantic-routing/k8s/semantic-router-values.yaml
@@ -149,10 +149,19 @@ config:
         - eventual-consistency
         - leased message
         - delayed, duplicated, and reordered
+        - etcd election
+        - version acknowledgement
+        - duplicate side effects
+        - eventually consistent
+        - durable saga
+        - partition ownership
+        - replayed events
+        - zero-downtime
         case_sensitive: false
       - name: routine_coding_markers
         operator: OR
-        method: bm25
+        # Use literal matching so common coding vocabulary does not suppress
+        # an advanced operational-design request.
         keywords:
         - implement
         - refactor
@@ -165,7 +174,6 @@ config:
         - simple bug
         - straightforward
         case_sensitive: false
-        bm25_threshold: 0.1
 
       embeddings:
       - name: routine_coding_intent
@@ -188,6 +196,9 @@ config:
         - Design conflict resolution for replicated state and justify convergence, monotonic growth, and deletion semantics.
         - Compare competing collaboration or consistency approaches and recommend one based on their tradeoffs.
         - Debug a rare production incident involving timing, retries, and consistency.
+        - Design an idempotent workflow resilient to retries, duplicate delivery, leases, and crash recovery.
+        - Design a migration or replay protocol that preserves ordering, consistency, and safe recovery.
+        - Analyze cross-region replication, failover, and reconciliation under partitions.
 
       context:
       - name: long_context
@@ -239,6 +250,8 @@ config:
           - debug a complex distributed production incident
           - synthesize research and produce a technical recommendation
           - analyze consistency, consensus, and failure recovery
+          - design an idempotent workflow with retries, duplicate delivery, and crash recovery
+          - design a migration, replay, or failover protocol that preserves ordering and consistency
         easy:
           candidates:
           - write a small helper function


### PR DESCRIPTION
## Summary
- add high-specificity operational-design markers for advanced coding requests
- broaden advanced embedding and complexity examples for retries, recovery, migration, replay, and failover
- use literal routine markers so broad topic matching does not suppress an advanced request

## Validation
- `helm template semantic-router oci://ghcr.io/vllm-project/charts/semantic-router --version 0.0.0-latest --values examples/llm-semantic-routing/k8s/semantic-router-values.yaml`