### PR TITLE
feat(mcp): add authentik as an MCP authentication provider

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -1921,6 +1921,7 @@ const (
 	BackendPolicySpec_McpAuthentication_KEYCLOAK    BackendPolicySpec_McpAuthentication_McpIDP = 2
 	BackendPolicySpec_McpAuthentication_OKTA        BackendPolicySpec_McpAuthentication_McpIDP = 3
 	BackendPolicySpec_McpAuthentication_DESCOPE     BackendPolicySpec_McpAuthentication_McpIDP = 4
+	BackendPolicySpec_McpAuthentication_AUTHENTIK   BackendPolicySpec_McpAuthentication_McpIDP = 5
 )
 
 // Enum value maps for BackendPolicySpec_McpAuthentication_McpIDP.
@@ -1931,6 +1932,7 @@ var (
 		2: "KEYCLOAK",
 		3: "OKTA",
 		4: "DESCOPE",
+		5: "AUTHENTIK",
 	}
 	BackendPolicySpec_McpAuthentication_McpIDP_value = map[string]int32{
 		"UNSPECIFIED": 0,
@@ -1938,6 +1940,7 @@ var (
 		"KEYCLOAK":    2,
 		"OKTA":        3,
 		"DESCOPE":     4,
+		"AUTHENTIK":   5,
 	}
 )
 
@@ -16286,7 +16289,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xe3X\n" +
+	"\x04kind\"\xf2X\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -16515,7 +16518,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x10McpAuthorization\x12\x14\n" +
 	"\x05allow\x18\x01 \x03(\tR\x05allow\x12\x12\n" +
 	"\x04deny\x18\x02 \x03(\tR\x04deny\x12\x18\n" +
-	"\arequire\x18\x03 \x03(\tR\arequire\x1a\xfa\a\n" +
+	"\arequire\x18\x03 \x03(\tR\arequire\x1a\x89\b\n" +
 	"\x11McpAuthentication\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x1c\n" +
 	"\taudiences\x18\x02 \x03(\tR\taudiences\x12\x1f\n" +
@@ -16532,13 +16535,14 @@ const file_resource_proto_rawDesc = "" +
 	"\n" +
 	"ExtraEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
-	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"I\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"X\n" +
 	"\x06McpIDP\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05AUTH0\x10\x01\x12\f\n" +
 	"\bKEYCLOAK\x10\x02\x12\b\n" +
 	"\x04OKTA\x10\x03\x12\v\n" +
