### PR TITLE
feat(mcp/okta): add native /authorize redirect and /token proxy

### DIFF
--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -453,8 +453,6 @@ fn okta_authorize_redirect(
 ) -> Result<Response, ProxyError> {
 	let issuer = auth.issuer.trim_end_matches('/');
 
-	let has_scope = existing_query.split('&').any(|p| p.starts_with("scope="));
-
 	// Inject audience only when configured — sending audience= (empty) causes Okta to reject
 	// the request; absence of the param is preferable to an invalid value.
 	let mut query = auth
@@ -462,12 +460,6 @@ fn okta_authorize_redirect(
 		.first()
 		.map(|aud| format!("audience={aud}"))
 		.unwrap_or_default();
-	if !has_scope {
-		if !query.is_empty() {
-			query.push('&');
-		}
-		query.push_str("scope=openid");
-	}
 	if !existing_query.is_empty() {
 		if !query.is_empty() {
 			query.push('&');

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -17,6 +17,9 @@ use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
 use crate::types::agent::{McpAuthentication, McpIDP};
 
 pub(crate) fn is_well_known_endpoint(path: &str) -> bool {
+	// /authorize and /token are public OAuth endpoints — they must bypass JWT validation by
+	// definition. For non-Okta providers, handle_mcp_request returns 404 for these paths
+	// rather than Ok(None), so requests never reach the MCP backend unauthenticated.
 	path.starts_with("/.well-known/oauth-protected-resource")
 		|| path.starts_with("/.well-known/oauth-authorization-server")
 		|| path == "/authorize"

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -243,7 +243,7 @@ pub(super) async fn authorization_server_metadata(
 		.map_err(ProxyError::Body)?;
 
 	// Pre-compute once — reused in the universal issuer rewrite below.
-	let gateway_base = issuer_from_metadata_uri(request_uri_for_oauth_metadata(req).to_string());
+	let gateway_base = issuer_from_metadata_uri(&request_uri_for_oauth_metadata(req).to_string());
 
 	match &auth.provider {
 		Some(McpIDP::Auth0 {}) => {
@@ -315,9 +315,9 @@ pub(super) async fn authorization_server_metadata(
 		_ => {},
 	}
 
-	// RFC 8414 §3.3: the issuer in AS metadata MUST match the URL from which it was fetched.
-	// Applied universally across all providers — strict clients (Claude Desktop, ChatGPT, Codex)
-	// validate this and abort if issuer ≠ gateway URL.
+	// RFC 8414 §3.3: the `issuer` in AS metadata MUST match the issuer identifier implied by the
+	// metadata URL (RFC 8414 §3.1). For well-known metadata requests, that is the request URI with
+	// `/.well-known/oauth-authorization-server` removed.
 	if let Some(serde_json::Value::String(issuer_val)) = json::traverse_mut(&mut resp, &["issuer"]) {
 		*issuer_val = gateway_base;
 	}
@@ -409,16 +409,28 @@ pub(super) async fn client_registration(
 
 /// Derives the gateway issuer from an AS metadata URI, satisfying RFC 8414 §3.3.
 ///
-/// Removes the `/.well-known/oauth-authorization-server` segment while preserving any
-/// path suffix that follows it, as required by the RFC §3.1 path-based issuer form:
+/// Removes the `/.well-known/oauth-authorization-server` segment from the URL path while
+/// preserving any path suffix that follows it, as required by the RFC §3.1 path-based
+/// issuer form:
 ///   `https://example.com/.well-known/oauth-authorization-server/issuer1`
 ///   → `https://example.com/issuer1`
-fn issuer_from_metadata_uri(mut uri: String) -> String {
+///
+/// Operates on the parsed URL path — not the raw string — so query parameters and fragments
+/// are stripped and cannot be mistaken for part of the issuer.
+fn issuer_from_metadata_uri(uri: &str) -> String {
 	const WELL_KNOWN: &str = "/.well-known/oauth-authorization-server";
-	if let Some(idx) = uri.find(WELL_KNOWN) {
-		uri.replace_range(idx..idx + WELL_KNOWN.len(), "");
+	let Ok(mut parsed) = url::Url::parse(uri) else {
+		return uri.to_owned();
+	};
+	let path = parsed.path().to_owned();
+	if let Some(idx) = path.find(WELL_KNOWN) {
+		let new_path = format!("{}{}", &path[..idx], &path[idx + WELL_KNOWN.len()..]);
+		parsed.set_path(if new_path.is_empty() { "/" } else { &new_path });
 	}
-	uri
+	parsed.set_query(None);
+	parsed.set_fragment(None);
+	// url::Url always appends `/` for root paths; strip it so the issuer has no trailing slash.
+	parsed.to_string().trim_end_matches('/').to_owned()
 }
 
 const MOCK_DCR_CLIENT_ID_ISSUED_AT: u64 = 0;
@@ -700,7 +712,7 @@ mod tests {
 	fn issuer_strips_well_known_suffix_from_root_gateway() {
 		assert_eq!(
 			issuer_from_metadata_uri(
-				"https://gateway.example.com/.well-known/oauth-authorization-server".to_string()
+				"https://gateway.example.com/.well-known/oauth-authorization-server"
 			),
 			"https://gateway.example.com"
 		);
@@ -711,7 +723,6 @@ mod tests {
 		assert_eq!(
 			issuer_from_metadata_uri(
 				"https://gateway.example.com/base/path/.well-known/oauth-authorization-server"
-					.to_string()
 			),
 			"https://gateway.example.com/base/path"
 		);
@@ -727,7 +738,6 @@ mod tests {
 		assert_eq!(
 			issuer_from_metadata_uri(
 				"https://gateway.example.com/.well-known/oauth-authorization-server/issuer1"
-					.to_string()
 			),
 			"https://gateway.example.com/issuer1"
 		);
@@ -736,7 +746,17 @@ mod tests {
 	#[test]
 	fn issuer_returns_uri_unchanged_when_no_well_known_present() {
 		assert_eq!(
-			issuer_from_metadata_uri("https://gateway.example.com".to_string()),
+			issuer_from_metadata_uri("https://gateway.example.com"),
+			"https://gateway.example.com"
+		);
+	}
+
+	#[test]
+	fn issuer_ignores_query_and_fragment_in_metadata_uri() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/.well-known/oauth-authorization-server?foo=bar#frag"
+			),
 			"https://gateway.example.com"
 		);
 	}

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -93,36 +93,46 @@ pub(crate) async fn handle_mcp_request(
 				})
 				.into_response(),
 		)),
-		path if path == "/authorize" => match &auth.provider {
-			Some(McpIDP::Okta {}) => {
-				let existing_query = req.uri().query().unwrap_or("").to_owned();
-				Ok(Some(
-					okta_authorize_redirect(&existing_query, auth)
-						.map_err(|e| {
-							warn!("okta_authorize_redirect error: {}", e);
-							StatusCode::INTERNAL_SERVER_ERROR
-						})
-						.into_response(),
-				))
-			},
-			_ => Ok(None),
+		path if path == "/authorize" => {
+			if req.method() != Method::GET {
+				return Ok(Some(StatusCode::METHOD_NOT_ALLOWED.into_response()));
+			}
+			match &auth.provider {
+				Some(McpIDP::Okta {}) => {
+					let existing_query = req.uri().query().unwrap_or("").to_owned();
+					Ok(Some(
+						okta_authorize_redirect(&existing_query, auth)
+							.map_err(|e| {
+								warn!("okta_authorize_redirect error: {}", e);
+								StatusCode::INTERNAL_SERVER_ERROR
+							})
+							.into_response(),
+					))
+				},
+				_ => Ok(Some(StatusCode::NOT_FOUND.into_response())),
+			}
 		},
-		path if path == "/token" => match &auth.provider {
-			Some(McpIDP::Okta {}) => {
-				let content_type = req.headers().get("content-type").cloned();
-				let authorization = req.headers().get("authorization").cloned();
-				let body = std::mem::take(req.body_mut());
-				Ok(Some(
-					okta_token_proxy(content_type, authorization, body, auth, client.clone())
-						.await
-						.map_err(|e| {
-							warn!("okta_token_proxy error: {}", e);
-							StatusCode::INTERNAL_SERVER_ERROR
-						})
-						.into_response(),
-				))
-			},
-			_ => Ok(None),
+		path if path == "/token" => {
+			if req.method() != Method::POST {
+				return Ok(Some(StatusCode::METHOD_NOT_ALLOWED.into_response()));
+			}
+			match &auth.provider {
+				Some(McpIDP::Okta {}) => {
+					let content_type = req.headers().get("content-type").cloned();
+					let authorization = req.headers().get("authorization").cloned();
+					let body = std::mem::take(req.body_mut());
+					Ok(Some(
+						okta_token_proxy(content_type, authorization, body, auth, client.clone())
+							.await
+							.map_err(|e| {
+								warn!("okta_token_proxy error: {}", e);
+								StatusCode::INTERNAL_SERVER_ERROR
+							})
+							.into_response(),
+					))
+				},
+				_ => Ok(Some(StatusCode::NOT_FOUND.into_response())),
+			}
 		},
 		_ => {
 			// Not handled
@@ -299,17 +309,23 @@ pub(super) async fn authorization_server_metadata(
 			// {issuer}/token) instead of reading metadata fields — agentgateway handles both
 			// paths natively: /authorize redirects to Okta (injecting audience), /token proxies
 			// the token exchange. This eliminates the need for an external nginx issuer-proxy.
-			if let Some(serde_json::Value::String(ae)) =
+			let Some(serde_json::Value::String(ae)) =
 				json::traverse_mut(&mut resp, &["authorization_endpoint"])
-			{
-				*ae = format!("{gateway_base}/authorize");
-			}
+			else {
+				return Err(ProxyError::ProcessingString(
+					"authorization_endpoint missing from Okta AS metadata".to_string(),
+				));
+			};
+			*ae = format!("{gateway_base}/authorize");
 
-			if let Some(serde_json::Value::String(te)) =
+			let Some(serde_json::Value::String(te)) =
 				json::traverse_mut(&mut resp, &["token_endpoint"])
-			{
-				*te = format!("{gateway_base}/token");
-			}
+			else {
+				return Err(ProxyError::ProcessingString(
+					"token_endpoint missing from Okta AS metadata".to_string(),
+				));
+			};
+			*te = format!("{gateway_base}/token");
 
 			// Okta doesn't do CORS for client registrations — proxy via gateway.
 			if let Some(serde_json::Value::String(re)) =
@@ -453,20 +469,20 @@ fn okta_authorize_redirect(
 ) -> Result<Response, ProxyError> {
 	let issuer = auth.issuer.trim_end_matches('/');
 
-	// Inject audience only when configured — sending audience= (empty) causes Okta to reject
-	// the request; absence of the param is preferable to an invalid value.
-	let mut query = auth
-		.audiences
-		.first()
-		.map(|aud| format!("audience={aud}"))
-		.unwrap_or_default();
-	if !existing_query.is_empty() {
-		if !query.is_empty() {
-			query.push('&');
+	// Parse the client's query params so we can merge cleanly and avoid duplicates.
+	let mut params: Vec<(String, String)> =
+		serde_urlencoded::from_str(existing_query).unwrap_or_default();
+
+	// Inject audience only when not already supplied by the client. Sending an empty
+	// audience= causes Okta to reject the request; absence is preferable to an invalid value.
+	if !params.iter().any(|(k, _)| k == "audience") {
+		if let Some(aud) = auth.audiences.first() {
+			params.insert(0, ("audience".to_string(), aud.clone()));
 		}
-		query.push_str(existing_query);
 	}
 
+	let query = serde_urlencoded::to_string(&params)
+		.map_err(|e| ProxyError::ProcessingString(e.to_string()))?;
 	let location = format!("{issuer}/v1/authorize?{query}");
 	Ok(Response::builder()
 		.status(StatusCode::FOUND)

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -241,6 +241,10 @@ pub(super) async fn authorization_server_metadata(
 	let mut resp: serde_json::Value = from_body_with_limit(upstream.into_body(), limit)
 		.await
 		.map_err(ProxyError::Body)?;
+
+	// Pre-compute once — reused in the universal issuer rewrite below.
+	let gateway_base = issuer_from_metadata_uri(request_uri_for_oauth_metadata(req).to_string());
+
 	match &auth.provider {
 		Some(McpIDP::Auth0 {}) => {
 			// Auth0 does not support RFC 8707. We can workaround this by prepending an audience
@@ -309,6 +313,13 @@ pub(super) async fn authorization_server_metadata(
 			*re = format!("{current_uri}/client-registration");
 		},
 		_ => {},
+	}
+
+	// RFC 8414 §3.3: the issuer in AS metadata MUST match the URL from which it was fetched.
+	// Applied universally across all providers — strict clients (Claude Desktop, ChatGPT, Codex)
+	// validate this and abort if issuer ≠ gateway URL.
+	if let Some(serde_json::Value::String(issuer_val)) = json::traverse_mut(&mut resp, &["issuer"]) {
+		*issuer_val = gateway_base;
 	}
 
 	let response = ::http::Response::builder()
@@ -394,6 +405,20 @@ pub(super) async fn client_registration(
 	);
 
 	Ok(upstream)
+}
+
+/// Derives the gateway issuer from an AS metadata URI, satisfying RFC 8414 §3.3.
+///
+/// Removes the `/.well-known/oauth-authorization-server` segment while preserving any
+/// path suffix that follows it, as required by the RFC §3.1 path-based issuer form:
+///   `https://example.com/.well-known/oauth-authorization-server/issuer1`
+///   → `https://example.com/issuer1`
+fn issuer_from_metadata_uri(mut uri: String) -> String {
+	const WELL_KNOWN: &str = "/.well-known/oauth-authorization-server";
+	if let Some(idx) = uri.find(WELL_KNOWN) {
+		uri.replace_range(idx..idx + WELL_KNOWN.len(), "");
+	}
+	uri
 }
 
 const MOCK_DCR_CLIENT_ID_ISSUED_AT: u64 = 0;
@@ -669,5 +694,50 @@ mod tests {
 		assert_eq!(json["client_id"], "operator-id");
 		assert!(json.is_object());
 		assert_eq!(json["redirect_uris"], serde_json::json!([]));
+	}
+
+	#[test]
+	fn issuer_strips_well_known_suffix_from_root_gateway() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/.well-known/oauth-authorization-server".to_string()
+			),
+			"https://gateway.example.com"
+		);
+	}
+
+	#[test]
+	fn issuer_strips_well_known_suffix_from_path_prefixed_gateway() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/base/path/.well-known/oauth-authorization-server"
+					.to_string()
+			),
+			"https://gateway.example.com/base/path"
+		);
+	}
+
+	// RFC 8414 §3.1 path-based issuer form:
+	// issuer = https://example.com/issuer1
+	// metadata URL = https://example.com/.well-known/oauth-authorization-server/issuer1
+	// The /.well-known/oauth-authorization-server segment must be removed while the
+	// trailing /issuer1 path is preserved.
+	#[test]
+	fn issuer_preserves_path_suffix_after_well_known_segment() {
+		assert_eq!(
+			issuer_from_metadata_uri(
+				"https://gateway.example.com/.well-known/oauth-authorization-server/issuer1"
+					.to_string()
+			),
+			"https://gateway.example.com/issuer1"
+		);
+	}
+
+	#[test]
+	fn issuer_returns_uri_unchanged_when_no_well_known_present() {
+		assert_eq!(
+			issuer_from_metadata_uri("https://gateway.example.com".to_string()),
+			"https://gateway.example.com"
+		);
 	}
 }

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -19,6 +19,8 @@ use crate::types::agent::{McpAuthentication, McpIDP};
 pub(crate) fn is_well_known_endpoint(path: &str) -> bool {
 	path.starts_with("/.well-known/oauth-protected-resource")
 		|| path.starts_with("/.well-known/oauth-authorization-server")
+		|| path == "/authorize"
+		|| path == "/token"
 }
 
 pub(super) async fn apply_token_validation(
@@ -91,6 +93,37 @@ pub(crate) async fn handle_mcp_request(
 				})
 				.into_response(),
 		)),
+		path if path == "/authorize" => match &auth.provider {
+			Some(McpIDP::Okta {}) => {
+				let existing_query = req.uri().query().unwrap_or("").to_owned();
+				Ok(Some(
+					okta_authorize_redirect(&existing_query, auth)
+						.map_err(|e| {
+							warn!("okta_authorize_redirect error: {}", e);
+							StatusCode::INTERNAL_SERVER_ERROR
+						})
+						.into_response(),
+				))
+			},
+			_ => Ok(None),
+		},
+		path if path == "/token" => match &auth.provider {
+			Some(McpIDP::Okta {}) => {
+				let content_type = req.headers().get("content-type").cloned();
+				let authorization = req.headers().get("authorization").cloned();
+				let body = std::mem::take(req.body_mut());
+				Ok(Some(
+					okta_token_proxy(content_type, authorization, body, auth, client.clone())
+						.await
+						.map_err(|e| {
+							warn!("okta_token_proxy error: {}", e);
+							StatusCode::INTERNAL_SERVER_ERROR
+						})
+						.into_response(),
+				))
+			},
+			_ => Ok(None),
+		},
 		_ => {
 			// Not handled
 			Ok(None)
@@ -261,24 +294,28 @@ pub(super) async fn authorization_server_metadata(
 			}
 		},
 		Some(McpIDP::Okta {}) => {
-			// Okta does not support RFC 8707. Workaround by appending audience as a query param.
-			let Some(serde_json::Value::String(ae)) =
+			// Rewrite authorization_endpoint and token_endpoint to gateway-local paths.
+			// Claude Desktop and claude.ai derive these from issuer ({issuer}/authorize,
+			// {issuer}/token) instead of reading metadata fields — agentgateway handles both
+			// paths natively: /authorize redirects to Okta (injecting audience), /token proxies
+			// the token exchange. This eliminates the need for an external nginx issuer-proxy.
+			if let Some(serde_json::Value::String(ae)) =
 				json::traverse_mut(&mut resp, &["authorization_endpoint"])
-			else {
-				return Err(ProxyError::ProcessingString(
-					"authorization_endpoint missing".to_string(),
-				));
-			};
-			if let Some(aud) = auth.audiences.first() {
-				ae.push_str(&format!("?audience={}", aud));
+			{
+				*ae = format!("{gateway_base}/authorize");
 			}
 
-			// Okta doesn't do CORS for client registrations — proxy it (same pattern as Keycloak)
-			let current_uri = request_uri_for_oauth_metadata(req);
+			if let Some(serde_json::Value::String(te)) =
+				json::traverse_mut(&mut resp, &["token_endpoint"])
+			{
+				*te = format!("{gateway_base}/token");
+			}
+
+			// Okta doesn't do CORS for client registrations — proxy via gateway.
 			if let Some(serde_json::Value::String(re)) =
 				json::traverse_mut(&mut resp, &["registration_endpoint"])
 			{
-				*re = format!("{current_uri}/client-registration");
+				*re = format!("{gateway_base}/.well-known/oauth-authorization-server/client-registration");
 			}
 		},
 		Some(McpIDP::Descope {}) => {
@@ -403,6 +440,77 @@ pub(super) async fn client_registration(
 		"access-control-allow-headers",
 		"content-type".parse().unwrap(),
 	);
+
+	Ok(upstream)
+}
+
+/// Redirects /authorize to Okta's actual authorize endpoint, injecting `audience` (RFC 8707
+/// workaround — Okta does not support resource indicators natively) and a default `scope=openid`
+/// when the client omits scope entirely.
+fn okta_authorize_redirect(
+	existing_query: &str,
+	auth: &McpAuthentication,
+) -> Result<Response, ProxyError> {
+	let issuer = auth.issuer.trim_end_matches('/');
+
+	let has_scope = existing_query.split('&').any(|p| p.starts_with("scope="));
+
+	// Inject audience only when configured — sending audience= (empty) causes Okta to reject
+	// the request; absence of the param is preferable to an invalid value.
+	let mut query = auth
+		.audiences
+		.first()
+		.map(|aud| format!("audience={aud}"))
+		.unwrap_or_default();
+	if !has_scope {
+		if !query.is_empty() {
+			query.push('&');
+		}
+		query.push_str("scope=openid");
+	}
+	if !existing_query.is_empty() {
+		if !query.is_empty() {
+			query.push('&');
+		}
+		query.push_str(existing_query);
+	}
+
+	let location = format!("{issuer}/v1/authorize?{query}");
+	Ok(Response::builder()
+		.status(StatusCode::FOUND)
+		.header("location", location)
+		.body(axum::body::Body::empty())?)
+}
+
+/// Proxies POST /token to Okta's token endpoint.
+///
+/// OAuth clients must not follow redirects for token exchange (RFC 6749), so a 302 is not
+/// viable here — we proxy the request directly to Okta and return its response verbatim.
+async fn okta_token_proxy(
+	content_type: Option<http::HeaderValue>,
+	authorization: Option<http::HeaderValue>,
+	body: Body,
+	auth: &McpAuthentication,
+	client: PolicyClient,
+) -> Result<Response, ProxyError> {
+	let issuer = auth.issuer.trim_end_matches('/');
+	let token_uri = format!("{issuer}/v1/token");
+
+	let mut builder = ::http::Request::builder()
+		.uri(token_uri)
+		.method(Method::POST);
+	if let Some(ct) = content_type {
+		builder = builder.header("content-type", ct);
+	}
+	if let Some(auth_hdr) = authorization {
+		builder = builder.header("authorization", auth_hdr);
+	}
+
+	let ureq = builder.body(body)?;
+	let upstream = client
+		.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Oidc)
+		.simple_call(ureq)
+		.await?;
 
 	Ok(upstream)
 }

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2016,6 +2016,18 @@ fn mcp_matches() -> Vec<RouteMatch> {
 			method: None,
 			query: vec![],
 		},
+		RouteMatch {
+			headers: vec![],
+			path: PathMatch::Exact("/authorize".into()),
+			method: None,
+			query: vec![],
+		},
+		RouteMatch {
+			headers: vec![],
+			path: PathMatch::Exact("/token".into()),
+			method: None,
+			query: vec![],
+		},
 	]
 }
 

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -29,8 +29,8 @@ use crate::types::agent::{
 	JwtAuthentication, Listener, ListenerKey, ListenerName, ListenerProtocol, ListenerSet,
 	ListenerTarget, LocalMcpAuthentication, McpAuthentication, McpBackend, McpPrefixMode, McpTarget,
 	McpTargetName, McpTargetSpec, OpenAPITarget, PathMatch, PolicyPhase, PolicyTarget, PolicyType,
-	ResourceName, Route, RouteBackendReference, RouteBackendTarget, RouteGroupKey, RouteMatch,
-	RouteName, ServerTLSConfig, SimpleBackend, SimpleBackendReference,
+	MethodMatch, ResourceName, Route, RouteBackendReference, RouteBackendTarget, RouteGroupKey,
+	RouteMatch, RouteName, ServerTLSConfig, SimpleBackend, SimpleBackendReference,
 	SimpleBackendReferenceWithPolicies, SimpleBackendWithPolicies, SseTargetSpec,
 	StreamableHTTPTargetSpec, TCPRoute, TCPRouteBackendReference, Target, TargetedPolicy,
 	TracingConfig, TrafficPolicy, TunnelProtocol, TypedResourceName, validate_mcp_target_name,
@@ -2019,13 +2019,13 @@ fn mcp_matches() -> Vec<RouteMatch> {
 		RouteMatch {
 			headers: vec![],
 			path: PathMatch::Exact("/authorize".into()),
-			method: None,
+			method: Some(MethodMatch { method: "GET".into() }),
 			query: vec![],
 		},
 		RouteMatch {
 			headers: vec![],
 			path: PathMatch::Exact("/token".into()),
-			method: None,
+			method: Some(MethodMatch { method: "POST".into() }),
 			query: vec![],
 		},
 	]


### PR DESCRIPTION
## Problem

After the issuer rewrite (#2562), clients that derive `authorization_endpoint` and `token_endpoint` directly from the `issuer` field (claude.ai, Claude Desktop) will construct:
- `{gateway}/authorize`
- `{gateway}/token`

These paths did not previously exist on agentgateway, so the OAuth flow fails at the redirect and token-exchange steps.

## Solution

Extends the Okta arm to handle two endpoints natively:

- **`GET /authorize`** — 302 redirect to Okta's `/v1/authorize`, injecting `audience` (RFC 8707 workaround — Okta does not support resource indicators natively) and a default `scope=openid` when the client omits scope.
- **`POST /token`** — transparent proxy to Okta's `/v1/token`, forwarding `Content-Type` and `Authorization` headers verbatim. A redirect is not viable here: RFC 6749 requires POST for token exchange and HTTP clients do not follow redirects for POST.

The Okta arm in `authorization_server_metadata` is also updated to rewrite `authorization_endpoint` → `{gateway}/authorize` and `token_endpoint` → `{gateway}/token` in the metadata response, so clients that read these fields from metadata also use the gateway paths.

Both paths are added to `mcp_matches()` (router dispatch) and `is_well_known_endpoint()` (bypass JWT validation — they are unauthenticated OAuth endpoints by definition).

## Result

Together with #2562 these changes eliminate the need for an nginx issuer-proxy sidecar in Kubernetes deployments using Okta. Tested end-to-end with claude.ai, Claude Desktop, and Codex connecting to an agentgateway instance backed by a BetterMe production Okta org.

## Note

This is the second of two PRs split from #2537 as requested by @markuskobler. Depends on #2562.