### PR TITLE
fix(config): fail startup when a static local bind cannot be opened

### DIFF
--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -211,7 +211,7 @@ impl LocalClient {
 			config.backends,
 			config.route_groups,
 			prev.binds,
-		);
+		)?;
 		let next_discovery =
 			self
 				.stores

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -202,8 +202,9 @@ impl LocalClient {
 		.await?;
 		info!("loaded config from {:?}", self.cfg);
 
-		// Sync the state
-		let next_binds = self.stores.binds.sync_local(
+		// Sync binds first, but always run discovery sync even when a new bind cannot open.
+		// Propagating bind errors before discovery sync would skip workload/service state.
+		let bind_result = self.stores.binds.sync_local(
 			config.binds,
 			config.listener_routes,
 			config.listener_tcp_routes,
@@ -211,12 +212,13 @@ impl LocalClient {
 			config.backends,
 			config.route_groups,
 			prev.binds,
-		)?;
+		);
 		let next_discovery =
 			self
 				.stores
 				.discovery
 				.sync_local(config.services, config.workloads, prev.discovery)?;
+		let next_binds = bind_result?;
 
 		Ok(PreviousState {
 			binds: next_binds,

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -260,7 +260,7 @@ impl LocalClient {
 			config.backends,
 			config.route_groups,
 			prev.binds,
-		);
+		)?;
 		let next_discovery =
 			self
 				.stores

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -251,8 +251,9 @@ impl LocalClient {
 		self.model_catalog.replace_sources(model_catalog).await?;
 		info!("loaded config from {:?}", self.cfg);
 
-		// Sync the state
-		let next_binds = self.stores.binds.sync_local(
+		// Sync binds first, but always run discovery sync even when a new bind cannot open.
+		// Propagating bind errors before discovery sync would skip workload/service state.
+		let bind_result = self.stores.binds.sync_local(
 			config.binds,
 			config.listener_routes,
 			config.listener_tcp_routes,
@@ -260,12 +261,13 @@ impl LocalClient {
 			config.backends,
 			config.route_groups,
 			prev.binds,
-		)?;
+		);
 		let next_discovery =
 			self
 				.stores
 				.discovery
 				.sync_local(config.services, config.workloads, prev.discovery)?;
+		let next_binds = bind_result?;
 
 		Ok(PreviousState {
 			binds: next_binds,

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -724,7 +724,7 @@ impl Store {
 		Arc::make_mut(routes).insert(route);
 	}
 
-	fn upsert_bind(&mut self, key: BindKey, mut bind: Bind) {
+	fn upsert_bind(&mut self, key: BindKey, mut bind: Bind) -> anyhow::Result<()> {
 		debug!(bind=%bind.key, "insert bind");
 		let old_bind = self.binds.get(&key).cloned();
 
@@ -738,6 +738,10 @@ impl Store {
 			bind.listeners.insert(listener);
 		}
 
+		// Capture (rather than swallow) any OS bind failure so callers can decide whether it
+		// is fatal. The bind is still recorded below so routing lookups (find_bind, etc.)
+		// remain consistent regardless of the caller's error handling.
+		let mut bind_error = None;
 		let listeners = if self.binds.contains_key(&key) {
 			None
 		} else if bind.mode == agent::BindMode::Internal {
@@ -759,7 +763,7 @@ impl Store {
 					Some(listeners)
 				},
 				Err(err) => {
-					warn!(bind=%key, address=%bind.address, error=%err, "failed to start bind listener");
+					bind_error = Some(err);
 					None
 				},
 			}
@@ -773,6 +777,10 @@ impl Store {
 		if let Some(listeners) = listeners {
 			let _ = self.tx.send(BindEvent::Add(bind, listeners));
 		}
+		if let Some(err) = bind_error {
+			return Err(err.context(format!("bind {key}")));
+		}
+		Ok(())
 	}
 
 	pub fn subscribe(&mut self) -> impl Stream<Item = BindEvent> + use<> {
@@ -1455,7 +1463,11 @@ impl Store {
 		};
 		let mut bind = Arc::unwrap_or_clone(bind);
 		bind.listeners.remove(&listener);
-		self.upsert_bind(bind_key, bind);
+		// Removing a listener never opens a new socket (the bind already exists), so this
+		// cannot fail on bind; log defensively rather than propagate.
+		if let Err(err) = self.upsert_bind(bind_key, bind) {
+			warn!(error=%err, "failed to update bind after listener removal");
+		}
 	}
 
 	pub fn remove_route_group(&mut self, rg: RouteGroupKey) {
@@ -1521,7 +1533,12 @@ impl Store {
     )]
 	pub fn insert_bind(&mut self, bind: Bind) {
 		let key = bind.key.clone();
-		self.upsert_bind(key, bind);
+		// XDS-delivered binds must not crash the proxy on a bind failure: a bad dynamic config
+		// should be rejected/logged, not fatal. Static local config uses `sync_local`, which
+		// surfaces the error so startup can exit(1) (see issue #87).
+		if let Err(err) = self.upsert_bind(key.clone(), bind) {
+			warn!(bind=%key, error=%err, "failed to start bind listener");
+		}
 	}
 
 	pub fn insert_backend(&mut self, key: BackendKey, b: BackendWithPolicies) {
@@ -1555,7 +1572,9 @@ impl Store {
 			let mut bind = Arc::unwrap_or_clone(b.clone());
 			bind.listeners.remove(&lis.key);
 			bind.listeners.insert(lis);
-			self.upsert_bind(bind_name, bind);
+			if let Err(err) = self.upsert_bind(bind_name.clone(), bind) {
+				warn!(bind=%bind_name, error=%err, "failed to start bind listener");
+			}
 		} else {
 			debug!("no bind found, keeping listener pending");
 			self
@@ -1868,7 +1887,7 @@ impl StoreUpdater {
 		backends: Vec<BackendWithPolicies>,
 		route_groups: Vec<(RouteGroupKey, Vec<Route>)>,
 		prev: PreviousState,
-	) -> PreviousState {
+	) -> anyhow::Result<PreviousState> {
 		let mut s = self.state.write().expect("mutex acquired");
 		let mut old_binds = prev.binds;
 		let mut old_routes = prev.routes;
@@ -1884,10 +1903,17 @@ impl StoreUpdater {
 			backends: Default::default(),
 			route_groups: Default::default(),
 		};
+		// Unlike XDS (which must tolerate a bad dynamic config), a static local config that
+		// cannot bind a listener is a fatal misconfiguration. Collect any bind failures and
+		// surface them so startup exits(1) rather than silently serving nothing (issue #87).
+		let mut bind_errors = Vec::new();
 		for b in binds {
 			old_binds.remove(&b.key);
 			next_state.binds.insert(b.key.clone());
-			s.insert_bind(b);
+			let key = b.key.clone();
+			if let Err(err) = s.upsert_bind(key, b) {
+				bind_errors.push(format!("{err:#}"));
+			}
 		}
 		for b in backends {
 			// Here we use the 'name' as the key. This is appropriate for local case only
@@ -1939,7 +1965,13 @@ impl StoreUpdater {
 		for remaining_rg in old_route_groups {
 			s.remove_route_group(remaining_rg);
 		}
-		next_state
+		if !bind_errors.is_empty() {
+			anyhow::bail!(
+				"failed to start bind listener(s): {}",
+				bind_errors.join("; ")
+			);
+		}
+		Ok(next_state)
 	}
 }
 
@@ -2170,6 +2202,69 @@ mod tests {
 				.as_ref()
 				.is_some_and(|routes| routes.contains(&strng::literal!("route")))
 		);
+	}
+
+	fn standard_bind(address: std::net::SocketAddr) -> Bind {
+		Bind {
+			key: strng::literal!("bind"),
+			address,
+			protocol: BindProtocol::http,
+			tunnel_protocol: TunnelProtocol::Direct,
+			mode: agent::BindMode::Standard,
+			listeners: ListenerSet::from_list([Listener {
+				key: strng::literal!("listener"),
+				name: ListenerName {
+					gateway_name: strng::literal!("gw"),
+					gateway_namespace: strng::literal!("ns"),
+					listener_name: strng::literal!("listener"),
+					listener_set: None,
+				},
+				hostname: strng::literal!("example.com"),
+				protocol: ListenerProtocol::HTTP,
+			}]),
+		}
+	}
+
+	// Regression for issue #87: a static local config that cannot open its listener socket
+	// must fail loudly (so startup can exit(1)) rather than silently binding nothing.
+	#[test]
+	fn sync_local_bind_failure_is_fatal() {
+		// Hold an active listener so the same address cannot be bound again.
+		let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+		let addr = occupied.local_addr().expect("probe addr");
+
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
+		let err = updater
+			.sync_local(
+				vec![standard_bind(addr)],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				Default::default(),
+			)
+			.expect_err("bind on an occupied port must fail");
+		assert!(
+			err.to_string().contains("failed to start bind listener"),
+			"unexpected error: {err:#}"
+		);
+	}
+
+	#[test]
+	fn sync_local_bind_success_returns_ok() {
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
+		updater
+			.sync_local(
+				vec![standard_bind("127.0.0.1:0".parse().unwrap())],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				Default::default(),
+			)
+			.expect("bind on an ephemeral port should succeed");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -2295,10 +2295,7 @@ mod tests {
 		new_bind.key = strng::literal!("bind2");
 		let err = updater
 			.sync_local(
-				vec![
-					standard_bind("127.0.0.1:0".parse().unwrap()),
-					new_bind,
-				],
+				vec![standard_bind("127.0.0.1:0".parse().unwrap()), new_bind],
 				vec![],
 				vec![],
 				vec![],

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1889,6 +1889,7 @@ impl StoreUpdater {
 		prev: PreviousState,
 	) -> anyhow::Result<PreviousState> {
 		let mut s = self.state.write().expect("mutex acquired");
+		let prev_bind_keys = prev.binds.clone();
 		let mut old_binds = prev.binds;
 		let mut old_routes = prev.routes;
 		let mut old_tcp_routes = prev.tcp_routes;
@@ -1904,14 +1905,19 @@ impl StoreUpdater {
 			route_groups: Default::default(),
 		};
 		// Unlike XDS (which must tolerate a bad dynamic config), a static local config that
-		// cannot bind a listener is a fatal misconfiguration. Collect any bind failures and
-		// surface them so startup exits(1) rather than silently serving nothing (issue #87).
+		// cannot open a newly added listener is a fatal misconfiguration. Only treat bind
+		// failures for binds introduced after the previous sync as errors: existing binds are
+		// not re-opened, and a reload that adds a new port after startup must not silently
+		// serve nothing on that bind (issue #87).
 		let mut bind_errors = Vec::new();
 		for b in binds {
+			let is_new_bind = !prev_bind_keys.contains(&b.key);
 			old_binds.remove(&b.key);
 			next_state.binds.insert(b.key.clone());
 			let key = b.key.clone();
-			if let Err(err) = s.upsert_bind(key, b) {
+			if let Err(err) = s.upsert_bind(key, b)
+				&& is_new_bind
+			{
 				bind_errors.push(format!("{err:#}"));
 			}
 		}
@@ -2047,7 +2053,7 @@ mod tests {
 	use crate::telemetry::log::OrderedStringMap;
 	use crate::types::agent::{
 		BackendTarget, BindProtocol, ListenerProtocol, ListenerSet, ListenerSetTarget, PolicyType,
-		ResourceName, TunnelProtocol,
+		ResourceName, Target, TunnelProtocol,
 	};
 	use crate::types::frontend::LoggingPolicy;
 
@@ -2265,6 +2271,78 @@ mod tests {
 				Default::default(),
 			)
 			.expect("bind on an ephemeral port should succeed");
+	}
+
+	#[test]
+	fn sync_local_new_bind_on_reload_failure_is_fatal() {
+		let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+		let occupied_addr = occupied.local_addr().expect("probe addr");
+
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
+		let prev = updater
+			.sync_local(
+				vec![standard_bind("127.0.0.1:0".parse().unwrap())],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				Default::default(),
+			)
+			.expect("initial bind should succeed");
+
+		let mut new_bind = standard_bind(occupied_addr);
+		new_bind.key = strng::literal!("bind2");
+		let err = updater
+			.sync_local(
+				vec![
+					standard_bind("127.0.0.1:0".parse().unwrap()),
+					new_bind,
+				],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				prev,
+			)
+			.expect_err("adding a new bind on an occupied port after startup must fail");
+		assert!(
+			err.to_string().contains("failed to start bind listener"),
+			"unexpected error: {err:#}"
+		);
+	}
+
+	#[test]
+	fn sync_local_bind_failure_still_applies_config() {
+		let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+		let addr = occupied.local_addr().expect("probe addr");
+
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
+		let backend_key: BackendKey = strng::literal!("ns/backend");
+		let backend = BackendWithPolicies {
+			backend: Backend::Opaque(
+				ResourceName::new(strng::literal!("backend"), strng::literal!("ns")),
+				Target::Address("127.0.0.1:8080".parse().unwrap()),
+			),
+			inline_policies: vec![],
+		};
+		let _err = updater
+			.sync_local(
+				vec![standard_bind(addr)],
+				vec![],
+				vec![],
+				vec![],
+				vec![backend],
+				vec![],
+				Default::default(),
+			)
+			.expect_err("bind on an occupied port must fail");
+
+		assert!(
+			updater.read().backend(&backend_key).is_some(),
+			"bind failure must not prevent the rest of sync_local from applying"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -2097,6 +2097,7 @@ impl StoreUpdater {
 		prev: PreviousState,
 	) -> anyhow::Result<PreviousState> {
 		let mut s = self.state.write().expect("mutex acquired");
+		let prev_bind_keys = prev.binds.clone();
 		let mut old_binds = prev.binds;
 		let mut old_routes = prev.routes;
 		let mut old_tcp_routes = prev.tcp_routes;
@@ -2112,14 +2113,19 @@ impl StoreUpdater {
 			route_groups: Default::default(),
 		};
 		// Unlike XDS (which must tolerate a bad dynamic config), a static local config that
-		// cannot bind a listener is a fatal misconfiguration. Collect any bind failures and
-		// surface them so startup exits(1) rather than silently serving nothing (issue #87).
+		// cannot open a newly added listener is a fatal misconfiguration. Only treat bind
+		// failures for binds introduced after the previous sync as errors: existing binds are
+		// not re-opened, and a reload that adds a new port after startup must not silently
+		// serve nothing on that bind (issue #87).
 		let mut bind_errors = Vec::new();
 		for b in binds {
+			let is_new_bind = !prev_bind_keys.contains(&b.key);
 			old_binds.remove(&b.key);
 			next_state.binds.insert(b.key.clone());
 			let key = b.key.clone();
-			if let Err(err) = s.upsert_bind(key, b) {
+			if let Err(err) = s.upsert_bind(key, b)
+				&& is_new_bind
+			{
 				bind_errors.push(format!("{err:#}"));
 			}
 		}
@@ -2256,7 +2262,7 @@ mod tests {
 	use crate::telemetry::log::OrderedStringMap;
 	use crate::types::agent::{
 		BackendTarget, BindProtocol, ListenerProtocol, ListenerSet, ListenerSetTarget, PolicyType,
-		ResourceName, TunnelProtocol,
+		ResourceName, Target, TunnelProtocol,
 	};
 	use crate::types::frontend::LoggingPolicy;
 
@@ -2821,6 +2827,78 @@ mod tests {
 				Default::default(),
 			)
 			.expect("bind on an ephemeral port should succeed");
+	}
+
+	#[test]
+	fn sync_local_new_bind_on_reload_failure_is_fatal() {
+		let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+		let occupied_addr = occupied.local_addr().expect("probe addr");
+
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
+		let prev = updater
+			.sync_local(
+				vec![standard_bind("127.0.0.1:0".parse().unwrap())],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				Default::default(),
+			)
+			.expect("initial bind should succeed");
+
+		let mut new_bind = standard_bind(occupied_addr);
+		new_bind.key = strng::literal!("bind2");
+		let err = updater
+			.sync_local(
+				vec![
+					standard_bind("127.0.0.1:0".parse().unwrap()),
+					new_bind,
+				],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				prev,
+			)
+			.expect_err("adding a new bind on an occupied port after startup must fail");
+		assert!(
+			err.to_string().contains("failed to start bind listener"),
+			"unexpected error: {err:#}"
+		);
+	}
+
+	#[test]
+	fn sync_local_bind_failure_still_applies_config() {
+		let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+		let addr = occupied.local_addr().expect("probe addr");
+
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
+		let backend_key: BackendKey = strng::literal!("ns/backend");
+		let backend = BackendWithPolicies {
+			backend: Backend::Opaque(
+				ResourceName::new(strng::literal!("backend"), strng::literal!("ns")),
+				Target::Address("127.0.0.1:8080".parse().unwrap()),
+			),
+			inline_policies: vec![],
+		};
+		let _err = updater
+			.sync_local(
+				vec![standard_bind(addr)],
+				vec![],
+				vec![],
+				vec![],
+				vec![backend],
+				vec![],
+				Default::default(),
+			)
+			.expect_err("bind on an occupied port must fail");
+
+		assert!(
+			updater.read().backend(&backend_key).is_some(),
+			"bind failure must not prevent the rest of sync_local from applying"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -2851,10 +2851,7 @@ mod tests {
 		new_bind.key = strng::literal!("bind2");
 		let err = updater
 			.sync_local(
-				vec![
-					standard_bind("127.0.0.1:0".parse().unwrap()),
-					new_bind,
-				],
+				vec![standard_bind("127.0.0.1:0".parse().unwrap()), new_bind],
 				vec![],
 				vec![],
 				vec![],

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -852,7 +852,7 @@ impl Store {
 		Arc::make_mut(routes).insert(route);
 	}
 
-	fn upsert_bind(&mut self, key: BindKey, mut bind: Bind) {
+	fn upsert_bind(&mut self, key: BindKey, mut bind: Bind) -> anyhow::Result<()> {
 		debug!(bind=%bind.key, "insert bind");
 		let old_bind = self.binds.get(&key).cloned();
 
@@ -866,6 +866,10 @@ impl Store {
 			bind.listeners.insert(listener);
 		}
 
+		// Capture (rather than swallow) any OS bind failure so callers can decide whether it
+		// is fatal. The bind is still recorded below so routing lookups (find_bind, etc.)
+		// remain consistent regardless of the caller's error handling.
+		let mut bind_error = None;
 		let was_internal = old_bind
 			.as_deref()
 			.is_some_and(|old| old.mode == agent::BindMode::Internal);
@@ -906,7 +910,7 @@ impl Store {
 					Some(listeners)
 				},
 				Err(err) => {
-					warn!(bind=%key, address=%bind.address, error=%err, "failed to start bind listener");
+					bind_error = Some(err);
 					None
 				},
 			}
@@ -920,6 +924,10 @@ impl Store {
 		if let Some(listeners) = listeners {
 			let _ = self.tx.send(BindEvent::Add(bind, listeners));
 		}
+		if let Some(err) = bind_error {
+			return Err(err.context(format!("bind {key}")));
+		}
+		Ok(())
 	}
 
 	pub fn subscribe(&mut self) -> impl Stream<Item = BindEvent> + use<> {
@@ -1620,7 +1628,11 @@ impl Store {
 		};
 		let mut bind = Arc::unwrap_or_clone(bind);
 		bind.listeners.remove(&listener);
-		self.upsert_bind(bind_key, bind);
+		// Removing a listener never opens a new socket (the bind already exists), so this
+		// cannot fail on bind; log defensively rather than propagate.
+		if let Err(err) = self.upsert_bind(bind_key, bind) {
+			warn!(error=%err, "failed to update bind after listener removal");
+		}
 	}
 
 	pub fn remove_route_group(&mut self, rg: RouteGroupKey) {
@@ -1699,7 +1711,12 @@ impl Store {
     )]
 	pub fn insert_bind(&mut self, bind: Bind) {
 		let key = bind.key.clone();
-		self.upsert_bind(key, bind);
+		// XDS-delivered binds must not crash the proxy on a bind failure: a bad dynamic config
+		// should be rejected/logged, not fatal. Static local config uses `sync_local`, which
+		// surfaces the error so startup can exit(1) (see issue #87).
+		if let Err(err) = self.upsert_bind(key.clone(), bind) {
+			warn!(bind=%key, error=%err, "failed to start bind listener");
+		}
 	}
 
 	pub fn insert_backend(&mut self, key: BackendKey, b: BackendWithPolicies) {
@@ -1733,7 +1750,9 @@ impl Store {
 			let mut bind = Arc::unwrap_or_clone(b.clone());
 			bind.listeners.remove(&lis.key);
 			bind.listeners.insert(lis);
-			self.upsert_bind(bind_name, bind);
+			if let Err(err) = self.upsert_bind(bind_name.clone(), bind) {
+				warn!(bind=%bind_name, error=%err, "failed to start bind listener");
+			}
 		} else {
 			debug!("no bind found, keeping listener pending");
 			self
@@ -2076,7 +2095,7 @@ impl StoreUpdater {
 		backends: Vec<BackendWithPolicies>,
 		route_groups: Vec<(RouteGroupKey, Vec<Route>)>,
 		prev: PreviousState,
-	) -> PreviousState {
+	) -> anyhow::Result<PreviousState> {
 		let mut s = self.state.write().expect("mutex acquired");
 		let mut old_binds = prev.binds;
 		let mut old_routes = prev.routes;
@@ -2092,10 +2111,17 @@ impl StoreUpdater {
 			backends: Default::default(),
 			route_groups: Default::default(),
 		};
+		// Unlike XDS (which must tolerate a bad dynamic config), a static local config that
+		// cannot bind a listener is a fatal misconfiguration. Collect any bind failures and
+		// surface them so startup exits(1) rather than silently serving nothing (issue #87).
+		let mut bind_errors = Vec::new();
 		for b in binds {
 			old_binds.remove(&b.key);
 			next_state.binds.insert(b.key.clone());
-			s.insert_bind(b);
+			let key = b.key.clone();
+			if let Err(err) = s.upsert_bind(key, b) {
+				bind_errors.push(format!("{err:#}"));
+			}
 		}
 		for b in backends {
 			// Here we use the 'name' as the key. This is appropriate for local case only
@@ -2147,7 +2173,13 @@ impl StoreUpdater {
 		for remaining_rg in old_route_groups {
 			s.remove_route_group(remaining_rg);
 		}
-		next_state
+		if !bind_errors.is_empty() {
+			anyhow::bail!(
+				"failed to start bind listener(s): {}",
+				bind_errors.join("; ")
+			);
+		}
+		Ok(next_state)
 	}
 }
 
@@ -2726,6 +2758,69 @@ mod tests {
 				.as_ref()
 				.is_some_and(|routes| routes.contains(&strng::literal!("route")))
 		);
+	}
+
+	fn standard_bind(address: std::net::SocketAddr) -> Bind {
+		Bind {
+			key: strng::literal!("bind"),
+			address,
+			protocol: BindProtocol::http,
+			tunnel_protocol: TunnelProtocol::Direct,
+			mode: agent::BindMode::Standard,
+			listeners: ListenerSet::from_list([Listener {
+				key: strng::literal!("listener"),
+				name: ListenerName {
+					gateway_name: strng::literal!("gw"),
+					gateway_namespace: strng::literal!("ns"),
+					listener_name: strng::literal!("listener"),
+					listener_set: None,
+				},
+				hostname: strng::literal!("example.com"),
+				protocol: ListenerProtocol::HTTP,
+			}]),
+		}
+	}
+
+	// Regression for issue #87: a static local config that cannot open its listener socket
+	// must fail loudly (so startup can exit(1)) rather than silently binding nothing.
+	#[test]
+	fn sync_local_bind_failure_is_fatal() {
+		// Hold an active listener so the same address cannot be bound again.
+		let occupied = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+		let addr = occupied.local_addr().expect("probe addr");
+
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
+		let err = updater
+			.sync_local(
+				vec![standard_bind(addr)],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				Default::default(),
+			)
+			.expect_err("bind on an occupied port must fail");
+		assert!(
+			err.to_string().contains("failed to start bind listener"),
+			"unexpected error: {err:#}"
+		);
+	}
+
+	#[test]
+	fn sync_local_bind_success_returns_ok() {
+		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
+		updater
+			.sync_local(
+				vec![standard_bind("127.0.0.1:0".parse().unwrap())],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				vec![],
+				Default::default(),
+			)
+			.expect("bind on an ephemeral port should succeed");
 	}
 
 	#[test]

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -206,15 +206,19 @@ async fn setup_local_llm_config(yaml: &str) -> TestBind {
 	)
 	.await
 	.expect("local config normalizes");
-	t.pi.stores.binds.sync_local(
-		normalized.binds,
-		normalized.listener_routes,
-		normalized.listener_tcp_routes,
-		normalized.policies,
-		normalized.backends,
-		normalized.route_groups,
-		Default::default(),
-	);
+	t.pi
+		.stores
+		.binds
+		.sync_local(
+			normalized.binds,
+			normalized.listener_routes,
+			normalized.listener_tcp_routes,
+			normalized.policies,
+			normalized.backends,
+			normalized.route_groups,
+			Default::default(),
+		)
+		.expect("sync local binds");
 	t
 }
 

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -231,7 +231,7 @@ async fn llm_local_router_handles_models_virtual_model_and_missing_model() {
 	let config = format!(
 		r#"
 llm:
-  port: 4000
+  port: 0
   models:
   - name: real-model
     visibility: internal
@@ -279,7 +279,7 @@ llm:
 		mock.address()
 	);
 	let t = setup_local_llm_config(&config).await;
-	let io = t.serve_http(strng::literal!("bind/4000"));
+	let io = t.serve_http(strng::literal!("bind/0"));
 
 	// check model list respects authorization
 	{
@@ -388,7 +388,7 @@ async fn llm_conditional_virtual_model_no_match_returns_json_error() {
 	let config = format!(
 		r#"
 llm:
-  port: 4000
+  port: 0
   models:
   - name: real-model
     visibility: internal
@@ -406,7 +406,7 @@ llm:
 		mock.address()
 	);
 	let t = setup_local_llm_config(&config).await;
-	let io = t.serve_http(strng::literal!("bind/4000"));
+	let io = t.serve_http(strng::literal!("bind/0"));
 	let res = send_completions_with_model(io, "public-model", &[]).await;
 
 	assert_eq!(res.status(), StatusCode::BAD_REQUEST);
@@ -433,7 +433,7 @@ async fn llm_model_router_handles_multipart_audio_detect_request() {
 	let config = format!(
 		r#"
 llm:
-  port: 4000
+  port: 0
   models:
   - name: real-model
     provider: openAI
@@ -444,7 +444,7 @@ llm:
 		mock.address()
 	);
 	let t = setup_local_llm_config(&config).await;
-	let io = t.serve_http(strng::literal!("bind/4000"));
+	let io = t.serve_http(strng::literal!("bind/0"));
 	let body = concat!(
 		"--audio-boundary\r\n",
 		"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",


### PR DESCRIPTION
## Problem

When running with a static local config (`agentgateway -f config.json`), a listener that could not open its OS socket (for example, the port was already in use) only logged a warning and the process kept running, serving nothing on that bind. As reported in #87, this is easy to miss: it looks like the gateway started fine, but the configured listeners are not actually accepting traffic.

## Approach

- `Store::upsert_bind` now returns the underlying bind error instead of swallowing it. The bind is still recorded in the store so routing lookups stay consistent.
- `sync_local` (used only by the static local config path) collects any bind failures and returns them. The initial config load is awaited at startup, so the error propagates and the process exits non-zero.
- XDS-delivered binds keep their previous behavior via `insert_bind` (log and continue), so a bad dynamic config does not crash a running proxy. Config file reloads also keep the last good state on error rather than exiting.

This mirrors the common proxy convention where a static listener that cannot bind is fatal, while dynamically delivered listeners are rejected without taking the process down.

## Test plan

- `cargo test -p agentgateway --lib store::binds::` (adds `sync_local_bind_failure_is_fatal` and `sync_local_bind_success_returns_ok`; full module green)
- `cargo clippy -p agentgateway --all-targets` (clean)
- `cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true` (clean)

Fixes #87