-	"\aDESCOPE\x10\x04\"0\n" +
+	"\aDESCOPE\x10\x04\x12\r\n" +
+	"\tAUTHENTIK\x10\x05\"0\n" +
 	"\x04Mode\x12\f\n" +
 	"\bOPTIONAL\x10\x00\x12\n" +
 	"\n" +

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -1974,10 +1974,11 @@ type MCPAuthentication struct {
 type McpIDP string
 
 const (
-	Auth0    McpIDP = "Auth0"
-	Keycloak McpIDP = "Keycloak"
-	Okta     McpIDP = "Okta"
-	Descope  McpIDP = "Descope"
+	Auth0     McpIDP = "Auth0"
+	Keycloak  McpIDP = "Keycloak"
+	Okta      McpIDP = "Okta"
+	Descope   McpIDP = "Descope"
+	Authentik McpIDP = "Authentik"
 )
 
 type BackendTunnel struct {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -21049,6 +21049,7 @@ spec:
                             description: Identity provider to use for authentication.
                             enum:
                             - Auth0
+                            - Authentik
                             - Descope
                             - Keycloak
                             - Okta

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -8788,6 +8788,7 @@ spec:
                             description: Identity provider to use for authentication.
                             enum:
                             - Auth0
+                            - Authentik
                             - Descope
                             - Keycloak
                             - Okta
@@ -12873,6 +12874,7 @@ spec:
                               flows.
                             enum:
                             - Auth0
+                            - Authentik
                             - Descope
                             - Keycloak
                             - Okta

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -689,6 +689,9 @@ func translateMcpIDP(provider *agentgateway.McpIDP) api.BackendPolicySpec_McpAut
 	if *provider == agentgateway.Descope {
 		return api.BackendPolicySpec_McpAuthentication_DESCOPE
 	}
+	if *provider == agentgateway.Authentik {
+		return api.BackendPolicySpec_McpAuthentication_AUTHENTIK
+	}
 	return api.BackendPolicySpec_McpAuthentication_UNSPECIFIED
 }
 

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -223,11 +223,12 @@ pub(super) async fn authorization_server_metadata(
 	// RFC 8414 URL for standard AS metadata. Keycloak does not implement RFC 8414; it only
 	// exposes OpenID Provider Metadata at {issuer}/.well-known/openid-configuration (OIDC Discovery).
 	let metadata_uri = match &auth.provider {
-		// Keycloak, Okta, and Descope do not support the RFC 8414 path-based issuer format;
-		// they serve metadata at {issuer}/.well-known/openid-configuration (OIDC Discovery).
-		Some(McpIDP::Keycloak { .. }) | Some(McpIDP::Okta {}) | Some(McpIDP::Descope {}) => {
-			openid_configuration_metadata_url(&auth.issuer)
-		},
+		// Keycloak, Okta, Descope, and authentik do not support the RFC 8414 path-based issuer
+		// format; they serve metadata at {issuer}/.well-known/openid-configuration (OIDC Discovery).
+		Some(McpIDP::Keycloak { .. })
+		| Some(McpIDP::Okta {})
+		| Some(McpIDP::Descope {})
+		| Some(McpIDP::Authentik {}) => openid_configuration_metadata_url(&auth.issuer),
 		_ => authorization_server_metadata_url(&auth.issuer),
 	};
 	let ureq = ::http::Request::builder()
@@ -308,6 +309,24 @@ pub(super) async fn authorization_server_metadata(
 			};
 			*re = format!("{current_uri}/client-registration");
 		},
+		Some(McpIDP::Authentik {}) => {
+			// authentik does not support RFC 8707, and has no audience query parameter workaround.
+			// Tokens carry the OAuth client ID in `aud`, so users must configure `audiences`
+			// with the pre-registered client ID.
+
+			// authentik does not implement Dynamic Client Registration (RFC 7591), so its
+			// discovery metadata has no registration_endpoint at all:
+			// https://github.com/goauthentik/authentik/issues/8751
+			// Inject one pointing at the gateway so MCP clients can complete DCR against
+			// the pre-registered client configured via `clientId`.
+			let current_uri = request_uri_for_oauth_metadata(req);
+			if let Some(obj) = resp.as_object_mut() {
+				obj.insert(
+					"registration_endpoint".to_string(),
+					serde_json::Value::String(format!("{current_uri}/client-registration")),
+				);
+			}
+		},
 		_ => {},
 	}
 
@@ -367,6 +386,14 @@ pub(super) async fn client_registration(
 					"Descope DCR requires an agentic issuer URL".to_string(),
 				));
 			}
