### PR TITLE
fix(llm): extract Gemini generateContent model and usage in detect mode

### DIFF
--- a/crates/llm/src/types/detect.rs
+++ b/crates/llm/src/types/detect.rs
@@ -114,6 +114,7 @@ impl RequestType for Request {
 
 pub fn amend_request_info(llm_info: &mut LLMRequest, path: &str) {
 	if path.ends_with(":streamRawPredict")
+		|| path.ends_with(":streamGenerateContent")
 		|| path.ends_with("/invoke-with-response-stream")
 		|| path.ends_with("/converse-stream")
 	{
@@ -125,9 +126,14 @@ pub fn amend_request_info(llm_info: &mut LLMRequest, path: &str) {
 }
 
 pub fn extract_model_from_path(path: &str) -> Option<Strng> {
-	let model = if path.ends_with(":streamRawPredict") || path.ends_with(":rawPredict") {
+	let model = if path.ends_with(":streamRawPredict")
+		|| path.ends_with(":rawPredict")
+		|| path.ends_with(":streamGenerateContent")
+		|| path.ends_with(":generateContent")
+	{
 		path
-			.split_once("/publishers/anthropic/models/")
+			.split_once("/publishers/")
+			.and_then(|(_, rest)| rest.split_once("/models/"))
 			.and_then(|(_, rest)| rest.split_once(':').map(|(model, _)| model))
 	} else if path.ends_with("/invoke-with-response-stream")
 		|| path.ends_with("/invoke")
@@ -247,6 +253,57 @@ mod tests {
 		assert_eq!(llm_info.request_model, "vertex-detect");
 		assert!(llm_info.streaming);
 	}
+
+	#[test]
+	fn amend_request_info_extracts_vertex_gemini_generate_content_model() {
+		let mut llm_info = llm_request();
+
+		amend_request_info(
+			&mut llm_info,
+			"/projects/hello-world-project/locations/global/publishers/google/models/gemini-2.5-flash:generateContent",
+		);
+
+		assert_eq!(llm_info.request_model, "gemini-2.5-flash");
+		assert!(!llm_info.streaming);
+	}
+
+	#[test]
+	fn amend_request_info_extracts_vertex_gemini_stream_generate_content_model() {
+		let mut llm_info = llm_request();
+
+		amend_request_info(
+			&mut llm_info,
+			"/projects/hello-world-project/locations/global/publishers/google/models/gemini-2.5-flash:streamGenerateContent",
+		);
+
+		assert_eq!(llm_info.request_model, "gemini-2.5-flash");
+		assert!(llm_info.streaming);
+	}
+
+	#[test]
+	fn to_llm_response_extracts_gemini_native_usage() {
+		let resp = Response::Json(serde_json::json!({
+			"candidates": [{
+				"content": {
+					"role": "model",
+					"parts": [{"text": "Hello!"}]
+				},
+				"finishReason": "STOP"
+			}],
+			"usageMetadata": {
+				"promptTokenCount": 8,
+				"candidatesTokenCount": 14,
+				"totalTokenCount": 22
+			},
+			"modelVersion": "gemini-2.5-flash"
+		}));
+
+		let llm_response = resp.to_llm_response(false);
+
+		assert_eq!(llm_response.input_tokens, Some(8));
+		assert_eq!(llm_response.output_tokens, Some(14));
+		assert_eq!(llm_response.total_tokens, Some(22));
+	}
 }
 
 #[derive(Debug, Clone)]
@@ -281,7 +338,7 @@ mod lookups {
 	pub const MAX_TOKENS: [&[&str]; 2] = [&["max_completion_tokens"], &["max_tokens"]];
 	pub const ENCODING_FORMAT: [&[&str]; 1] = [&["encoding_format"]];
 	pub const DIMENSIONS: [&[&str]; 1] = [&["dimensions"]];
-	pub const USAGE_INPUT_TOKENS: [&[&str]; 5] = [
+	pub const USAGE_INPUT_TOKENS: [&[&str]; 6] = [
 		&["usage", "input_tokens"],
 		// Responses streaming
 		&["response", "usage", "input_tokens"],
@@ -290,8 +347,10 @@ mod lookups {
 		&["usage", "inputTokens"],
 		// Bedrock invoke
 		&["metadata", "usage", "inputTokens"],
+		// Gemini generateContent
+		&["usageMetadata", "promptTokenCount"],
 	];
-	pub const USAGE_OUTPUT_TOKENS: [&[&str]; 5] = [
+	pub const USAGE_OUTPUT_TOKENS: [&[&str]; 6] = [
 		&["usage", "output_tokens"],
 		// Responses streaming
 		&["response", "usage", "output_tokens"],
@@ -300,9 +359,16 @@ mod lookups {
 		&["usage", "outputTokens"],
 		// Bedrock invoke
 		&["metadata", "usage", "outputTokens"],
+		// Gemini generateContent
+		&["usageMetadata", "candidatesTokenCount"],
 	];
-	pub const USAGE_TOTAL_TOKENS: [&[&str]; 2] =
-		[&["usage", "total_tokens"], &["usage", "totalTokens"]];
+	pub const USAGE_TOTAL_TOKENS: [&[&str]; 3] = [
+		&["usage", "total_tokens"],
+		// Bedrock converse
+		&["usage", "totalTokens"],
+		// Gemini generateContent
+		&["usageMetadata", "totalTokenCount"],
+	];
 	pub const INPUT_IMAGE_TOKENS: [&[&str]; 1] = [&["usage", "input_tokens_details", "image_tokens"]];
 	pub const INPUT_TEXT_TOKENS: [&[&str]; 1] = [&["usage", "input_tokens_details", "text_tokens"]];
 	pub const INPUT_AUDIO_TOKENS: [&[&str]; 1] =


### PR DESCRIPTION
  ## Summary

  Detect-mode traffic to Gemini's native `generateContent` API produced empty telemetry: `gen_ai.request.model` was
  blank and no `gen_ai.usage.*` fields were logged, even though the upstream response contained all of the data. Any
  logging, metrics, or usage accounting built on these fields silently sees nothing for Gemini native traffic.

  This matters because some Gemini features are only reachable through detect mode. For example, Search grounding
  (`tools: [{"google_search": {}}]`) is rejected by both AI Studio's and Vertex's OpenAI-compatible endpoints
  (`"Expected the 'type' field of a(n) 'tools' array element to be 'function'; found 'google_search'"`), so grounding
  requests must use the native API — where telemetry was silently dropped.

  Reproduced against live Vertex traffic before writing the fix: a successful grounded `generateContent` call logged
  `gen_ai.request.model=` (empty) and no usage fields.

  Two root causes in `crates/llm/src/types/detect.rs`, fixed independently:

  1. **Model extraction** — `extract_model_from_path` hardcoded `/publishers/anthropic/models/` and only matched the
  `:rawPredict`/`:streamRawPredict` verbs, so Gemini paths (`/publishers/google/models/{model}:generateContent`) never
  matched. Now splits on the generic `/publishers/` + `/models/` markers (the same approach #2539 applied to the
  path-*rewrite* side) and additionally matches `:generateContent`/`:streamGenerateContent`. `amend_request_info` also
  treats `:streamGenerateContent` as streaming.
  2. **Usage extraction** — the token lookup tables only knew OpenAI/Anthropic/Bedrock response shapes. Added Gemini's
  native shape: `usageMetadata.promptTokenCount` / `candidatesTokenCount` / `totalTokenCount`.

  Both changes are additive: the new lookup entries are tried only after all existing ones miss, the
  Anthropic-on-Vertex path extraction is a strict generalization (existing tests untouched and passing), and no other
  provider's behavior changes.

  ## Test plan

  - [x] `cargo test -p agent-llm` — 133 passed, including 3 new tests: model extraction for `:generateContent` and
  `:streamGenerateContent` paths (with streaming flag), and usage extraction from a realistic Gemini native response
  body
  - [x] `make lint` — clean
  - [x] Existing Anthropic-on-Vertex tests (`amend_request_info_extracts_vertex_raw_predict_model`,
  `..._stream_raw_predict_model`) left untouched as regression checks for the publisher generalization

  ## Out of scope / follow-ups

  - **`provider_model`**: Gemini native responses report the served model under `modelVersion`, which isn't in the 
  `MODEL` lookup, so response-side model attribution remains `None`. Deferred because that const is also used for 
  request-side lookups and deserves its own consideration.
  - **Virtual-model path rewriting**: `rewrite_path_model` doesn't handle the `:generateContent` verbs yet (it 
  degrades to a no-op, not an error). Natural follow-up mirroring #2539.