### PR TITLE
helm: scrape proxy metrics with PodMonitor

### DIFF
--- a/controller/install/helm/agentgateway/templates/monitoring.yaml
+++ b/controller/install/helm/agentgateway/templates/monitoring.yaml
@@ -1,7 +1,8 @@
 {{- if .Values.monitoring.enabled }}
-{{- if .Values.monitoring.serviceMonitor.enabled }}
+{{- if .Values.monitoring.proxy.podMonitor.enabled }}
+---
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: {{ include "agentgateway.fullname" . }}-proxy
   namespace: {{ .Release.Namespace }}
@@ -12,16 +13,23 @@ metadata:
     {{- end }}
 spec:
   selector:
-    matchLabels:
-      gateway.networking.k8s.io/gateway-class-name: agentgateway
+    matchExpressions:
+    - key: gateway.networking.k8s.io/gateway-class-name
+      operator: In
+      values:
+      {{- range .Values.monitoring.proxy.gatewayClassNames }}
+      - {{ . | quote }}
+      {{- end }}
   {{- with .Values.monitoring.proxy.namespaceSelector }}
   namespaceSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  endpoints:
+  podMetricsEndpoints:
   - port: metrics
     path: /metrics
     interval: {{ .Values.monitoring.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -46,9 +54,7 @@ spec:
     interval: {{ .Values.monitoring.serviceMonitor.interval }}
 {{- end }}
 {{- if .Values.monitoring.grafanaDashboard.enabled }}
-{{- if .Values.monitoring.serviceMonitor.enabled }}
 ---
-{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/controller/install/helm/agentgateway/values.yaml
+++ b/controller/install/helm/agentgateway/values.yaml
@@ -255,16 +255,23 @@ monitoring:
   enabled: false
 
   serviceMonitor:
-    # -- Create ServiceMonitor resources.
+    # -- Create the controller ServiceMonitor.
     enabled: true
-    # -- Scrape interval for both ServiceMonitors.
+    # -- Scrape interval for the controller ServiceMonitor and the proxy PodMonitor.
     interval: 15s
-    # -- Additional labels to add to both ServiceMonitor resources (e.g. release: prometheus).
+    # -- Additional labels to add to the controller ServiceMonitor and the proxy PodMonitor (e.g. release: prometheus).
     extraLabels: {}
 
   proxy:
-    # -- Namespace selector used by the proxy ServiceMonitor.
-    # The proxy ServiceMonitor always selects Services with gateway.networking.k8s.io/gateway-class-name=agentgateway.
+    podMonitor:
+      # -- Create a PodMonitor that scrapes provisioned proxy pods on the pod's
+      #    metrics port (15020) directly, without requiring a metrics port on the
+      #    provisioned Service.
+      enabled: true
+    # -- GatewayClass names whose proxy pods are selected by the proxy PodMonitor.
+    gatewayClassNames:
+      - agentgateway
+    # -- Namespace selector used by the proxy PodMonitor. Defaults to the release namespace only.
     namespaceSelector: {}
 
   grafanaDashboard:

--- a/controller/test/helm/helm_version_test.go
+++ b/controller/test/helm/helm_version_test.go
@@ -349,6 +349,29 @@ func TestHelmChartTemplate(t *testing.T) {
     enabled: false
 `,
 		},
+		{
+			name: "monitoring-custom-gateway-class-names",
+			valuesYAML: `monitoring:
+  enabled: true
+  proxy:
+    gatewayClassNames:
+    - agentgateway
+    - custom-class
+  grafanaDashboard:
+    enabled: false
+`,
+		},
+		{
+			name: "monitoring-no-pod-monitor",
+			valuesYAML: `monitoring:
+  enabled: true
+  proxy:
+    podMonitor:
+      enabled: false
+  grafanaDashboard:
+    enabled: false
+`,
+		},
 	}
 
 	for _, chart := range charts {

--- a/controller/test/helm/testdata/agentgateway/monitoring-custom-gateway-class-names.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-custom-gateway-class-names.golden
@@ -384,7 +384,35 @@ spec:
       operator: In
       values:
       - "agentgateway"
+      - "custom-class"
   podMetricsEndpoints:
+  - port: metrics
+    path: /metrics
+    interval: 15s
+---
+# Source: agentgateway/templates/monitoring.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: test-release-agentgateway
+  namespace: default
+  labels:
+    helm.sh/chart: agentgateway-0.0.2
+    agentgateway: agentgateway
+    app.kubernetes.io/name: agentgateway
+    app.kubernetes.io/instance: test-release
+    app.kubernetes.io/version: "0.0.0-dev"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      agentgateway: agentgateway
+      app.kubernetes.io/name: agentgateway
+      app.kubernetes.io/instance: test-release
+  namespaceSelector:
+    matchNames:
+    - default
+  endpoints:
   - port: metrics
     path: /metrics
     interval: 15s

--- a/controller/test/helm/testdata/agentgateway/monitoring-custom-proxy-namespace-selector.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-custom-proxy-namespace-selector.golden
@@ -366,7 +366,7 @@ spec:
 ---
 # Source: agentgateway/templates/monitoring.yaml
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: test-release-agentgateway-proxy
   namespace: default
@@ -379,11 +379,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
-    matchLabels:
-      gateway.networking.k8s.io/gateway-class-name: agentgateway
+    matchExpressions:
+    - key: gateway.networking.k8s.io/gateway-class-name
+      operator: In
+      values:
+      - "agentgateway"
   namespaceSelector:
     any: true
-  endpoints:
+  podMetricsEndpoints:
   - port: metrics
     path: /metrics
     interval: 15s

--- a/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-dashboard.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-dashboard.golden
@@ -366,7 +366,7 @@ spec:
 ---
 # Source: agentgateway/templates/monitoring.yaml
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: test-release-agentgateway-proxy
   namespace: default
@@ -379,9 +379,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
-    matchLabels:
-      gateway.networking.k8s.io/gateway-class-name: agentgateway
-  endpoints:
+    matchExpressions:
+    - key: gateway.networking.k8s.io/gateway-class-name
+      operator: In
+      values:
+      - "agentgateway"
+  podMetricsEndpoints:
   - port: metrics
     path: /metrics
     interval: 15s

--- a/controller/test/helm/testdata/agentgateway/monitoring-enabled.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-enabled.golden
@@ -366,7 +366,7 @@ spec:
 ---
 # Source: agentgateway/templates/monitoring.yaml
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: test-release-agentgateway-proxy
   namespace: default
@@ -380,12 +380,15 @@ metadata:
     release: prometheus
 spec:
   selector:
-    matchLabels:
-      gateway.networking.k8s.io/gateway-class-name: agentgateway
+    matchExpressions:
+    - key: gateway.networking.k8s.io/gateway-class-name
+      operator: In
+      values:
+      - "agentgateway"
   namespaceSelector:
     matchNames:
     - default
-  endpoints:
+  podMetricsEndpoints:
   - port: metrics
     path: /metrics
     interval: 30s

--- a/controller/test/helm/testdata/agentgateway/monitoring-no-pod-monitor.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-no-pod-monitor.golden
@@ -366,9 +366,9 @@ spec:
 ---
 # Source: agentgateway/templates/monitoring.yaml
 apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
+kind: ServiceMonitor
 metadata:
-  name: test-release-agentgateway-proxy
+  name: test-release-agentgateway
   namespace: default
   labels:
     helm.sh/chart: agentgateway-0.0.2
@@ -379,12 +379,14 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
-    matchExpressions:
-    - key: gateway.networking.k8s.io/gateway-class-name
-      operator: In
-      values:
-      - "agentgateway"
-  podMetricsEndpoints:
+    matchLabels:
+      agentgateway: agentgateway
+      app.kubernetes.io/name: agentgateway
+      app.kubernetes.io/instance: test-release
+  namespaceSelector:
+    matchNames:
+    - default
+  endpoints:
   - port: metrics
     path: /metrics
     interval: 15s


### PR DESCRIPTION
fixes:  #2334 

# summary

 - Replace the proxy metrics `ServiceMonitor` with a `PodMonitor` so provisioned proxy pods are scraped directly from their `metrics` port
  - Add `monitoring.proxy.podMonitor.enabled` to control proxy `PodMonitor` rendering independently from the controller `ServiceMonitor`
  - Add `monitoring.proxy.gatewayClassNames` so proxy metrics scraping is not hardcoded to the `agentgateway` GatewayClass
 
## confirm working

```sh
$ cd controller
$ go test ./test/helm/... -count=1
ok      github.com/agentgateway/agentgateway/controller/test/helm       25.599s
```