### PR TITLE
feat(oauth): support custom token types and OAuth 2.1 exchange defaults

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -8331,11 +8331,13 @@ type OAuthTokenExchange struct {
 	// ----- Token request parameters -----
 	// Properties sent only when non-empty.
 	Audiences []string `protobuf:"bytes,2,rep,name=audiences,proto3" json:"audiences,omitempty"`
-	Scopes    []string `protobuf:"bytes,3,rep,name=scopes,proto3" json:"scopes,omitempty"` // joined with spaces into a single `scope` param
+	// OAuth scope-token values joined with spaces into a single `scope` param.
+	// Each entry must already be a single scope token, not a space-delimited list.
+	Scopes    []string `protobuf:"bytes,3,rep,name=scopes,proto3" json:"scopes,omitempty"`
 	Resources []string `protobuf:"bytes,4,rep,name=resources,proto3" json:"resources,omitempty"`
 	// requested_token_type parameter sent under TOKEN_EXCHANGE only. Rejected
-	// under JWT_BEARER. When unset, no requested_token_type is sent; if the token
-	// endpoint returns issued_token_type, the gateway expects access_token.
+	// under JWT_BEARER. When unset under TOKEN_EXCHANGE, the gateway sends
+	// access_token because this backend auth policy forwards bearer access tokens.
 	RequestedTokenType *string `protobuf:"bytes,5,opt,name=requested_token_type,json=requestedTokenType,proto3,oneof" json:"requested_token_type,omitempty"`
 	// Arbitrary extra string form fields appended to the token exchange request.
 	// Values are CEL expressions evaluated against the incoming request.

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -15273,8 +15273,9 @@ type OAuthTokenExchange_TokenSpec struct {
 	// from the Claims extension when an upstream JWT policy has stripped the
 	// header, so the default keeps working behind a JWT auth policy.
 	Source *AuthorizationLocation `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
-	// RFC 8693 §3 token type URN sent as subject_token_type / actor_token_type.
-	// e.g. "urn:ietf:params:oauth:token-type:access_token"
+	// RFC 8693 token type URI sent as subject_token_type / actor_token_type.
+	// Built-ins such as "urn:ietf:params:oauth:token-type:access_token" and
+	// custom absolute URIs such as "urn:company:domain:human" are accepted.
 	// Empty defaults to access_token under TOKEN_EXCHANGE. Ignored for the
 	// JWT_BEARER subject token because RFC 7523 sends the token as `assertion`
 	// and has no subject_token_type parameter.
@@ -15335,8 +15336,8 @@ type OAuthTokenExchange_ActorToken struct {
 	// be set explicitly so actor and subject are not accidentally the same
 	// credential.
 	Source *AuthorizationLocation `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
-	// RFC 8693 §3 token type URN sent as actor_token_type.
-	// e.g. "urn:ietf:params:oauth:token-type:access_token"
+	// RFC 8693 token type URI sent as actor_token_type. Built-ins and custom
+	// absolute URIs are accepted.
 	// Empty defaults to access_token, and actor_token_type is still sent.
 	TokenType string `protobuf:"bytes,2,opt,name=token_type,json=tokenType,proto3" json:"token_type,omitempty"`
 	// Enforce that the subject's `may_act` claim authorizes the actor before exchanging.

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -1385,6 +1385,8 @@ type OAuthTokenExchange struct {
 	GrantType *OAuthGrantType `json:"grantType,omitempty"`
 
 	// Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+	// The token type may be a built-in value or a custom absolute URI for providers
+	// that support custom token exchange profiles.
 	// +optional
 	SubjectToken *OAuthTokenSpec `json:"subjectToken,omitempty"`
 
@@ -1410,7 +1412,9 @@ type OAuthTokenExchange struct {
 	// +optional
 	Resources []string `json:"resources,omitempty"`
 
-	// RFC 8693 requested_token_type.
+	// RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+	// built-in values may be requested; custom URIs are not supported here.
+	// +kubebuilder:validation:Enum=AccessToken;Jwt;IdToken;IdJag
 	// +optional
 	RequestedTokenType *OAuthTokenType `json:"requestedTokenType,omitempty"`
 
@@ -1446,7 +1450,8 @@ type OAuthTokenSpec struct {
 	// +optional
 	Source *AuthorizationExtractionLocation `json:"source,omitempty"`
 
-	// OAuth token type. Empty defaults to AccessToken.
+	// OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+	// are supported for subject tokens.
 	// +optional
 	TokenType *OAuthTokenType `json:"tokenType,omitempty"`
 }
@@ -1457,7 +1462,8 @@ type OAuthActorToken struct {
 	// +required
 	Source AuthorizationExtractionLocation `json:"source"`
 
-	// OAuth token type. Empty defaults to AccessToken.
+	// OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+	// are supported for actor tokens.
 	// +optional
 	TokenType *OAuthTokenType `json:"tokenType,omitempty"`
 
@@ -1466,7 +1472,10 @@ type OAuthActorToken struct {
 	MayAct *OAuthMayActValidationMode `json:"mayAct,omitempty"`
 }
 
-// +k8s:enum
+// OAuthTokenType is an RFC 8693 token type. The built-in values below are
+// translated to their URN form; any other value must be a custom absolute URI
+// and is passed through unchanged. It is intentionally not a closed enum so
+// subject/actor tokens can use provider-specific token type URIs.
 type OAuthTokenType string
 
 const (

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -1120,15 +1120,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for actor tokens.
                                                                       type: string
                                                                   required:
                                                                   - source
@@ -1553,13 +1547,14 @@ spec:
                                                                   pattern: ^/
                                                                   type: string
                                                                 requestedTokenType:
-                                                                  description: RFC
-                                                                    8693 requested_token_type.
+                                                                  description: |-
+                                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                                    built-in values may be requested; custom URIs are not supported here.
                                                                   enum:
                                                                   - AccessToken
-                                                                  - IdJag
-                                                                  - IdToken
                                                                   - Jwt
+                                                                  - IdToken
+                                                                  - IdJag
                                                                   type: string
                                                                 resources:
                                                                   description: Resources
@@ -1580,11 +1575,10 @@ spec:
                                                                   minItems: 1
                                                                   type: array
                                                                 subjectToken:
-                                                                  description: Subject
-                                                                    token / assertion
-                                                                    source and type.
-                                                                    Defaults to Authorization
-                                                                    Bearer, AccessToken.
+                                                                  description: |-
+                                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                                    that support custom token exchange profiles.
                                                                   properties:
                                                                     source:
                                                                       description: Where
@@ -1662,15 +1656,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for subject tokens.
                                                                       type: string
                                                                   type: object
                                                               required:
@@ -2649,15 +2637,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for actor tokens.
                                                                       type: string
                                                                   required:
                                                                   - source
@@ -3082,13 +3064,14 @@ spec:
                                                                   pattern: ^/
                                                                   type: string
                                                                 requestedTokenType:
-                                                                  description: RFC
-                                                                    8693 requested_token_type.
+                                                                  description: |-
+                                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                                    built-in values may be requested; custom URIs are not supported here.
                                                                   enum:
                                                                   - AccessToken
-                                                                  - IdJag
-                                                                  - IdToken
                                                                   - Jwt
+                                                                  - IdToken
+                                                                  - IdJag
                                                                   type: string
                                                                 resources:
                                                                   description: Resources
@@ -3109,11 +3092,10 @@ spec:
                                                                   minItems: 1
                                                                   type: array
                                                                 subjectToken:
-                                                                  description: Subject
-                                                                    token / assertion
-                                                                    source and type.
-                                                                    Defaults to Authorization
-                                                                    Bearer, AccessToken.
+                                                                  description: |-
+                                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                                    that support custom token exchange profiles.
                                                                   properties:
                                                                     source:
                                                                       description: Where
@@ -3191,15 +3173,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for subject tokens.
                                                                       type: string
                                                                   type: object
                                                               required:
@@ -4174,15 +4150,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for actor tokens.
                                                                       type: string
                                                                   required:
                                                                   - source
@@ -4607,13 +4577,14 @@ spec:
                                                                   pattern: ^/
                                                                   type: string
                                                                 requestedTokenType:
-                                                                  description: RFC
-                                                                    8693 requested_token_type.
+                                                                  description: |-
+                                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                                    built-in values may be requested; custom URIs are not supported here.
                                                                   enum:
                                                                   - AccessToken
-                                                                  - IdJag
-                                                                  - IdToken
                                                                   - Jwt
+                                                                  - IdToken
+                                                                  - IdJag
                                                                   type: string
                                                                 resources:
                                                                   description: Resources
@@ -4634,11 +4605,10 @@ spec:
                                                                   minItems: 1
                                                                   type: array
                                                                 subjectToken:
-                                                                  description: Subject
-                                                                    token / assertion
-                                                                    source and type.
-                                                                    Defaults to Authorization
-                                                                    Bearer, AccessToken.
+                                                                  description: |-
+                                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                                    that support custom token exchange profiles.
                                                                   properties:
                                                                     source:
                                                                       description: Where
@@ -4716,15 +4686,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for subject tokens.
                                                                       type: string
                                                                   type: object
                                                               required:
@@ -5931,15 +5895,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for actor tokens.
                                                                       type: string
                                                                   required:
                                                                   - source
@@ -6364,13 +6322,14 @@ spec:
                                                                   pattern: ^/
                                                                   type: string
                                                                 requestedTokenType:
-                                                                  description: RFC
-                                                                    8693 requested_token_type.
+                                                                  description: |-
+                                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                                    built-in values may be requested; custom URIs are not supported here.
                                                                   enum:
                                                                   - AccessToken
-                                                                  - IdJag
-                                                                  - IdToken
                                                                   - Jwt
+                                                                  - IdToken
+                                                                  - IdJag
                                                                   type: string
                                                                 resources:
                                                                   description: Resources
@@ -6391,11 +6350,10 @@ spec:
                                                                   minItems: 1
                                                                   type: array
                                                                 subjectToken:
-                                                                  description: Subject
-                                                                    token / assertion
-                                                                    source and type.
-                                                                    Defaults to Authorization
-                                                                    Bearer, AccessToken.
+                                                                  description: |-
+                                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                                    that support custom token exchange profiles.
                                                                   properties:
                                                                     source:
                                                                       description: Where
@@ -6473,15 +6431,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for subject tokens.
                                                                       type: string
                                                                   type: object
                                                               required:
@@ -7460,15 +7412,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for actor tokens.
                                                                       type: string
                                                                   required:
                                                                   - source
@@ -7893,13 +7839,14 @@ spec:
                                                                   pattern: ^/
                                                                   type: string
                                                                 requestedTokenType:
-                                                                  description: RFC
-                                                                    8693 requested_token_type.
+                                                                  description: |-
+                                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                                    built-in values may be requested; custom URIs are not supported here.
                                                                   enum:
                                                                   - AccessToken
-                                                                  - IdJag
-                                                                  - IdToken
                                                                   - Jwt
+                                                                  - IdToken
+                                                                  - IdJag
                                                                   type: string
                                                                 resources:
                                                                   description: Resources
@@ -7920,11 +7867,10 @@ spec:
                                                                   minItems: 1
                                                                   type: array
                                                                 subjectToken:
-                                                                  description: Subject
-                                                                    token / assertion
-                                                                    source and type.
-                                                                    Defaults to Authorization
-                                                                    Bearer, AccessToken.
+                                                                  description: |-
+                                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                                    that support custom token exchange profiles.
                                                                   properties:
                                                                     source:
                                                                       description: Where
@@ -8002,15 +7948,9 @@ spec:
                                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                                           == 1'
                                                                     tokenType:
-                                                                      description: OAuth
-                                                                        token type.
-                                                                        Empty defaults
-                                                                        to AccessToken.
-                                                                      enum:
-                                                                      - AccessToken
-                                                                      - IdJag
-                                                                      - IdToken
-                                                                      - Jwt
+                                                                      description: |-
+                                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                                        are supported for subject tokens.
                                                                       type: string
                                                                   type: object
                                                               required:
@@ -9216,13 +9156,9 @@ spec:
                                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                     == 1'
                                               tokenType:
-                                                description: OAuth token type. Empty
-                                                  defaults to AccessToken.
-                                                enum:
-                                                - AccessToken
-                                                - IdJag
-                                                - IdToken
-                                                - Jwt
+                                                description: |-
+                                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                  are supported for actor tokens.
                                                 type: string
                                             required:
                                             - source
@@ -9559,12 +9495,14 @@ spec:
                                             pattern: ^/
                                             type: string
                                           requestedTokenType:
-                                            description: RFC 8693 requested_token_type.
+                                            description: |-
+                                              RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                              built-in values may be requested; custom URIs are not supported here.
                                             enum:
                                             - AccessToken
-                                            - IdJag
-                                            - IdToken
                                             - Jwt
+                                            - IdToken
+                                            - IdJag
                                             type: string
                                           resources:
                                             description: Resources sent to the token
@@ -9583,9 +9521,10 @@ spec:
                                             minItems: 1
                                             type: array
                                           subjectToken:
-                                            description: Subject token / assertion
-                                              source and type. Defaults to Authorization
-                                              Bearer, AccessToken.
+                                            description: |-
+                                              Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                              The token type may be a built-in value or a custom absolute URI for providers
+                                              that support custom token exchange profiles.
                                             properties:
                                               source:
                                                 description: Where to read the token.
@@ -9651,13 +9590,9 @@ spec:
                                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                     == 1'
                                               tokenType:
-                                                description: OAuth token type. Empty
-                                                  defaults to AccessToken.
-                                                enum:
-                                                - AccessToken
-                                                - IdJag
-                                                - IdToken
-                                                - Jwt
+                                                description: |-
+                                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                  are supported for subject tokens.
                                                 type: string
                                             type: object
                                         required:
@@ -11461,13 +11396,9 @@ spec:
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                   == 1'
                                             tokenType:
-                                              description: OAuth token type. Empty
-                                                defaults to AccessToken.
-                                              enum:
-                                              - AccessToken
-                                              - IdJag
-                                              - IdToken
-                                              - Jwt
+                                              description: |-
+                                                OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                are supported for actor tokens.
                                               type: string
                                           required:
                                           - source
@@ -11799,12 +11730,14 @@ spec:
                                           pattern: ^/
                                           type: string
                                         requestedTokenType:
-                                          description: RFC 8693 requested_token_type.
+                                          description: |-
+                                            RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                            built-in values may be requested; custom URIs are not supported here.
                                           enum:
                                           - AccessToken
-                                          - IdJag
-                                          - IdToken
                                           - Jwt
+                                          - IdToken
+                                          - IdJag
                                           type: string
                                         resources:
                                           description: Resources sent to the token
@@ -11822,9 +11755,10 @@ spec:
                                           minItems: 1
                                           type: array
                                         subjectToken:
-                                          description: Subject token / assertion source
-                                            and type. Defaults to Authorization Bearer,
-                                            AccessToken.
+                                          description: |-
+                                            Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                            The token type may be a built-in value or a custom absolute URI for providers
+                                            that support custom token exchange profiles.
                                           properties:
                                             source:
                                               description: Where to read the token.
@@ -11890,13 +11824,9 @@ spec:
                                                 rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                   == 1'
                                             tokenType:
-                                              description: OAuth token type. Empty
-                                                defaults to AccessToken.
-                                              enum:
-                                              - AccessToken
-                                              - IdJag
-                                              - IdToken
-                                              - Jwt
+                                              description: |-
+                                                OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                are supported for subject tokens.
                                               type: string
                                           type: object
                                       required:
@@ -12973,13 +12903,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -13328,12 +13254,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -13352,9 +13280,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -13422,13 +13351,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -14294,13 +14219,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -14649,12 +14570,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -14673,9 +14596,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -14743,13 +14667,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -15610,13 +15530,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -15965,12 +15881,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -15989,9 +15907,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -16059,13 +15978,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -17152,13 +17067,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -17507,12 +17418,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -17531,9 +17444,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -17601,13 +17515,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -18473,13 +18383,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -18828,12 +18734,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -18852,9 +18760,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -18922,13 +18831,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -20052,12 +19957,9 @@ spec:
                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                     == 1'
                               tokenType:
-                                description: OAuth token type. Empty defaults to AccessToken.
-                                enum:
-                                - AccessToken
-                                - IdJag
-                                - IdToken
-                                - Jwt
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for actor tokens.
                                 type: string
                             required:
                             - source
@@ -20369,12 +20271,14 @@ spec:
                             pattern: ^/
                             type: string
                           requestedTokenType:
-                            description: RFC 8693 requested_token_type.
+                            description: |-
+                              RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                              built-in values may be requested; custom URIs are not supported here.
                             enum:
                             - AccessToken
-                            - IdJag
-                            - IdToken
                             - Jwt
+                            - IdToken
+                            - IdJag
                             type: string
                           resources:
                             description: Resources sent to the token endpoint.
@@ -20391,8 +20295,10 @@ spec:
                             minItems: 1
                             type: array
                           subjectToken:
-                            description: Subject token / assertion source and type.
-                              Defaults to Authorization Bearer, AccessToken.
+                            description: |-
+                              Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                              The token type may be a built-in value or a custom absolute URI for providers
+                              that support custom token exchange profiles.
                             properties:
                               source:
                                 description: Where to read the token. CEL `expression`
@@ -20456,12 +20362,9 @@ spec:
                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                     == 1'
                               tokenType:
-                                description: OAuth token type. Empty defaults to AccessToken.
-                                enum:
-                                - AccessToken
-                                - IdJag
-                                - IdToken
-                                - Jwt
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for subject tokens.
                                 type: string
                             type: object
                         required:

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -712,13 +712,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -1067,12 +1063,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -1091,9 +1089,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -1161,13 +1160,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -2033,13 +2028,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -2388,12 +2379,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -2412,9 +2405,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -2482,13 +2476,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -3349,13 +3339,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -3704,12 +3690,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -3728,9 +3716,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -3798,13 +3787,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -4891,13 +4876,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -5246,12 +5227,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -5270,9 +5253,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -5340,13 +5324,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -6212,13 +6192,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for actor tokens.
                                                       type: string
                                                   required:
                                                   - source
@@ -6567,12 +6543,14 @@ spec:
                                                   pattern: ^/
                                                   type: string
                                                 requestedTokenType:
-                                                  description: RFC 8693 requested_token_type.
+                                                  description: |-
+                                                    RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                                                    built-in values may be requested; custom URIs are not supported here.
                                                   enum:
                                                   - AccessToken
-                                                  - IdJag
-                                                  - IdToken
                                                   - Jwt
+                                                  - IdToken
+                                                  - IdJag
                                                   type: string
                                                 resources:
                                                   description: Resources sent to the
@@ -6591,9 +6569,10 @@ spec:
                                                   minItems: 1
                                                   type: array
                                                 subjectToken:
-                                                  description: Subject token / assertion
-                                                    source and type. Defaults to Authorization
-                                                    Bearer, AccessToken.
+                                                  description: |-
+                                                    Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                                                    The token type may be a built-in value or a custom absolute URI for providers
+                                                    that support custom token exchange profiles.
                                                   properties:
                                                     source:
                                                       description: Where to read the
@@ -6661,13 +6640,9 @@ spec:
                                                         rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                                           == 1'
                                                     tokenType:
-                                                      description: OAuth token type.
-                                                        Empty defaults to AccessToken.
-                                                      enum:
-                                                      - AccessToken
-                                                      - IdJag
-                                                      - IdToken
-                                                      - Jwt
+                                                      description: |-
+                                                        OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                                        are supported for subject tokens.
                                                       type: string
                                                   type: object
                                               required:
@@ -7791,12 +7766,9 @@ spec:
                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                     == 1'
                               tokenType:
-                                description: OAuth token type. Empty defaults to AccessToken.
-                                enum:
-                                - AccessToken
-                                - IdJag
-                                - IdToken
-                                - Jwt
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for actor tokens.
                                 type: string
                             required:
                             - source
@@ -8108,12 +8080,14 @@ spec:
                             pattern: ^/
                             type: string
                           requestedTokenType:
-                            description: RFC 8693 requested_token_type.
+                            description: |-
+                              RFC 8693 requested_token_type. Unlike subject/actor token types, only the
+                              built-in values may be requested; custom URIs are not supported here.
                             enum:
                             - AccessToken
-                            - IdJag
-                            - IdToken
                             - Jwt
+                            - IdToken
+                            - IdJag
                             type: string
                           resources:
                             description: Resources sent to the token endpoint.
@@ -8130,8 +8104,10 @@ spec:
                             minItems: 1
                             type: array
                           subjectToken:
-                            description: Subject token / assertion source and type.
-                              Defaults to Authorization Bearer, AccessToken.
+                            description: |-
+                              Subject token / assertion source and type. Defaults to Authorization Bearer, AccessToken.
+                              The token type may be a built-in value or a custom absolute URI for providers
+                              that support custom token exchange profiles.
                             properties:
                               source:
                                 description: Where to read the token. CEL `expression`
@@ -8195,12 +8171,9 @@ spec:
                                   rule: '[has(self.header),has(self.queryParameter),has(self.cookie),has(self.expression)].filter(x,x==true).size()
                                     == 1'
                               tokenType:
-                                description: OAuth token type. Empty defaults to AccessToken.
-                                enum:
-                                - AccessToken
-                                - IdJag
-                                - IdToken
-                                - Jwt
+                                description: |-
+                                  OAuth token type. Empty defaults to AccessToken. Custom absolute URI values
+                                  are supported for subject tokens.
                                 type: string
                             type: object
                         required:

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	jsonpb "google.golang.org/protobuf/encoding/protojson"
@@ -1005,10 +1006,16 @@ func BuildOAuthTokenExchange(ctx PolicyCtx, auth *agentgateway.OAuthTokenExchang
 		if err := validateExtractionAuthorizationLocation(auth.SubjectToken.Source, "oauth subjectToken source"); err != nil {
 			errs = append(errs, err)
 		}
+		if auth.SubjectToken.TokenType != nil {
+			errs = append(errs, validateOAuthTokenType(*auth.SubjectToken.TokenType, "oauth subjectToken tokenType"))
+		}
 	}
 	if auth.ActorToken != nil {
 		if err := validateExtractionAuthorizationLocation(&auth.ActorToken.Source, "oauth actorToken source"); err != nil {
 			errs = append(errs, err)
+		}
+		if auth.ActorToken.TokenType != nil {
+			errs = append(errs, validateOAuthTokenType(*auth.ActorToken.TokenType, "oauth actorToken tokenType"))
 		}
 	}
 
@@ -1173,6 +1180,21 @@ func translateOAuthTokenTypePtr(tokenType *agentgateway.OAuthTokenType) *string 
 		return nil
 	}
 	return new(translateOAuthTokenType(*tokenType))
+}
+
+func validateOAuthTokenType(tokenType agentgateway.OAuthTokenType, field string) error {
+	switch tokenType {
+	case agentgateway.OAuthTokenTypeAccessToken,
+		agentgateway.OAuthTokenTypeJWT,
+		agentgateway.OAuthTokenTypeIDToken,
+		agentgateway.OAuthTokenTypeIDJAG:
+		return nil
+	}
+	parsed, err := url.Parse(string(tokenType))
+	if err != nil || !parsed.IsAbs() || parsed.Fragment != "" {
+		return fmt.Errorf("%s %q must be a built-in token type or an absolute URI without a fragment", field, tokenType)
+	}
+	return nil
 }
 
 func translateOAuthTokenType(tokenType agentgateway.OAuthTokenType) string {

--- a/controller/pkg/agentgateway/plugins/oauth_auth_test.go
+++ b/controller/pkg/agentgateway/plugins/oauth_auth_test.go
@@ -518,7 +518,7 @@ func TestOAuthTokenExchangeCustomSubjectTokenTypeTranslation(t *testing.T) {
 		BackendRef: oauthTokenEndpointRef(),
 		Path:       &path,
 		SubjectToken: &agentgateway.OAuthTokenSpec{
-			TokenType: ptr.Of(customTokenType),
+			TokenType: new(customTokenType),
 		},
 	}, "default")
 	if err != nil {
@@ -544,7 +544,7 @@ func TestOAuthTokenExchangeRejectsInvalidCustomTokenTypes(t *testing.T) {
 				return &agentgateway.OAuthTokenExchange{
 					BackendRef: oauthTokenEndpointRef(),
 					SubjectToken: &agentgateway.OAuthTokenSpec{
-						TokenType: ptr.Of(tokenType),
+						TokenType: new(tokenType),
 					},
 				}
 			},
@@ -557,7 +557,7 @@ func TestOAuthTokenExchangeRejectsInvalidCustomTokenTypes(t *testing.T) {
 				return &agentgateway.OAuthTokenExchange{
 					BackendRef: oauthTokenEndpointRef(),
 					SubjectToken: &agentgateway.OAuthTokenSpec{
-						TokenType: ptr.Of(tokenType),
+						TokenType: new(tokenType),
 					},
 				}
 			},
@@ -575,7 +575,7 @@ func TestOAuthTokenExchangeRejectsInvalidCustomTokenTypes(t *testing.T) {
 								Header: &agentgateway.AuthorizationHeaderLocation{Name: "X-Actor-Token"},
 							},
 						},
-						TokenType: ptr.Of(tokenType),
+						TokenType: new(tokenType),
 					},
 				}
 			},
@@ -593,7 +593,7 @@ func TestOAuthTokenExchangeRejectsInvalidCustomTokenTypes(t *testing.T) {
 								Header: &agentgateway.AuthorizationHeaderLocation{Name: "X-Actor-Token"},
 							},
 						},