+		},
+		Some(McpIDP::Authentik {}) => {
+			// authentik has no DCR endpoint to proxy to (RFC 7591 is unimplemented:
+			// https://github.com/goauthentik/authentik/issues/8751). The only supported flow
+			// is a pre-registered client via `clientId`, which is handled above.
+			return Err(ProxyError::ProcessingString(
+				"authentik does not support Dynamic Client Registration; set clientId to a pre-registered public client".to_string(),
+			));
 		},
 		// Keycloak and default
 		_ => format!("{issuer}/clients-registrations/openid-connect"),

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2843,7 +2843,9 @@ pub struct LocalMcpAuthentication {
 	/// Protected resource metadata returned to MCP clients.
 	pub resource_metadata: ResourceMetadata,
 	/// JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.
-	pub jwks: FileInlineOrRemote,
+	/// If omitted, the JWKS URL is derived from the issuer and provider.
+	#[serde(default)]
+	pub jwks: Option<FileInlineOrRemote>,
 	/// Controls whether MCP requests must include a valid JWT.
 	#[serde(default)]
 	pub mode: McpAuthenticationMode,
@@ -2858,45 +2860,60 @@ pub struct LocalMcpAuthentication {
 }
 
 impl LocalMcpAuthentication {
+	/// Derive the JWKS URL from the issuer and provider, for configs that do not set `jwks`.
+	fn derived_jwks_url(&self) -> anyhow::Result<::http::Uri> {
+		Ok(match &self.provider {
+			None | Some(McpIDP::Auth0 { .. }) | Some(McpIDP::Okta { .. }) => {
+				format!("{}/.well-known/jwks.json", self.issuer).parse()?
+			},
+			Some(McpIDP::Descope {}) => {
+				// For agentic issuers (https://api.descope.com/v1/apps/agentic/{project-id}/{server-id}),
+				// JWKS lives at the project level: https://api.descope.com/{project-id}/.well-known/jwks.json
+				let parsed: url::Url = self.issuer.parse()?;
+				let segments: Vec<&str> = parsed.path().trim_start_matches('/').split('/').collect();
+				if segments.len() >= 5
+					&& segments[0] == "v1"
+					&& segments[1] == "apps"
+					&& segments[2] == "agentic"
+				{
+					let project_id = segments[3];
+					let base = format!(
+						"{}://{}/{}",
+						parsed.scheme(),
+						parsed.host_str().unwrap_or_default(),
+						project_id
+					);
+					format!("{base}/.well-known/jwks.json").parse()?
+				} else {
+					format!("{}/.well-known/jwks.json", self.issuer).parse()?
+				}
+			},
+			Some(McpIDP::Keycloak { .. }) => {
+				format!("{}/protocol/openid-connect/certs", self.issuer).parse()?
+			},
+			Some(McpIDP::Authentik {}) => {
+				// authentik issuers look like https://<host>/application/o/<app-slug>/
+				// (note the trailing slash) and serve JWKS at {issuer}/jwks/.
+				format!("{}/jwks/", self.issuer.trim_end_matches('/')).parse()?
+			},
+		})
+	}
+
 	pub fn as_jwt(&self) -> anyhow::Result<http::jwt::LocalJwtConfig> {
 		let jwks = match &self.jwks {
-			FileInlineOrRemote::Remote { url } => FileInlineOrRemote::Remote {
+			None => FileInlineOrRemote::Remote {
+				url: self.derived_jwks_url()?,
+			},
+			Some(FileInlineOrRemote::Remote { url }) => FileInlineOrRemote::Remote {
 				url: if !url.to_string().is_empty() {
 					url.clone()
 				} else {
-					match &self.provider {
-						None | Some(McpIDP::Auth0 { .. }) | Some(McpIDP::Okta { .. }) => {
-							format!("{}/.well-known/jwks.json", self.issuer).parse()?
-						},
-						Some(McpIDP::Descope {}) => {
-							// For agentic issuers (https://api.descope.com/v1/apps/agentic/{project-id}/{server-id}),
-							// JWKS lives at the project level: https://api.descope.com/{project-id}/.well-known/jwks.json
-							let parsed: url::Url = self.issuer.parse()?;
-							let segments: Vec<&str> = parsed.path().trim_start_matches('/').split('/').collect();
-							if segments.len() >= 5
-								&& segments[0] == "v1"
-								&& segments[1] == "apps"
-								&& segments[2] == "agentic"
-							{
-								let project_id = segments[3];
-								let base = format!(
-									"{}://{}/{}",
-									parsed.scheme(),
-									parsed.host_str().unwrap_or_default(),
-									project_id
-								);
-								format!("{base}/.well-known/jwks.json").parse()?
-							} else {
-								format!("{}/.well-known/jwks.json", self.issuer).parse()?
-							}
-						},
-						Some(McpIDP::Keycloak { .. }) => {
-							format!("{}/protocol/openid-connect/certs", self.issuer).parse()?
-						},
-					}
+					self.derived_jwks_url()?
 				},
 			},
-			FileInlineOrRemote::Inline(_) | FileInlineOrRemote::File { .. } => self.jwks.clone(),
+			Some(jwks @ (FileInlineOrRemote::Inline(_) | FileInlineOrRemote::File { .. })) => {
+				jwks.clone()
+			},
 		};
 
 		Ok(http::jwt::LocalJwtConfig::Single {
@@ -2934,6 +2951,7 @@ pub enum McpIDP {
 	Keycloak {},
 	Okta {},
 	Descope {},
+	Authentik {},
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -3534,6 +3552,31 @@ jwtValidationOptions:
 					jwt_validation_options.required_claims.is_empty(),
 					"jwt_validation_options should be propagated to LocalJwtConfig"
 				);
+			},
+			_ => panic!("Expected LocalJwtConfig::Single"),
+		}
+	}
+
+	#[test]
+	fn test_local_mcp_authentication_authentik_jwks_derivation() {
+		let auth: LocalMcpAuthentication = serde_json::from_value(serde_json::json!({
+			"issuer": "https://authentik.example.com/application/o/mcp/",
+			"audiences": ["my-client-id"],
+			"provider": {"authentik": {}},
+			"resourceMetadata": {},
+		}))
+		.unwrap();
+		let jwt_config = auth.as_jwt().unwrap();
+
+		match jwt_config {
+			http::jwt::LocalJwtConfig::Single { jwks, .. } => match jwks {
+				FileInlineOrRemote::Remote { url } => {
+					assert_eq!(
+						url.to_string(),
+						"https://authentik.example.com/application/o/mcp/jwks/"
+					);
+				},
+				other => panic!("expected remote JWKS, got {other:?}"),
 			},
 			_ => panic!("Expected LocalJwtConfig::Single"),
 		}

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -491,6 +491,7 @@ fn convert_mcp_provider(provider: i32) -> Option<McpIDP> {
 		x if x == McpIdp::Keycloak as i32 => Some(McpIDP::Keycloak {}),
 		x if x == McpIdp::Okta as i32 => Some(McpIDP::Okta {}),
 		x if x == McpIdp::Descope as i32 => Some(McpIDP::Descope {}),
+		x if x == McpIdp::Authentik as i32 => Some(McpIDP::Authentik {}),
 		_ => None,
 	}
 }

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1485,6 +1485,7 @@ message BackendPolicySpec {
       KEYCLOAK = 2;
       OKTA = 3;
       DESCOPE = 4;
+      AUTHENTIK = 5;
     }
 
     // Validation mode for JWT authentication

--- a/examples/mcp-authentication/README.md
+++ b/examples/mcp-authentication/README.md
@@ -126,7 +126,7 @@ Also in `examples/mcp-authentication/config.yaml`:
 ### Scenario C: Adapting a vendor Authorization Server (e.g., Keycloak)
 
 When your Authorization Server doesn’t implement the spec as-is, agentgateway can fill in the gaps.
-Currently, four providers are supported: Keycloak, Auth0, Okta, and Descope.
+Currently, five providers are supported: Keycloak, Auth0, Okta, Descope, and authentik.
 
 Excerpt from `examples/mcp-authentication/config.yaml`:
 
@@ -175,6 +175,7 @@ What setting a provider does (high level):
   - Keycloak → `<issuer>/protocol/openid-connect/certs`
   - Okta → `<issuer>/.well-known/jwks.json`
   - Descope → `https://api.descope.com/{project-id}/.well-known/jwks.json` (derived from agentic issuer path)
+  - authentik → `<issuer>/jwks/`
 
 Auth0-specific notes:
 - Gateway appends `?audience=...` to the authorization endpoint it exposes.
@@ -188,6 +189,12 @@ Okta-specific notes:
 - No RFC 8707 support; gateway appends `?audience=...` to the authorization endpoint (same workaround as Auth0).
 - Client registration is proxied by the gateway at `.../client-registration` to forward to Okta’s `oauth2/v1/clients`.
 - Okta DCR requires an SSWS API token; the gateway proxies the request and the MCP client must provide the token.
+
+authentik-specific notes:
+- Uses OIDC discovery (`{issuer}/.well-known/openid-configuration`), not RFC 8414. The issuer is per-application: `https://<host>/application/o/<app-slug>/`.
+- No RFC 8707 support, and no audience query parameter workaround. authentik sets `aud` to the OAuth client ID, so configure `audiences` with the pre-registered client ID.
+- No Dynamic Client Registration support ([goauthentik/authentik#8751](https://github.com/goauthentik/authentik/issues/8751)). **Setting `clientId` is required**: the gateway injects a `registration_endpoint` into the AS metadata it exposes and answers registration requests itself with the pre-registered client.
+- The pre-registered authentik client must be a **public** client (the mock registration response advertises `token_endpoint_auth_method: none`) with PKCE, and its redirect URIs must cover your MCP clients (authentik supports regex redirect URIs).
 
 Descope-specific notes:
 - Uses OIDC discovery (`{issuer}/.well-known/openid-configuration`), not RFC 8414.

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -263,5 +263,50 @@ binds:
             #         - header
             #         resourceDocumentation: http://localhost:3000/descope/docs
             #         resourcePolicyUri: http://localhost:3000/descope/policies
+            # Example configuration for authentik:
+            # - backends:
+            #   - mcp:
+            #       targets:
+            #       - name: everything
+            #         stdio:
+            #           args:
+            #           - '@modelcontextprotocol/server-everything'
+            #           cmd: npx
+            #   matches:
+            #   - path:
+            #       exact: /authentik/mcp
+            #   - path:
+            #       exact: /.well-known/oauth-protected-resource/authentik/mcp
+            #   - path:
+            #       exact: /.well-known/oauth-authorization-server/authentik/mcp
+            #   - path:
+            #       exact: /.well-known/oauth-authorization-server/authentik/mcp/client-registration
+            #   policies:
+            #     cors:
+            #       allowHeaders:
+            #       - mcp-protocol-version
+            #       - content-type
+            #       allowOrigins:
+            #       - '*'
+            #     mcpAuthentication:
+            #       issuer: https://authentik.example.com/application/o/<app-slug>/
+            #       audiences:
+            #       # authentik sets `aud` to the OAuth client ID
+            #       - <pre-registered-client-id>
+            #       provider:
+            #         authentik: {}
+            #       # clientId is required — authentik does not support DCR, so the gateway
+            #       # answers registration requests with this pre-registered public client
+            #       clientId: <pre-registered-client-id>
+            #       resourceMetadata:
+            #         resource: http://localhost:3000/authentik/mcp
+            #         scopesSupported:
+            #         - openid
+            #         - profile
+            #         - offline_access
+            #         bearerMethodsSupported:
+            #         - header
+            #         resourceDocumentation: http://localhost:3000/authentik/docs
+            #         resourcePolicyUri: http://localhost:3000/authentik/policies
   # Public port to listen on
   port: 3000

--- a/schema/config.json
+++ b/schema/config.json
@@ -4069,8 +4069,15 @@
           "$ref": "#/$defs/ResourceMetadata"
         },
         "jwks": {
-          "description": "JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.",
-          "$ref": "#/$defs/FileInlineOrRemote"
+          "description": "JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.\nIf omitted, the JWKS URL is derived from the issuer and provider.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FileInlineOrRemote"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "mode": {
           "description": "Controls whether MCP requests must include a valid JWT.",
@@ -4103,8 +4110,7 @@
       "required": [
         "issuer",
         "audiences",
-        "resourceMetadata",
-        "jwks"
+        "resourceMetadata"
       ]
     },
     "McpIDP": {
@@ -4158,6 +4164,19 @@
           },
           "required": [
             "descope"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "authentik": {
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "authentik"
           ],
           "additionalProperties": false
         }


### PR DESCRIPTION
# Add authentik as an MCP authentication provider

## Description

This PR adds [authentik](https://goauthentik.io/) as a supported identity
provider for the `mcpAuthentication` policy, alongside Keycloak, Auth0, Okta,
and Descope. authentik is a widely deployed self-hosted IdP, but MCP clients
cannot complete the authorization flow against it today: authentik does not
implement Dynamic Client Registration (RFC 7591) at all
(goauthentik/authentik#8751), so clients that discover the AS metadata find no
`registration_endpoint` and the flow dead-ends.

## Changes

1. **Authorization Server Metadata** (`mcp/auth.rs`): routes authentik to the
   OIDC Discovery endpoint (`{issuer}/.well-known/openid-configuration`) like
   Keycloak/Okta/Descope — authentik does not serve RFC 8414 path-based
   metadata. Its issuers are per-application:
   `https://<host>/application/o/<app-slug>/`.
2. **DCR** (`mcp/auth.rs`): since authentik publishes no
   `registration_endpoint`, the gateway *injects* one into the AS metadata it
   exposes, pointing at its own `.../client-registration` endpoint, so MCP
   clients can complete DCR against the pre-registered client configured via
   `clientId` (the existing mock-DCR short-circuit). If `clientId` is not set,
   registration returns a clear error since there is no upstream endpoint to
   proxy to.
3. **RFC 8707**: not supported by authentik, and unlike Auth0/Okta there is no
   audience query parameter workaround. authentik tokens carry the OAuth client
   ID in `aud`, so `audiences` must be configured with the pre-registered
   client ID (same "hardcode the audience" situation as Keycloak).
4. **JWKS derivation** (`types/agent.rs`): derived as `{issuer}/jwks/` when
   `jwks` is not explicitly configured.
5. **Make `mcpAuthentication.jwks` optional**: while wiring up (4) I found the
   provider-derived JWKS URL branch was unreachable for every provider —
   `jwks` was a required field, and an empty remote `url` fails `Uri`
   deserialization, even though the README and examples describe `jwks` as
   optional with provider-based derivation. `jwks` is now
   `Option<FileInlineOrRemote>` (derivation logic refactored into
   `derived_jwks_url()`, covered by a test). Existing configs with explicit
   `jwks` are unaffected.
6. Full plumbing as in the Descope PR (#2376): proto enum + regenerated Go
   API, controller CRD enum + `translateMcpIDP` + regenerated CRDs, JSON
   schema, example config, and README notes.

## Usage

```yaml
mcpAuthentication:
  issuer: https://authentik.example.com/application/o/<app-slug>/
  audiences: [<client-id>]
  provider:
    authentik: {}
  # required: authentik has no DCR, the gateway answers registration
  # requests with this pre-registered public client
  clientId: <client-id>
```
The pre-registered authentik client must be a public client with PKCE
(the mock registration response advertises token_endpoint_auth_method: none), with redirect URIs covering the intended MCP clients (authentik
supports regex redirect URIs).

Testing

- [x] make lint and cargo test --workspace pass (one pre-existing
agent-core telemetry doctest failure occurs on a clean checkout of main
as well, unrelated to this change).
- [x] New unit test for the authentik JWKS derivation via as_jwt().
- [x] Controller: go build ./... and go test ./pkg/agentgateway/plugins/...
pass.
- [x] Validated end-to-end against a live authentik 2025.x instance: 401 challenge,
  gateway-served PRM, AS metadata with injected registration_endpoint, mock DCR,
  browser authorization + PKCE token exchange (public client), and an
  authenticated MCP `initialize` through the gateway with the derived JWKS.