### PR TITLE
security: document test-only rmcp advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,8 @@ features = []
 [advisories]
 version = 2
 ignore = [
-    { id= "RUSTSEC-2024-0436", reason = "acceptable unmaintained package used in non-critical areas"}
+    { id= "RUSTSEC-2024-0436", reason = "acceptable unmaintained package used in non-critical areas"},
+    { id= "RUSTSEC-2026-0189", reason = "rmcp 0.10.0 is test-only and does not use the affected Streamable HTTP server transport"}
 ]
 
 [licenses]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,4 @@
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0189"
+ignoreUntil = 2027-01-20
+reason = "rmcp 0.10.0 is used only by legacy SSE tests; the affected Streamable HTTP server transport is neither exercised nor shipped"


### PR DESCRIPTION
## Summary

- retain the test-only `rmcp 0.10.0` dependency used by legacy SSE compatibility tests
- add an expiring OSV Scanner exception for RUSTSEC-2026-0189
- add the same documented exception to the existing `cargo-deny` advisory policy

## Rationale

The advisory affects rmcp's Streamable HTTP server transport. This dependency is used only by legacy SSE tests, does not exercise the affected transport, and is not shipped to users. The OSV exception expires on January 20, 2027 for reassessment.

## Testing

- `osv-scanner --lockfile=Cargo.lock`
- verified the scanner loads `osv-scanner.toml` and filters RUSTSEC-2026-0189 and its aliases with the documented reason
