### PR TITLE
fix(mcp): rewrite issuer in AS metadata universally to satisfy RFC 8414 §3.3

### DIFF
--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -243,7 +243,7 @@ pub(super) async fn authorization_server_metadata(
 		.map_err(ProxyError::Body)?;
 
 	// Pre-compute once — reused in the universal issuer rewrite below.
-	let gateway_base = issuer_from_metadata_uri(request_uri_for_oauth_metadata(req).to_string());
+	let gateway_base = issuer_from_metadata_uri(&request_uri_for_oauth_metadata(req).to_string());
 
 	match &auth.provider {
 		Some(McpIDP::Auth0 {}) => {
@@ -315,9 +315,9 @@ pub(super) async fn authorization_server_metadata(
 		_ => {},
 	}
 
-	// RFC 8414 §3.3: the issuer in AS metadata MUST match the URL from which it was fetched.
-	// Applied universally across all providers — strict clients (Claude Desktop, ChatGPT, Codex)
-	// validate this and abort if issuer ≠ gateway URL.
+	// RFC 8414 §3.3: the `issuer` in AS metadata MUST match the issuer identifier implied by the
+	// metadata URL (RFC 8414 §3.1). For well-known metadata requests, that is the request URI with
+	// `/.well-known/oauth-authorization-server` removed.
 	if let Some(serde_json::Value::String(issuer_val)) = json::traverse_mut(&mut resp, &["issuer"]) {
 		*issuer_val = gateway_base;
 	}
@@ -409,16 +409,28 @@ pub(super) async fn client_registration(
 
 /// Derives the gateway issuer from an AS metadata URI, satisfying RFC 8414 §3.3.
 ///
-/// Removes the `/.well-known/oauth-authorization-server` segment while preserving any
-/// path suffix that follows it, as required by the RFC §3.1 path-based issuer form:
+/// Removes the `/.well-known/oauth-authorization-server` segment from the URL path while
+/// preserving any path suffix that follows it, as required by the RFC §3.1 path-based
+/// issuer form:
 ///   `https://example.com/.well-known/oauth-authorization-server/issuer1`
 ///   → `https://example.com/issuer1`
-fn issuer_from_metadata_uri(mut uri: String) -> String {
+///
+/// Operates on the parsed URL path — not the raw string — so query parameters and fragments
+/// are stripped and cannot be mistaken for part of the issuer.
+fn issuer_from_metadata_uri(uri: &str) -> String {
 	const WELL_KNOWN: &str = "/.well-known/oauth-authorization-server";
-	if let Some(idx) = uri.find(WELL_KNOWN) {
-		uri.replace_range(idx..idx + WELL_KNOWN.len(), "");
+	let Ok(mut parsed) = url::Url::parse(uri) else {
+		return uri.to_owned();
+	};
+	let path = parsed.path().to_owned();
+	if let Some(idx) = path.find(WELL_KNOWN) {
+		let new_path = format!("{}{}", &path[..idx], &path[idx + WELL_KNOWN.len()..]);
+		parsed.set_path(if new_path.is_empty() { "/" } else { &new_path });
 	}
-	uri
+	parsed.set_query(None);
+	parsed.set_fragment(None);
+	// url::Url always appends `/` for root paths; strip it so the issuer has no trailing slash.
+	parsed.to_string().trim_end_matches('/').to_owned()
 }
 
 const MOCK_DCR_CLIENT_ID_ISSUED_AT: u64 = 0;
@@ -700,7 +712,7 @@ mod tests {
 	fn issuer_strips_well_known_suffix_from_root_gateway() {
 		assert_eq!(
 			issuer_from_metadata_uri(
-				"https://gateway.example.com/.well-known/oauth-authorization-server".to_string()
+				"https://gateway.example.com/.well-known/oauth-authorization-server"
 			),
 			"https://gateway.example.com"
 		);
@@ -711,7 +723,6 @@ mod tests {
 		assert_eq!(
 			issuer_from_metadata_uri(
 				"https://gateway.example.com/base/path/.well-known/oauth-authorization-server"
-					.to_string()
 			),
 			"https://gateway.example.com/base/path"
 		);
@@ -727,7 +738,6 @@ mod tests {
 		assert_eq!(
 			issuer_from_metadata_uri(
 				"https://gateway.example.com/.well-known/oauth-authorization-server/issuer1"
-					.to_string()
 			),
 			"https://gateway.example.com/issuer1"
 		);
@@ -736,7 +746,17 @@ mod tests {
 	#[test]
 	fn issuer_returns_uri_unchanged_when_no_well_known_present() {
 		assert_eq!(
-			issuer_from_metadata_uri("https://gateway.example.com".to_string()),
+			issuer_from_metadata_uri("https://gateway.example.com"),
+			"https://gateway.example.com"
+		);
+	}
+
+	#[test]
+	fn issuer_ignores_query_and_fragment_in_metadata_uri() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/.well-known/oauth-authorization-server?foo=bar#frag"
+			),
 			"https://gateway.example.com"
 		);
 	}

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -241,6 +241,10 @@ pub(super) async fn authorization_server_metadata(
 	let mut resp: serde_json::Value = from_body_with_limit(upstream.into_body(), limit)
 		.await
 		.map_err(ProxyError::Body)?;
+
+	// Pre-compute once — reused in the universal issuer rewrite below.
+	let gateway_base = issuer_from_metadata_uri(request_uri_for_oauth_metadata(req).to_string());
+
 	match &auth.provider {
 		Some(McpIDP::Auth0 {}) => {
 			// Auth0 does not support RFC 8707. We can workaround this by prepending an audience
@@ -309,6 +313,13 @@ pub(super) async fn authorization_server_metadata(
 			*re = format!("{current_uri}/client-registration");
 		},
 		_ => {},
+	}
+
+	// RFC 8414 §3.3: the issuer in AS metadata MUST match the URL from which it was fetched.
+	// Applied universally across all providers — strict clients (Claude Desktop, ChatGPT, Codex)
+	// validate this and abort if issuer ≠ gateway URL.
+	if let Some(serde_json::Value::String(issuer_val)) = json::traverse_mut(&mut resp, &["issuer"]) {
+		*issuer_val = gateway_base;
 	}
 
 	let response = ::http::Response::builder()
@@ -394,6 +405,20 @@ pub(super) async fn client_registration(
 	);
 
 	Ok(upstream)
+}
+
+/// Derives the gateway issuer from an AS metadata URI, satisfying RFC 8414 §3.3.
+///
+/// Removes the `/.well-known/oauth-authorization-server` segment while preserving any
+/// path suffix that follows it, as required by the RFC §3.1 path-based issuer form:
+///   `https://example.com/.well-known/oauth-authorization-server/issuer1`
+///   → `https://example.com/issuer1`
+fn issuer_from_metadata_uri(mut uri: String) -> String {
+	const WELL_KNOWN: &str = "/.well-known/oauth-authorization-server";
+	if let Some(idx) = uri.find(WELL_KNOWN) {
+		uri.replace_range(idx..idx + WELL_KNOWN.len(), "");
+	}
+	uri
 }
 
 const MOCK_DCR_CLIENT_ID_ISSUED_AT: u64 = 0;
@@ -669,5 +694,50 @@ mod tests {
 		assert_eq!(json["client_id"], "operator-id");
 		assert!(json.is_object());
 		assert_eq!(json["redirect_uris"], serde_json::json!([]));
+	}
+
+	#[test]
+	fn issuer_strips_well_known_suffix_from_root_gateway() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/.well-known/oauth-authorization-server".to_string()
+			),
+			"https://gateway.example.com"
+		);
+	}
+
+	#[test]
+	fn issuer_strips_well_known_suffix_from_path_prefixed_gateway() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/base/path/.well-known/oauth-authorization-server"
+					.to_string()
+			),
+			"https://gateway.example.com/base/path"
+		);
+	}
+
+	// RFC 8414 §3.1 path-based issuer form:
+	// issuer = https://example.com/issuer1
+	// metadata URL = https://example.com/.well-known/oauth-authorization-server/issuer1
+	// The /.well-known/oauth-authorization-server segment must be removed while the
+	// trailing /issuer1 path is preserved.
+	#[test]
+	fn issuer_preserves_path_suffix_after_well_known_segment() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/.well-known/oauth-authorization-server/issuer1"
+					.to_string()
+			),
+			"https://gateway.example.com/issuer1"
+		);
+	}
+
+	#[test]
+	fn issuer_returns_uri_unchanged_when_no_well_known_present() {
+		assert_eq!(
+			issuer_from_metadata_uri("https://gateway.example.com".to_string()),
+			"https://gateway.example.com"
+		);
 	}
 }


### PR DESCRIPTION
## Problem

The `issuer` field returned by `authorization_server_metadata` must be identical to the URL from which the metadata was fetched (RFC 8414 §3.3). Previously, agentgateway proxied the upstream IdP issuer unchanged. Strict clients — **Claude Desktop**, **ChatGPT**, **Codex** — validate this and abort if `issuer` ≠ gateway URL, causing the OAuth flow to fail immediately.

## Solution

Apply the issuer rewrite universally across all providers (not Okta-only) since the compliance requirement is provider-agnostic.

A helper `issuer_from_metadata_uri` derives the gateway base URL from the incoming metadata request URI by stripping the `/.well-known/oauth-authorization-server` segment while preserving any path suffix, satisfying the RFC §3.1 path-based issuer form:

```
https://example.com/.well-known/oauth-authorization-server/issuer1
→ https://example.com/issuer1
```

Tests cover: root gateway, path-prefixed gateway, RFC §3.1 path-based issuer, and a no-op case (URI with no well-known segment).

## Note

This is the first of two PRs split from #2537 as requested by @markuskobler. The second PR adds native `/authorize` redirect and `/token` proxy handlers and will follow once this is merged.