### PR TITLE
Add substrate router support

### DIFF
--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -28,6 +28,7 @@ mod peekbody;
 mod recordbody;
 pub mod remoteratelimit;
 pub mod sessionpersistence;
+pub mod substrate;
 pub mod tests_common;
 pub mod transformation_cel;
 

--- a/crates/agentgateway/src/http/substrate/egress.rs
+++ b/crates/agentgateway/src/http/substrate/egress.rs
@@ -1,0 +1,88 @@
+use super::{ActorRef, valid_resource_name};
+use crate::http::{PolicyResponse, Request};
+use crate::proxy::ProxyError;
+use crate::proxy::httpproxy::PolicyClient;
+use crate::store::RequestPolicyTrait;
+use crate::telemetry::log::RequestLog;
+use crate::types::agent::SimpleBackendReferenceWithPolicies;
+use crate::*;
+
+const ATESPACE_HEADER: &str = "x-ate-atespace";
+const ACTOR_HEADER: &str = "x-ate-actor";
+const ACTOR_VERSION_HEADER: &str = "x-ate-actor-version";
+
+/// Authorizes an actor's egress to the hostname recovered from an internal CONNECT listener.
+#[apply(schema!)]
+pub struct SubstrateEgress {
+	/// Backend that receives GetActor calls and policies used when connecting to it.
+	#[serde(flatten)]
+	pub target: SimpleBackendReferenceWithPolicies,
+}
+
+impl SubstrateEgress {
+	fn metadata(req: &Request) -> Result<(ActorRef, i64), ProxyError> {
+		let headers = &req
+			.extensions()
+			.get::<crate::cel::SourceContext>()
+			.ok_or_else(|| {
+				ProxyError::SubstrateEgressDenied(
+					"request did not originate from a CONNECT tunnel".to_owned(),
+				)
+			})?
+			.connect_headers;
+		let required = |name: &'static str| -> Result<&str, ProxyError> {
+			let mut values = headers.get_all(name).iter();
+			let value = values.next().ok_or_else(|| {
+				ProxyError::SubstrateEgressDenied(format!("missing {name} CONNECT header"))
+			})?;
+			if values.next().is_some() {
+				return Err(ProxyError::SubstrateEgressDenied(format!(
+					"multiple {name} CONNECT headers"
+				)));
+			}
+			value
+				.to_str()
+				.map_err(|_| ProxyError::SubstrateEgressDenied(format!("invalid {name} CONNECT header")))
+		};
+		let atespace = required(ATESPACE_HEADER)?;
+		let name = required(ACTOR_HEADER)?;
+		if !valid_resource_name(atespace) || !valid_resource_name(name) {
+			return Err(ProxyError::SubstrateEgressDenied(
+				"invalid actor identity CONNECT headers".to_owned(),
+			));
+		}
+		let version = required(ACTOR_VERSION_HEADER)?
+			.parse::<i64>()
+			.map_err(|_| {
+				ProxyError::SubstrateEgressDenied("X-Ate-Actor-Version must be a positive int64".to_owned())
+			})?;
+		if version <= 0 {
+			return Err(ProxyError::SubstrateEgressDenied(
+				"X-Ate-Actor-Version must be a positive int64".to_owned(),
+			));
+		}
+		Ok((
+			ActorRef {
+				atespace: atespace.to_owned(),
+				name: name.to_owned(),
+			},
+			version,
+		))
+	}
+}
+
+impl RequestPolicyTrait for SubstrateEgress {
+	async fn apply(
+		&self,
+		_client: &PolicyClient,
+		log: &mut RequestLog,
+		req: &mut Request,
+	) -> Result<PolicyResponse, crate::proxy::ProxyResponse> {
+		let (actor, _minimum_version) = Self::metadata(req)?;
+		log.ate_actor_id = Some(actor.name.clone());
+		log.ate_atespace = Some(actor.atespace.clone());
+		// TODO: implement egress policy in Substrate. Then, we can look it up, cache it, and enforce it.
+		// For now, we just add ate metadata
+		Ok(PolicyResponse::default())
+	}
+}

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -1,0 +1,504 @@
+use std::net::{IpAddr, SocketAddr};
+use std::num::NonZeroU16;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use ::http::StatusCode;
+use quick_cache::sync::Cache;
+use tonic::Code;
+
+use super::{ActorRef, CACHE_CAPACITY, TRACE_POLICY_KIND, valid_resource_name};
+use crate::http::{PolicyResponse, Request, Response};
+use crate::proxy::dtrace::{Severity, pol_event};
+use crate::proxy::httpproxy::PolicyClient;
+use crate::proxy::{ProxyError, dtrace};
+use crate::store::RequestPolicyTrait;
+use crate::telemetry::log::RequestLog;
+use crate::types::agent::{SimpleBackendReferenceWithPolicies, Target};
+use crate::*;
+
+const ACTOR_DNS_SUFFIX: &str = ".actors.resources.substrate.ate.dev";
+const RESUME_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const STALE_ASSIGNMENT_HEADER: &str = "x-ate-assignment-stale";
+
+#[derive(Debug, Clone, thiserror::Error)]
+enum ResumeError {
+	#[error("{0:?}: {1}")]
+	Status(Code, String),
+	#[error("{0}")]
+	InvalidResponse(String),
+}
+
+impl ResumeError {
+	fn into_proxy_error(self, actor: &ActorRef) -> ProxyError {
+		let (status, body) = match self {
+			Self::Status(Code::NotFound, _) => (
+				StatusCode::NOT_FOUND,
+				format!("actor {:?} not found", actor.name),
+			),
+			Self::Status(Code::FailedPrecondition, message) => (
+				StatusCode::SERVICE_UNAVAILABLE,
+				format!("actor {:?} unavailable: {message}", actor.name),
+			),
+			Self::Status(Code::Unavailable, _) => (
+				StatusCode::SERVICE_UNAVAILABLE,
+				format!("actor {:?} unavailable", actor.name),
+			),
+			Self::Status(Code::DeadlineExceeded, _) => (
+				StatusCode::GATEWAY_TIMEOUT,
+				format!("actor {:?} request timed out", actor.name),
+			),
+			Self::Status(Code::PermissionDenied, _) => (
+				StatusCode::FORBIDDEN,
+				format!("actor {:?} access denied", actor.name),
+			),
+			Self::Status(Code::Unauthenticated, _) => (
+				StatusCode::UNAUTHORIZED,
+				format!("actor {:?} authentication required", actor.name),
+			),
+			Self::Status(Code::ResourceExhausted, _) => (
+				StatusCode::TOO_MANY_REQUESTS,
+				format!("actor {:?} rate limited", actor.name),
+			),
+			Self::Status(_, _) | Self::InvalidResponse(_) => (
+				StatusCode::INTERNAL_SERVER_ERROR,
+				format!("error resuming actor {:?}", actor.name),
+			),
+		};
+		ProxyError::SubstrateIngressFailed(status, body)
+	}
+}
+
+#[derive(Debug, Clone)]
+struct CachedAssignment {
+	target: SocketAddr,
+	expires_at: Instant,
+	generation: u64,
+}
+
+#[derive(Clone, Copy)]
+enum ResolutionSource {
+	Request,
+	Cache,
+	AteApi,
+}
+
+impl ResolutionSource {
+	fn name(self) -> &'static str {
+		match self {
+			Self::Request => "request",
+			Self::Cache => "cache",
+			Self::AteApi => "ateApi",
+		}
+	}
+
+	fn cached(self) -> bool {
+		matches!(self, Self::Request | Self::Cache)
+	}
+}
+
+type ResolutionResult =
+	Result<(CachedAssignment, ResolutionSource), (ResumeError, ResolutionSource)>;
+
+struct AssignmentCache {
+	entries: Cache<ActorRef, Result<CachedAssignment, ResumeError>>,
+	next_generation: AtomicU64,
+}
+
+impl std::fmt::Debug for AssignmentCache {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("AssignmentCache").finish_non_exhaustive()
+	}
+}
+
+impl AssignmentCache {
+	fn remove_generation(&self, actor: &ActorRef, generation: u64) {
+		self.entries.remove_if(
+			actor,
+			|entry| matches!(entry, Ok(cached) if cached.generation == generation),
+		);
+	}
+}
+
+#[derive(Clone)]
+pub(crate) struct SubstrateRequestState {
+	actor: ActorRef,
+	ingress: SubstrateIngress,
+	client: PolicyClient,
+	current: Arc<Mutex<Option<CachedAssignment>>>,
+}
+
+fn default_target_port() -> NonZeroU16 {
+	NonZeroU16::new(80).unwrap()
+}
+
+fn default_cache_ttl() -> Duration {
+	Duration::from_secs(5)
+}
+
+fn default_cache() -> Arc<AssignmentCache> {
+	Arc::new(AssignmentCache {
+		entries: Cache::new(CACHE_CAPACITY),
+		next_generation: AtomicU64::new(0),
+	})
+}
+
+/// Resolves Substrate actor hostnames through the ate-api for dynamic route backends.
+#[apply(schema!)]
+pub struct SubstrateIngress {
+	/// Backend that receives ResumeActor calls and policies used when connecting to it.
+	#[serde(flatten)]
+	pub target: SimpleBackendReferenceWithPolicies,
+	/// Port on the resumed actor pod. Defaults to 80.
+	#[serde(default = "default_target_port")]
+	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]
+	pub target_port: NonZeroU16,
+	/// How long successful actor assignments are reused. Defaults to 5s; 0s disables reuse.
+	#[serde(default = "default_cache_ttl", with = "serde_dur")]
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	pub cache_ttl: Duration,
+	#[serde(skip, default = "default_cache")]
+	#[cfg_attr(feature = "schema", schemars(skip))]
+	cache: Arc<AssignmentCache>,
+}
+
+impl SubstrateIngress {
+	async fn resume_actor(
+		&self,
+		client: &PolicyClient,
+		actor: &ActorRef,
+	) -> Result<SocketAddr, ResumeError> {
+		tokio::time::timeout(RESUME_TIMEOUT, async {
+			let channel = self.target.grpc_channel(client.clone());
+			let mut control = protos::ateapi::control_client::ControlClient::new(channel);
+			let message = protos::ateapi::ResumeActorRequest {
+				actor: Some(protos::ateapi::ObjectRef {
+					atespace: actor.atespace.clone(),
+					name: actor.name.clone(),
+				}),
+				boot: false,
+			};
+			let mut delay = Duration::from_millis(200);
+			for attempt in 0..7 {
+				let response = {
+					let _scope = dtrace::start_scope(TRACE_POLICY_KIND);
+					control.resume_actor(message.clone()).await
+				};
+				match response {
+					Ok(response) => {
+						let actor = response.into_inner().actor.ok_or_else(|| {
+							ResumeError::InvalidResponse(
+								"ResumeActor response did not include an actor".to_owned(),
+							)
+						})?;
+						let ip = actor.ateom_pod_ip.parse::<IpAddr>().map_err(|error| {
+							ResumeError::InvalidResponse(format!(
+								"invalid ateom_pod_ip {:?}: {error}",
+								actor.ateom_pod_ip
+							))
+						})?;
+						return Ok(SocketAddr::new(ip, self.target_port.get()));
+					},
+					Err(status) if status.code() == Code::Aborted && attempt < 6 => {
+						tokio::time::sleep(delay).await;
+						delay = delay.mul_f64(1.5);
+					},
+					Err(status) => {
+						return Err(ResumeError::Status(
+							status.code(),
+							status.message().to_owned(),
+						));
+					},
+				}
+			}
+			unreachable!()
+		})
+		.await
+		.unwrap_or_else(|_| {
+			Err(ResumeError::Status(
+				Code::DeadlineExceeded,
+				"ResumeActor timed out after 15s".to_owned(),
+			))
+		})
+	}
+
+	async fn resolve(&self, client: &PolicyClient, actor: ActorRef) -> ResolutionResult {
+		loop {
+			match self.cache.entries.get_value_or_guard_async(&actor).await {
+				Ok(Ok(cached)) if cached.expires_at > Instant::now() => {
+					return Ok((cached, ResolutionSource::Cache));
+				},
+				Ok(Ok(expired)) => {
+					self.cache.remove_generation(&actor, expired.generation);
+				},
+				Ok(Err(error)) => {
+					self.cache.entries.remove_if(&actor, |entry| entry.is_err());
+					return Err((error, ResolutionSource::Cache));
+				},
+				Err(guard) => {
+					let result = self
+						.resume_actor(client, &actor)
+						.await
+						.map(|target| CachedAssignment {
+							target,
+							expires_at: Instant::now() + self.cache_ttl,
+							generation: self.cache.next_generation.fetch_add(1, Ordering::Relaxed),
+						});
+					let _ = guard.insert(result.clone());
+					match &result {
+						Err(_) => {
+							self.cache.entries.remove_if(&actor, |entry| entry.is_err());
+						},
+						Ok(cached) if self.cache_ttl.is_zero() => {
+							self.cache.remove_generation(&actor, cached.generation);
+						},
+						Ok(_) => {},
+					}
+					return result
+						.map(|assignment| (assignment, ResolutionSource::AteApi))
+						.map_err(|error| (error, ResolutionSource::AteApi));
+				},
+			}
+		}
+	}
+}
+
+impl SubstrateRequestState {
+	pub(crate) async fn resolve_target(&self) -> Result<Target, crate::proxy::ProxyResponse> {
+		if let Some(current) = self.current.lock().unwrap().as_ref() {
+			pol_event!(
+				TRACE_POLICY_KIND,
+				Severity::Info,
+				details = serde_json::json!({
+					"operation": "resumeActor",
+					"actor": self.actor.name,
+					"atespace": self.actor.atespace,
+					"source": ResolutionSource::Request.name(),
+					"cached": true,
+					"lookedUp": false,
+					"target": current.target.to_string(),
+				}),
+			);
+			return Ok(Target::Address(current.target));
+		}
+		match self.ingress.resolve(&self.client, self.actor.clone()).await {
+			Ok((assignment, source)) => {
+				let target = assignment.target;
+				pol_event!(
+					TRACE_POLICY_KIND,
+					Severity::Info,
+					details = serde_json::json!({
+						"operation": "resumeActor",
+						"actor": self.actor.name,
+						"atespace": self.actor.atespace,
+						"source": source.name(),
+						"cached": source.cached(),
+						"lookedUp": matches!(source, ResolutionSource::AteApi),
+						"target": target.to_string(),
+					}),
+				);
+				*self.current.lock().unwrap() = Some(assignment);
+				Ok(Target::Address(target))
+			},
+			Err((error, source)) => {
+				pol_event!(
+					TRACE_POLICY_KIND,
+					Severity::Error,
+					details = serde_json::json!({
+						"operation": "resumeActor",
+						"actor": self.actor.name,
+						"atespace": self.actor.atespace,
+						"source": source.name(),
+						"cached": source.cached(),
+						"lookedUp": matches!(source, ResolutionSource::AteApi),
+						"error": error.to_string(),
+					}),
+				);
+				match &error {
+					ResumeError::Status(code, message) => warn!(
+						actor = self.actor.name,
+						atespace = self.actor.atespace,
+						grpc.code = ?code,
+						grpc.message = message,
+						"substrate ResumeActor failed"
+					),
+					ResumeError::InvalidResponse(message) => warn!(
+						actor = self.actor.name,
+						atespace = self.actor.atespace,
+						error = message,
+						"substrate ResumeActor returned an invalid response"
+					),
+				}
+				Err(error.into_proxy_error(&self.actor).into())
+			},
+		}
+	}
+
+	pub(crate) fn evict(&self) {
+		if let Some(current) = self.current.lock().unwrap().take() {
+			self
+				.ingress
+				.cache
+				.remove_generation(&self.actor, current.generation);
+		}
+	}
+}
+
+pub(crate) fn is_stale_assignment(response: &Response) -> bool {
+	response.status() == StatusCode::MISDIRECTED_REQUEST
+		&& response
+			.headers()
+			.get(STALE_ASSIGNMENT_HEADER)
+			.is_some_and(|value| value == "true")
+}
+
+impl RequestPolicyTrait for SubstrateIngress {
+	async fn apply(
+		&self,
+		client: &PolicyClient,
+		log: &mut RequestLog,
+		req: &mut Request,
+	) -> Result<PolicyResponse, crate::proxy::ProxyResponse> {
+		let host = crate::http::get_host(req).unwrap_or_default();
+		let host = host.strip_suffix('.').unwrap_or(host);
+		let parsed = host
+			.strip_suffix(ACTOR_DNS_SUFFIX)
+			.and_then(|prefix| prefix.split_once('.'))
+			.filter(|(_, atespace)| !atespace.contains('.'));
+		let Some((name, atespace)) =
+			parsed.filter(|(name, atespace)| valid_resource_name(name) && valid_resource_name(atespace))
+		else {
+			return Err(
+				ProxyError::SubstrateIngressFailed(
+					StatusCode::NOT_FOUND,
+					format!("invalid host {host:?}: expected <actor>.<atespace>{ACTOR_DNS_SUFFIX}"),
+				)
+				.into(),
+			);
+		};
+
+		let actor = ActorRef {
+			atespace: atespace.to_owned(),
+			name: name.to_owned(),
+		};
+		log.ate_actor_id = Some(actor.name.clone());
+		log.ate_atespace = Some(actor.atespace.clone());
+		req.extensions_mut().insert(SubstrateRequestState {
+			actor,
+			ingress: self.clone(),
+			client: client.clone(),
+			current: Arc::new(Mutex::new(None)),
+		});
+		Ok(PolicyResponse::default())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::Arc;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
+	use ::http::Method;
+	use protos::ateapi::control_server::{Control, ControlServer};
+	use protos::ateapi::{Actor, GetActorRequest, ResumeActorRequest, ResumeActorResponse};
+	use tonic::{Request as GrpcRequest, Response as GrpcResponse, Status};
+	use wiremock::matchers::{header, method};
+	use wiremock::{Mock, MockServer, ResponseTemplate};
+
+	use super::STALE_ASSIGNMENT_HEADER;
+	use crate::strng;
+	use crate::test_helpers::proxymock::{
+		basic_named_route, send_request, setup_proxy_test, simple_bind,
+	};
+	use crate::types::agent::{Backend, ResourceName};
+
+	#[derive(Clone)]
+	struct MockControl {
+		pod_ip: String,
+		calls: Arc<AtomicUsize>,
+	}
+
+	#[tonic::async_trait]
+	impl Control for MockControl {
+		async fn get_actor(
+			&self,
+			_request: GrpcRequest<GetActorRequest>,
+		) -> Result<GrpcResponse<Actor>, Status> {
+			Err(Status::unimplemented("not used"))
+		}
+
+		async fn resume_actor(
+			&self,
+			request: GrpcRequest<ResumeActorRequest>,
+		) -> Result<GrpcResponse<ResumeActorResponse>, Status> {
+			let actor = request.into_inner().actor.unwrap();
+			if actor.name != "my-actor" || actor.atespace != "my-space" {
+				return Err(Status::invalid_argument("wrong actor"));
+			}
+			self.calls.fetch_add(1, Ordering::Relaxed);
+			Ok(GrpcResponse::new(ResumeActorResponse {
+				actor: Some(Actor {
+					ateom_pod_ip: self.pod_ip.clone(),
+					..Default::default()
+				}),
+			}))
+		}
+	}
+
+	#[tokio::test]
+	async fn stale_assignment_is_refreshed_then_cached() {
+		let actor = MockServer::start().await;
+		let actor_calls = Arc::new(AtomicUsize::new(0));
+		let responder_calls = actor_calls.clone();
+		Mock::given(method("GET"))
+			.and(header(
+				"host",
+				"my-actor.my-space.actors.resources.substrate.ate.dev",
+			))
+			.respond_with(move |_: &wiremock::Request| {
+				if responder_calls.fetch_add(1, Ordering::Relaxed) == 0 {
+					ResponseTemplate::new(421).insert_header(STALE_ASSIGNMENT_HEADER, "true")
+				} else {
+					ResponseTemplate::new(200)
+				}
+			})
+			.mount(&actor)
+			.await;
+		let control_calls = Arc::new(AtomicUsize::new(0));
+		let control = crate::test_helpers::spawn_service(ControlServer::new(MockControl {
+			pod_ip: actor.address().ip().to_string(),
+			calls: control_calls.clone(),
+		}))
+		.await;
+
+		let dynamic = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+		let mut proxy = setup_proxy_test("{}")
+			.unwrap()
+			.with_raw_backend(dynamic.into())
+			.with_bind(simple_bind())
+			.with_route(basic_named_route(strng::literal!("/dynamic")));
+		proxy
+			.attach_route_policy(serde_json::json!({
+				"substrateIngress": {
+					"host": control.address.to_string(),
+					"targetPort": actor.address().port(),
+					"cacheTtl": "5s"
+				}
+			}))
+			.await;
+		let client = proxy.serve_http("bind".into());
+
+		for _ in 0..2 {
+			let response = send_request(
+				client.clone(),
+				Method::GET,
+				"http://my-actor.my-space.actors.resources.substrate.ate.dev/",
+			)
+			.await;
+			assert_eq!(response.status(), ::http::StatusCode::OK);
+		}
+		assert_eq!(actor_calls.load(Ordering::Relaxed), 3);
+		assert_eq!(control_calls.load(Ordering::Relaxed), 2);
+	}
+}

--- a/crates/agentgateway/src/http/substrate/mod.rs
+++ b/crates/agentgateway/src/http/substrate/mod.rs
@@ -1,0 +1,25 @@
+mod egress;
+mod ingress;
+
+pub use egress::SubstrateEgress;
+pub use ingress::SubstrateIngress;
+pub(crate) use ingress::{SubstrateRequestState, is_stale_assignment};
+
+const CACHE_CAPACITY: usize = 10_000;
+const TRACE_POLICY_KIND: &str = "substrate";
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct ActorRef {
+	atespace: String,
+	name: String,
+}
+
+fn valid_resource_name(name: &str) -> bool {
+	let bytes = name.as_bytes();
+	(1..=63).contains(&bytes.len())
+		&& bytes.first().is_some_and(u8::is_ascii_alphanumeric)
+		&& bytes.last().is_some_and(u8::is_ascii_alphanumeric)
+		&& bytes
+			.iter()
+			.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'-')
+}

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -902,7 +902,7 @@ impl Gateway {
 					dtrace::DebugTracer::maybe_scope(req, |req| async move {
 						proxy.proxy(connection, req).map(Ok::<_, Infallible>).await
 					})
-					.assert_size::<{ 16 * 1024 }>(),
+					.assert_size::<{ 17 * 1024 }>(),
 				)
 			}),
 		);

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -182,6 +182,14 @@ async fn apply_request_policies(
 		.authorization
 		.apply_without_response("authorization", c, l, req, rp.headers())
 		.await?;
+	pol
+		.substrate_egress
+		.apply_without_response("substrate egress", c, l, req, rp.headers())
+		.await?;
+	pol
+		.substrate_ingress
+		.apply_without_response("substrate ingress", c, l, req, rp.headers())
+		.await?;
 
 	rp.llm_request_policies.local_rate_limit = pol
 		.local_rate_limit
@@ -679,7 +687,15 @@ impl HTTPProxy {
 		});
 
 		sensitive_headers(&mut req);