-						TokenType: ptr.Of(tokenType),
+						TokenType: new(tokenType),
 					},
 				}
 			},

--- a/controller/pkg/agentgateway/plugins/oauth_auth_test.go
+++ b/controller/pkg/agentgateway/plugins/oauth_auth_test.go
@@ -508,3 +508,111 @@ func TestOAuthTokenExchangeTokenTypeTranslation(t *testing.T) {
 		t.Fatalf("authorization location header = %q, want X-Exchanged-Token", oauth.GetAuthorizationLocation().GetHeader().GetName())
 	}
 }
+
+func TestOAuthTokenExchangeCustomSubjectTokenTypeTranslation(t *testing.T) {
+	ctx := oauthTestPolicyCtx(t)
+
+	path := "/oauth/token"
+	customTokenType := agentgateway.OAuthTokenType("urn:company:domain:human")
+	policy, err := buildOAuthTokenExchangePolicy(ctx, &agentgateway.OAuthTokenExchange{
+		BackendRef: oauthTokenEndpointRef(),
+		Path:       &path,
+		SubjectToken: &agentgateway.OAuthTokenSpec{
+			TokenType: ptr.Of(customTokenType),
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("buildOAuthTokenExchangePolicy() error = %v, want nil", err)
+	}
+
+	oauth := policy.GetOauthTokenExchange()
+	if oauth.GetSubjectToken().GetTokenType() != string(customTokenType) {
+		t.Fatalf("subject token type = %q, want %q", oauth.GetSubjectToken().GetTokenType(), customTokenType)
+	}
+}
+
+func TestOAuthTokenExchangeRejectsInvalidCustomTokenTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		buildAuth func(agentgateway.OAuthTokenType) *agentgateway.OAuthTokenExchange
+		tokenType agentgateway.OAuthTokenType
+		wantErr   string
+	}{
+		{
+			name: "subject typo",
+			buildAuth: func(tokenType agentgateway.OAuthTokenType) *agentgateway.OAuthTokenExchange {
+				return &agentgateway.OAuthTokenExchange{
+					BackendRef: oauthTokenEndpointRef(),
+					SubjectToken: &agentgateway.OAuthTokenSpec{
+						TokenType: ptr.Of(tokenType),
+					},
+				}
+			},
+			tokenType: agentgateway.OAuthTokenType("JWt"),
+			wantErr:   "oauth subjectToken tokenType",
+		},
+		{
+			name: "subject fragment",
+			buildAuth: func(tokenType agentgateway.OAuthTokenType) *agentgateway.OAuthTokenExchange {
+				return &agentgateway.OAuthTokenExchange{
+					BackendRef: oauthTokenEndpointRef(),
+					SubjectToken: &agentgateway.OAuthTokenSpec{
+						TokenType: ptr.Of(tokenType),
+					},
+				}
+			},
+			tokenType: agentgateway.OAuthTokenType("https://tokens.example/custom#fragment"),
+			wantErr:   "without a fragment",
+		},
+		{
+			name: "actor typo",
+			buildAuth: func(tokenType agentgateway.OAuthTokenType) *agentgateway.OAuthTokenExchange {
+				return &agentgateway.OAuthTokenExchange{
+					BackendRef: oauthTokenEndpointRef(),
+					ActorToken: &agentgateway.OAuthActorToken{
+						Source: agentgateway.AuthorizationExtractionLocation{
+							AuthorizationLocationFields: agentgateway.AuthorizationLocationFields{
+								Header: &agentgateway.AuthorizationHeaderLocation{Name: "X-Actor-Token"},
+							},
+						},
+						TokenType: ptr.Of(tokenType),
+					},
+				}
+			},
+			tokenType: agentgateway.OAuthTokenType("JWt"),
+			wantErr:   "oauth actorToken tokenType",
+		},
+		{
+			name: "actor fragment",
+			buildAuth: func(tokenType agentgateway.OAuthTokenType) *agentgateway.OAuthTokenExchange {
+				return &agentgateway.OAuthTokenExchange{
+					BackendRef: oauthTokenEndpointRef(),
+					ActorToken: &agentgateway.OAuthActorToken{
+						Source: agentgateway.AuthorizationExtractionLocation{
+							AuthorizationLocationFields: agentgateway.AuthorizationLocationFields{
+								Header: &agentgateway.AuthorizationHeaderLocation{Name: "X-Actor-Token"},
+							},
+						},
+						TokenType: ptr.Of(tokenType),
+					},
+				}
+			},
+			tokenType: agentgateway.OAuthTokenType("https://tokens.example/custom#fragment"),
+			wantErr:   "without a fragment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := oauthTestPolicyCtx(t)
+
+			_, err := buildOAuthTokenExchangePolicy(ctx, tt.buildAuth(tt.tokenType), "default")
+			if err == nil {
+				t.Fatal("buildOAuthTokenExchangePolicy() error = nil, want invalid token type error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("buildOAuthTokenExchangePolicy() error = %q, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/crates/agentgateway/src/http/auth/oauth/mod.rs
+++ b/crates/agentgateway/src/http/auth/oauth/mod.rs
@@ -66,8 +66,8 @@ pub struct OAuthTokenExchangeAuth {
 	/// `resource` parameters with the target service URIs.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	resources: Vec<String>,
-	/// `requested_token_type` parameter. When unset, the form field is omitted
-	/// and a declared response type is expected to be access_token.
+	/// `requested_token_type` parameter. Under token exchange, unset defaults to
+	/// access_token because this policy forwards bearer access tokens.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
 	requested_token_type: Option<OAuthTokenType>,
@@ -142,6 +142,8 @@ impl ChainedExchange {
 		if let Some(client_auth) = &self.client_auth {
 			client_auth.validate_load()?;
 		}
+		warn_on_invalid_resources("chained oauth token exchange", &self.resources);
+		warn_on_invalid_scopes("chained oauth token exchange scopes", &self.scopes);
 		validate_additional_params(&self.additional_params)?;
 		Ok(())
 	}
@@ -194,6 +196,8 @@ impl OAuthTokenExchangeAuth {
 			));
 		}
 
+		warn_on_invalid_resources("oauth token exchange", &self.resources);
+		warn_on_invalid_scopes("oauth token exchange scopes", &self.scopes);
 		validate_additional_params(&self.additional_params)?;
 
 		if let Some(chained_exchange) = &self.chained_exchange {
@@ -226,6 +230,14 @@ impl OAuthTokenExchangeAuth {
 			AuthorizationLocation::Expression { .. }
 		) {
 			return Err("expression auth location is only supported for credential extraction".into());
+		}
+		if matches!(
+			self.authorization_location,
+			AuthorizationLocation::QueryParameter { .. }
+		) {
+			warn!(
+				"oauth token exchange is configured to forward the exchanged bearer token in a URI query parameter; OAuth 2.1 omits this bearer-token usage and future versions may reject it"
+			);
 		}
 		Ok(())
 	}
@@ -314,11 +326,17 @@ impl OAuthTokenExchangeAuth {
 		Ok(auth)
 	}
 
-	fn expected_issued_token_type(&self) -> Option<OAuthTokenType> {
+	fn requested_token_type_param(&self) -> Option<OAuthTokenType> {
 		match self.grant_type {
 			OAuthGrantType::TokenExchange => Some(self.requested_token_type.clone().unwrap_or_default()),
 			OAuthGrantType::JwtBearer => None,
 		}
+	}
+
+	// We expect the authorization server to issue exactly the token type we
+	// requested, so the expected issued type mirrors the requested param.
+	fn expected_issued_token_type(&self) -> Option<OAuthTokenType> {
+		self.requested_token_type_param()
 	}
 
 	/// Evaluate the configured `additional_params` CEL expressions against the
@@ -626,12 +644,41 @@ fn validate_additional_params(
 	Ok(())
 }
 
+fn warn_on_invalid_resources(context: &str, resources: &[String]) {
+	for resource in resources {
+		if !is_oauth_absolute_uri(resource) {
+			warn!(
+				resource,
+				"{context} resource is not an absolute URI without a fragment; future OAuth 2.1 compliance enforcement may reject it"
+			);
+		}
+	}
+}
+
 // RFC 8707 resource identifiers and RFC 8693 token type identifiers must both be
 // absolute URIs without a fragment.
 fn is_oauth_absolute_uri(value: &str) -> bool {
 	url::Url::parse(value)
 		.map(|url| url.fragment().is_none())
 		.unwrap_or(false)
+}
+
+fn warn_on_invalid_scopes(context: &str, scopes: &[String]) {
+	for scope in scopes {
+		if !is_valid_scope_token(scope) {
+			warn!(
+				scope,
+				"{context} contains an invalid OAuth scope-token; scopes must be non-empty and free of spaces, quotes, backslashes, control characters, and non-ASCII characters; future OAuth 2.1 compliance enforcement may reject it"
+			);
+		}
+	}
+}
+
+fn is_valid_scope_token(scope: &str) -> bool {
+	!scope.is_empty()
+		&& scope
+			.bytes()
+			.all(|b| b == 0x21 || (0x23..=0x5b).contains(&b) || (0x5d..=0x7e).contains(&b))
 }
 
 fn evaluate_additional_params(

--- a/crates/agentgateway/src/http/auth/oauth/mod.rs
+++ b/crates/agentgateway/src/http/auth/oauth/mod.rs
@@ -188,6 +188,11 @@ impl OAuthTokenExchangeAuth {
 		if let Some(client_auth) = &self.client_auth {
 			client_auth.validate_load()?;
 		}
+		if let Some(OAuthTokenType::Custom(token_type)) = &self.requested_token_type {
+			return Err(format!(
+				"unsupported requested_token_type {token_type:?}; custom token types are only supported for subject_token and actor_token"
+			));
+		}
 
 		validate_additional_params(&self.additional_params)?;
 
@@ -252,9 +257,10 @@ impl OAuthTokenExchangeAuth {
 			.transpose()?;
 
 		let requested_token_type = match t.requested_token_type {
-			Some(token_type) if !token_type.is_empty() => {
-				Some(proto_token_type("requested_token_type", &token_type)?)
-			},
+			Some(token_type) if !token_type.is_empty() => Some(proto_requested_token_type(
+				"requested_token_type",
+				&token_type,
+			)?),
 			_ => None,
 		};
 		if requested_token_type == Some(OAuthTokenType::IdJag) {
@@ -310,7 +316,7 @@ impl OAuthTokenExchangeAuth {
 
 	fn expected_issued_token_type(&self) -> Option<OAuthTokenType> {
 		match self.grant_type {
-			OAuthGrantType::TokenExchange => Some(self.requested_token_type.unwrap_or_default()),
+			OAuthGrantType::TokenExchange => Some(self.requested_token_type.clone().unwrap_or_default()),
 			OAuthGrantType::JwtBearer => None,
 		}
 	}
@@ -350,7 +356,7 @@ impl OAuthTokenExchangeAuth {
 
 		Ok(ExchangeRequest {
 			subject_token: subject_token.into(),
-			subject_token_type: self.subject_token.token_type,
+			subject_token_type: self.subject_token.token_type.clone(),
 			actor,
 			extra_params,
 			chained_extra_params,
@@ -385,19 +391,14 @@ pub enum OAuthGrantType {
 	JwtBearer,
 }
 
-#[derive(
-	Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 enum OAuthTokenType {
-	#[serde(rename = "urn:ietf:params:oauth:token-type:access_token")]
 	#[default]
 	AccessToken,
-	#[serde(rename = "urn:ietf:params:oauth:token-type:jwt")]
 	Jwt,
-	#[serde(rename = "urn:ietf:params:oauth:token-type:id_token")]
 	IdToken,
-	#[serde(rename = "urn:ietf:params:oauth:token-type:id-jag")]
 	IdJag,
+	Custom(String),
 }
 
 impl OAuthTokenType {
@@ -407,17 +408,52 @@ impl OAuthTokenType {
 			TOKEN_TYPE_JWT => Some(Self::Jwt),
 			TOKEN_TYPE_ID => Some(Self::IdToken),
 			TOKEN_TYPE_ID_JAG => Some(Self::IdJag),
+			_ if is_oauth_absolute_uri(token_type) => Some(Self::Custom(token_type.into())),
 			_ => None,
 		}
 	}
 
-	fn as_str(self) -> &'static str {
+	fn supported_requested_from_urn(token_type: &str) -> Option<Self> {
+		match token_type {
+			TOKEN_TYPE_ACCESS => Some(Self::AccessToken),
+			TOKEN_TYPE_JWT => Some(Self::Jwt),
+			TOKEN_TYPE_ID => Some(Self::IdToken),
+			TOKEN_TYPE_ID_JAG => Some(Self::IdJag),
+			_ => None,
+		}
+	}
+
+	fn as_str(&self) -> &str {
 		match self {
 			Self::AccessToken => TOKEN_TYPE_ACCESS,
 			Self::Jwt => TOKEN_TYPE_JWT,
 			Self::IdToken => TOKEN_TYPE_ID,
 			Self::IdJag => TOKEN_TYPE_ID_JAG,
+			Self::Custom(token_type) => token_type,
 		}
+	}
+}
+
+impl serde::Serialize for OAuthTokenType {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		serializer.serialize_str(self.as_str())
+	}
+}
+
+impl<'de> serde::Deserialize<'de> for OAuthTokenType {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		let token_type = <String as serde::Deserialize>::deserialize(deserializer)?;
+		Self::from_urn(&token_type).ok_or_else(|| {
+			serde::de::Error::custom(format!(
+				"OAuth token type must be an absolute URI without a fragment, got {token_type:?}"
+			))
+		})
 	}
 }
 
@@ -590,6 +626,14 @@ fn validate_additional_params(
 	Ok(())
 }
 
+// RFC 8707 resource identifiers and RFC 8693 token type identifiers must both be
+// absolute URIs without a fragment.
+fn is_oauth_absolute_uri(value: &str) -> bool {
+	url::Url::parse(value)
+		.map(|url| url.fragment().is_none())
+		.unwrap_or(false)
+}
+
 fn evaluate_additional_params(
 	params: &BTreeMap<String, Arc<cel::Expression>>,
 	req: &Request,
@@ -706,7 +750,7 @@ fn actor_token_from_request(
 		debug!("oauth token exchange actor is not authorized by the subject's may_act claim");
 		return Err(ProxyError::AuthorizationFailed);
 	}
-	Ok((SecretString::from(token), spec.token_type))
+	Ok((SecretString::from(token), spec.token_type.clone()))
 }
 
 fn may_act_authorizes(req: &Request, subject_token: &str, actor_token: &str) -> bool {
@@ -772,6 +816,11 @@ fn claim_satisfies(actor_value: Option<&Value>, expected: &Value) -> bool {
 
 fn proto_token_type(field: &str, token_type: &str) -> Result<OAuthTokenType, ProtoError> {
 	OAuthTokenType::from_urn(token_type)
+		.ok_or_else(|| ProtoError::Generic(format!("unsupported {field} {token_type:?}")))
+}
+
+fn proto_requested_token_type(field: &str, token_type: &str) -> Result<OAuthTokenType, ProtoError> {
+	OAuthTokenType::supported_requested_from_urn(token_type)
 		.ok_or_else(|| ProtoError::Generic(format!("unsupported {field} {token_type:?}")))
 }
 

--- a/crates/agentgateway/src/http/auth/oauth/tests.rs
+++ b/crates/agentgateway/src/http/auth/oauth/tests.rs
@@ -249,12 +249,15 @@ fn local_cache_config_can_disable_storage() {
 }
 
 #[test]
-fn deserialize_rejects_unsupported_subject_token_type() {
-	let err = serde_json::from_str::<OAuthTokenExchangeAuth>(
-		r#"{"host": "localhost:8089", "subjectToken": {"tokenType": "urn:ietf:params:oauth:token-type:saml2"}}"#,
+fn deserializes_custom_subject_token_type_uri() {
+	let auth = serde_json::from_str::<OAuthTokenExchangeAuth>(
+		r#"{"host": "localhost:8089", "subjectToken": {"tokenType": "urn:company:domain:human"}}"#,
 	)
-	.expect_err("unsupported token type should fail to deserialize");
-	assert!(err.to_string().contains("unknown variant"), "got: {err}");
+	.expect("custom absolute URI token type should deserialize");
+	assert_eq!(
+		auth.subject_token.token_type.as_str(),
+		"urn:company:domain:human"
+	);
 }
 
 #[tokio::test]
@@ -335,6 +338,28 @@ async fn sends_optional_params() {
 		!pairs.contains_key("client_secret"),
 		"public client sends no secret"
 	);
+}
+
+#[tokio::test]
+async fn sends_custom_subject_token_type() {
+	let mock = mock_token_endpoint(ResponseTemplate::new(200).set_body_json(token_body())).await;
+	let a = OAuthTokenExchangeAuth {
+		subject_token: TokenSpec {
+			source: AuthorizationLocation::default(),
+			token_type: token_type_from_urn("urn:company:domain:human"),
+		},
+		..base_auth(endpoint(&mock))
+	};
+
+	fetch_token(
+		&policy_client(),
+		&a,
+		exchange_req("subj", "urn:company:domain:human"),
+	)
+	.await
+	.unwrap();
+	let pairs = sent_form_params(&mock).await;
+	assert_eq!(pairs["subject_token_type"], "urn:company:domain:human");
 }
 
 #[tokio::test]
@@ -1172,10 +1197,10 @@ fn private_key_jwt_client_auth_from_proto() {
 	},
 	"only supported by local backendAuth.crossAppAccess"
 )]
-#[case::unsupported_subject_token_type(
+#[case::invalid_subject_token_type(
 	proto::OAuthTokenExchange {
 		subject_token: Some(proto::o_auth_token_exchange::TokenSpec {
-			token_type: "urn:ietf:params:oauth:token-type:saml2".to_string(),
+			token_type: "not a uri".to_string(),
 			..Default::default()
 		}),
 		..Default::default()
@@ -1400,7 +1425,10 @@ fn in_memory_cache_from_proto_accepts_large_default_ttl() {
 #[case(TOKEN_TYPE_ACCESS, true)]
 #[case(TOKEN_TYPE_JWT, true)]
 #[case(TOKEN_TYPE_ID, true)]
-#[case("urn:ietf:params:oauth:token-type:saml2", false)]
+#[case("urn:ietf:params:oauth:token-type:saml2", true)]
+#[case("urn:company:domain:human", true)]
+#[case("not a uri", false)]
+#[case("https://tokens.example/custom#fragment", false)]
 fn oauth_token_type_from_urn_cases(#[case] token_type: &str, #[case] expected: bool) {
 	assert_eq!(OAuthTokenType::from_urn(token_type).is_some(), expected);
 }

--- a/crates/agentgateway/src/http/auth/oauth/tests.rs
+++ b/crates/agentgateway/src/http/auth/oauth/tests.rs
@@ -303,7 +303,8 @@ async fn sends_form_params() {
 	assert_eq!(pairs["subject_token"], "subj-jwt");
 	assert_eq!(pairs["subject_token_type"], TOKEN_TYPE_ACCESS);
 	assert_eq!(pairs["audience"], "https://upstream.example");
-	for k in ["scope", "resource", "requested_token_type", "client_id"] {
+	assert_eq!(pairs["requested_token_type"], TOKEN_TYPE_ACCESS);
+	for k in ["scope", "resource", "client_id"] {
 		assert!(!pairs.contains_key(k), "unset param {k} must not be sent");
 	}
 }
@@ -360,6 +361,7 @@ async fn sends_custom_subject_token_type() {
 	.unwrap();
 	let pairs = sent_form_params(&mock).await;
 	assert_eq!(pairs["subject_token_type"], "urn:company:domain:human");
+	assert_eq!(pairs["requested_token_type"], TOKEN_TYPE_ACCESS);
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/http/auth/oauth/transport.rs
+++ b/crates/agentgateway/src/http/auth/oauth/transport.rs
@@ -176,7 +176,7 @@ impl<'a> From<&'a OAuthTokenExchangeAuth> for TokenRequestSpec<'a> {
 			audiences: &auth.audiences,
 			scopes: &auth.scopes,
 			resources: &auth.resources,
-			requested_token_type: auth.requested_token_type,
+			requested_token_type: auth.requested_token_type.clone(),
 			expected_issued_token_type: auth.expected_issued_token_type(),
 		}
 	}
@@ -228,7 +228,7 @@ pub(super) async fn request_token(
 	json::from_body_with_limit::<TokenResponse>(resp.into_body(), limit)
 		.await
 		.map_err(|e| FetchError::Upstream(anyhow!("token exchange response decode failed: {e}")))?
-		.into_token(spec.expected_issued_token_type)
+		.into_token(spec.expected_issued_token_type.clone())
 }
 
 fn classify_token_endpoint_error(status: StatusCode, body: String) -> FetchError {
@@ -292,7 +292,7 @@ fn build_token_request_form(
 					.append_pair("actor_token", actor_token.expose_secret())
 					.append_pair("actor_token_type", actor_token_type.as_str());
 			}
-			if let Some(rtt) = spec.requested_token_type {
+			if let Some(rtt) = &spec.requested_token_type {
 				ser.append_pair("requested_token_type", rtt.as_str());
 			}
 		},

--- a/crates/agentgateway/src/http/auth/oauth/transport.rs
+++ b/crates/agentgateway/src/http/auth/oauth/transport.rs
@@ -176,7 +176,7 @@ impl<'a> From<&'a OAuthTokenExchangeAuth> for TokenRequestSpec<'a> {
 			audiences: &auth.audiences,
 			scopes: &auth.scopes,
 			resources: &auth.resources,
-			requested_token_type: auth.requested_token_type.clone(),
+			requested_token_type: auth.requested_token_type_param(),
 			expected_issued_token_type: auth.expected_issued_token_type(),
 		}
 	}

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1818,8 +1818,9 @@ message OAuthTokenExchange {
     // from the Claims extension when an upstream JWT policy has stripped the
     // header, so the default keeps working behind a JWT auth policy.
     AuthorizationLocation source = 1;
-    // RFC 8693 §3 token type URN sent as subject_token_type / actor_token_type.
-    // e.g. "urn:ietf:params:oauth:token-type:access_token"
+    // RFC 8693 token type URI sent as subject_token_type / actor_token_type.
+    // Built-ins such as "urn:ietf:params:oauth:token-type:access_token" and
+    // custom absolute URIs such as "urn:company:domain:human" are accepted.
     // Empty defaults to access_token under TOKEN_EXCHANGE. Ignored for the
     // JWT_BEARER subject token because RFC 7523 sends the token as `assertion`
     // and has no subject_token_type parameter.
@@ -1834,8 +1835,8 @@ message OAuthTokenExchange {
     // credential.
     AuthorizationLocation source = 1;
 
-    // RFC 8693 §3 token type URN sent as actor_token_type.
-    // e.g. "urn:ietf:params:oauth:token-type:access_token"
+    // RFC 8693 token type URI sent as actor_token_type. Built-ins and custom
+    // absolute URIs are accepted.
     // Empty defaults to access_token, and actor_token_type is still sent.
     string token_type = 2;
 

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1869,11 +1869,13 @@ message OAuthTokenExchange {
   // ----- Token request parameters -----
   // Properties sent only when non-empty.
   repeated string audiences = 2;
-  repeated string scopes = 3; // joined with spaces into a single `scope` param
+  // OAuth scope-token values joined with spaces into a single `scope` param.
+  // Each entry must already be a single scope token, not a space-delimited list.
+  repeated string scopes = 3;
   repeated string resources = 4;
   // requested_token_type parameter sent under TOKEN_EXCHANGE only. Rejected
-  // under JWT_BEARER. When unset, no requested_token_type is sent; if the token
-  // endpoint returns issued_token_type, the gateway expects access_token.
+  // under JWT_BEARER. When unset under TOKEN_EXCHANGE, the gateway sends
+  // access_token because this backend auth policy forwards bearer access tokens.
   optional string requested_token_type = 5;
   // Arbitrary extra string form fields appended to the token exchange request.
   // Values are CEL expressions evaluated against the incoming request.

--- a/examples/traffic-token-exchange/oauth-rfc8693/README.md
+++ b/examples/traffic-token-exchange/oauth-rfc8693/README.md
@@ -59,6 +59,9 @@ curl -s http://localhost:3000/exchange -H "authorization: Bearer $SUBJECT_TOKEN"
 The gateway POSTs to Keycloak's token endpoint as the confidential client
 `requester-client` (`clientSecretBasic`), exchanging the user's token for one
 scoped to `audience=target-client`, and forwards *that* token upstream.
+For RFC 8693 token exchange, the gateway sends
+`requested_token_type=urn:ietf:params:oauth:token-type:access_token` unless you
+configure a different `requestedTokenType`.
 
 Decoded result (inbound vs forwarded):
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -3501,7 +3501,7 @@
           }
         },
         "requestedTokenType": {
-          "description": "`requested_token_type` parameter. When unset, the form field is omitted\nand a declared response type is expected to be access_token.",
+          "description": "`requested_token_type` parameter. Under token exchange, unset defaults to\naccess_token because this policy forwards bearer access tokens.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
Adds support for custom OAuth token type URIs for token exchange subject and actor tokens, while keeping `requested_token_type` restricted to supported built-in values. The controller now validates custom token types before emitting xDS config.

Also updates OAuth token exchange behavior to send `requested_token_type=access_token` by default for RFC 8693 exchanges, adds OAuth 2.1-oriented validation warnings for resource/scope/  query-token usage, and refreshes generated schema/proto docs plus the token exchange example.

Fixes: #2478 