### PR TITLE
feat(transformation): add CEL replace mode for headers

### DIFF
--- a/crates/agentgateway/src/http/transformation_cel.rs
+++ b/crates/agentgateway/src/http/transformation_cel.rs
@@ -1,6 +1,7 @@
-use ::http::{HeaderName, header};
+use ::http::{HeaderName, HeaderValue, header};
 use agent_core::prelude::Strng;
 use serde_with::serde_as;
+use tracing::debug;
 
 use crate::cel::{Expression, RequestSnapshot};
 use crate::http::{
@@ -36,6 +37,13 @@ pub struct LocalTransform {
 	/// Header names to remove.
 	#[serde(default)]
 	pub remove: Vec<Strng>,
+	/// CEL expression that computes the full set of headers, replacing all existing headers.
+	/// The expression must evaluate to a map of header name to value (a string, or a list of
+	/// strings for a repeated header). Pseudo-headers (`:method`, `:path`, etc.) are ignored;
+	/// set those explicitly with `set`/`add`. `replace` is applied before `add`/`set`/`remove`,
+	/// so those still operate on top of the replaced headers.
+	#[serde(default)]
+	pub replace: Option<Strng>,
 	/// CEL expression that computes a replacement body.
 	#[serde(default)]
 	pub body: Option<Strng>,
@@ -96,6 +104,10 @@ impl TransformerConfig {
 			.into_iter()
 			.map(|k| HeaderName::try_from(k.as_str()))
 			.collect::<Result<_, _>>()?;
+		let replace = req
+			.replace
+			.map(|b| compile(b.as_str(), strict, warnings))
+			.transpose()?;
 		let body = req
 			.body
 			.map(|b| compile(b.as_str(), strict, warnings))
@@ -109,6 +121,7 @@ impl TransformerConfig {
 			set,
 			add,
 			remove,
+			replace,
 			body,
 			metadata,
 		})
@@ -166,6 +179,8 @@ pub struct TransformerConfig {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub remove: Vec<HeaderName>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub replace: Option<cel::Expression>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub body: Option<cel::Expression>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub metadata: Vec<(Strng, cel::Expression)>,
@@ -210,6 +225,26 @@ fn eval_metadata(
 				.and_then(|v| v.json().map_err(|e| cel::Error::Variable(e.to_string())))
 				.map_err(anyhow::Error::from)
 		},
+	}
+}
+
+fn eval_headers(
+	r: &RequestOrResponse,
+	expr: &Expression,
+	request: Option<&cel::RequestSnapshot>,
+) -> anyhow::Result<serde_json::Map<String, serde_json::Value>> {
+	match eval_metadata(r, expr, request)? {
+		serde_json::Value::Object(map) => Ok(map),
+		other => anyhow::bail!("replace expression must evaluate to a map, got {other}"),
+	}
+}
+
+fn json_to_header_value(v: &serde_json::Value) -> Option<HeaderValue> {
+	match v {
+		serde_json::Value::String(s) => HeaderValue::from_str(s).ok(),
+		serde_json::Value::Number(n) => HeaderValue::from_str(&n.to_string()).ok(),
+		serde_json::Value::Bool(b) => HeaderValue::from_str(&b.to_string()).ok(),
+		serde_json::Value::Null | serde_json::Value::Array(_) | serde_json::Value::Object(_) => None,
 	}
 }
 
@@ -276,6 +311,40 @@ impl Transformation {
 				}
 			}
 		}