-		normalize_uri(log.tls_info.as_ref(), &mut req)
+		// TLS metadata may describe an outer CONNECT transport rather than the
+		// request currently being routed. In particular, a CONNECT tunnel that
+		// re-enters a plaintext HTTP bind retains the outer mTLS identity for
+		// authorization. Use the selected inner listener to determine the URI
+		// scheme so that dynamic backends do not incorrectly default to port 443.
+		let request_is_tls = selected_listener
+			.as_ref()
+			.is_some_and(|listener| matches!(listener.protocol, ListenerProtocol::HTTPS(_)));
+		normalize_uri(request_is_tls, &mut req)
 			.map_err(ProxyError::Processing)
 			.snapshot_on_err(log, &mut req)?;
 		let connect_upgrade = if req.method() == ::http::Method::CONNECT {
@@ -845,6 +861,7 @@ impl HTTPProxy {
 		// Register all expressions
 		route_policies.register_cel_expressions(log.cel.ctx());
 		let mut route_retry = route_policies.retry.select("retry", &req);
+		let explicit_route_retry = route_retry.is_some();
 		log.retry_backoff = route_retry.as_ref().and_then(|r| r.backoff);
 		// Evaluate the retry precondition (if any) against the request before it is consumed.
 		if let Some(retry) = route_retry.as_ref()
@@ -876,6 +893,12 @@ impl HTTPProxy {
 		.await
 		.snapshot_on_err(log, &mut req)?;
 		dtrace::snapshot!(Request, "route policies", &req);
+		// With no explicit retry policy, Substrate only retries stale actor assignments.
+		let substrate_default_retry = !explicit_route_retry
+			&& req
+				.extensions()
+				.get::<http::substrate::SubstrateRequestState>()
+				.is_some();
 
 		let selected_backend_ref = selected_route_chain
 			.backend
@@ -957,7 +980,11 @@ impl HTTPProxy {
 		let llm_request_policies = Arc::new(llm_request_policies);
 
 		// attempts is the total number of attempts, not the retries
-		let attempts = retries.as_ref().map(|r| r.attempts.get() + 1).unwrap_or(1);
+		let attempts = if substrate_default_retry {
+			3
+		} else {
+			retries.as_ref().map(|r| r.attempts.get() + 1).unwrap_or(1)
+		};
 		let retry_backoff = retries.as_ref().and_then(|r| r.backoff);
 		let request_timeout = response_policies
 			.timeout
@@ -973,13 +1000,17 @@ impl HTTPProxy {
 		} else {
 			Err(body)
 		};
+		let substrate_state = head
+			.extensions
+			.get::<http::substrate::SubstrateRequestState>()
+			.cloned();
 		let mut next = match body {
 			Ok(retry) => Some(retry),
 			Err(body) => {
 				trace!("no retries");
 				// no retries at all, just send the request as normal
 				let req = Request::from_parts(head, http::Body::new(body));
-				return self
+				let response = self
 					.attempt_upstream(
 						log,
 						&mut req_upgrade,
@@ -991,6 +1022,14 @@ impl HTTPProxy {
 						req,
 					)
 					.await;
+				// The body cannot be retried, but future requests must not reuse this assignment.
+				if response
+					.as_ref()
+					.is_ok_and(http::substrate::is_stale_assignment)
+				{
+					substrate_state.as_ref().inspect(|state| state.evict());
+				}
+				return response;
 			},
 		};
 		let mut last_res: Option<Result<Response, SnapshottedProxyResponse>> = None;
@@ -1028,12 +1067,22 @@ impl HTTPProxy {
 					req,
 				)
 				.await;
-			if last
-				|| !should_retry(
-					&res,
-					retries.as_ref().unwrap(),
-					log.request_snapshot.as_deref(),
-				) {
+			let stale_assignment = res.as_ref().is_ok_and(http::substrate::is_stale_assignment);
+			if stale_assignment {
+				// Clear the request-local assignment and evict the same generation from the shared cache.
+				substrate_state.as_ref().inspect(|state| state.evict());
+			}
+			let retryable = !last
+				&& if substrate_default_retry {
+					stale_assignment
+				} else {
+					should_retry(
+						&res,
+						retries.as_ref().unwrap(),
+						log.request_snapshot.as_deref(),
+					)
+				};
+			if !retryable {
 				if !last {
 					debug!("response not retry-able");
 				}
@@ -1776,7 +1825,13 @@ impl DerefMut for MustSnapshot<'_> {
 	}
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct DynamicBackendOverride(pub Target);
+
 fn target_from_request(req: &Request) -> Result<Target, ProxyError> {
+	if let Some(target) = req.extensions().get::<DynamicBackendOverride>() {
+		return Ok(target.0.clone());
+	}
 	let host = http::get_host(req)?;
 	let port = req
 		.uri()
@@ -1985,6 +2040,7 @@ async fn make_backend_call(
 		},
 		_ => (backend, base_policies),
 	};
+	handle_substrate_backend_selection(&mut req, backend).await?;
 
 	log.add(|l| {
 		l.backend_info = Some(backend.backend_info());
@@ -2591,6 +2647,37 @@ async fn make_backend_call(
 	let response_body_limit = crate::http::response_buffer_limit(&resp);
 	let resp = resp.map(|b| dtrace::TracingBody::maybe_wrap("response", b, response_body_limit));
 	Ok(resp)
+}
+
+/// Resolves a Substrate actor assignment into the generic override used by dynamic backends.
+async fn handle_substrate_backend_selection(
+	req: &mut MustSnapshot<'_>,
+	backend: &Backend,
+) -> Result<(), ProxyResponse> {
+	if let Some(state) = req
+		.extensions()
+		.get::<http::substrate::SubstrateRequestState>()
+		.cloned()
+	{
+		if !matches!(backend, Backend::Dynamic(_, _)) {
+			return Err(
+				ProxyError::ProcessingString(
+					"substrateIngress requires a dynamic route backend".to_owned(),
+				)
+				.into(),
+			);
+		}
+		let target = Box::pin(state.resolve_target()).await?;
+		req.extensions_mut().insert(DynamicBackendOverride(target));
+	} else if req.extensions().get::<DynamicBackendOverride>().is_some()
+		&& !matches!(backend, Backend::Dynamic(_, _))
+	{
+		return Err(
+			ProxyError::ProcessingString("substrateIngress requires a dynamic route backend".to_owned())
+				.into(),
+		);
+	}
+	Ok(())
 }
 
 fn set_backend_cel_context(req: &mut http::Request, log: Option<&&mut RequestLog>) {
@@ -3661,7 +3748,7 @@ fn sensitive_headers(req: &mut Request) {
 
 // The http library will not put the authority into req.uri().authority for HTTP/1. Normalize so
 // the rest of the code doesn't need to worry about it
-fn normalize_uri(tls: Option<&TLSConnectionInfo>, req: &mut Request) -> anyhow::Result<()> {
+fn normalize_uri(tls: bool, req: &mut Request) -> anyhow::Result<()> {
 	debug!("request before normalization: {req:?}");
 	if let ::http::Version::HTTP_10 | ::http::Version::HTTP_11 = req.version() {
 		let host = req.headers_mut().remove(http::header::HOST);
@@ -3675,7 +3762,7 @@ fn normalize_uri(tls: Option<&TLSConnectionInfo>, req: &mut Request) -> anyhow::
 			parts.authority = Some(host);
 			if parts.path_and_query.is_some() {
 				// TODO: or always do this?
-				if tls.is_some() {
+				if tls {
 					parts.scheme = Some(Scheme::HTTPS);
 				} else {
 					parts.scheme = Some(Scheme::HTTP);

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -54,6 +54,8 @@ impl ProxyResponse {
 			| ProxyError::MethodNotAllowed
 			| ProxyError::ProcessingString(_)
 			| ProxyError::Processing(_)
+			| ProxyError::SubstrateIngressFailed(_, _)
+			| ProxyError::SubstrateEgressUnavailable(_)
 			| ProxyError::RouteCycleDetected
 			| ProxyError::Body(_)
 			| ProxyError::Http(_)
@@ -66,9 +68,9 @@ impl ProxyResponse {
 			ProxyError::APIKeyAuthenticationFailure(_) => ProxyResponseReason::APIKeyAuth,
 			ProxyError::ExternalAuthorizationFailed(_) => ProxyResponseReason::ExtAuth,
 			ProxyError::MCP(_) => ProxyResponseReason::MCP,
-			ProxyError::AuthorizationFailed | ProxyError::CsrfValidationFailed => {
-				ProxyResponseReason::Authorization
-			},
+			ProxyError::AuthorizationFailed
+			| ProxyError::SubstrateEgressDenied(_)
+			| ProxyError::CsrfValidationFailed => ProxyResponseReason::Authorization,
 			ProxyError::UpstreamCallFailed(_)
 			| ProxyError::UpstreamTCPCallFailed(_)
 			| ProxyError::BackendAuthenticationFailed(_)
@@ -201,6 +203,12 @@ pub enum ProxyError {
 	ExtProc(#[from] ext_proc::Error),
 	#[error("processing failed: {0}")]
 	ProcessingString(String),
+	#[error("{1}")]
+	SubstrateIngressFailed(StatusCode, String),
+	#[error("{0}")]
+	SubstrateEgressDenied(String),
+	#[error("{0}")]
+	SubstrateEgressUnavailable(String),
 	#[error("rate limit exceeded")]
 	RateLimitExceeded {
 		limit: u64,
@@ -281,6 +289,8 @@ impl ProxyError {
 			ProxyError::APIKeyAuthenticationFailure(_) => StatusCode::UNAUTHORIZED,
 			ProxyError::McpJwtAuthenticationFailure(_, _) => StatusCode::UNAUTHORIZED,
 			ProxyError::AuthorizationFailed => StatusCode::FORBIDDEN,
+			ProxyError::SubstrateEgressDenied(_) => StatusCode::FORBIDDEN,
+			ProxyError::SubstrateEgressUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
 			ProxyError::ExternalAuthorizationFailed(status) => status.unwrap_or(StatusCode::FORBIDDEN),
 
 			ProxyError::DnsResolution => StatusCode::SERVICE_UNAVAILABLE,
@@ -293,6 +303,7 @@ impl ProxyError {
 			ProxyError::Http(_) => StatusCode::SERVICE_UNAVAILABLE,
 			ProxyError::Body(_) => StatusCode::SERVICE_UNAVAILABLE,
 			ProxyError::ProcessingString(_) => StatusCode::SERVICE_UNAVAILABLE,
+			ProxyError::SubstrateIngressFailed(status, _) => status,
 			ProxyError::RateLimitExceeded { .. } => StatusCode::TOO_MANY_REQUESTS,
 			// Rate limit service communication failure is a server error (500), not a rate limit (429).
 			// This matches Envoy's behavior (status_on_error defaults to 500).

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -16,7 +16,9 @@ use crate::http::auth::BackendAuth;
 use crate::http::authorization::{HTTPAuthorizationSet, NetworkAuthorizationSet};
 use crate::http::backendtls::BackendTLS;
 use crate::http::ext_proc::InferenceRouting;
-use crate::http::{ext_authz, ext_proc, filters, health, oidc, remoteratelimit, retry, timeout};
+use crate::http::{
+	ext_authz, ext_proc, filters, health, oidc, remoteratelimit, retry, substrate, timeout,
+};
 use crate::llm::policy::ResponseGuard;
 use crate::mcp::McpAuthorizationSet;
 use crate::proxy::dtrace;
@@ -356,6 +358,8 @@ pub struct RoutePolicies {
 	pub basic_auth: RequestPolicy<http::basicauth::BasicAuthentication>,
 	pub api_key: RequestPolicy<http::apikey::APIKeyAuthentication>,
 	pub ext_authz: RequestPolicy<ext_authz::ExtAuthz>,
+	pub substrate_egress: RequestPolicy<substrate::SubstrateEgress>,
+	pub substrate_ingress: RequestPolicy<substrate::SubstrateIngress>,
 	pub ext_proc: RequestPolicy<ext_proc::ExtProc>,
 	pub transformation: RequestPolicy<http::transformation_cel::Transformation>,
 	pub csrf: RequestPolicy<http::csrf::Csrf>,
@@ -424,6 +428,8 @@ impl RoutePolicies {
 			&self.basic_auth as &dyn PolicyExpressions,
 			&self.api_key as &dyn PolicyExpressions,
 			&self.ext_authz as &dyn PolicyExpressions,
+			&self.substrate_egress as &dyn PolicyExpressions,
+			&self.substrate_ingress as &dyn PolicyExpressions,
 			&self.ext_proc as &dyn PolicyExpressions,
 			&self.transformation as &dyn PolicyExpressions,
 			&self.csrf as &dyn PolicyExpressions,
@@ -942,6 +948,16 @@ impl Store {
 				},
 				TrafficPolicy::Buffer(p) => {
 					pol.buffer.set_if_unset(p);
+				},
+				TrafficPolicy::SubstrateIngress(p) => {
+					pol
+						.substrate_ingress
+						.merge_with_inheritance(p, lock_inheritance);
+				},
+				TrafficPolicy::SubstrateEgress(p) => {
+					pol
+						.substrate_egress
+						.merge_with_inheritance(p, lock_inheritance);
 				},
 			}
 		}

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -935,6 +935,8 @@ impl RequestLog {
 			llm_response: Default::default(),
 			a2a_method: None,
 			inference_pool: None,
+			ate_actor_id: None,
+			ate_atespace: None,
 			request_handle: None,
 			request_snapshot: None,
 			response_snapshot: None,
@@ -1089,6 +1091,9 @@ pub struct RequestLog {
 	pub a2a_method: Option<Strng>,
 
 	pub inference_pool: Option<SocketAddr>,
+
+	pub ate_actor_id: Option<String>,
+	pub ate_atespace: Option<String>,
 
 	pub request_handle: Option<ActiveHandle>,
 	pub request_snapshot: Option<Arc<cel::RequestSnapshot>>,
@@ -1418,6 +1423,8 @@ impl Drop for DropOnLog {
 					"inferencepool.selected_endpoint",
 					log.inference_pool.display(),
 				),
+				("ate.actor.id", log.ate_actor_id.display()),
+				("ate.atespace", log.ate_atespace.display()),
 				// OpenTelemetry Gen AI Semantic Conventions v1.40.0
 				(
 					"gen_ai.operation.name",

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -171,6 +171,7 @@ pub enum OutboundCallSubtype {
 
 	// Policy
 	ExtAuthz,
+	Substrate,
 	ExtProc,
 	Guardrail,
 	RateLimit,

--- a/crates/agentgateway/src/test_helpers/ateapimock.rs
+++ b/crates/agentgateway/src/test_helpers/ateapimock.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use protos::ateapi::control_server::{Control, ControlServer};
+use protos::ateapi::{Actor, GetActorRequest, ResumeActorRequest, ResumeActorResponse};
+use tonic::{Request, Response, Status};
+
+#[async_trait]
+pub trait Handler {
+	async fn get_actor(&mut self, _request: &GetActorRequest) -> Result<Actor, Status> {
+		Err(Status::unimplemented("GetActor is not implemented"))
+	}
+
+	async fn resume_actor(
+		&mut self,
+		_request: &ResumeActorRequest,
+	) -> Result<ResumeActorResponse, Status> {
+		Err(Status::unimplemented("ResumeActor is not implemented"))
+	}
+}
+
+/// Mock Substrate ate-api server for testing.
+pub struct AteApiMock<T> {
+	handler: Arc<dyn Fn() -> T + Send + Sync + 'static>,
+}
+
+impl<T> Clone for AteApiMock<T> {
+	fn clone(&self) -> Self {
+		Self {
+			handler: self.handler.clone(),
+		}
+	}
+}
+
+impl<T> AteApiMock<T>
+where
+	T: Handler + Send + Sync + 'static,
+{
+	pub fn new(handler: impl Fn() -> T + Send + Sync + 'static) -> Self {
+		Self {
+			handler: Arc::new(handler),
+		}
+	}
+
+	pub async fn spawn(&self) -> super::common::MockInstance {
+		super::common::spawn_service(ControlServer::new(self.clone())).await
+	}
+
+	pub async fn spawn_on(&self, address: std::net::SocketAddr) -> super::common::MockInstance {
+		super::common::spawn_service_on(ControlServer::new(self.clone()), address).await
+	}
+}
+
+#[tonic::async_trait]
+impl<T> Control for AteApiMock<T>
+where
+	T: Handler + Send + Sync + 'static,
+{
+	async fn get_actor(&self, request: Request<GetActorRequest>) -> Result<Response<Actor>, Status> {
+		let mut handler = (self.handler)();
+		Ok(Response::new(handler.get_actor(request.get_ref()).await?))
+	}
+
+	async fn resume_actor(
+		&self,
+		request: Request<ResumeActorRequest>,
+	) -> Result<Response<ResumeActorResponse>, Status> {
+		let mut handler = (self.handler)();
+		Ok(Response::new(
+			handler.resume_actor(request.get_ref()).await?,
+		))
+	}
+}

--- a/crates/agentgateway/src/test_helpers/mod.rs
+++ b/crates/agentgateway/src/test_helpers/mod.rs
@@ -1,3 +1,4 @@
+pub mod ateapimock;
 pub mod extauthmock;
 pub mod extmcpmock;
 pub mod extprocmock;
@@ -8,6 +9,8 @@ mod policy;
 pub mod proxymock;
 pub mod ratelimitmock;
 pub use common::MockInstance;
+#[cfg(test)]
+pub(crate) use common::spawn_service;
 #[cfg(any(test, feature = "internal_benches"))]
 pub use policy::{policy_client, test_policy};
 

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -916,6 +916,7 @@ impl TestBind {
 			});
 		}
 	}
+
 	pub async fn attach_gateway_policy(&mut self, p: serde_json::Value) {
 		let oidc_key = strng::format!("pol/{}", self.policies + 1);
 		let pol: local::FilterOrPolicy = serde_json::from_value(p).unwrap();

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2649,6 +2649,8 @@ pub enum TrafficPolicy {
 	LocalRateLimit(RequestPolicy<Vec<crate::http::localratelimit::RateLimit>>),
 	RemoteRateLimit(RequestPolicy<remoteratelimit::RemoteRateLimit>),
 	ExtAuthz(RequestPolicy<ext_authz::ExtAuthz>),
+	SubstrateEgress(RequestPolicy<crate::http::substrate::SubstrateEgress>),
+	SubstrateIngress(RequestPolicy<crate::http::substrate::SubstrateIngress>),
 	ExtProc(RequestPolicy<ext_proc::ExtProc>),
 	JwtAuth(RequestPolicy<JwtAuthentication>),
 	Oidc(RequestPolicy<crate::http::oidc::OidcPolicy>),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -3276,6 +3276,8 @@ fn traffic_policy_kind_name(policy: &TrafficPolicy) -> &'static str {
 		TrafficPolicy::LocalRateLimit(_) => "localRateLimit",
 		TrafficPolicy::RemoteRateLimit(_) => "remoteRateLimit",
 		TrafficPolicy::ExtAuthz(_) => "extAuthz",
+		TrafficPolicy::SubstrateEgress(_) => "substrateEgress",
+		TrafficPolicy::SubstrateIngress(_) => "substrateIngress",
 		TrafficPolicy::ExtProc(_) => "extProc",
 		TrafficPolicy::JwtAuth(_) => "jwt",
 		TrafficPolicy::Oidc(_) => "oidc",

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2733,6 +2733,12 @@ pub struct FilterOrPolicy {
 	/// Send request and response data to an external processing service.
 	#[serde(default)]
 	ext_proc: Option<LocalExtProcPolicy>,
+	/// Resolve Substrate actor hostnames for dynamic route backends on ingress.
+	#[serde(default)]
+	substrate_ingress: Option<crate::http::substrate::SubstrateIngress>,
+	/// Authorize CONNECT egress using the originating actor's dynamic policy.
+	#[serde(default)]
+	substrate_egress: Option<crate::http::substrate::SubstrateEgress>,
 	/// Modify request and response headers, bodies, or metadata.
 	#[serde(default)]
 	#[cfg_attr(
@@ -5122,6 +5128,8 @@ pub(crate) async fn split_policies_for_target(
 		csrf,
 		ext_authz,
 		ext_proc,
+		substrate_ingress,
+		substrate_egress,
 		buffer,
 		timeout,
 		retry,
@@ -5288,6 +5296,12 @@ pub(crate) async fn split_policies_for_target(
 	}
 	if let Some(p) = ext_proc {
 		route_policies.push(TrafficPolicy::ExtProc(p.into_policy()?))
+	}
+	if let Some(p) = substrate_ingress {
+		route_policies.push(TrafficPolicy::SubstrateIngress(RequestPolicy::single(p)))
+	}
+	if let Some(p) = substrate_egress {
+		route_policies.push(TrafficPolicy::SubstrateEgress(RequestPolicy::single(p)))
 	}
 	if let Some(p) = local_rate_limit
 		&& !p.is_empty()

--- a/crates/agentgateway/tests/tests/mod.rs
+++ b/crates/agentgateway/tests/tests/mod.rs
@@ -10,5 +10,6 @@ mod llm;
 mod llm_providers;
 mod policy;
 mod smoke;
+mod substrate;
 mod tls;
 mod waypoint;

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -1,0 +1,134 @@
+use agentgateway::test_helpers::ateapimock;
+use agentgateway::types::agent::{Backend, BindMode};
+use protos::ateapi::{Actor, ResumeActorResponse};
+
+use crate::common::prelude::*;
+
+#[derive(Clone)]
+struct IngressHandler {
+	pod_ip: String,
+	calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl ateapimock::Handler for IngressHandler {
+	async fn resume_actor(
+		&mut self,
+		request: &protos::ateapi::ResumeActorRequest,
+	) -> Result<ResumeActorResponse, tonic::Status> {
+		let actor = request.actor.as_ref().unwrap();
+		assert_eq!(actor.atespace, "demo");
+		assert_eq!(actor.name, "my-actor");
+		self.calls.fetch_add(1, Ordering::Relaxed);
+		Ok(ResumeActorResponse {
+			actor: Some(Actor {
+				ateom_pod_ip: self.pod_ip.clone(),
+				..Default::default()
+			}),
+		})
+	}
+}
+
+#[tokio::test]
+async fn actor_ingress_resolves_the_dynamic_backend() {
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || IngressHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+		}
+	})
+	.spawn()
+	.await;
+
+	let dynamic = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+	let mut gateway = setup_proxy_test("{}")
+		.unwrap()
+		.with_raw_backend(dynamic.into())
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::literal!("/dynamic")));
+	gateway
+		.attach_route_policy(json!({
+			"substrateIngress": {
+				"host": api.address.to_string(),
+				"targetPort": actor.address().port(),
+			}
+		}))
+		.await;
+
+	let response = send_request(
+		gateway.serve_http(BIND_KEY),
+		Method::GET,
+		"http://my-actor.demo.actors.resources.substrate.ate.dev/",
+	)
+	.await;
+	assert_eq!(response.status(), StatusCode::OK);
+	assert_eq!(calls.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn substrate_egress_authorizes_a_reentered_connect_request() {
+	let upstream = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+
+	let mut outer = simple_bind();
+	outer.key = strng::literal!("outer");
+	outer.address = "127.0.0.1:15012".parse().unwrap();
+	let mut inner = simple_bind();
+	inner.address = "127.0.0.1:18080".parse().unwrap();
+	inner.mode = BindMode::Internal;
+	let mut gateway = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*upstream.address())
+		.with_bind(outer)
+		.with_bind(inner)
+		.with_route(basic_route(*upstream.address()))
+		.with_connect_mode_on_port(agentgateway::types::frontend::ConnectMode::Tunnel, 15012);
+	gateway
+		.attach_route_policy(json!({
+			"substrateEgress": {
+				"host": "http://dummy", // Egress is not yet implemented
+			}
+		}))
+		.await;
+
+	let mut io = gateway.serve_tunnel(strng::literal!("outer"));
+	io.write_all(
+		b"CONNECT allowed.example:18080 HTTP/1.1\r\nHost: allowed.example:18080\r\nX-Ate-Atespace: demo\r\nX-Ate-Actor: my-actor\r\nX-Ate-Actor-Version: 1\r\n\r\n",
+	)
+	.await
+	.unwrap();
+	let mut response = Vec::new();
+	loop {
+		let mut chunk = [0; 1024];
+		let n = io.read(&mut chunk).await.unwrap();
+		assert!(n > 0, "CONNECT response unexpectedly closed");
+		response.extend_from_slice(&chunk[..n]);
+		if response.windows(4).any(|window| window == b"\r\n\r\n") {
+			break;
+		}
+	}
+	assert!(
+		String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK\r\n"),
+		"unexpected CONNECT response: {}",
+		String::from_utf8_lossy(&response),
+	);
+
+	io.write_all(b"GET / HTTP/1.1\r\nHost: allowed.example\r\nConnection: close\r\n\r\n")
+		.await
+		.unwrap();
+	let mut tunneled = Vec::new();
+	tokio::time::timeout(Duration::from_secs(5), io.read_to_end(&mut tunneled))
+		.await
+		.expect("timed out waiting for tunneled response")
+		.unwrap();
+	assert!(
+		String::from_utf8_lossy(&tunneled).starts_with("HTTP/1.1 200 OK\r\n"),
+		"unexpected tunneled response: {}",
+		String::from_utf8_lossy(&tunneled),
+	);
+	assert_eq!(calls.load(Ordering::Relaxed), 0);
+}

--- a/crates/protos/build.rs
+++ b/crates/protos/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), anyhow::Error> {
 		"proto/ext_mcp.proto",
 		"proto/ext_proc.proto",
 		"proto/rls.proto",
+		"proto/ateapi.proto",
 		"proto/workload.proto",
 		"proto/resource.proto",
 	]

--- a/crates/protos/proto/ateapi.proto
+++ b/crates/protos/proto/ateapi.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package ateapi;
+
+// Minimal wire-compatible subset of the Substrate control API used by
+// agentgateway's actor policies.
+service Control {
+  rpc GetActor(GetActorRequest) returns (Actor) {}
+  rpc ResumeActor(ResumeActorRequest) returns (ResumeActorResponse) {}
+}
+
+message Actor {
+  ResourceMetadata metadata = 1;
+  string ateom_pod_ip = 7;
+//  ActorEgressPolicy egress_policy = 13;
+}
+
+message ResourceMetadata {
+  int64 version = 4;
+}
+
+//message ActorEgressPolicy {
+//  repeated ActorEgressHost hosts = 1;
+//}
+//
+//message ActorEgressHost {
+//  string hostname = 1;
+//}
+
+message ObjectRef {
+  string atespace = 1;
+  string name = 2;
+}
+
+message ResumeActorRequest {
+  ObjectRef actor = 1;
+  bool boot = 2;
+}
+
+message ResumeActorResponse {
+  Actor actor = 1;
+}
+
+message GetActorRequest {
+  ObjectRef actor = 1;
+}

--- a/crates/protos/src/lib.rs
+++ b/crates/protos/src/lib.rs
@@ -79,3 +79,9 @@ pub mod ext_mcp {
 pub mod workload {
 	pub use crate::istio::workload::*;
 }
+
+#[allow(warnings)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+pub mod ateapi {
+	tonic::include_proto!("ateapi");
+}

--- a/schema/config.json
+++ b/schema/config.json
@@ -1827,6 +1827,30 @@
             }
           ]
         },
+        "substrateIngress": {
+          "description": "Resolve Substrate actor hostnames for dynamic route backends on ingress.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubstrateIngress"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "substrateEgress": {
+          "description": "Authorize CONNECT egress using the originating actor's dynamic policy.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubstrateEgress"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "transformations": {
           "description": "Modify request and response headers, bodies, or metadata.",
           "anyOf": [
@@ -6626,6 +6650,168 @@
         }
       },
       "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "description": "Service reference. Service must be defined in the top level services list.",
+          "type": "object",
+          "properties": {
+            "service": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of the target Service, as defined in the top-level `services` list.",
+                  "$ref": "#/$defs/NamespacedHostname"
+                },
+                "port": {
+                  "description": "Port on the target Service to route to.",
+                  "type": "integer",
+                  "format": "uint16",
+                  "minimum": 0,
+                  "maximum": 65535
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "port"
+              ]
+            }
+          },
+          "required": [
+            "service"
+          ]
+        },
+        {
+          "description": "Hostname or IP address",
+          "type": "object",
+          "properties": {
+            "host": {
+              "description": "Hostname or IP address",
+              "type": "string"
+            }
+          },
+          "required": [
+            "host"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "backend": {
+              "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+              "type": "string"
+            }
+          },
+          "required": [
+            "backend"
+          ]
+        }
+      ]
+    },
+    "SubstrateIngress": {
+      "description": "Resolves Substrate actor hostnames through the ate-api for dynamic route backends.",
+      "type": "object",
+      "properties": {
+        "policies": {
+          "description": "Backend policies used when connecting to the service.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "targetPort": {
+          "description": "Port on the resumed actor pod. Defaults to 80.",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 80
+        },
+        "cacheTtl": {
+          "description": "How long successful actor assignments are reused. Defaults to 5s; 0s disables reuse.",
+          "type": "string",
+          "default": "5s"
+        }
+      },
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "description": "Service reference. Service must be defined in the top level services list.",
+          "type": "object",
+          "properties": {
+            "service": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "Name of the target Service, as defined in the top-level `services` list.",
+                  "$ref": "#/$defs/NamespacedHostname"
+                },
+                "port": {
+                  "description": "Port on the target Service to route to.",
+                  "type": "integer",
+                  "format": "uint16",
+                  "minimum": 0,
+                  "maximum": 65535
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "port"
+              ]
+            }
+          },
+          "required": [
+            "service"
+          ]
+        },
+        {
+          "description": "Hostname or IP address",
+          "type": "object",
+          "properties": {
+            "host": {
+              "description": "Hostname or IP address",
+              "type": "string"
+            }
+          },
+          "required": [
+            "host"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "backend": {
+              "description": "Explicit backend reference. Backend must be defined in the top level backends list",
+              "type": "string"
+            }
+          },
+          "required": [
+            "backend"
+          ]
+        }
+      ]
+    },
+    "SubstrateEgress": {
+      "description": "Authorizes an actor's egress to the hostname recovered from an internal CONNECT listener.",
+      "type": "object",
+      "properties": {
+        "policies": {
+          "description": "Backend policies used when connecting to the service.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SimpleLocalBackendPolicies"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
       "oneOf": [
         {
           "description": "Service reference. Service must be defined in the top level services list.",


### PR DESCRIPTION
This adds support for substrate routing. This includes and ingress and egress substrate policy. For now, the egress does mostly nothing until an egress API is decided on in substrate.