+		if let Some(expr) = &cfg.replace {
+			match eval_headers(&r, expr, request) {
+				Ok(headers) => {
+					// Replace the full header set. Do this before add/set/remove so those still
+					// operate on top of the replaced headers.
+					r.headers().clear();
+					for (name, value) in headers {
+						// Only real headers are replaced; pseudo-headers must be set via set/add.
+						let Ok(HeaderOrPseudo::Header(name)) = HeaderOrPseudo::try_from(name.as_str()) else {
+							continue;
+						};
+						match value {
+							serde_json::Value::Array(items) => {
+								for item in &items {
+									if let Some(hv) = json_to_header_value(item) {
+										r.headers().append(name.clone(), hv);
+									}
+								}
+							},
+							other => {
+								if let Some(hv) = json_to_header_value(&other) {
+									r.headers().insert(name.clone(), hv);
+								}
+							},
+						}
+					}
+				},
+				// On evaluation error (or a non-map result), leave headers untouched rather than
+				// dropping every header because of a transient failure.
+				Err(e) => {
+					debug!("transformation replace expression did not produce a header map: {e}");
+				},
+			}
+		}
 		for (k, v) in &cfg.add {
 			let val = Self::exec_header(&r, v, k, request);
 			r.apply_header(k, val, http::HeaderMutationAction::AppendIfExistsOrAdd);
@@ -329,10 +398,12 @@ impl crate::store::RequestPolicyTrait for Transformation {
 			.iter()
 			.map(|v| &v.1)
 			.chain(self.request.set.iter().map(|v| &v.1))
+			.chain(self.request.replace.as_ref())
 			.chain(self.request.body.as_ref())
 			.chain(self.request.metadata.iter().map(|v| &v.1))
 			.chain(self.response.add.iter().map(|v| &v.1))
 			.chain(self.response.set.iter().map(|v| &v.1))
+			.chain(self.response.replace.as_ref())
 			.chain(self.response.body.as_ref())
 			.chain(self.response.metadata.iter().map(|v| &v.1))
 	}

--- a/crates/agentgateway/src/http/transformation_cel_tests.rs
+++ b/crates/agentgateway/src/http/transformation_cel_tests.rs
@@ -226,6 +226,122 @@ fn test_transformation_host_header_lifts_to_authority() {
 }
 
 #[test]
+fn test_transformation_replace_headers() {
+	let mut req = ::http::Request::builder()
+		.method("GET")
+		.uri("https://www.rust-lang.org/")
+		.header("x-remove-me", "gone")
+		.header("x-keep-src", "kept-value")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	let c = super::LocalTransformationConfig {
+		request: Some(super::LocalTransform {
+			replace: Some(r#"{"x-kept": request.headers["x-keep-src"], "x-static": "hi"}"#.into()),
+			..Default::default()
+		}),
+		response: None,
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+	xfm.apply_request(&mut req);
+	// Headers not present in the replacement map are dropped.
+	assert!(req.headers().get("x-remove-me").is_none());
+	assert_eq!(req.headers().get("x-kept").unwrap(), "kept-value");
+	assert_eq!(req.headers().get("x-static").unwrap(), "hi");
+}
+
+#[test]
+fn test_transformation_replace_then_set_overrides() {
+	let mut req = ::http::Request::builder()
+		.method("GET")
+		.uri("https://www.rust-lang.org/")
+		.header("x-old", "1")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	let c = super::LocalTransformationConfig {
+		request: Some(super::LocalTransform {
+			replace: Some(r#"{"x-a": "from-replace", "x-b": "b"}"#.into()),
+			set: vec![("x-a".into(), r#""from-set""#.into())],
+			..Default::default()
+		}),
+		response: None,
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+	xfm.apply_request(&mut req);
+	// replace runs first; set then overrides on top of the replaced headers.
+	assert_eq!(req.headers().get("x-a").unwrap(), "from-set");
+	assert_eq!(req.headers().get("x-b").unwrap(), "b");
+	assert!(req.headers().get("x-old").is_none());
+}
+
+#[test]
+fn test_transformation_replace_repeated_header() {
+	let mut req = ::http::Request::builder()
+		.method("GET")
+		.uri("https://www.rust-lang.org/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	let c = super::LocalTransformationConfig {
+		request: Some(super::LocalTransform {
+			replace: Some(r#"{"x-multi": ["a", "b"]}"#.into()),
+			..Default::default()
+		}),
+		response: None,
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+	xfm.apply_request(&mut req);
+	let values: Vec<_> = req
+		.headers()
+		.get_all("x-multi")
+		.iter()
+		.map(|v| v.to_str().unwrap().to_string())
+		.collect();
+	assert_eq!(values, vec!["a".to_string(), "b".to_string()]);
+}
+
+#[test]
+fn test_transformation_replace_ignores_pseudo_headers() {
+	let mut req = ::http::Request::builder()
+		.method("GET")
+		.uri("https://www.rust-lang.org/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	let c = super::LocalTransformationConfig {
+		request: Some(super::LocalTransform {
+			replace: Some(r#"{":method": "POST", "x-real": "y"}"#.into()),
+			..Default::default()
+		}),
+		response: None,
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+	xfm.apply_request(&mut req);
+	// Pseudo-header keys are ignored; the method is unchanged and no `:method` header exists.
+	assert_eq!(req.method().as_str(), "GET");
+	assert_eq!(req.headers().get("x-real").unwrap(), "y");
+	assert!(req.headers().get(":method").is_none());
+}
+
+#[test]
+fn test_transformation_replace_non_map_leaves_headers() {
+	let mut req = ::http::Request::builder()
+		.method("GET")
+		.uri("https://www.rust-lang.org/")
+		.header("x-orig", "keep")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	let c = super::LocalTransformationConfig {
+		request: Some(super::LocalTransform {
+			replace: Some(r#""not a map""#.into()),
+			..Default::default()
+		}),
+		response: None,
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+	xfm.apply_request(&mut req);
+	// A non-map result must not wipe the existing headers.
+	assert_eq!(req.headers().get("x-orig").unwrap(), "keep");
+}
+
+#[test]
 fn test_transformation_metadata() {
 	let mut req = ::http::Request::builder()
 		.method("GET")

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1723,6 +1723,9 @@ fn transformation_from_proto(
 			add,
 			set,
 			remove,
+			// `replace` is only available via local file config today; the XDS proto does not
+			// carry it yet, so dynamic configs leave it unset.
+			replace: None,
 			body,
 			metadata,
 		}

--- a/schema/config.json
+++ b/schema/config.json
@@ -2686,6 +2686,14 @@
           },
           "default": []
         },
+        "replace": {
+          "description": "CEL expression that computes the full set of headers, replacing all existing headers.\nThe expression must evaluate to a map of header name to value (a string, or a list of\nstrings for a repeated header). Pseudo-headers (`:method`, `:path`, etc.) are ignored;\nset those explicitly with `set`/`add`. `replace` is applied before `add`/`set`/`remove`,\nso those still operate on top of the replaced headers.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
         "body": {
           "description": "CEL expression that computes a replacement body.",
           "type": [


### PR DESCRIPTION
## Problem

Header transformations (`transformation.request` / `transformation.response`) can only `add`, `set`, or `remove` individual headers. As requested in #677, there is no way to compute the complete final set of headers from a single CEL expression (for example, to keep only an allow-list of headers, or to build a fresh header set from source context).

## Approach

Add a `replace` mode: a CEL expression that evaluates to a map of header name to value and replaces the entire header set with the result.

- A value may be a string (single header) or a list of strings (a repeated header). Non-string scalars (numbers, bools) are stringified; null/nested values are skipped.
- Pseudo-headers (`:method`, `:path`, `:authority`, `:scheme`, `:status`) are ignored, so a `replace` cannot accidentally strip the path or method. Set those explicitly with `set`/`add`, as noted in the issue.
- `replace` is applied before `add`/`set`/`remove`, so those still refine the replaced headers.
- If the expression errors or does not evaluate to a map, the existing headers are left untouched rather than being dropped.

Example:

```yaml
# keep only an allow-list, plus a derived header
transformation:
  request:
    replace: |
      {
        "x-forwarded-for": request.headers["x-forwarded-for"],
        "x-original-ip": source.address,
      }
```

Scope: this wires `replace` for the local file config. The XDS `TransformationPolicy` proto does not carry the field yet, so dynamically delivered configs leave it unset (no behavior change); adding proto + controller support can follow.

## Test plan

- `cargo test -p agentgateway --lib http::transformation_cel::` (adds 5 tests: basic replace, replace-then-set precedence, repeated-header list values, pseudo-header keys ignored, non-map result leaves headers intact; full module green)
- `cargo xtask schema` (regenerated `schema/config.json` + `schema/config.md`; only `replace` additions)
- `cargo clippy -p agentgateway --all-targets` (clean)
- `cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true` (clean)

Fixes #677
