### PR TITLE
crdgen: shorten generated CRD descriptions

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -179,24 +179,24 @@ const (
 )
 
 type BackendSimple struct {
-	// Settings for managing TCP connections to the backend.
+	// Settings for managing TCP connections to the backend
 	// +optional
 	TCP *BackendTCP `json:"tcp,omitempty"`
-	// Settings for managing TLS connections to the backend.
+	// Settings for managing TLS connections to the backend
 	//
-	// If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-	// validate the server, and the SNI will automatically be set based on the destination.
+	// When set, TLS is originated to the backend using the system trusted CA
+	// certificates, and SNI is inferred from the destination.
 	// +optional
 	TLS *BackendTLS `json:"tls,omitempty"`
-	// Settings for managing HTTP requests to the backend.
+	// Settings for managing HTTP requests to the backend
 	// +optional
 	HTTP *BackendHTTP `json:"http,omitempty"`
 
-	// Settings for managing tunnel connections, with behavior like `HTTPS_PROXY`, to the backend.
+	// Settings for managing tunnel connections to the backend, like `HTTPS_PROXY`
 	// +optional
 	Tunnel *BackendTunnel `json:"tunnel,omitempty"`
 
-	// Settings for managing authentication to the backend.
+	// Settings for managing authentication to the backend
 	// +optional
 	Auth *BackendAuth `json:"auth,omitempty"`
 }
@@ -249,13 +249,12 @@ type BackendEviction struct {
 	// +optional
 	ConsecutiveFailures *int32 `json:"consecutiveFailures,omitempty"`
 
-	// EWMA health score threshold, expressed as 0 to 100.
-	// When set, a backend is only evicted if its computed health drops below this value after an unhealthy response.
-	// For example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.
-	// Unlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average
-	// so a single success in a stream of failures can delay eviction.
-	// When both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.
-	// When neither is set, a single unhealthy response triggers eviction.
+	// EWMA health score threshold, from 0 to 100. When set, a backend is evicted
+	// only if its computed health drops below this value after an unhealthy
+	// response (e.g. 50 evicts when EWMA health falls below 50%). Unlike
+	// consecutiveFailures, this sliding-window average lets a single success delay
+	// eviction. If both are set, either condition evicts; if neither, a single
+	// unhealthy response evicts.
 	//
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=100
@@ -395,15 +394,11 @@ const (
 // +kubebuilder:validation:XValidation:rule="has(self.insecureSkipVerify) && self.insecureSkipVerify == 'All' ? !has(self.caCertificateRefs) : true",message="insecureSkipVerify All and caCertificateRefs may not be set together"
 // +kubebuilder:validation:XValidation:rule="has(self.insecureSkipVerify) ? !has(self.verifySubjectAltNames) : true",message="insecureSkipVerify and verifySubjectAltNames may not be set together"
 type BackendTLS struct {
-	// Enables mutual TLS to the backend, using the
-	// specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-	// credential source, defaulting to a Kubernetes `Secret`.
-	//
-	// An optional `ca.cert` field, if present, will be used to verify the
-	// server certificate. If `caCertificateRefs` is also specified, the
-	// `caCertificateRefs` field takes priority.
-	//
-	// If unspecified, no client certificate will be used.
+	// Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+	// referenced credential source (defaulting to a Kubernetes `Secret`). An
+	// optional `ca.cert`, if present, verifies the server certificate, but
+	// `caCertificateRefs` takes priority. If unspecified, no client certificate
+	// is used.
 	//
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=1
@@ -418,15 +413,13 @@ type BackendTLS struct {
 	// +optional
 	CACertificateRefs []corev1.LocalObjectReference `json:"caCertificateRefs,omitempty"`
 
-	// Originates TLS but skips verification of the backend's certificate.
-	// WARNING: This is an insecure option that should only be used if the risks are understood.
+	// Originates TLS but skips verification of the backend's certificate
+	// WARNING: insecure; only use if the risks are understood
 	//
-	// There are two modes:
-	// * `All` disables all TLS verification.
-	// * `Hostname` verifies the CA certificate is trusted, but ignores any
-	//   mismatch of hostname or SANs. Note that this method is still insecure;
-	//   prefer setting `verifySubjectAltNames` to customize the valid hostnames
-	//   if possible.
+	// Modes:
+	// * `All` disables all TLS verification
+	// * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+	//   Still insecure; prefer `verifySubjectAltNames` where possible.
 	//
 	// +optional
 	InsecureSkipVerify *InsecureTLSMode `json:"insecureSkipVerify,omitempty"`
@@ -1361,20 +1354,16 @@ type BackendAuth struct {
 	// +optional
 	InlineKey *string `json:"key,omitempty"`
 
-	// Credential source, defaulting to a Kubernetes
-	// `Secret`, storing the key to use as the authorization value. When using
-	// the default Secret resolver, this must be stored in the `Authorization`
-	// key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-	// stored value is stripped only when reading the default `Authorization`
-	// key.
+	// Credential source for the authorization value, defaulting to a Kubernetes
+	// `Secret`. By default, the value is read from the `Authorization` key; set
+	// `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+	// the default `Authorization` key.
 	// +optional
 	SecretRef *LocalSecretKeyRef `json:"secretRef,omitempty"`
 
-	// Passes through an existing token that has been sent by the
-	// client and validated. Other policies, like JWT and API key
-	// authentication, will strip the original client credentials. Passthrough backend authentication
-	// causes the original token to be added back into the request. If there are no client authentication policies on the
-	// request, the original token would be unchanged, so this would have no effect.
+	// Reuses a client token already validated by another policy. Those policies
+	// may strip client credentials; passthrough adds the original token back to
+	// the backend request. Without client auth policies, this has no effect.
 	// +optional
 	Passthrough *BackendAuthPassthrough `json:"passthrough,omitempty"`
 
@@ -1399,9 +1388,9 @@ type BackendAuth struct {
 	// +optional
 	OAuthTokenExchange *OAuthTokenExchange `json:"oauthTokenExchange,omitempty"`
 
-	// Where backend credentials are inserted.
-	// If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-	// This applies to `key`, `secretRef`, and `passthrough`.
+	// Where backend credentials are inserted. Defaults to the `Authorization`
+	// header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+	// `passthrough`.
 	// +optional
 	Location *AuthorizationLocation `json:"location,omitempty"`
 }
@@ -1622,11 +1611,10 @@ type GcpAuth struct {
 	//
 	// +optional
 	Type *GcpAuthType `json:"type,omitempty"`
-	// Credential source, defaulting to a Kubernetes
-	// `Secret`, containing ADC-compatible Google credential JSON. When using
-	// the default Secret resolver, this must be stored in the `credentials.json`
-	// key by default; override via `secretRef.key`. When omitted, ambient
-	// credentials are used.
+	// Credential source for ADC-compatible Google credential JSON, defaulting to
+	// a Kubernetes `Secret`. By default, the value is read from
+	// `credentials.json`; set `secretRef.key` to override it. When omitted,
+	// ambient credentials are used.
 	//
 	// +optional
 	SecretRef *LocalSecretKeyRef `json:"secretRef,omitempty"`
@@ -1642,10 +1630,9 @@ type GcpAuth struct {
 //
 // +kubebuilder:validation:XValidation:rule="!(has(self.secretRef) && has(self.assumeRole))",message="secretRef and assumeRole are mutually exclusive"
 type AwsAuth struct {
-	// Credential source, defaulting to a Kubernetes
-	// `Secret`, containing the AWS credentials. When using the default Secret
-	// resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-	// optionally `sessionToken`.
+	// Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+	// The default Secret resolver expects `accessKey`, `secretKey`, and optional
+	// `sessionToken` keys.
 	// +optional
 	SecretRef *LocalSecretObjectRef `json:"secretRef,omitempty"`
 
@@ -1689,9 +1676,8 @@ type AwsAssumeRole struct {
 	// +optional
 	SessionNameExpression *CELExpression `json:"sessionNameExpression,omitempty"`
 
-	// Tags are session tags passed to STS AssumeRole. Once activated as cost
-	// allocation tags, they appear in the AWS Cost & Usage Report for cost
-	// attribution. STS allows at most 50 session tags per role session.
+	// Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+	// & Usage Report, once activated. STS allows at most 50 per role session.
 	//
 	// +optional
 	// +listType=map
@@ -1718,10 +1704,9 @@ type AwsSessionTag struct {
 	// +kubebuilder:validation:MaxLength=256
 	Value *string `json:"value,omitempty"`
 
-	// Expression is a CEL expression evaluated against each request to produce
-	// the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-	// expression does not produce a valid tag value at request time, the request
-	// is rejected.
+	// CEL expression evaluated against each request to produce the tag value,
+	// for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+	// tag values are rejected.
 	//
 	// +optional
 	Expression *CELExpression `json:"expression,omitempty"`
@@ -1734,10 +1719,9 @@ type AwsSessionTag struct {
 //
 // +kubebuilder:validation:AtMostOneOf=secretRef;managedIdentity;workloadIdentity
 type AzureAuth struct {
-	// Credential source, defaulting to a Kubernetes
-	// `Secret`, containing the Azure credentials. When using the default Secret
-	// resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-	// `clientSecret`.
+	// Credential source for Azure credentials, defaulting to a Kubernetes
+	// `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+	// `clientSecret` keys.
 	//
 	// +optional
 	SecretRef *LocalSecretObjectRef `json:"secretRef,omitempty"`
@@ -1747,12 +1731,9 @@ type AzureAuth struct {
 	// +optional
 	ManagedIdentity *AzureManagedIdentity `json:"managedIdentity,omitempty"`
 
-	// Workload identity authentication settings. Uses the federated token
-	// projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-	// `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-	// environment variables) to authenticate. This is the recommended method
-	// when running on Azure Kubernetes Service (AKS) with Workload Identity
-	// enabled.
+	// Workload identity authentication settings. Uses the federated token and
+	// Azure env vars projected into the data plane pod. Recommended on AKS with
+	// Workload Identity enabled.
 	//
 	// +optional
 	WorkloadIdentity *AzureWorkloadIdentity `json:"workloadIdentity,omitempty"`
@@ -2029,17 +2010,10 @@ type BackendTunnel struct {
 }
 
 type BackendHTTP struct {
-	// HTTP protocol version to use when connecting to
-	// the backend.
-	// If not specified, the version is automatically determined:
-	// * `Service` types can specify it with `appProtocol` on the `Service`
-	//   port.
-	// * If traffic is identified as gRPC, `HTTP2` is used.
-	// * If the incoming traffic was plaintext HTTP, the original protocol will
-	//   be used.
-	// * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-	//   because most clients will transparently upgrade HTTPS traffic to
-	//   `HTTP2`, even if the backend doesn't support it.
+	// HTTP protocol version for backend connections. If unset, it is inferred:
+	// `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+	// plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+	// to HTTP/2 even when the backend does not support it.
 	// +optional
 	Version *HTTPVersion `json:"version,omitempty"`
 

--- a/controller/api/v1alpha1/agentgateway/shared_types.go
+++ b/controller/api/v1alpha1/agentgateway/shared_types.go
@@ -146,51 +146,45 @@ type HeaderModifiers struct {
 	Response *gwv1.HTTPHeaderFilter `json:"response,omitempty"`
 }
 
-// References a same-namespace credential.
-// Set only `name` to reference a Kubernetes Secret.
+// References a same-namespace credential
+// Set only `name` for a Kubernetes Secret
 //
 // +structType=atomic
 // +kubebuilder:validation:XValidation:rule="(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)",message="custom credential refs must set both group and kind"
 type LocalSecretObjectRef struct {
-	// The name of the referenced credential.
+	// Name of the referenced credential
 	// +required
 	Name gwv1.ObjectName `json:"name"`
 
-	// The API group of the referenced credential.
-	// Empty selects the core API group.
+	// API group of the referenced credential; empty selects the core API group
 	// +optional
 	Group string `json:"group,omitempty"`
 
-	// The kind of the referenced credential.
-	// Empty defaults to `Secret`.
+	// Kind of the referenced credential; empty defaults to `Secret`
 	// +optional
 	Kind string `json:"kind,omitempty"`
 }
 
-// References a same-namespace credential and, optionally, a specific key
-// within it whose value should be used. Set only `name` to reference a
-// Kubernetes Secret. When `key` is omitted, a location-specific default key
-// is used.
+// References a same-namespace credential and optional key
+// Set only `name` for a Kubernetes Secret. When `key` is omitted, a
+// location-specific default key is used.
 //
 // +structType=atomic
 // +kubebuilder:validation:XValidation:rule="(!has(self.group) || size(self.group) == 0) ? (!has(self.kind) || size(self.kind) == 0 || self.kind == 'Secret') : (has(self.kind) && size(self.kind) > 0)",message="custom credential refs must set both group and kind"
 type LocalSecretKeyRef struct {
-	// The name of the referenced credential.
+	// Name of the referenced credential
 	// +required
 	Name gwv1.ObjectName `json:"name"`
 
-	// The API group of the referenced credential.
-	// Empty selects the core API group.
+	// API group of the referenced credential; empty selects the core API group
 	// +optional
 	Group string `json:"group,omitempty"`
 
-	// The kind of the referenced credential.
-	// Empty defaults to `Secret`.
+	// Kind of the referenced credential; empty defaults to `Secret`
 	// +optional
 	Kind string `json:"kind,omitempty"`
 
-	// The key in the referenced Secret whose value is used. If omitted, a
-	// location-specific default key is used.
+	// Key in the referenced Secret. If omitted, a location-specific default is used
 	//
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253

--- a/controller/hack/crdgen/main.go
+++ b/controller/hack/crdgen/main.go
@@ -163,6 +163,11 @@ func generateCRDs(paths []string, outputDir string, maxDescLen int, crdVersion s
 		return fmt.Errorf("found zero Kubernetes kinds for paths: %s", strings.Join(paths, ", "))
 	}
 
+	// After kind discovery: this indexes imported packages, which would otherwise make FindKubeKinds emit upstream CRDs
+	if err := applyImportedDescriptionOverrides(parser, roots); err != nil {
+		return fmt.Errorf("apply imported description overrides: %w", err)
+	}
+
 	for _, groupKind := range kubeKinds {
 		parser.NeedCRDFor(groupKind, &maxDescLen)
 		crdRaw := parser.CustomResourceDefinitions[groupKind]
@@ -911,6 +916,187 @@ func typeIdentForExpr(parser *crd.Parser, contextPkg *loader.Package, expr ast.E
 			return crd.TypeIdent{}, false
 		}
 	}
+}
+
+// importedDescriptionOverride shortens an imported symbol's description, keyed
+// by Go symbol so every inlined use inherits it.
+type importedDescriptionOverride struct {
+	pkgPath  string
+	typeName string
+	field    string // empty targets the type's own description
+	doc      string
+}
+
+var importedDescriptionOverrides = []importedDescriptionOverride{
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPHeaderName",
+		doc:      "Name of an HTTP header. HTTP/2 pseudo-headers (names beginning with `:`) are not supported",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "BackendObjectReference",
+		field:    "Group",
+		doc:      "Group of the referent, for example `gateway.networking.k8s.io`. Empty selects the core API group",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "BackendObjectReference",
+		field:    "Kind",
+		doc:      "Kubernetes resource kind of the referent, for example `Service`. Defaults to `Service`",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "BackendObjectReference",
+		field:    "Namespace",
+		doc:      "Namespace of the referent. Defaults to the local namespace. A cross-namespace reference requires a ReferenceGrant in the referent namespace",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "BackendObjectReference",
+		field:    "Port",
+		doc:      "Destination port number. Required when the referent is a Kubernetes `Service`",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPHeaderMatch",
+		field:    "Type",
+		doc:      "How to match against the header value: `Exact` (default) or `RegularExpression`. The regex dialect is implementation-specific",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPHeaderMatch",
+		field:    "Name",
+		doc:      "Name of the HTTP header to match, case-insensitive. When names are equivalent, only the first matching entry is used",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPHeaderMatch",
+		field:    "Value",
+		doc:      "Value of the HTTP header to match",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPHeader",
+		field:    "Name",
+		doc:      "Name of the HTTP header, case-insensitive",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPHeader",
+		field:    "Value",
+		doc:      "Value for the HTTP header",
+	},
+	{
+		pkgPath:  "k8s.io/api/core/v1",
+		typeName: "LocalObjectReference",
+		field:    "Name",
+		doc:      "Name of the referent",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPCORSFilter",
+		field:    "AllowOrigins",
+		doc:      "Origins allowed to share the response, each as `<scheme>://<host>(:<port>)`; the host may use the `*` wildcard, and a bare `*` allows all origins. Sets `Access-Control-Allow-Origin`. When credentials are allowed, a specific origin is echoed instead of `*`. Support: Extended",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPCORSFilter",
+		field:    "AllowMethods",
+		doc:      "HTTP methods allowed for the resource, or `*` for all. CORS-safelisted methods (`GET`, `HEAD`, `POST`) are always allowed. Sets `Access-Control-Allow-Methods`. Support: Extended",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPCORSFilter",
+		field:    "AllowHeaders",
+		doc:      "Request headers allowed when accessing the resource, or `*` for all. Sets `Access-Control-Allow-Headers`. Support: Extended",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPCORSFilter",
+		field:    "ExposeHeaders",
+		doc:      "Response headers exposed to client scripts, or `*` for all. Sets `Access-Control-Expose-Headers`. Support: Extended",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "HTTPRouteRetry",
+		field:    "Backoff",
+		doc:      "Minimum duration to wait between retry attempts, in Gateway API Duration format. Implementations may add jitter or use exponential backoff, and must not exceed a configured request timeout. Support: Extended",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "ParentReference",
+		field:    "Namespace",
+		doc:      "Namespace of the referent. Defaults to the Route's local namespace. Cross-namespace references must be explicitly allowed, for example via ReferenceGrant. Support: Core",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "ParentReference",
+		field:    "SectionName",
+		doc:      "Name of a section within the target resource, for example a Gateway Listener name or Service port name. Empty references the entire resource. Support: Core",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "ParentReference",
+		field:    "Port",
+		doc:      "Port this Route targets on the parent, interpreted per parent kind (for example a Gateway listener port or Service port). Support: Extended",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "PolicyAncestorStatus",
+		doc:      "Status of a policy with respect to an associated ancestor resource, usually a Gateway",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "PolicyAncestorStatus",
+		field:    "Conditions",
+		doc:      "Conditions describing the status of the policy for this ancestor",
+	},
+	{
+		pkgPath:  "sigs.k8s.io/gateway-api/apis/v1",
+		typeName: "PolicyStatus",
+		field:    "Ancestors",
+		doc:      "Ancestor resources (usually Gateways) associated with the policy, with the policy's status for each. At most 16 entries; an empty list means the policy is not relevant to any ancestor",
+	},
+}
+
+// applyImportedDescriptionOverrides rewrites parsed docs before schema generation and validates override targets
+func applyImportedDescriptionOverrides(parser *crd.Parser, roots []*loader.Package) error {
+	for _, o := range importedDescriptionOverrides {
+		pkg := importedPackageForPath(parser, roots, o.pkgPath)
+		if pkg == nil {
+			return fmt.Errorf("package %q not imported by any root", o.pkgPath)
+		}
+		parser.NeedPackage(pkg)
+
+		info := parser.LookupType(pkg, o.typeName)
+		if info == nil {
+			return fmt.Errorf("type %s.%s not found", o.pkgPath, o.typeName)
+		}
+
+		if o.field == "" {
+			info.Doc = o.doc
+			continue
+		}
+
+		idx := slices.IndexFunc(info.Fields, func(field markers.FieldInfo) bool {
+			return field.Name == o.field
+		})
+		if idx < 0 {
+			return fmt.Errorf("field %s.%s.%s not found", o.pkgPath, o.typeName, o.field)
+		}
+		info.Fields[idx].Doc = o.doc
+	}
+	return nil
+}
+
+func importedPackageForPath(parser *crd.Parser, roots []*loader.Package, pkgPath string) *loader.Package {
+	for _, root := range roots {
+		if pkg := packageForPath(parser, root, pkgPath); pkg != nil {
+			return pkg
+		}
+	}
+	return nil
 }
 
 func packageForPath(parser *crd.Parser, contextPkg *loader.Package, pkgPath string) *loader.Package {

--- a/controller/hack/crdgen/main.go
+++ b/controller/hack/crdgen/main.go
@@ -1060,12 +1060,12 @@ var importedDescriptionOverrides = []importedDescriptionOverride{
 	},
 }
 
-// applyImportedDescriptionOverrides rewrites parsed docs before schema generation and validates override targets
 func applyImportedDescriptionOverrides(parser *crd.Parser, roots []*loader.Package) error {
 	for _, o := range importedDescriptionOverrides {
 		pkg := importedPackageForPath(parser, roots, o.pkgPath)
 		if pkg == nil {
-			return fmt.Errorf("package %q not imported by any root", o.pkgPath)
+			_, _ = fmt.Fprintf(os.Stderr, "warning: package %q not imported by any root; skipping imported description override\n", o.pkgPath)
+			continue
 		}
 		parser.NeedPackage(pkg)
 

--- a/controller/hack/crdgen/main_test.go
+++ b/controller/hack/crdgen/main_test.go
@@ -101,6 +101,19 @@ func TestApplyImportedDescriptionOverridesErrorsForMissingField(t *testing.T) {
 	require.EqualError(t, err, "field github.com/agentgateway/agentgateway/controller/hack/crdgen/testdata/overrideembedded/upstream.FullPolicy.Missing not found")
 }
 
+func TestApplyImportedDescriptionOverridesSkipsMissingPackage(t *testing.T) {
+	roots, parser := newTestParser(t, overrideEmbeddedRootPath)
+	withImportedDescriptionOverrides(t, []importedDescriptionOverride{
+		{
+			pkgPath:  "example.com/not/imported",
+			typeName: "Missing",
+			doc:      "Short missing doc",
+		},
+	})
+
+	require.NoError(t, applyImportedDescriptionOverrides(parser, roots))
+}
+
 func withImportedDescriptionOverrides(t *testing.T, overrides []importedDescriptionOverride) {
 	t.Helper()
 

--- a/controller/hack/crdgen/main_test.go
+++ b/controller/hack/crdgen/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,6 +9,11 @@ import (
 	"sigs.k8s.io/controller-tools/pkg/crd"
 	"sigs.k8s.io/controller-tools/pkg/loader"
 	"sigs.k8s.io/controller-tools/pkg/markers"
+)
+
+const (
+	overrideEmbeddedRootPath = "github.com/agentgateway/agentgateway/controller/hack/crdgen/testdata/overrideembedded/api/v1"
+	overrideEmbeddedPkgPath  = "github.com/agentgateway/agentgateway/controller/hack/crdgen/testdata/overrideembedded/upstream"
 )
 
 func newTestParser(t *testing.T, rootPath string) ([]*loader.Package, *crd.Parser) {
@@ -47,6 +53,62 @@ func TestAllJSONFieldNamesForTypeIncludesImportedInlineFields(t *testing.T) {
 	fields, err := allJSONFieldNamesForType(parser, typ, info, map[crd.TypeIdent][]string{}, map[crd.TypeIdent]bool{})
 	require.NoError(t, err)
 	require.Equal(t, []string{"bar", "baz", "foo"}, fields)
+}
+
+func TestApplyImportedDescriptionOverridesUpdatesTypeAndFieldDocs(t *testing.T) {
+	roots, parser := newTestParser(t, overrideEmbeddedRootPath)
+	withImportedDescriptionOverrides(t, []importedDescriptionOverride{
+		{
+			pkgPath:  overrideEmbeddedPkgPath,
+			typeName: "FullPolicy",
+			doc:      "Short policy doc",
+		},
+		{
+			pkgPath:  overrideEmbeddedPkgPath,
+			typeName: "FullPolicy",
+			field:    "Health",
+			doc:      "Short health doc",
+		},
+	})
+
+	require.NoError(t, applyImportedDescriptionOverrides(parser, roots))
+
+	pkg := importedPackageForPath(parser, roots, overrideEmbeddedPkgPath)
+	require.NotNil(t, pkg)
+	info := parser.LookupType(pkg, "FullPolicy")
+	require.NotNil(t, info)
+	require.Equal(t, "Short policy doc", info.Doc)
+
+	idx := slices.IndexFunc(info.Fields, func(field markers.FieldInfo) bool {
+		return field.Name == "Health"
+	})
+	require.NotEqual(t, -1, idx)
+	require.Equal(t, "Short health doc", info.Fields[idx].Doc)
+}
+
+func TestApplyImportedDescriptionOverridesErrorsForMissingField(t *testing.T) {
+	roots, parser := newTestParser(t, overrideEmbeddedRootPath)
+	withImportedDescriptionOverrides(t, []importedDescriptionOverride{
+		{
+			pkgPath:  overrideEmbeddedPkgPath,
+			typeName: "FullPolicy",
+			field:    "Missing",
+			doc:      "Short missing doc",
+		},
+	})
+
+	err := applyImportedDescriptionOverrides(parser, roots)
+	require.EqualError(t, err, "field github.com/agentgateway/agentgateway/controller/hack/crdgen/testdata/overrideembedded/upstream.FullPolicy.Missing not found")
+}
+
+func withImportedDescriptionOverrides(t *testing.T, overrides []importedDescriptionOverride) {
+	t.Helper()
+
+	original := importedDescriptionOverrides
+	importedDescriptionOverrides = overrides
+	t.Cleanup(func() {
+		importedDescriptionOverrides = original
+	})
 }
 
 func TestOverrideXValidationReplacesExactlyOneMatch(t *testing.T) {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -639,7 +639,7 @@ spec:
                                                         auth:
                                                           description: Settings for
                                                             managing authentication
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             aws:
                                                               description: |-
@@ -675,9 +675,8 @@ spec:
                                                                       type: string
                                                                     tags:
                                                                       description: |-
-                                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                                        attribution. STS allows at most 50 session tags per role session.
+                                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                                       items:
                                                                         description: |-
                                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -685,10 +684,9 @@ spec:
                                                                         properties:
                                                                           expression:
                                                                             description: |-
-                                                                              Expression is a CEL expression evaluated against each request to produce
-                                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                                              expression does not produce a valid tag value at request time, the request
-                                                                              is rejected.
+                                                                              CEL expression evaluated against each request to produce the tag value,
+                                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                                              tag values are rejected.
                                                                             maxLength: 16384
                                                                             minLength: 1
                                                                             type: string
@@ -738,26 +736,30 @@ spec:
                                                                       <= 1'
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
+                                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                                    `sessionToken` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -816,26 +818,30 @@ spec:
                                                                   type: object
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
+                                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                                    `clientSecret` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -859,12 +865,9 @@ spec:
                                                                       > 0)'
                                                                 workloadIdentity:
                                                                   description: |-
-                                                                    Workload identity authentication settings. Uses the federated token
-                                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                                    environment variables) to authenticate. This is the recommended method
-                                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                                    enabled.
+                                                                    Workload identity authentication settings. Uses the federated token and
+                                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                                    Workload Identity enabled.
                                                                   type: object
                                                               type: object
                                                               x-kubernetes-validations:
@@ -890,34 +893,42 @@ spec:
                                                                   type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                                    credentials are used.
+                                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                                    ambient credentials are used.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     key:
-                                                                      description: |-
-                                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                                        location-specific default key is used.
+                                                                      description: Key
+                                                                        in the referenced
+                                                                        Secret. If
+                                                                        omitted, a
+                                                                        location-specific
+                                                                        default is
+                                                                        used
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -965,9 +976,9 @@ spec:
                                                               type: string
                                                             location:
                                                               description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                                `passthrough`.
                                                               properties:
                                                                 cookie:
                                                                   properties:
@@ -981,19 +992,13 @@ spec:
                                                                 header:
                                                                   properties:
                                                                     name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
+                                                                      description: Name
+                                                                        of an HTTP
+                                                                        header. HTTP/2
+                                                                        pseudo-headers
+                                                                        (names beginning
+                                                                        with `:`)
+                                                                        are not supported
                                                                       maxLength: 256
                                                                       minLength: 1
                                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1074,19 +1079,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1175,29 +1181,25 @@ spec:
                                                                   properties:
                                                                     group:
                                                                       default: ""
-                                                                      description: |-
-                                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                        When unspecified or empty string, core API group is inferred.
+                                                                      description: Group
+                                                                        of the referent,
+                                                                        for example
+                                                                        `gateway.networking.k8s.io`.
+                                                                        Empty selects
+                                                                        the core API
+                                                                        group
                                                                       maxLength: 253
                                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                       type: string
                                                                     kind:
                                                                       default: Service
-                                                                      description: |-
-                                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                                        "Service".
-
-                                                                        Defaults to "Service" when not specified.
-
-                                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                                        outside of the cluster and as such are difficult to reason about in
-                                                                        terms of conformance. They also may not be safe to forward to (see
-                                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                        support ExternalName Services.
-
-                                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                                      description: Kubernetes
+                                                                        resource kind
+                                                                        of the referent,
+                                                                        for example
+                                                                        `Service`.
+                                                                        Defaults to
+                                                                        `Service`
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1210,27 +1212,28 @@ spec:
                                                                       minLength: 1
                                                                       type: string
                                                                     namespace:
-                                                                      description: |-
-                                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                                        namespace is inferred.
-
-                                                                        Note that when a namespace different than the local namespace is specified,
-                                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                                        documentation for details.
-
-                                                                        Support: Core
+                                                                      description: Namespace
+                                                                        of the referent.
+                                                                        Defaults to
+                                                                        the local
+                                                                        namespace.
+                                                                        A cross-namespace
+                                                                        reference
+                                                                        requires a
+                                                                        ReferenceGrant
+                                                                        in the referent
+                                                                        namespace
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                       type: string
                                                                     port:
-                                                                      description: |-
-                                                                        Port specifies the destination port number to use for this resource.
-                                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                                        case, the port number is the service port number, not the target port.
-                                                                        For other resources, destination port might be derived from the referent
-                                                                        resource or this field.
+                                                                      description: Destination
+                                                                        port number.
+                                                                        Required when
+                                                                        the referent
+                                                                        is a Kubernetes
+                                                                        `Service`
                                                                       format: int32
                                                                       maximum: 65535
                                                                       minimum: 1
@@ -1338,29 +1341,52 @@ spec:
                                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                                           properties:
                                                                             group:
-                                                                              description: |-
-                                                                                The API group of the referenced credential.
-                                                                                Empty selects the core API group.
+                                                                              description: API
+                                                                                group
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential;
+                                                                                empty
+                                                                                selects
+                                                                                the
+                                                                                core
+                                                                                API
+                                                                                group
                                                                               type: string
                                                                             key:
-                                                                              description: |-
-                                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                                location-specific default key is used.
+                                                                              description: Key
+                                                                                in
+                                                                                the
+                                                                                referenced
+                                                                                Secret.
+                                                                                If
+                                                                                omitted,
+                                                                                a
+                                                                                location-specific
+                                                                                default
+                                                                                is
+                                                                                used
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
                                                                             kind:
-                                                                              description: |-
-                                                                                The kind of the referenced credential.
-                                                                                Empty defaults to `Secret`.
-                                                                              type: string
-                                                                            name:
-                                                                              description: The
-                                                                                name
+                                                                              description: Kind
                                                                                 of
                                                                                 the
                                                                                 referenced
-                                                                                credential.
+                                                                                credential;
+                                                                                empty
+                                                                                defaults
+                                                                                to
+                                                                                `Secret`
+                                                                              type: string
+                                                                            name:
+                                                                              description: Name
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
@@ -1400,27 +1426,42 @@ spec:
                                                                         is only valid with ClientSecretPost.
                                                                       properties:
                                                                         group:
-                                                                          description: |-
-                                                                            The API group of the referenced credential.
-                                                                            Empty selects the core API group.
+                                                                          description: API
+                                                                            group
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            selects
+                                                                            the core
+                                                                            API group
                                                                           type: string
                                                                         key:
-                                                                          description: |-
-                                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                                            location-specific default key is used.
+                                                                          description: Key
+                                                                            in the
+                                                                            referenced
+                                                                            Secret.
+                                                                            If omitted,
+                                                                            a location-specific
+                                                                            default
+                                                                            is used
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
                                                                         kind:
-                                                                          description: |-
-                                                                            The kind of the referenced credential.
-                                                                            Empty defaults to `Secret`.
+                                                                          description: Kind
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            defaults
+                                                                            to `Secret`
                                                                           type: string
                                                                         name:
-                                                                          description: The
-                                                                            name of
-                                                                            the referenced
-                                                                            credential.
+                                                                          description: Name
+                                                                            of the
+                                                                            referenced
+                                                                            credential
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
@@ -1502,19 +1543,16 @@ spec:
                                                                     header:
                                                                       properties:
                                                                         name:
-                                                                          description: |-
-                                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                                            Valid values include:
-
-                                                                            * "Authorization"
-                                                                            * "Set-Cookie"
-
-                                                                            Invalid values include:
-
-                                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                headers are not currently supported by this type.
-                                                                              - "/invalid" - "/ " is an invalid character
+                                                                          description: Name
+                                                                            of an
+                                                                            HTTP header.
+                                                                            HTTP/2
+                                                                            pseudo-headers
+                                                                            (names
+                                                                            beginning
+                                                                            with `:`)
+                                                                            are not
+                                                                            supported
                                                                           maxLength: 256
                                                                           minLength: 1
                                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1616,19 +1654,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1699,42 +1738,43 @@ spec:
                                                                   != ''IdJag'''
                                                             passthrough:
                                                               description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
+                                                                Reuses a client token already validated by another policy. Those policies
+                                                                may strip client credentials; passthrough adds the original token back to
+                                                                the backend request. Without client auth policies, this has no effect.
                                                               type: object
                                                             secretRef:
                                                               description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                                stored value is stripped only when reading the default `Authorization`
-                                                                key.
+                                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                                the default `Authorization` key.
                                                               properties:
                                                                 group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
+                                                                  description: API
+                                                                    group of the referenced
+                                                                    credential; empty
+                                                                    selects the core
+                                                                    API group
                                                                   type: string
                                                                 key:
-                                                                  description: |-
-                                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                                    location-specific default key is used.
+                                                                  description: Key
+                                                                    in the referenced
+                                                                    Secret. If omitted,
+                                                                    a location-specific
+                                                                    default is used
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
                                                                 kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
+                                                                  description: Kind
+                                                                    of the referenced
+                                                                    credential; empty
+                                                                    defaults to `Secret`
                                                                   type: string
                                                                 name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
+                                                                  description: Name
+                                                                    of the referenced
+                                                                    credential
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
@@ -1774,7 +1814,7 @@ spec:
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
@@ -1793,17 +1833,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -1812,7 +1845,7 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
@@ -1876,10 +1909,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -1906,12 +1939,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -1920,15 +1949,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -1947,34 +1974,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -2043,9 +2071,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -2054,29 +2081,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2089,27 +2108,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -2168,7 +2185,7 @@ spec:
                                                         auth:
                                                           description: Settings for
                                                             managing authentication
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             aws:
                                                               description: |-
@@ -2204,9 +2221,8 @@ spec:
                                                                       type: string
                                                                     tags:
                                                                       description: |-
-                                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                                        attribution. STS allows at most 50 session tags per role session.
+                                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                                       items:
                                                                         description: |-
                                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -2214,10 +2230,9 @@ spec:
                                                                         properties:
                                                                           expression:
                                                                             description: |-
-                                                                              Expression is a CEL expression evaluated against each request to produce
-                                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                                              expression does not produce a valid tag value at request time, the request
-                                                                              is rejected.
+                                                                              CEL expression evaluated against each request to produce the tag value,
+                                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                                              tag values are rejected.
                                                                             maxLength: 16384
                                                                             minLength: 1
                                                                             type: string
@@ -2267,26 +2282,30 @@ spec:
                                                                       <= 1'
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
+                                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                                    `sessionToken` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -2345,26 +2364,30 @@ spec:
                                                                   type: object
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
+                                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                                    `clientSecret` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -2388,12 +2411,9 @@ spec:
                                                                       > 0)'
                                                                 workloadIdentity:
                                                                   description: |-
-                                                                    Workload identity authentication settings. Uses the federated token
-                                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                                    environment variables) to authenticate. This is the recommended method
-                                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                                    enabled.
+                                                                    Workload identity authentication settings. Uses the federated token and
+                                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                                    Workload Identity enabled.
                                                                   type: object
                                                               type: object
                                                               x-kubernetes-validations:
@@ -2419,34 +2439,42 @@ spec:
                                                                   type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                                    credentials are used.
+                                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                                    ambient credentials are used.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     key:
-                                                                      description: |-
-                                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                                        location-specific default key is used.
+                                                                      description: Key
+                                                                        in the referenced
+                                                                        Secret. If
+                                                                        omitted, a
+                                                                        location-specific
+                                                                        default is
+                                                                        used
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -2494,9 +2522,9 @@ spec:
                                                               type: string
                                                             location:
                                                               description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                                `passthrough`.
                                                               properties:
                                                                 cookie:
                                                                   properties:
@@ -2510,19 +2538,13 @@ spec:
                                                                 header:
                                                                   properties:
                                                                     name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
+                                                                      description: Name
+                                                                        of an HTTP
+                                                                        header. HTTP/2
+                                                                        pseudo-headers
+                                                                        (names beginning
+                                                                        with `:`)
+                                                                        are not supported
                                                                       maxLength: 256
                                                                       minLength: 1
                                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -2603,19 +2625,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -2704,29 +2727,25 @@ spec:
                                                                   properties:
                                                                     group:
                                                                       default: ""
-                                                                      description: |-
-                                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                        When unspecified or empty string, core API group is inferred.
+                                                                      description: Group
+                                                                        of the referent,
+                                                                        for example
+                                                                        `gateway.networking.k8s.io`.
+                                                                        Empty selects
+                                                                        the core API
+                                                                        group
                                                                       maxLength: 253
                                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                       type: string
                                                                     kind:
                                                                       default: Service
-                                                                      description: |-
-                                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                                        "Service".
-
-                                                                        Defaults to "Service" when not specified.
-
-                                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                                        outside of the cluster and as such are difficult to reason about in
-                                                                        terms of conformance. They also may not be safe to forward to (see
-                                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                        support ExternalName Services.
-
-                                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                                      description: Kubernetes
+                                                                        resource kind
+                                                                        of the referent,
+                                                                        for example
+                                                                        `Service`.
+                                                                        Defaults to
+                                                                        `Service`
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2739,27 +2758,28 @@ spec:
                                                                       minLength: 1
                                                                       type: string
                                                                     namespace:
-                                                                      description: |-
-                                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                                        namespace is inferred.
-
-                                                                        Note that when a namespace different than the local namespace is specified,
-                                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                                        documentation for details.
-
-                                                                        Support: Core
+                                                                      description: Namespace
+                                                                        of the referent.
+                                                                        Defaults to
+                                                                        the local
+                                                                        namespace.
+                                                                        A cross-namespace
+                                                                        reference
+                                                                        requires a
+                                                                        ReferenceGrant
+                                                                        in the referent
+                                                                        namespace
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                       type: string
                                                                     port:
-                                                                      description: |-
-                                                                        Port specifies the destination port number to use for this resource.
-                                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                                        case, the port number is the service port number, not the target port.
-                                                                        For other resources, destination port might be derived from the referent
-                                                                        resource or this field.
+                                                                      description: Destination
+                                                                        port number.
+                                                                        Required when
+                                                                        the referent
+                                                                        is a Kubernetes
+                                                                        `Service`
                                                                       format: int32
                                                                       maximum: 65535
                                                                       minimum: 1
@@ -2867,29 +2887,52 @@ spec:
                                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                                           properties:
                                                                             group:
-                                                                              description: |-
-                                                                                The API group of the referenced credential.
-                                                                                Empty selects the core API group.
+                                                                              description: API
+                                                                                group
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential;
+                                                                                empty
+                                                                                selects
+                                                                                the
+                                                                                core
+                                                                                API
+                                                                                group
                                                                               type: string
                                                                             key:
-                                                                              description: |-
-                                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                                location-specific default key is used.
+                                                                              description: Key
+                                                                                in
+                                                                                the
+                                                                                referenced
+                                                                                Secret.
+                                                                                If
+                                                                                omitted,
+                                                                                a
+                                                                                location-specific
+                                                                                default
+                                                                                is
+                                                                                used
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
                                                                             kind:
-                                                                              description: |-
-                                                                                The kind of the referenced credential.
-                                                                                Empty defaults to `Secret`.
-                                                                              type: string
-                                                                            name:
-                                                                              description: The
-                                                                                name
+                                                                              description: Kind
                                                                                 of
                                                                                 the
                                                                                 referenced
-                                                                                credential.
+                                                                                credential;
+                                                                                empty
+                                                                                defaults
+                                                                                to
+                                                                                `Secret`
+                                                                              type: string
+                                                                            name:
+                                                                              description: Name
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
@@ -2929,27 +2972,42 @@ spec:
                                                                         is only valid with ClientSecretPost.
                                                                       properties:
                                                                         group:
-                                                                          description: |-
-                                                                            The API group of the referenced credential.
-                                                                            Empty selects the core API group.
+                                                                          description: API
+                                                                            group
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            selects
+                                                                            the core
+                                                                            API group
                                                                           type: string
                                                                         key:
-                                                                          description: |-
-                                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                                            location-specific default key is used.
+                                                                          description: Key
+                                                                            in the
+                                                                            referenced
+                                                                            Secret.
+                                                                            If omitted,
+                                                                            a location-specific
+                                                                            default
+                                                                            is used
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
                                                                         kind:
-                                                                          description: |-
-                                                                            The kind of the referenced credential.
-                                                                            Empty defaults to `Secret`.
+                                                                          description: Kind
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            defaults
+                                                                            to `Secret`
                                                                           type: string
                                                                         name:
-                                                                          description: The
-                                                                            name of
-                                                                            the referenced
-                                                                            credential.
+                                                                          description: Name
+                                                                            of the
+                                                                            referenced
+                                                                            credential
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
@@ -3031,19 +3089,16 @@ spec:
                                                                     header:
                                                                       properties:
                                                                         name:
-                                                                          description: |-
-                                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                                            Valid values include:
-
-                                                                            * "Authorization"
-                                                                            * "Set-Cookie"
-
-                                                                            Invalid values include:
-
-                                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                headers are not currently supported by this type.
-                                                                              - "/invalid" - "/ " is an invalid character
+                                                                          description: Name
+                                                                            of an
+                                                                            HTTP header.
+                                                                            HTTP/2
+                                                                            pseudo-headers
+                                                                            (names
+                                                                            beginning
+                                                                            with `:`)
+                                                                            are not
+                                                                            supported
                                                                           maxLength: 256
                                                                           minLength: 1
                                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -3145,19 +3200,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -3228,42 +3284,43 @@ spec:
                                                                   != ''IdJag'''
                                                             passthrough:
                                                               description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
+                                                                Reuses a client token already validated by another policy. Those policies
+                                                                may strip client credentials; passthrough adds the original token back to
+                                                                the backend request. Without client auth policies, this has no effect.
                                                               type: object
                                                             secretRef:
                                                               description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                                stored value is stripped only when reading the default `Authorization`
-                                                                key.
+                                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                                the default `Authorization` key.
                                                               properties:
                                                                 group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
+                                                                  description: API
+                                                                    group of the referenced
+                                                                    credential; empty
+                                                                    selects the core
+                                                                    API group
                                                                   type: string
                                                                 key:
-                                                                  description: |-
-                                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                                    location-specific default key is used.
+                                                                  description: Key
+                                                                    in the referenced
+                                                                    Secret. If omitted,
+                                                                    a location-specific
+                                                                    default is used
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
                                                                 kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
+                                                                  description: Kind
+                                                                    of the referenced
+                                                                    credential; empty
+                                                                    defaults to `Secret`
                                                                   type: string
                                                                 name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
+                                                                  description: Name
+                                                                    of the referenced
+                                                                    credential
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
@@ -3303,7 +3360,7 @@ spec:
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
@@ -3322,17 +3379,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -3341,7 +3391,7 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
@@ -3405,10 +3455,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -3435,12 +3485,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -3449,15 +3495,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -3476,34 +3520,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -3572,9 +3617,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -3583,29 +3627,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3618,27 +3654,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -3693,7 +3727,7 @@ spec:
                                                         auth:
                                                           description: Settings for
                                                             managing authentication
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             aws:
                                                               description: |-
@@ -3729,9 +3763,8 @@ spec:
                                                                       type: string
                                                                     tags:
                                                                       description: |-
-                                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                                        attribution. STS allows at most 50 session tags per role session.
+                                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                                       items:
                                                                         description: |-
                                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -3739,10 +3772,9 @@ spec:
                                                                         properties:
                                                                           expression:
                                                                             description: |-
-                                                                              Expression is a CEL expression evaluated against each request to produce
-                                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                                              expression does not produce a valid tag value at request time, the request
-                                                                              is rejected.
+                                                                              CEL expression evaluated against each request to produce the tag value,
+                                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                                              tag values are rejected.
                                                                             maxLength: 16384
                                                                             minLength: 1
                                                                             type: string
@@ -3792,26 +3824,30 @@ spec:
                                                                       <= 1'
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
+                                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                                    `sessionToken` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -3870,26 +3906,30 @@ spec:
                                                                   type: object
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
+                                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                                    `clientSecret` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -3913,12 +3953,9 @@ spec:
                                                                       > 0)'
                                                                 workloadIdentity:
                                                                   description: |-
-                                                                    Workload identity authentication settings. Uses the federated token
-                                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                                    environment variables) to authenticate. This is the recommended method
-                                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                                    enabled.
+                                                                    Workload identity authentication settings. Uses the federated token and
+                                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                                    Workload Identity enabled.
                                                                   type: object
                                                               type: object
                                                               x-kubernetes-validations:
@@ -3944,34 +3981,42 @@ spec:
                                                                   type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                                    credentials are used.
+                                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                                    ambient credentials are used.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     key:
-                                                                      description: |-
-                                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                                        location-specific default key is used.
+                                                                      description: Key
+                                                                        in the referenced
+                                                                        Secret. If
+                                                                        omitted, a
+                                                                        location-specific
+                                                                        default is
+                                                                        used
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -4019,9 +4064,9 @@ spec:
                                                               type: string
                                                             location:
                                                               description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                                `passthrough`.
                                                               properties:
                                                                 cookie:
                                                                   properties:
@@ -4035,19 +4080,13 @@ spec:
                                                                 header:
                                                                   properties:
                                                                     name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
+                                                                      description: Name
+                                                                        of an HTTP
+                                                                        header. HTTP/2
+                                                                        pseudo-headers
+                                                                        (names beginning
+                                                                        with `:`)
+                                                                        are not supported
                                                                       maxLength: 256
                                                                       minLength: 1
                                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -4128,19 +4167,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -4229,29 +4269,25 @@ spec:
                                                                   properties:
                                                                     group:
                                                                       default: ""
-                                                                      description: |-
-                                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                        When unspecified or empty string, core API group is inferred.
+                                                                      description: Group
+                                                                        of the referent,
+                                                                        for example
+                                                                        `gateway.networking.k8s.io`.
+                                                                        Empty selects
+                                                                        the core API
+                                                                        group
                                                                       maxLength: 253
                                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                       type: string
                                                                     kind:
                                                                       default: Service
-                                                                      description: |-
-                                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                                        "Service".
-
-                                                                        Defaults to "Service" when not specified.
-
-                                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                                        outside of the cluster and as such are difficult to reason about in
-                                                                        terms of conformance. They also may not be safe to forward to (see
-                                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                        support ExternalName Services.
-
-                                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                                      description: Kubernetes
+                                                                        resource kind
+                                                                        of the referent,
+                                                                        for example
+                                                                        `Service`.
+                                                                        Defaults to
+                                                                        `Service`
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -4264,27 +4300,28 @@ spec:
                                                                       minLength: 1
                                                                       type: string
                                                                     namespace:
-                                                                      description: |-
-                                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                                        namespace is inferred.
-
-                                                                        Note that when a namespace different than the local namespace is specified,
-                                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                                        documentation for details.
-
-                                                                        Support: Core
+                                                                      description: Namespace
+                                                                        of the referent.
+                                                                        Defaults to
+                                                                        the local
+                                                                        namespace.
+                                                                        A cross-namespace
+                                                                        reference
+                                                                        requires a
+                                                                        ReferenceGrant
+                                                                        in the referent
+                                                                        namespace
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                       type: string
                                                                     port:
-                                                                      description: |-
-                                                                        Port specifies the destination port number to use for this resource.
-                                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                                        case, the port number is the service port number, not the target port.
-                                                                        For other resources, destination port might be derived from the referent
-                                                                        resource or this field.
+                                                                      description: Destination
+                                                                        port number.
+                                                                        Required when
+                                                                        the referent
+                                                                        is a Kubernetes
+                                                                        `Service`
                                                                       format: int32
                                                                       maximum: 65535
                                                                       minimum: 1
@@ -4392,29 +4429,52 @@ spec:
                                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                                           properties:
                                                                             group:
-                                                                              description: |-
-                                                                                The API group of the referenced credential.
-                                                                                Empty selects the core API group.
+                                                                              description: API
+                                                                                group
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential;
+                                                                                empty
+                                                                                selects
+                                                                                the
+                                                                                core
+                                                                                API
+                                                                                group
                                                                               type: string
                                                                             key:
-                                                                              description: |-
-                                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                                location-specific default key is used.
+                                                                              description: Key
+                                                                                in
+                                                                                the
+                                                                                referenced
+                                                                                Secret.
+                                                                                If
+                                                                                omitted,
+                                                                                a
+                                                                                location-specific
+                                                                                default
+                                                                                is
+                                                                                used
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
                                                                             kind:
-                                                                              description: |-
-                                                                                The kind of the referenced credential.
-                                                                                Empty defaults to `Secret`.
-                                                                              type: string
-                                                                            name:
-                                                                              description: The
-                                                                                name
+                                                                              description: Kind
                                                                                 of
                                                                                 the
                                                                                 referenced
-                                                                                credential.
+                                                                                credential;
+                                                                                empty
+                                                                                defaults
+                                                                                to
+                                                                                `Secret`
+                                                                              type: string
+                                                                            name:
+                                                                              description: Name
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
@@ -4454,27 +4514,42 @@ spec:
                                                                         is only valid with ClientSecretPost.
                                                                       properties:
                                                                         group:
-                                                                          description: |-
-                                                                            The API group of the referenced credential.
-                                                                            Empty selects the core API group.
+                                                                          description: API
+                                                                            group
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            selects
+                                                                            the core
+                                                                            API group
                                                                           type: string
                                                                         key:
-                                                                          description: |-
-                                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                                            location-specific default key is used.
+                                                                          description: Key
+                                                                            in the
+                                                                            referenced
+                                                                            Secret.
+                                                                            If omitted,
+                                                                            a location-specific
+                                                                            default
+                                                                            is used
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
                                                                         kind:
-                                                                          description: |-
-                                                                            The kind of the referenced credential.
-                                                                            Empty defaults to `Secret`.
+                                                                          description: Kind
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            defaults
+                                                                            to `Secret`
                                                                           type: string
                                                                         name:
-                                                                          description: The
-                                                                            name of
-                                                                            the referenced
-                                                                            credential.
+                                                                          description: Name
+                                                                            of the
+                                                                            referenced
+                                                                            credential
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
@@ -4556,19 +4631,16 @@ spec:
                                                                     header:
                                                                       properties:
                                                                         name:
-                                                                          description: |-
-                                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                                            Valid values include:
-
-                                                                            * "Authorization"
-                                                                            * "Set-Cookie"
-
-                                                                            Invalid values include:
-
-                                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                headers are not currently supported by this type.
-                                                                              - "/invalid" - "/ " is an invalid character
+                                                                          description: Name
+                                                                            of an
+                                                                            HTTP header.
+                                                                            HTTP/2
+                                                                            pseudo-headers
+                                                                            (names
+                                                                            beginning
+                                                                            with `:`)
+                                                                            are not
+                                                                            supported
                                                                           maxLength: 256
                                                                           minLength: 1
                                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -4670,19 +4742,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -4753,42 +4826,43 @@ spec:
                                                                   != ''IdJag'''
                                                             passthrough:
                                                               description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
+                                                                Reuses a client token already validated by another policy. Those policies
+                                                                may strip client credentials; passthrough adds the original token back to
+                                                                the backend request. Without client auth policies, this has no effect.
                                                               type: object
                                                             secretRef:
                                                               description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                                stored value is stripped only when reading the default `Authorization`
-                                                                key.
+                                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                                the default `Authorization` key.
                                                               properties:
                                                                 group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
+                                                                  description: API
+                                                                    group of the referenced
+                                                                    credential; empty
+                                                                    selects the core
+                                                                    API group
                                                                   type: string
                                                                 key:
-                                                                  description: |-
-                                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                                    location-specific default key is used.
+                                                                  description: Key
+                                                                    in the referenced
+                                                                    Secret. If omitted,
+                                                                    a location-specific
+                                                                    default is used
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
                                                                 kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
+                                                                  description: Kind
+                                                                    of the referenced
+                                                                    credential; empty
+                                                                    defaults to `Secret`
                                                                   type: string
                                                                 name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
+                                                                  description: Name
+                                                                    of the referenced
+                                                                    credential
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
@@ -4828,7 +4902,7 @@ spec:
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
@@ -4847,17 +4921,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -4866,7 +4933,7 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
@@ -4930,10 +4997,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -4960,12 +5027,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -4974,15 +5037,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -5001,34 +5062,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -5097,9 +5159,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -5108,29 +5169,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -5143,27 +5196,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -5268,29 +5319,20 @@ spec:
                                                       properties:
                                                         group:
                                                           default: ""
-                                                          description: |-
-                                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                            When unspecified or empty string, core API group is inferred.
+                                                          description: Group of the
+                                                            referent, for example
+                                                            `gateway.networking.k8s.io`.
+                                                            Empty selects the core
+                                                            API group
                                                           maxLength: 253
                                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                           type: string
                                                         kind:
                                                           default: Service
-                                                          description: |-
-                                                            Kind is the Kubernetes resource kind of the referent. For example
-                                                            "Service".
-
-                                                            Defaults to "Service" when not specified.
-
-                                                            ExternalName services can refer to CNAME DNS records that may live
-                                                            outside of the cluster and as such are difficult to reason about in
-                                                            terms of conformance. They also may not be safe to forward to (see
-                                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                            support ExternalName Services.
-
-                                                            Support: Core (Services with a type other than ExternalName)
-
-                                                            Support: Implementation-specific (Services with type ExternalName)
+                                                          description: Kubernetes
+                                                            resource kind of the referent,
+                                                            for example `Service`.
+                                                            Defaults to `Service`
                                                           maxLength: 63
                                                           minLength: 1
                                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -5302,27 +5344,21 @@ spec:
                                                           minLength: 1
                                                           type: string
                                                         namespace:
-                                                          description: |-
-                                                            Namespace is the namespace of the backend. When unspecified, the local
-                                                            namespace is inferred.
-
-                                                            Note that when a namespace different than the local namespace is specified,
-                                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                                            documentation for details.
-
-                                                            Support: Core
+                                                          description: Namespace of
+                                                            the referent. Defaults
+                                                            to the local namespace.
+                                                            A cross-namespace reference
+                                                            requires a ReferenceGrant
+                                                            in the referent namespace
                                                           maxLength: 63
                                                           minLength: 1
                                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                           type: string
                                                         port:
-                                                          description: |-
-                                                            Port specifies the destination port number to use for this resource.
-                                                            Port is required when the referent is a Kubernetes Service. In this
-                                                            case, the port number is the service port number, not the target port.
-                                                            For other resources, destination port might be derived from the referent
-                                                            resource or this field.
+                                                          description: Destination
+                                                            port number. Required
+                                                            when the referent is a
+                                                            Kubernetes `Service`
                                                           format: int32
                                                           maximum: 65535
                                                           minimum: 1
@@ -5357,51 +5393,31 @@ spec:
                                                           headers.
                                                         properties:
                                                           name:
-                                                            description: |-
-                                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                                              If multiple entries specify equivalent header names, only the first
-                                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                                              entries with an equivalent header name MUST be ignored. Due to the
-                                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                                              equivalent.
-
-                                                              When a header is repeated in an HTTP request, it is
-                                                              implementation-specific behavior as to how this is represented.
-                                                              Generally, proxies should follow the guidance from the RFC:
-                                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                                              processing a repeated header, with special handling for "Set-Cookie".
+                                                            description: Name of the
+                                                              HTTP header to match,
+                                                              case-insensitive. When
+                                                              names are equivalent,
+                                                              only the first matching
+                                                              entry is used
                                                             maxLength: 256
                                                             minLength: 1
                                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                                             type: string
                                                           type:
                                                             default: Exact
-                                                            description: |-
-                                                              Type specifies how to match against the value of the header.
-
-                                                              Support: Core (Exact)
-
-                                                              Support: Implementation-specific (RegularExpression)
-
-                                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                                              of regular expressions. Please read the implementation's documentation to
-                                                              determine the supported dialect.
+                                                            description: 'How to match
+                                                              against the header value:
+                                                              `Exact` (default) or
+                                                              `RegularExpression`.
+                                                              The regex dialect is
+                                                              implementation-specific'
                                                             enum:
                                                             - Exact
                                                             - RegularExpression
                                                             type: string
                                                           value:
-                                                            description: |-
-                                                              Value is the value of HTTP Header to be matched.
-                                                              <gateway:experimental:description>
-                                                              Must consist of printable US-ASCII characters, optionally separated
-                                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                                              </gateway:experimental:description>
-
-                                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                                            description: Value of
+                                                              the HTTP header to match
                                                             maxLength: 4096
                                                             minLength: 1
                                                             type: string
@@ -5450,7 +5466,7 @@ spec:
                                                         auth:
                                                           description: Settings for
                                                             managing authentication
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             aws:
                                                               description: |-
@@ -5486,9 +5502,8 @@ spec:
                                                                       type: string
                                                                     tags:
                                                                       description: |-
-                                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                                        attribution. STS allows at most 50 session tags per role session.
+                                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                                       items:
                                                                         description: |-
                                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -5496,10 +5511,9 @@ spec:
                                                                         properties:
                                                                           expression:
                                                                             description: |-
-                                                                              Expression is a CEL expression evaluated against each request to produce
-                                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                                              expression does not produce a valid tag value at request time, the request
-                                                                              is rejected.
+                                                                              CEL expression evaluated against each request to produce the tag value,
+                                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                                              tag values are rejected.
                                                                             maxLength: 16384
                                                                             minLength: 1
                                                                             type: string
@@ -5549,26 +5563,30 @@ spec:
                                                                       <= 1'
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
+                                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                                    `sessionToken` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -5627,26 +5645,30 @@ spec:
                                                                   type: object
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
+                                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                                    `clientSecret` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -5670,12 +5692,9 @@ spec:
                                                                       > 0)'
                                                                 workloadIdentity:
                                                                   description: |-
-                                                                    Workload identity authentication settings. Uses the federated token
-                                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                                    environment variables) to authenticate. This is the recommended method
-                                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                                    enabled.
+                                                                    Workload identity authentication settings. Uses the federated token and
+                                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                                    Workload Identity enabled.
                                                                   type: object
                                                               type: object
                                                               x-kubernetes-validations:
@@ -5701,34 +5720,42 @@ spec:
                                                                   type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                                    credentials are used.
+                                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                                    ambient credentials are used.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     key:
-                                                                      description: |-
-                                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                                        location-specific default key is used.
+                                                                      description: Key
+                                                                        in the referenced
+                                                                        Secret. If
+                                                                        omitted, a
+                                                                        location-specific
+                                                                        default is
+                                                                        used
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -5776,9 +5803,9 @@ spec:
                                                               type: string
                                                             location:
                                                               description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                                `passthrough`.
                                                               properties:
                                                                 cookie:
                                                                   properties:
@@ -5792,19 +5819,13 @@ spec:
                                                                 header:
                                                                   properties:
                                                                     name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
+                                                                      description: Name
+                                                                        of an HTTP
+                                                                        header. HTTP/2
+                                                                        pseudo-headers
+                                                                        (names beginning
+                                                                        with `:`)
+                                                                        are not supported
                                                                       maxLength: 256
                                                                       minLength: 1
                                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -5885,19 +5906,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -5986,29 +6008,25 @@ spec:
                                                                   properties:
                                                                     group:
                                                                       default: ""
-                                                                      description: |-
-                                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                        When unspecified or empty string, core API group is inferred.
+                                                                      description: Group
+                                                                        of the referent,
+                                                                        for example
+                                                                        `gateway.networking.k8s.io`.
+                                                                        Empty selects
+                                                                        the core API
+                                                                        group
                                                                       maxLength: 253
                                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                       type: string
                                                                     kind:
                                                                       default: Service
-                                                                      description: |-
-                                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                                        "Service".
-
-                                                                        Defaults to "Service" when not specified.
-
-                                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                                        outside of the cluster and as such are difficult to reason about in
-                                                                        terms of conformance. They also may not be safe to forward to (see
-                                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                        support ExternalName Services.
-
-                                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                                      description: Kubernetes
+                                                                        resource kind
+                                                                        of the referent,
+                                                                        for example
+                                                                        `Service`.
+                                                                        Defaults to
+                                                                        `Service`
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -6021,27 +6039,28 @@ spec:
                                                                       minLength: 1
                                                                       type: string
                                                                     namespace:
-                                                                      description: |-
-                                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                                        namespace is inferred.
-
-                                                                        Note that when a namespace different than the local namespace is specified,
-                                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                                        documentation for details.
-
-                                                                        Support: Core
+                                                                      description: Namespace
+                                                                        of the referent.
+                                                                        Defaults to
+                                                                        the local
+                                                                        namespace.
+                                                                        A cross-namespace
+                                                                        reference
+                                                                        requires a
+                                                                        ReferenceGrant
+                                                                        in the referent
+                                                                        namespace
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                       type: string
                                                                     port:
-                                                                      description: |-
-                                                                        Port specifies the destination port number to use for this resource.
-                                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                                        case, the port number is the service port number, not the target port.
-                                                                        For other resources, destination port might be derived from the referent
-                                                                        resource or this field.
+                                                                      description: Destination
+                                                                        port number.
+                                                                        Required when
+                                                                        the referent
+                                                                        is a Kubernetes
+                                                                        `Service`
                                                                       format: int32
                                                                       maximum: 65535
                                                                       minimum: 1
@@ -6149,29 +6168,52 @@ spec:
                                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                                           properties:
                                                                             group:
-                                                                              description: |-
-                                                                                The API group of the referenced credential.
-                                                                                Empty selects the core API group.
+                                                                              description: API
+                                                                                group
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential;
+                                                                                empty
+                                                                                selects
+                                                                                the
+                                                                                core
+                                                                                API
+                                                                                group
                                                                               type: string
                                                                             key:
-                                                                              description: |-
-                                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                                location-specific default key is used.
+                                                                              description: Key
+                                                                                in
+                                                                                the
+                                                                                referenced
+                                                                                Secret.
+                                                                                If
+                                                                                omitted,
+                                                                                a
+                                                                                location-specific
+                                                                                default
+                                                                                is
+                                                                                used
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
                                                                             kind:
-                                                                              description: |-
-                                                                                The kind of the referenced credential.
-                                                                                Empty defaults to `Secret`.
-                                                                              type: string
-                                                                            name:
-                                                                              description: The
-                                                                                name
+                                                                              description: Kind
                                                                                 of
                                                                                 the
                                                                                 referenced
-                                                                                credential.
+                                                                                credential;
+                                                                                empty
+                                                                                defaults
+                                                                                to
+                                                                                `Secret`
+                                                                              type: string
+                                                                            name:
+                                                                              description: Name
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
@@ -6211,27 +6253,42 @@ spec:
                                                                         is only valid with ClientSecretPost.
                                                                       properties:
                                                                         group:
-                                                                          description: |-
-                                                                            The API group of the referenced credential.
-                                                                            Empty selects the core API group.
+                                                                          description: API
+                                                                            group
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            selects
+                                                                            the core
+                                                                            API group
                                                                           type: string
                                                                         key:
-                                                                          description: |-
-                                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                                            location-specific default key is used.
+                                                                          description: Key
+                                                                            in the
+                                                                            referenced
+                                                                            Secret.
+                                                                            If omitted,
+                                                                            a location-specific
+                                                                            default
+                                                                            is used
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
                                                                         kind:
-                                                                          description: |-
-                                                                            The kind of the referenced credential.
-                                                                            Empty defaults to `Secret`.
+                                                                          description: Kind
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            defaults
+                                                                            to `Secret`
                                                                           type: string
                                                                         name:
-                                                                          description: The
-                                                                            name of
-                                                                            the referenced
-                                                                            credential.
+                                                                          description: Name
+                                                                            of the
+                                                                            referenced
+                                                                            credential
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
@@ -6313,19 +6370,16 @@ spec:
                                                                     header:
                                                                       properties:
                                                                         name:
-                                                                          description: |-
-                                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                                            Valid values include:
-
-                                                                            * "Authorization"
-                                                                            * "Set-Cookie"
-
-                                                                            Invalid values include:
-
-                                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                headers are not currently supported by this type.
-                                                                              - "/invalid" - "/ " is an invalid character
+                                                                          description: Name
+                                                                            of an
+                                                                            HTTP header.
+                                                                            HTTP/2
+                                                                            pseudo-headers
+                                                                            (names
+                                                                            beginning
+                                                                            with `:`)
+                                                                            are not
+                                                                            supported
                                                                           maxLength: 256
                                                                           minLength: 1
                                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6427,19 +6481,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6510,42 +6565,43 @@ spec:
                                                                   != ''IdJag'''
                                                             passthrough:
                                                               description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
+                                                                Reuses a client token already validated by another policy. Those policies
+                                                                may strip client credentials; passthrough adds the original token back to
+                                                                the backend request. Without client auth policies, this has no effect.
                                                               type: object
                                                             secretRef:
                                                               description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                                stored value is stripped only when reading the default `Authorization`
-                                                                key.
+                                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                                the default `Authorization` key.
                                                               properties:
                                                                 group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
+                                                                  description: API
+                                                                    group of the referenced
+                                                                    credential; empty
+                                                                    selects the core
+                                                                    API group
                                                                   type: string
                                                                 key:
-                                                                  description: |-
-                                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                                    location-specific default key is used.
+                                                                  description: Key
+                                                                    in the referenced
+                                                                    Secret. If omitted,
+                                                                    a location-specific
+                                                                    default is used
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
                                                                 kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
+                                                                  description: Kind
+                                                                    of the referenced
+                                                                    credential; empty
+                                                                    defaults to `Secret`
                                                                   type: string
                                                                 name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
+                                                                  description: Name
+                                                                    of the referenced
+                                                                    credential
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
@@ -6585,7 +6641,7 @@ spec:
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
@@ -6604,17 +6660,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -6623,7 +6672,7 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
@@ -6687,10 +6736,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -6717,12 +6766,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -6731,15 +6776,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -6758,34 +6801,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -6854,9 +6898,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -6865,29 +6908,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -6900,27 +6935,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -6979,7 +7012,7 @@ spec:
                                                         auth:
                                                           description: Settings for
                                                             managing authentication
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             aws:
                                                               description: |-
@@ -7015,9 +7048,8 @@ spec:
                                                                       type: string
                                                                     tags:
                                                                       description: |-
-                                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                                        attribution. STS allows at most 50 session tags per role session.
+                                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                                       items:
                                                                         description: |-
                                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -7025,10 +7057,9 @@ spec:
                                                                         properties:
                                                                           expression:
                                                                             description: |-
-                                                                              Expression is a CEL expression evaluated against each request to produce
-                                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                                              expression does not produce a valid tag value at request time, the request
-                                                                              is rejected.
+                                                                              CEL expression evaluated against each request to produce the tag value,
+                                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                                              tag values are rejected.
                                                                             maxLength: 16384
                                                                             minLength: 1
                                                                             type: string
@@ -7078,26 +7109,30 @@ spec:
                                                                       <= 1'
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                                    optionally `sessionToken`.
+                                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                                    `sessionToken` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -7156,26 +7191,30 @@ spec:
                                                                   type: object
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                                    `clientSecret`.
+                                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                                    `clientSecret` keys.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -7199,12 +7238,9 @@ spec:
                                                                       > 0)'
                                                                 workloadIdentity:
                                                                   description: |-
-                                                                    Workload identity authentication settings. Uses the federated token
-                                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                                    environment variables) to authenticate. This is the recommended method
-                                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                                    enabled.
+                                                                    Workload identity authentication settings. Uses the federated token and
+                                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                                    Workload Identity enabled.
                                                                   type: object
                                                               type: object
                                                               x-kubernetes-validations:
@@ -7230,34 +7266,42 @@ spec:
                                                                   type: string
                                                                 secretRef:
                                                                   description: |-
-                                                                    Credential source, defaulting to a Kubernetes
-                                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                                    credentials are used.
+                                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                                    ambient credentials are used.
                                                                   properties:
                                                                     group:
-                                                                      description: |-
-                                                                        The API group of the referenced credential.
-                                                                        Empty selects the core API group.
+                                                                      description: API
+                                                                        group of the
+                                                                        referenced
+                                                                        credential;
+                                                                        empty selects
+                                                                        the core API
+                                                                        group
                                                                       type: string
                                                                     key:
-                                                                      description: |-
-                                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                                        location-specific default key is used.
+                                                                      description: Key
+                                                                        in the referenced
+                                                                        Secret. If
+                                                                        omitted, a
+                                                                        location-specific
+                                                                        default is
+                                                                        used
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
                                                                     kind:
-                                                                      description: |-
-                                                                        The kind of the referenced credential.
-                                                                        Empty defaults to `Secret`.
+                                                                      description: Kind
+                                                                        of the referenced
+                                                                        credential;
+                                                                        empty defaults
+                                                                        to `Secret`
                                                                       type: string
                                                                     name:
-                                                                      description: The
-                                                                        name of the
-                                                                        referenced
-                                                                        credential.
+                                                                      description: Name
+                                                                        of the referenced
+                                                                        credential
                                                                       maxLength: 253
                                                                       minLength: 1
                                                                       type: string
@@ -7305,9 +7349,9 @@ spec:
                                                               type: string
                                                             location:
                                                               description: |-
-                                                                Where backend credentials are inserted.
-                                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                                `passthrough`.
                                                               properties:
                                                                 cookie:
                                                                   properties:
@@ -7321,19 +7365,13 @@ spec:
                                                                 header:
                                                                   properties:
                                                                     name:
-                                                                      description: |-
-                                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                                        Valid values include:
-
-                                                                        * "Authorization"
-                                                                        * "Set-Cookie"
-
-                                                                        Invalid values include:
-
-                                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                            headers are not currently supported by this type.
-                                                                          - "/invalid" - "/ " is an invalid character
+                                                                      description: Name
+                                                                        of an HTTP
+                                                                        header. HTTP/2
+                                                                        pseudo-headers
+                                                                        (names beginning
+                                                                        with `:`)
+                                                                        are not supported
                                                                       maxLength: 256
                                                                       minLength: 1
                                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -7414,19 +7452,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -7515,29 +7554,25 @@ spec:
                                                                   properties:
                                                                     group:
                                                                       default: ""
-                                                                      description: |-
-                                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                        When unspecified or empty string, core API group is inferred.
+                                                                      description: Group
+                                                                        of the referent,
+                                                                        for example
+                                                                        `gateway.networking.k8s.io`.
+                                                                        Empty selects
+                                                                        the core API
+                                                                        group
                                                                       maxLength: 253
                                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                       type: string
                                                                     kind:
                                                                       default: Service
-                                                                      description: |-
-                                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                                        "Service".
-
-                                                                        Defaults to "Service" when not specified.
-
-                                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                                        outside of the cluster and as such are difficult to reason about in
-                                                                        terms of conformance. They also may not be safe to forward to (see
-                                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                        support ExternalName Services.
-
-                                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                                      description: Kubernetes
+                                                                        resource kind
+                                                                        of the referent,
+                                                                        for example
+                                                                        `Service`.
+                                                                        Defaults to
+                                                                        `Service`
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -7550,27 +7585,28 @@ spec:
                                                                       minLength: 1
                                                                       type: string
                                                                     namespace:
-                                                                      description: |-
-                                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                                        namespace is inferred.
-
-                                                                        Note that when a namespace different than the local namespace is specified,
-                                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                                        documentation for details.
-
-                                                                        Support: Core
+                                                                      description: Namespace
+                                                                        of the referent.
+                                                                        Defaults to
+                                                                        the local
+                                                                        namespace.
+                                                                        A cross-namespace
+                                                                        reference
+                                                                        requires a
+                                                                        ReferenceGrant
+                                                                        in the referent
+                                                                        namespace
                                                                       maxLength: 63
                                                                       minLength: 1
                                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                       type: string
                                                                     port:
-                                                                      description: |-
-                                                                        Port specifies the destination port number to use for this resource.
-                                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                                        case, the port number is the service port number, not the target port.
-                                                                        For other resources, destination port might be derived from the referent
-                                                                        resource or this field.
+                                                                      description: Destination
+                                                                        port number.
+                                                                        Required when
+                                                                        the referent
+                                                                        is a Kubernetes
+                                                                        `Service`
                                                                       format: int32
                                                                       maximum: 65535
                                                                       minimum: 1
@@ -7678,29 +7714,52 @@ spec:
                                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                                           properties:
                                                                             group:
-                                                                              description: |-
-                                                                                The API group of the referenced credential.
-                                                                                Empty selects the core API group.
+                                                                              description: API
+                                                                                group
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential;
+                                                                                empty
+                                                                                selects
+                                                                                the
+                                                                                core
+                                                                                API
+                                                                                group
                                                                               type: string
                                                                             key:
-                                                                              description: |-
-                                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                                location-specific default key is used.
+                                                                              description: Key
+                                                                                in
+                                                                                the
+                                                                                referenced
+                                                                                Secret.
+                                                                                If
+                                                                                omitted,
+                                                                                a
+                                                                                location-specific
+                                                                                default
+                                                                                is
+                                                                                used
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
                                                                             kind:
-                                                                              description: |-
-                                                                                The kind of the referenced credential.
-                                                                                Empty defaults to `Secret`.
-                                                                              type: string
-                                                                            name:
-                                                                              description: The
-                                                                                name
+                                                                              description: Kind
                                                                                 of
                                                                                 the
                                                                                 referenced
-                                                                                credential.
+                                                                                credential;
+                                                                                empty
+                                                                                defaults
+                                                                                to
+                                                                                `Secret`
+                                                                              type: string
+                                                                            name:
+                                                                              description: Name
+                                                                                of
+                                                                                the
+                                                                                referenced
+                                                                                credential
                                                                               maxLength: 253
                                                                               minLength: 1
                                                                               type: string
@@ -7740,27 +7799,42 @@ spec:
                                                                         is only valid with ClientSecretPost.
                                                                       properties:
                                                                         group:
-                                                                          description: |-
-                                                                            The API group of the referenced credential.
-                                                                            Empty selects the core API group.
+                                                                          description: API
+                                                                            group
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            selects
+                                                                            the core
+                                                                            API group
                                                                           type: string
                                                                         key:
-                                                                          description: |-
-                                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                                            location-specific default key is used.
+                                                                          description: Key
+                                                                            in the
+                                                                            referenced
+                                                                            Secret.
+                                                                            If omitted,
+                                                                            a location-specific
+                                                                            default
+                                                                            is used
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
                                                                         kind:
-                                                                          description: |-
-                                                                            The kind of the referenced credential.
-                                                                            Empty defaults to `Secret`.
+                                                                          description: Kind
+                                                                            of the
+                                                                            referenced
+                                                                            credential;
+                                                                            empty
+                                                                            defaults
+                                                                            to `Secret`
                                                                           type: string
                                                                         name:
-                                                                          description: The
-                                                                            name of
-                                                                            the referenced
-                                                                            credential.
+                                                                          description: Name
+                                                                            of the
+                                                                            referenced
+                                                                            credential
                                                                           maxLength: 253
                                                                           minLength: 1
                                                                           type: string
@@ -7842,19 +7916,16 @@ spec:
                                                                     header:
                                                                       properties:
                                                                         name:
-                                                                          description: |-
-                                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                                            Valid values include:
-
-                                                                            * "Authorization"
-                                                                            * "Set-Cookie"
-
-                                                                            Invalid values include:
-
-                                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                headers are not currently supported by this type.
-                                                                              - "/invalid" - "/ " is an invalid character
+                                                                          description: Name
+                                                                            of an
+                                                                            HTTP header.
+                                                                            HTTP/2
+                                                                            pseudo-headers
+                                                                            (names
+                                                                            beginning
+                                                                            with `:`)
+                                                                            are not
+                                                                            supported
                                                                           maxLength: 256
                                                                           minLength: 1
                                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -7956,19 +8027,20 @@ spec:
                                                                         header:
                                                                           properties:
                                                                             name:
-                                                                              description: |-
-                                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                                Valid values include:
-
-                                                                                * "Authorization"
-                                                                                * "Set-Cookie"
-
-                                                                                Invalid values include:
-
-                                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                                    headers are not currently supported by this type.
-                                                                                  - "/invalid" - "/ " is an invalid character
+                                                                              description: Name
+                                                                                of
+                                                                                an
+                                                                                HTTP
+                                                                                header.
+                                                                                HTTP/2
+                                                                                pseudo-headers
+                                                                                (names
+                                                                                beginning
+                                                                                with
+                                                                                `:`)
+                                                                                are
+                                                                                not
+                                                                                supported
                                                                               maxLength: 256
                                                                               minLength: 1
                                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -8039,42 +8111,43 @@ spec:
                                                                   != ''IdJag'''
                                                             passthrough:
                                                               description: |-
-                                                                Passes through an existing token that has been sent by the
-                                                                client and validated. Other policies, like JWT and API key
-                                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                                request, the original token would be unchanged, so this would have no effect.
+                                                                Reuses a client token already validated by another policy. Those policies
+                                                                may strip client credentials; passthrough adds the original token back to
+                                                                the backend request. Without client auth policies, this has no effect.
                                                               type: object
                                                             secretRef:
                                                               description: |-
-                                                                Credential source, defaulting to a Kubernetes
-                                                                `Secret`, storing the key to use as the authorization value. When using
-                                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                                stored value is stripped only when reading the default `Authorization`
-                                                                key.
+                                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                                the default `Authorization` key.
                                                               properties:
                                                                 group:
-                                                                  description: |-
-                                                                    The API group of the referenced credential.
-                                                                    Empty selects the core API group.
+                                                                  description: API
+                                                                    group of the referenced
+                                                                    credential; empty
+                                                                    selects the core
+                                                                    API group
                                                                   type: string
                                                                 key:
-                                                                  description: |-
-                                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                                    location-specific default key is used.
+                                                                  description: Key
+                                                                    in the referenced
+                                                                    Secret. If omitted,
+                                                                    a location-specific
+                                                                    default is used
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
                                                                 kind:
-                                                                  description: |-
-                                                                    The kind of the referenced credential.
-                                                                    Empty defaults to `Secret`.
+                                                                  description: Kind
+                                                                    of the referenced
+                                                                    credential; empty
+                                                                    defaults to `Secret`
                                                                   type: string
                                                                 name:
-                                                                  description: The
-                                                                    name of the referenced
-                                                                    credential.
+                                                                  description: Name
+                                                                    of the referenced
+                                                                    credential
                                                                   maxLength: 253
                                                                   minLength: 1
                                                                   type: string
@@ -8114,7 +8187,7 @@ spec:
                                                         http:
                                                           description: Settings for
                                                             managing HTTP requests
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             requestTimeout:
                                                               description: Deadline
@@ -8133,17 +8206,10 @@ spec:
                                                                   >= duration('1ms')
                                                             version:
                                                               description: |-
-                                                                HTTP protocol version to use when connecting to
-                                                                the backend.
-                                                                If not specified, the version is automatically determined:
-                                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                                  port.
-                                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                                  be used.
-                                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                                  `HTTP2`, even if the backend doesn't support it.
+                                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                                to HTTP/2 even when the backend does not support it.
                                                               enum:
                                                               - HTTP1
                                                               - HTTP2
@@ -8152,7 +8218,7 @@ spec:
                                                         tcp:
                                                           description: Settings for
                                                             managing TCP connections
-                                                            to the backend.
+                                                            to the backend
                                                           properties:
                                                             connectTimeout:
                                                               description: |-
@@ -8216,10 +8282,10 @@ spec:
                                                           type: object
                                                         tls:
                                                           description: |-
-                                                            Settings for managing TLS connections to the backend.
+                                                            Settings for managing TLS connections to the backend
 
-                                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                                            validate the server, and the SNI will automatically be set based on the destination.
+                                                            When set, TLS is originated to the backend using the system trusted CA
+                                                            certificates, and SNI is inferred from the destination.
                                                           properties:
                                                             alpnProtocols:
                                                               description: |-
@@ -8246,12 +8312,8 @@ spec:
                                                                 properties:
                                                                   name:
                                                                     default: ""
-                                                                    description: |-
-                                                                      Name of the referent.
-                                                                      This field is effectively required, but due to backwards compatibility is
-                                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                                      almost certainly wrong.
-                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                    description: Name
+                                                                      of the referent
                                                                     type: string
                                                                 type: object
                                                                 x-kubernetes-map-type: atomic
@@ -8260,15 +8322,13 @@ spec:
                                                               x-kubernetes-list-type: atomic
                                                             insecureSkipVerify:
                                                               description: |-
-                                                                Originates TLS but skips verification of the backend's certificate.
-                                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                                Originates TLS but skips verification of the backend's certificate
+                                                                WARNING: insecure; only use if the risks are understood
 
-                                                                There are two modes:
-                                                                * `All` disables all TLS verification.
-                                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                                  if possible.
+                                                                Modes:
+                                                                * `All` disables all TLS verification
+                                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                                               enum:
                                                               - All
                                                               - Hostname
@@ -8287,34 +8347,35 @@ spec:
                                                               type: array
                                                             mtlsCertificateRef:
                                                               description: |-
-                                                                Enables mutual TLS to the backend, using the
-                                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                                `caCertificateRefs` field takes priority.
-
-                                                                If unspecified, no client certificate will be used.
+                                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                                is used.
                                                               items:
                                                                 description: |-
-                                                                  References a same-namespace credential.
-                                                                  Set only `name` to reference a Kubernetes Secret.
+                                                                  References a same-namespace credential
+                                                                  Set only `name` for a Kubernetes Secret
                                                                 properties:
                                                                   group:
-                                                                    description: |-
-                                                                      The API group of the referenced credential.
-                                                                      Empty selects the core API group.
+                                                                    description: API
+                                                                      group of the
+                                                                      referenced credential;
+                                                                      empty selects
+                                                                      the core API
+                                                                      group
                                                                     type: string
                                                                   kind:
-                                                                    description: |-
-                                                                      The kind of the referenced credential.
-                                                                      Empty defaults to `Secret`.
+                                                                    description: Kind
+                                                                      of the referenced
+                                                                      credential;
+                                                                      empty defaults
+                                                                      to `Secret`
                                                                     type: string
                                                                   name:
-                                                                    description: The
-                                                                      name of the
-                                                                      referenced credential.
+                                                                    description: Name
+                                                                      of the referenced
+                                                                      credential
                                                                     maxLength: 253
                                                                     minLength: 1
                                                                     type: string
@@ -8383,9 +8444,8 @@ spec:
                                                               <= 1'
                                                         tunnel:
                                                           description: Settings for
-                                                            managing tunnel connections,
-                                                            with behavior like `HTTPS_PROXY`,
-                                                            to the backend.
+                                                            managing tunnel connections
+                                                            to the backend, like `HTTPS_PROXY`
                                                           properties:
                                                             backendRef:
                                                               description: |-
@@ -8394,29 +8454,21 @@ spec:
                                                               properties:
                                                                 group:
                                                                   default: ""
-                                                                  description: |-
-                                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                                    When unspecified or empty string, core API group is inferred.
+                                                                  description: Group
+                                                                    of the referent,
+                                                                    for example `gateway.networking.k8s.io`.
+                                                                    Empty selects
+                                                                    the core API group
                                                                   maxLength: 253
                                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                                   type: string
                                                                 kind:
                                                                   default: Service
-                                                                  description: |-
-                                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                                    "Service".
-
-                                                                    Defaults to "Service" when not specified.
-
-                                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                                    outside of the cluster and as such are difficult to reason about in
-                                                                    terms of conformance. They also may not be safe to forward to (see
-                                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                                    support ExternalName Services.
-
-                                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                                  description: Kubernetes
+                                                                    resource kind
+                                                                    of the referent,
+                                                                    for example `Service`.
+                                                                    Defaults to `Service`
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8429,27 +8481,25 @@ spec:
                                                                   minLength: 1
                                                                   type: string
                                                                 namespace:
-                                                                  description: |-
-                                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                                    namespace is inferred.
-
-                                                                    Note that when a namespace different than the local namespace is specified,
-                                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                                    documentation for details.
-
-                                                                    Support: Core
+                                                                  description: Namespace
+                                                                    of the referent.
+                                                                    Defaults to the
+                                                                    local namespace.
+                                                                    A cross-namespace
+                                                                    reference requires
+                                                                    a ReferenceGrant
+                                                                    in the referent
+                                                                    namespace
                                                                   maxLength: 63
                                                                   minLength: 1
                                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                                   type: string
                                                                 port:
-                                                                  description: |-
-                                                                    Port specifies the destination port number to use for this resource.
-                                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                                    case, the port number is the service port number, not the target port.
-                                                                    For other resources, destination port might be derived from the referent
-                                                                    resource or this field.
+                                                                  description: Destination
+                                                                    port number. Required
+                                                                    when the referent
+                                                                    is a Kubernetes
+                                                                    `Service`
                                                                   format: int32
                                                                   maximum: 65535
                                                                   minimum: 1
@@ -8569,29 +8619,20 @@ spec:
                                                       properties:
                                                         group:
                                                           default: ""
-                                                          description: |-
-                                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                            When unspecified or empty string, core API group is inferred.
+                                                          description: Group of the
+                                                            referent, for example
+                                                            `gateway.networking.k8s.io`.
+                                                            Empty selects the core
+                                                            API group
                                                           maxLength: 253
                                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                           type: string
                                                         kind:
                                                           default: Service
-                                                          description: |-
-                                                            Kind is the Kubernetes resource kind of the referent. For example
-                                                            "Service".
-
-                                                            Defaults to "Service" when not specified.
-
-                                                            ExternalName services can refer to CNAME DNS records that may live
-                                                            outside of the cluster and as such are difficult to reason about in
-                                                            terms of conformance. They also may not be safe to forward to (see
-                                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                            support ExternalName Services.
-
-                                                            Support: Core (Services with a type other than ExternalName)
-
-                                                            Support: Implementation-specific (Services with type ExternalName)
+                                                          description: Kubernetes
+                                                            resource kind of the referent,
+                                                            for example `Service`.
+                                                            Defaults to `Service`
                                                           maxLength: 63
                                                           minLength: 1
                                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8603,27 +8644,21 @@ spec:
                                                           minLength: 1
                                                           type: string
                                                         namespace:
-                                                          description: |-
-                                                            Namespace is the namespace of the backend. When unspecified, the local
-                                                            namespace is inferred.
-
-                                                            Note that when a namespace different than the local namespace is specified,
-                                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                                            documentation for details.
-
-                                                            Support: Core
+                                                          description: Namespace of
+                                                            the referent. Defaults
+                                                            to the local namespace.
+                                                            A cross-namespace reference
+                                                            requires a ReferenceGrant
+                                                            in the referent namespace
                                                           maxLength: 63
                                                           minLength: 1
                                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                           type: string
                                                         port:
-                                                          description: |-
-                                                            Port specifies the destination port number to use for this resource.
-                                                            Port is required when the referent is a Kubernetes Service. In this
-                                                            case, the port number is the service port number, not the target port.
-                                                            For other resources, destination port might be derived from the referent
-                                                            resource or this field.
+                                                          description: Destination
+                                                            port number. Required
+                                                            when the referent is a
+                                                            Kubernetes `Service`
                                                           format: int32
                                                           maximum: 65535
                                                           minimum: 1
@@ -8658,51 +8693,31 @@ spec:
                                                           headers.
                                                         properties:
                                                           name:
-                                                            description: |-
-                                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                                              If multiple entries specify equivalent header names, only the first
-                                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                                              entries with an equivalent header name MUST be ignored. Due to the
-                                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                                              equivalent.
-
-                                                              When a header is repeated in an HTTP request, it is
-                                                              implementation-specific behavior as to how this is represented.
-                                                              Generally, proxies should follow the guidance from the RFC:
-                                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                                              processing a repeated header, with special handling for "Set-Cookie".
+                                                            description: Name of the
+                                                              HTTP header to match,
+                                                              case-insensitive. When
+                                                              names are equivalent,
+                                                              only the first matching
+                                                              entry is used
                                                             maxLength: 256
                                                             minLength: 1
                                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                                             type: string
                                                           type:
                                                             default: Exact
-                                                            description: |-
-                                                              Type specifies how to match against the value of the header.
-
-                                                              Support: Core (Exact)
-
-                                                              Support: Implementation-specific (RegularExpression)
-
-                                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                                              of regular expressions. Please read the implementation's documentation to
-                                                              determine the supported dialect.
+                                                            description: 'How to match
+                                                              against the header value:
+                                                              `Exact` (default) or
+                                                              `RegularExpression`.
+                                                              The regex dialect is
+                                                              implementation-specific'
                                                             enum:
                                                             - Exact
                                                             - RegularExpression
                                                             type: string
                                                           value:
-                                                            description: |-
-                                                              Value is the value of HTTP Header to be matched.
-                                                              <gateway:experimental:description>
-                                                              Must consist of printable US-ASCII characters, optionally separated
-                                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                                              </gateway:experimental:description>
-
-                                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                                            description: Value of
+                                                              the HTTP header to match
                                                             maxLength: 4096
                                                             minLength: 1
                                                             type: string
@@ -8801,7 +8816,7 @@ spec:
                                         >= 1'
                                   auth:
                                     description: Settings for managing authentication
-                                      to the backend.
+                                      to the backend
                                     properties:
                                       aws:
                                         description: |-
@@ -8835,9 +8850,8 @@ spec:
                                                 type: string
                                               tags:
                                                 description: |-
-                                                  Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                  allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                  attribution. STS allows at most 50 session tags per role session.
+                                                  Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                  & Usage Report, once activated. STS allows at most 50 per role session.
                                                 items:
                                                   description: |-
                                                     AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -8845,10 +8859,9 @@ spec:
                                                   properties:
                                                     expression:
                                                       description: |-
-                                                        Expression is a CEL expression evaluated against each request to produce
-                                                        the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                        expression does not produce a valid tag value at request time, the request
-                                                        is rejected.
+                                                        CEL expression evaluated against each request to produce the tag value,
+                                                        for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                        tag values are rejected.
                                                       maxLength: 16384
                                                       minLength: 1
                                                       type: string
@@ -8886,24 +8899,22 @@ spec:
                                                 <= 1'
                                           secretRef:
                                             description: |-
-                                              Credential source, defaulting to a Kubernetes
-                                              `Secret`, containing the AWS credentials. When using the default Secret
-                                              resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                              optionally `sessionToken`.
+                                              Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                              The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                              `sessionToken` keys.
                                             properties:
                                               group:
-                                                description: |-
-                                                  The API group of the referenced credential.
-                                                  Empty selects the core API group.
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
                                                 type: string
                                               kind:
-                                                description: |-
-                                                  The kind of the referenced credential.
-                                                  Empty defaults to `Secret`.
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
                                                 type: string
                                               name:
-                                                description: The name of the referenced
-                                                  credential.
+                                                description: Name of the referenced
+                                                  credential
                                                 maxLength: 253
                                                 minLength: 1
                                                 type: string
@@ -8953,24 +8964,22 @@ spec:
                                             type: object
                                           secretRef:
                                             description: |-
-                                              Credential source, defaulting to a Kubernetes
-                                              `Secret`, containing the Azure credentials. When using the default Secret
-                                              resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                              `clientSecret`.
+                                              Credential source for Azure credentials, defaulting to a Kubernetes
+                                              `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                              `clientSecret` keys.
                                             properties:
                                               group:
-                                                description: |-
-                                                  The API group of the referenced credential.
-                                                  Empty selects the core API group.
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
                                                 type: string
                                               kind:
-                                                description: |-
-                                                  The kind of the referenced credential.
-                                                  Empty defaults to `Secret`.
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
                                                 type: string
                                               name:
-                                                description: The name of the referenced
-                                                  credential.
+                                                description: Name of the referenced
+                                                  credential
                                                 maxLength: 253
                                                 minLength: 1
                                                 type: string
@@ -8988,12 +8997,9 @@ spec:
                                                 > 0)'
                                           workloadIdentity:
                                             description: |-
-                                              Workload identity authentication settings. Uses the federated token
-                                              projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                              `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                              environment variables) to authenticate. This is the recommended method
-                                              when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                              enabled.
+                                              Workload identity authentication settings. Uses the federated token and
+                                              Azure env vars projected into the data plane pod. Recommended on AKS with
+                                              Workload Identity enabled.
                                             type: object
                                         type: object
                                         x-kubernetes-validations:
@@ -9017,32 +9023,30 @@ spec:
                                             type: string
                                           secretRef:
                                             description: |-
-                                              Credential source, defaulting to a Kubernetes
-                                              `Secret`, containing ADC-compatible Google credential JSON. When using
-                                              the default Secret resolver, this must be stored in the `credentials.json`
-                                              key by default; override via `secretRef.key`. When omitted, ambient
-                                              credentials are used.
+                                              Credential source for ADC-compatible Google credential JSON, defaulting to
+                                              a Kubernetes `Secret`. By default, the value is read from
+                                              `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                              ambient credentials are used.
                                             properties:
                                               group:
-                                                description: |-
-                                                  The API group of the referenced credential.
-                                                  Empty selects the core API group.
+                                                description: API group of the referenced
+                                                  credential; empty selects the core
+                                                  API group
                                                 type: string
                                               key:
-                                                description: |-
-                                                  The key in the referenced Secret whose value is used. If omitted, a
-                                                  location-specific default key is used.
+                                                description: Key in the referenced
+                                                  Secret. If omitted, a location-specific
+                                                  default is used
                                                 maxLength: 253
                                                 minLength: 1
                                                 type: string
                                               kind:
-                                                description: |-
-                                                  The kind of the referenced credential.
-                                                  Empty defaults to `Secret`.
+                                                description: Kind of the referenced
+                                                  credential; empty defaults to `Secret`
                                                 type: string
                                               name:
-                                                description: The name of the referenced
-                                                  credential.
+                                                description: Name of the referenced
+                                                  credential
                                                 maxLength: 253
                                                 minLength: 1
                                                 type: string
@@ -9081,9 +9085,9 @@ spec:
                                         type: string
                                       location:
                                         description: |-
-                                          Where backend credentials are inserted.
-                                          If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                          This applies to `key`, `secretRef`, and `passthrough`.
+                                          Where backend credentials are inserted. Defaults to the `Authorization`
+                                          header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                          `passthrough`.
                                         properties:
                                           cookie:
                                             properties:
@@ -9097,19 +9101,9 @@ spec:
                                           header:
                                             properties:
                                               name:
-                                                description: |-
-                                                  HTTPHeaderName is the name of an HTTP header.
-
-                                                  Valid values include:
-
-                                                  * "Authorization"
-                                                  * "Set-Cookie"
-
-                                                  Invalid values include:
-
-                                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                      headers are not currently supported by this type.
-                                                    - "/invalid" - "/ " is an invalid character
+                                                description: Name of an HTTP header.
+                                                  HTTP/2 pseudo-headers (names beginning
+                                                  with `:`) are not supported
                                                 maxLength: 256
                                                 minLength: 1
                                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -9175,19 +9169,10 @@ spec:
                                                   header:
                                                     properties:
                                                       name:
-                                                        description: |-
-                                                          HTTPHeaderName is the name of an HTTP header.
-
-                                                          Valid values include:
-
-                                                          * "Authorization"
-                                                          * "Set-Cookie"
-
-                                                          Invalid values include:
-
-                                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                              headers are not currently supported by this type.
-                                                            - "/invalid" - "/ " is an invalid character
+                                                        description: Name of an HTTP
+                                                          header. HTTP/2 pseudo-headers
+                                                          (names beginning with `:`)
+                                                          are not supported
                                                         maxLength: 256
                                                         minLength: 1
                                                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -9258,29 +9243,17 @@ spec:
                                             properties:
                                               group:
                                                 default: ""
-                                                description: |-
-                                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                  When unspecified or empty string, core API group is inferred.
+                                                description: Group of the referent,
+                                                  for example `gateway.networking.k8s.io`.
+                                                  Empty selects the core API group
                                                 maxLength: 253
                                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                 type: string
                                               kind:
                                                 default: Service
-                                                description: |-
-                                                  Kind is the Kubernetes resource kind of the referent. For example
-                                                  "Service".
-
-                                                  Defaults to "Service" when not specified.
-
-                                                  ExternalName services can refer to CNAME DNS records that may live
-                                                  outside of the cluster and as such are difficult to reason about in
-                                                  terms of conformance. They also may not be safe to forward to (see
-                                                  CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                  support ExternalName Services.
-
-                                                  Support: Core (Services with a type other than ExternalName)
-
-                                                  Support: Implementation-specific (Services with type ExternalName)
+                                                description: Kubernetes resource kind
+                                                  of the referent, for example `Service`.
+                                                  Defaults to `Service`
                                                 maxLength: 63
                                                 minLength: 1
                                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -9292,27 +9265,19 @@ spec:
                                                 minLength: 1
                                                 type: string
                                               namespace:
-                                                description: |-
-                                                  Namespace is the namespace of the backend. When unspecified, the local
-                                                  namespace is inferred.
-
-                                                  Note that when a namespace different than the local namespace is specified,
-                                                  a ReferenceGrant object is required in the referent namespace to allow that
-                                                  namespace's owner to accept the reference. See the ReferenceGrant
-                                                  documentation for details.
-
-                                                  Support: Core
+                                                description: Namespace of the referent.
+                                                  Defaults to the local namespace.
+                                                  A cross-namespace reference requires
+                                                  a ReferenceGrant in the referent
+                                                  namespace
                                                 maxLength: 63
                                                 minLength: 1
                                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                 type: string
                                               port:
-                                                description: |-
-                                                  Port specifies the destination port number to use for this resource.
-                                                  Port is required when the referent is a Kubernetes Service. In this
-                                                  case, the port number is the service port number, not the target port.
-                                                  For other resources, destination port might be derived from the referent
-                                                  resource or this field.
+                                                description: Destination port number.
+                                                  Required when the referent is a
+                                                  Kubernetes `Service`
                                                 format: int32
                                                 maximum: 65535
                                                 minimum: 1
@@ -9391,25 +9356,26 @@ spec:
                                                       or EC private key; override the key name via `signingKeyRef.key`.
                                                     properties:
                                                       group:
-                                                        description: |-
-                                                          The API group of the referenced credential.
-                                                          Empty selects the core API group.
+                                                        description: API group of
+                                                          the referenced credential;
+                                                          empty selects the core API
+                                                          group
                                                         type: string
                                                       key:
-                                                        description: |-
-                                                          The key in the referenced Secret whose value is used. If omitted, a
-                                                          location-specific default key is used.
+                                                        description: Key in the referenced
+                                                          Secret. If omitted, a location-specific
+                                                          default is used
                                                         maxLength: 253
                                                         minLength: 1
                                                         type: string
                                                       kind:
-                                                        description: |-
-                                                          The kind of the referenced credential.
-                                                          Empty defaults to `Secret`.
+                                                        description: Kind of the referenced
+                                                          credential; empty defaults
+                                                          to `Secret`
                                                         type: string
                                                       name:
-                                                        description: The name of the
-                                                          referenced credential.
+                                                        description: Name of the referenced
+                                                          credential
                                                         maxLength: 253
                                                         minLength: 1
                                                         type: string
@@ -9437,25 +9403,25 @@ spec:
                                                   is only valid with ClientSecretPost.
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   key:
-                                                    description: |-
-                                                      The key in the referenced Secret whose value is used. If omitted, a
-                                                      location-specific default key is used.
+                                                    description: Key in the referenced
+                                                      Secret. If omitted, a location-specific
+                                                      default is used
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -9513,19 +9479,10 @@ spec:
                                               header:
                                                 properties:
                                                   name:
-                                                    description: |-
-                                                      HTTPHeaderName is the name of an HTTP header.
-
-                                                      Valid values include:
-
-                                                      * "Authorization"
-                                                      * "Set-Cookie"
-
-                                                      Invalid values include:
-
-                                                        - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                          headers are not currently supported by this type.
-                                                        - "/invalid" - "/ " is an invalid character
+                                                    description: Name of an HTTP header.
+                                                      HTTP/2 pseudo-headers (names
+                                                      beginning with `:`) are not
+                                                      supported
                                                     maxLength: 256
                                                     minLength: 1
                                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -9610,19 +9567,10 @@ spec:
                                                   header:
                                                     properties:
                                                       name:
-                                                        description: |-
-                                                          HTTPHeaderName is the name of an HTTP header.
-
-                                                          Valid values include:
-
-                                                          * "Authorization"
-                                                          * "Set-Cookie"
-
-                                                          Invalid values include:
-
-                                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                              headers are not currently supported by this type.
-                                                            - "/invalid" - "/ " is an invalid character
+                                                        description: Name of an HTTP
+                                                          header. HTTP/2 pseudo-headers
+                                                          (names beginning with `:`)
+                                                          are not supported
                                                         maxLength: 256
                                                         minLength: 1
                                                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -9679,41 +9627,35 @@ spec:
                                             self.requestedTokenType != ''IdJag'''
                                       passthrough:
                                         description: |-
-                                          Passes through an existing token that has been sent by the
-                                          client and validated. Other policies, like JWT and API key
-                                          authentication, will strip the original client credentials. Passthrough backend authentication
-                                          causes the original token to be added back into the request. If there are no client authentication policies on the
-                                          request, the original token would be unchanged, so this would have no effect.
+                                          Reuses a client token already validated by another policy. Those policies
+                                          may strip client credentials; passthrough adds the original token back to
+                                          the backend request. Without client auth policies, this has no effect.
                                         type: object
                                       secretRef:
                                         description: |-
-                                          Credential source, defaulting to a Kubernetes
-                                          `Secret`, storing the key to use as the authorization value. When using
-                                          the default Secret resolver, this must be stored in the `Authorization`
-                                          key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                          stored value is stripped only when reading the default `Authorization`
-                                          key.
+                                          Credential source for the authorization value, defaulting to a Kubernetes
+                                          `Secret`. By default, the value is read from the `Authorization` key; set
+                                          `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                          the default `Authorization` key.
                                         properties:
                                           group:
-                                            description: |-
-                                              The API group of the referenced credential.
-                                              Empty selects the core API group.
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
                                             type: string
                                           key:
-                                            description: |-
-                                              The key in the referenced Secret whose value is used. If omitted, a
-                                              location-specific default key is used.
+                                            description: Key in the referenced Secret.
+                                              If omitted, a location-specific default
+                                              is used
                                             maxLength: 253
                                             minLength: 1
                                             type: string
                                           kind:
-                                            description: |-
-                                              The kind of the referenced credential.
-                                              Empty defaults to `Secret`.
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
                                             type: string
                                           name:
-                                            description: The name of the referenced
-                                              credential.
+                                            description: Name of the referenced credential
                                             maxLength: 253
                                             minLength: 1
                                             type: string
@@ -9774,13 +9716,12 @@ spec:
                                               rule: duration(self) >= duration('1s')
                                           healthThreshold:
                                             description: |-
-                                              EWMA health score threshold, expressed as 0 to 100.
-                                              When set, a backend is only evicted if its computed health drops below this value after an unhealthy response.
-                                              For example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.
-                                              Unlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average
-                                              so a single success in a stream of failures can delay eviction.
-                                              When both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.
-                                              When neither is set, a single unhealthy response triggers eviction.
+                                              EWMA health score threshold, from 0 to 100. When set, a backend is evicted
+                                              only if its computed health drops below this value after an unhealthy
+                                              response (e.g. 50 evicts when EWMA health falls below 50%). Unlike
+                                              consecutiveFailures, this sliding-window average lets a single success delay
+                                              eviction. If both are set, either condition evicts; if neither, a single
+                                              unhealthy response evicts.
                                             format: int32
                                             maximum: 100
                                             minimum: 0
@@ -9810,7 +9751,7 @@ spec:
                                     type: object
                                   http:
                                     description: Settings for managing HTTP requests
-                                      to the backend.
+                                      to the backend
                                     properties:
                                       requestTimeout:
                                         description: Deadline for receiving a response
@@ -9824,17 +9765,10 @@ spec:
                                           rule: duration(self) >= duration('1ms')
                                       version:
                                         description: |-
-                                          HTTP protocol version to use when connecting to
-                                          the backend.
-                                          If not specified, the version is automatically determined:
-                                          * `Service` types can specify it with `appProtocol` on the `Service`
-                                            port.
-                                          * If traffic is identified as gRPC, `HTTP2` is used.
-                                          * If the incoming traffic was plaintext HTTP, the original protocol will
-                                            be used.
-                                          * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                            because most clients will transparently upgrade HTTPS traffic to
-                                            `HTTP2`, even if the backend doesn't support it.
+                                          HTTP protocol version for backend connections. If unset, it is inferred:
+                                          `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                          plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                          to HTTP/2 even when the backend does not support it.
                                         enum:
                                         - HTTP1
                                         - HTTP2
@@ -9842,7 +9776,7 @@ spec:
                                     type: object
                                   tcp:
                                     description: Settings for managing TCP connections
-                                      to the backend.
+                                      to the backend
                                     properties:
                                       connectTimeout:
                                         description: |-
@@ -9893,10 +9827,10 @@ spec:
                                     type: object
                                   tls:
                                     description: |-
-                                      Settings for managing TLS connections to the backend.
+                                      Settings for managing TLS connections to the backend
 
-                                      If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                      validate the server, and the SNI will automatically be set based on the destination.
+                                      When set, TLS is originated to the backend using the system trusted CA
+                                      certificates, and SNI is inferred from the destination.
                                     properties:
                                       alpnProtocols:
                                         description: |-
@@ -9923,12 +9857,7 @@ spec:
                                           properties:
                                             name:
                                               default: ""
-                                              description: |-
-                                                Name of the referent.
-                                                This field is effectively required, but due to backwards compatibility is
-                                                allowed to be empty. Instances of this type with an empty value here are
-                                                almost certainly wrong.
-                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              description: Name of the referent
                                               type: string
                                           type: object
                                           x-kubernetes-map-type: atomic
@@ -9937,15 +9866,13 @@ spec:
                                         x-kubernetes-list-type: atomic
                                       insecureSkipVerify:
                                         description: |-
-                                          Originates TLS but skips verification of the backend's certificate.
-                                          WARNING: This is an insecure option that should only be used if the risks are understood.
+                                          Originates TLS but skips verification of the backend's certificate
+                                          WARNING: insecure; only use if the risks are understood
 
-                                          There are two modes:
-                                          * `All` disables all TLS verification.
-                                          * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                            mismatch of hostname or SANs. Note that this method is still insecure;
-                                            prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                            if possible.
+                                          Modes:
+                                          * `All` disables all TLS verification
+                                          * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                            Still insecure; prefer `verifySubjectAltNames` where possible.
                                         enum:
                                         - All
                                         - Hostname
@@ -9964,33 +9891,28 @@ spec:
                                         type: array
                                       mtlsCertificateRef:
                                         description: |-
-                                          Enables mutual TLS to the backend, using the
-                                          specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                          credential source, defaulting to a Kubernetes `Secret`.
-
-                                          An optional `ca.cert` field, if present, will be used to verify the
-                                          server certificate. If `caCertificateRefs` is also specified, the
-                                          `caCertificateRefs` field takes priority.
-
-                                          If unspecified, no client certificate will be used.
+                                          Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                          referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                          optional `ca.cert`, if present, verifies the server certificate, but
+                                          `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                          is used.
                                         items:
                                           description: |-
-                                            References a same-namespace credential.
-                                            Set only `name` to reference a Kubernetes Secret.
+                                            References a same-namespace credential
+                                            Set only `name` for a Kubernetes Secret
                                           properties:
                                             group:
-                                              description: |-
-                                                The API group of the referenced credential.
-                                                Empty selects the core API group.
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
                                               type: string
                                             kind:
-                                              description: |-
-                                                The kind of the referenced credential.
-                                                Empty defaults to `Secret`.
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
                                               type: string
                                             name:
-                                              description: The name of the referenced
-                                                credential.
+                                              description: Name of the referenced
+                                                credential
                                               maxLength: 253
                                               minLength: 1
                                               type: string
@@ -10305,8 +10227,8 @@ spec:
                                       rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
                                         >= 1'
                                   tunnel:
-                                    description: Settings for managing tunnel connections,
-                                      with behavior like `HTTPS_PROXY`, to the backend.
+                                    description: Settings for managing tunnel connections
+                                      to the backend, like `HTTPS_PROXY`
                                     properties:
                                       backendRef:
                                         description: |-
@@ -10315,29 +10237,17 @@ spec:
                                         properties:
                                           group:
                                             default: ""
-                                            description: |-
-                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                              When unspecified or empty string, core API group is inferred.
+                                            description: Group of the referent, for
+                                              example `gateway.networking.k8s.io`.
+                                              Empty selects the core API group
                                             maxLength: 253
                                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                             type: string
                                           kind:
                                             default: Service
-                                            description: |-
-                                              Kind is the Kubernetes resource kind of the referent. For example
-                                              "Service".
-
-                                              Defaults to "Service" when not specified.
-
-                                              ExternalName services can refer to CNAME DNS records that may live
-                                              outside of the cluster and as such are difficult to reason about in
-                                              terms of conformance. They also may not be safe to forward to (see
-                                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                              support ExternalName Services.
-
-                                              Support: Core (Services with a type other than ExternalName)
-
-                                              Support: Implementation-specific (Services with type ExternalName)
+                                            description: Kubernetes resource kind
+                                              of the referent, for example `Service`.
+                                              Defaults to `Service`
                                             maxLength: 63
                                             minLength: 1
                                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -10348,27 +10258,18 @@ spec:
                                             minLength: 1
                                             type: string
                                           namespace:
-                                            description: |-
-                                              Namespace is the namespace of the backend. When unspecified, the local
-                                              namespace is inferred.
-
-                                              Note that when a namespace different than the local namespace is specified,
-                                              a ReferenceGrant object is required in the referent namespace to allow that
-                                              namespace's owner to accept the reference. See the ReferenceGrant
-                                              documentation for details.
-
-                                              Support: Core
+                                            description: Namespace of the referent.
+                                              Defaults to the local namespace. A cross-namespace
+                                              reference requires a ReferenceGrant
+                                              in the referent namespace
                                             maxLength: 63
                                             minLength: 1
                                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                             type: string
                                           port:
-                                            description: |-
-                                              Port specifies the destination port number to use for this resource.
-                                              Port is required when the referent is a Kubernetes Service. In this
-                                              case, the port number is the service port number, not the target port.
-                                              For other resources, destination port might be derived from the referent
-                                              resource or this field.
+                                            description: Destination port number.
+                                              Required when the referent is a Kubernetes
+                                              `Service`
                                             format: int32
                                             maximum: 65535
                                             minimum: 1
@@ -11017,12 +10918,7 @@ spec:
                               properties:
                                 name:
                                   default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  description: Name of the referent
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
@@ -11050,7 +10946,7 @@ spec:
                               properties:
                                 auth:
                                   description: Settings for managing authentication
-                                    to the backend.
+                                    to the backend
                                   properties:
                                     aws:
                                       description: |-
@@ -11084,9 +10980,8 @@ spec:
                                               type: string
                                             tags:
                                               description: |-
-                                                Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                attribution. STS allows at most 50 session tags per role session.
+                                                Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                & Usage Report, once activated. STS allows at most 50 per role session.
                                               items:
                                                 description: |-
                                                   AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -11094,10 +10989,9 @@ spec:
                                                 properties:
                                                   expression:
                                                     description: |-
-                                                      Expression is a CEL expression evaluated against each request to produce
-                                                      the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                      expression does not produce a valid tag value at request time, the request
-                                                      is rejected.
+                                                      CEL expression evaluated against each request to produce the tag value,
+                                                      for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                      tag values are rejected.
                                                     maxLength: 16384
                                                     minLength: 1
                                                     type: string
@@ -11134,24 +11028,22 @@ spec:
                                               <= 1'
                                         secretRef:
                                           description: |-
-                                            Credential source, defaulting to a Kubernetes
-                                            `Secret`, containing the AWS credentials. When using the default Secret
-                                            resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                            optionally `sessionToken`.
+                                            Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                            The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                            `sessionToken` keys.
                                           properties:
                                             group:
-                                              description: |-
-                                                The API group of the referenced credential.
-                                                Empty selects the core API group.
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
                                               type: string
                                             kind:
-                                              description: |-
-                                                The kind of the referenced credential.
-                                                Empty defaults to `Secret`.
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
                                               type: string
                                             name:
-                                              description: The name of the referenced
-                                                credential.
+                                              description: Name of the referenced
+                                                credential
                                               maxLength: 253
                                               minLength: 1
                                               type: string
@@ -11200,24 +11092,22 @@ spec:
                                           type: object
                                         secretRef:
                                           description: |-
-                                            Credential source, defaulting to a Kubernetes
-                                            `Secret`, containing the Azure credentials. When using the default Secret
-                                            resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                            `clientSecret`.
+                                            Credential source for Azure credentials, defaulting to a Kubernetes
+                                            `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                            `clientSecret` keys.
                                           properties:
                                             group:
-                                              description: |-
-                                                The API group of the referenced credential.
-                                                Empty selects the core API group.
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
                                               type: string
                                             kind:
-                                              description: |-
-                                                The kind of the referenced credential.
-                                                Empty defaults to `Secret`.
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
                                               type: string
                                             name:
-                                              description: The name of the referenced
-                                                credential.
+                                              description: Name of the referenced
+                                                credential
                                               maxLength: 253
                                               minLength: 1
                                               type: string
@@ -11234,12 +11124,9 @@ spec:
                                               && size(self.kind) > 0)'
                                         workloadIdentity:
                                           description: |-
-                                            Workload identity authentication settings. Uses the federated token
-                                            projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                            `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                            environment variables) to authenticate. This is the recommended method
-                                            when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                            enabled.
+                                            Workload identity authentication settings. Uses the federated token and
+                                            Azure env vars projected into the data plane pod. Recommended on AKS with
+                                            Workload Identity enabled.
                                           type: object
                                       type: object
                                       x-kubernetes-validations:
@@ -11263,32 +11150,30 @@ spec:
                                           type: string
                                         secretRef:
                                           description: |-
-                                            Credential source, defaulting to a Kubernetes
-                                            `Secret`, containing ADC-compatible Google credential JSON. When using
-                                            the default Secret resolver, this must be stored in the `credentials.json`
-                                            key by default; override via `secretRef.key`. When omitted, ambient
-                                            credentials are used.
+                                            Credential source for ADC-compatible Google credential JSON, defaulting to
+                                            a Kubernetes `Secret`. By default, the value is read from
+                                            `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                            ambient credentials are used.
                                           properties:
                                             group:
-                                              description: |-
-                                                The API group of the referenced credential.
-                                                Empty selects the core API group.
+                                              description: API group of the referenced
+                                                credential; empty selects the core
+                                                API group
                                               type: string
                                             key:
-                                              description: |-
-                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                location-specific default key is used.
+                                              description: Key in the referenced Secret.
+                                                If omitted, a location-specific default
+                                                is used
                                               maxLength: 253
                                               minLength: 1
                                               type: string
                                             kind:
-                                              description: |-
-                                                The kind of the referenced credential.
-                                                Empty defaults to `Secret`.
+                                              description: Kind of the referenced
+                                                credential; empty defaults to `Secret`
                                               type: string
                                             name:
-                                              description: The name of the referenced
-                                                credential.
+                                              description: Name of the referenced
+                                                credential
                                               maxLength: 253
                                               minLength: 1
                                               type: string
@@ -11326,9 +11211,9 @@ spec:
                                       type: string
                                     location:
                                       description: |-
-                                        Where backend credentials are inserted.
-                                        If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                        This applies to `key`, `secretRef`, and `passthrough`.
+                                        Where backend credentials are inserted. Defaults to the `Authorization`
+                                        header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                        `passthrough`.
                                       properties:
                                         cookie:
                                           properties:
@@ -11342,19 +11227,9 @@ spec:
                                         header:
                                           properties:
                                             name:
-                                              description: |-
-                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                Valid values include:
-
-                                                * "Authorization"
-                                                * "Set-Cookie"
-
-                                                Invalid values include:
-
-                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                    headers are not currently supported by this type.
-                                                  - "/invalid" - "/ " is an invalid character
+                                              description: Name of an HTTP header.
+                                                HTTP/2 pseudo-headers (names beginning
+                                                with `:`) are not supported
                                               maxLength: 256
                                               minLength: 1
                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -11420,19 +11295,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -11502,29 +11368,17 @@ spec:
                                           properties:
                                             group:
                                               default: ""
-                                              description: |-
-                                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                When unspecified or empty string, core API group is inferred.
+                                              description: Group of the referent,
+                                                for example `gateway.networking.k8s.io`.
+                                                Empty selects the core API group
                                               maxLength: 253
                                               pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                               type: string
                                             kind:
                                               default: Service
-                                              description: |-
-                                                Kind is the Kubernetes resource kind of the referent. For example
-                                                "Service".
-
-                                                Defaults to "Service" when not specified.
-
-                                                ExternalName services can refer to CNAME DNS records that may live
-                                                outside of the cluster and as such are difficult to reason about in
-                                                terms of conformance. They also may not be safe to forward to (see
-                                                CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                support ExternalName Services.
-
-                                                Support: Core (Services with a type other than ExternalName)
-
-                                                Support: Implementation-specific (Services with type ExternalName)
+                                              description: Kubernetes resource kind
+                                                of the referent, for example `Service`.
+                                                Defaults to `Service`
                                               maxLength: 63
                                               minLength: 1
                                               pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -11536,27 +11390,18 @@ spec:
                                               minLength: 1
                                               type: string
                                             namespace:
-                                              description: |-
-                                                Namespace is the namespace of the backend. When unspecified, the local
-                                                namespace is inferred.
-
-                                                Note that when a namespace different than the local namespace is specified,
-                                                a ReferenceGrant object is required in the referent namespace to allow that
-                                                namespace's owner to accept the reference. See the ReferenceGrant
-                                                documentation for details.
-
-                                                Support: Core
+                                              description: Namespace of the referent.
+                                                Defaults to the local namespace. A
+                                                cross-namespace reference requires
+                                                a ReferenceGrant in the referent namespace
                                               maxLength: 63
                                               minLength: 1
                                               pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                               type: string
                                             port:
-                                              description: |-
-                                                Port specifies the destination port number to use for this resource.
-                                                Port is required when the referent is a Kubernetes Service. In this
-                                                case, the port number is the service port number, not the target port.
-                                                For other resources, destination port might be derived from the referent
-                                                resource or this field.
+                                              description: Destination port number.
+                                                Required when the referent is a Kubernetes
+                                                `Service`
                                               format: int32
                                               maximum: 65535
                                               minimum: 1
@@ -11632,25 +11477,25 @@ spec:
                                                     or EC private key; override the key name via `signingKeyRef.key`.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -11677,25 +11522,25 @@ spec:
                                                 is only valid with ClientSecretPost.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -11753,19 +11598,9 @@ spec:
                                             header:
                                               properties:
                                                 name:
-                                                  description: |-
-                                                    HTTPHeaderName is the name of an HTTP header.
-
-                                                    Valid values include:
-
-                                                    * "Authorization"
-                                                    * "Set-Cookie"
-
-                                                    Invalid values include:
-
-                                                      - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                        headers are not currently supported by this type.
-                                                      - "/invalid" - "/ " is an invalid character
+                                                  description: Name of an HTTP header.
+                                                    HTTP/2 pseudo-headers (names beginning
+                                                    with `:`) are not supported
                                                   maxLength: 256
                                                   minLength: 1
                                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -11849,19 +11684,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -11917,41 +11743,35 @@ spec:
                                           != ''IdJag'''
                                     passthrough:
                                       description: |-
-                                        Passes through an existing token that has been sent by the
-                                        client and validated. Other policies, like JWT and API key
-                                        authentication, will strip the original client credentials. Passthrough backend authentication
-                                        causes the original token to be added back into the request. If there are no client authentication policies on the
-                                        request, the original token would be unchanged, so this would have no effect.
+                                        Reuses a client token already validated by another policy. Those policies
+                                        may strip client credentials; passthrough adds the original token back to
+                                        the backend request. Without client auth policies, this has no effect.
                                       type: object
                                     secretRef:
                                       description: |-
-                                        Credential source, defaulting to a Kubernetes
-                                        `Secret`, storing the key to use as the authorization value. When using
-                                        the default Secret resolver, this must be stored in the `Authorization`
-                                        key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                        stored value is stripped only when reading the default `Authorization`
-                                        key.
+                                        Credential source for the authorization value, defaulting to a Kubernetes
+                                        `Secret`. By default, the value is read from the `Authorization` key; set
+                                        `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                        the default `Authorization` key.
                                       properties:
                                         group:
-                                          description: |-
-                                            The API group of the referenced credential.
-                                            Empty selects the core API group.
+                                          description: API group of the referenced
+                                            credential; empty selects the core API
+                                            group
                                           type: string
                                         key:
-                                          description: |-
-                                            The key in the referenced Secret whose value is used. If omitted, a
-                                            location-specific default key is used.
+                                          description: Key in the referenced Secret.
+                                            If omitted, a location-specific default
+                                            is used
                                           maxLength: 253
                                           minLength: 1
                                           type: string
                                         kind:
-                                          description: |-
-                                            The kind of the referenced credential.
-                                            Empty defaults to `Secret`.
+                                          description: Kind of the referenced credential;
+                                            empty defaults to `Secret`
                                           type: string
                                         name:
-                                          description: The name of the referenced
-                                            credential.
+                                          description: Name of the referenced credential
                                           maxLength: 253
                                           minLength: 1
                                           type: string
@@ -11979,7 +11799,7 @@ spec:
                                       == 1'
                                 http:
                                   description: Settings for managing HTTP requests
-                                    to the backend.
+                                    to the backend
                                   properties:
                                     requestTimeout:
                                       description: Deadline for receiving a response
@@ -11992,17 +11812,10 @@ spec:
                                         rule: duration(self) >= duration('1ms')
                                     version:
                                       description: |-
-                                        HTTP protocol version to use when connecting to
-                                        the backend.
-                                        If not specified, the version is automatically determined:
-                                        * `Service` types can specify it with `appProtocol` on the `Service`
-                                          port.
-                                        * If traffic is identified as gRPC, `HTTP2` is used.
-                                        * If the incoming traffic was plaintext HTTP, the original protocol will
-                                          be used.
-                                        * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                          because most clients will transparently upgrade HTTPS traffic to
-                                          `HTTP2`, even if the backend doesn't support it.
+                                        HTTP protocol version for backend connections. If unset, it is inferred:
+                                        `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                        plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                        to HTTP/2 even when the backend does not support it.
                                       enum:
                                       - HTTP1
                                       - HTTP2
@@ -12010,7 +11823,7 @@ spec:
                                   type: object
                                 tcp:
                                   description: Settings for managing TCP connections
-                                    to the backend.
+                                    to the backend
                                   properties:
                                     connectTimeout:
                                       description: |-
@@ -12059,10 +11872,10 @@ spec:
                                   type: object
                                 tls:
                                   description: |-
-                                    Settings for managing TLS connections to the backend.
+                                    Settings for managing TLS connections to the backend
 
-                                    If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                    validate the server, and the SNI will automatically be set based on the destination.
+                                    When set, TLS is originated to the backend using the system trusted CA
+                                    certificates, and SNI is inferred from the destination.
                                   properties:
                                     alpnProtocols:
                                       description: |-
@@ -12089,12 +11902,7 @@ spec:
                                         properties:
                                           name:
                                             default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            description: Name of the referent
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
@@ -12103,15 +11911,13 @@ spec:
                                       x-kubernetes-list-type: atomic
                                     insecureSkipVerify:
                                       description: |-
-                                        Originates TLS but skips verification of the backend's certificate.
-                                        WARNING: This is an insecure option that should only be used if the risks are understood.
+                                        Originates TLS but skips verification of the backend's certificate
+                                        WARNING: insecure; only use if the risks are understood
 
-                                        There are two modes:
-                                        * `All` disables all TLS verification.
-                                        * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                          mismatch of hostname or SANs. Note that this method is still insecure;
-                                          prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                          if possible.
+                                        Modes:
+                                        * `All` disables all TLS verification
+                                        * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                          Still insecure; prefer `verifySubjectAltNames` where possible.
                                       enum:
                                       - All
                                       - Hostname
@@ -12130,33 +11936,27 @@ spec:
                                       type: array
                                     mtlsCertificateRef:
                                       description: |-
-                                        Enables mutual TLS to the backend, using the
-                                        specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                        credential source, defaulting to a Kubernetes `Secret`.
-
-                                        An optional `ca.cert` field, if present, will be used to verify the
-                                        server certificate. If `caCertificateRefs` is also specified, the
-                                        `caCertificateRefs` field takes priority.
-
-                                        If unspecified, no client certificate will be used.
+                                        Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                        referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                        optional `ca.cert`, if present, verifies the server certificate, but
+                                        `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                        is used.
                                       items:
                                         description: |-
-                                          References a same-namespace credential.
-                                          Set only `name` to reference a Kubernetes Secret.
+                                          References a same-namespace credential
+                                          Set only `name` for a Kubernetes Secret
                                         properties:
                                           group:
-                                            description: |-
-                                              The API group of the referenced credential.
-                                              Empty selects the core API group.
+                                            description: API group of the referenced
+                                              credential; empty selects the core API
+                                              group
                                             type: string
                                           kind:
-                                            description: |-
-                                              The kind of the referenced credential.
-                                              Empty defaults to `Secret`.
+                                            description: Kind of the referenced credential;
+                                              empty defaults to `Secret`
                                             type: string
                                           name:
-                                            description: The name of the referenced
-                                              credential.
+                                            description: Name of the referenced credential
                                             maxLength: 253
                                             minLength: 1
                                             type: string
@@ -12211,8 +12011,8 @@ spec:
                                     rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
                                       <= 1'
                                 tunnel:
-                                  description: Settings for managing tunnel connections,
-                                    with behavior like `HTTPS_PROXY`, to the backend.
+                                  description: Settings for managing tunnel connections
+                                    to the backend, like `HTTPS_PROXY`
                                   properties:
                                     backendRef:
                                       description: |-
@@ -12221,29 +12021,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -12254,27 +12042,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -12550,7 +12328,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -12585,9 +12363,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -12595,10 +12372,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -12638,24 +12414,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -12705,24 +12480,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -12740,12 +12514,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -12769,32 +12540,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -12834,9 +12604,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -12850,19 +12620,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -12931,19 +12692,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -13016,29 +12769,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -13050,27 +12793,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -13151,26 +12886,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -13200,25 +12938,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -13281,19 +13021,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -13380,19 +13111,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -13450,41 +13173,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -13514,7 +13233,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -13528,17 +13247,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -13546,7 +13258,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -13598,10 +13310,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -13628,12 +13340,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -13642,15 +13349,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -13669,33 +13374,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -13753,8 +13454,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -13763,29 +13463,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -13797,27 +13485,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -13871,7 +13551,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -13906,9 +13586,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -13916,10 +13595,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -13959,24 +13637,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -14026,24 +13703,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -14061,12 +13737,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -14090,32 +13763,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -14155,9 +13827,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -14171,19 +13843,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -14252,19 +13915,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -14337,29 +13992,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -14371,27 +14016,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -14472,26 +14109,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -14521,25 +14161,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -14602,19 +14244,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -14701,19 +14334,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -14771,41 +14396,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -14835,7 +14456,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -14849,17 +14470,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -14867,7 +14481,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -14919,10 +14533,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -14949,12 +14563,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -14963,15 +14572,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -14990,33 +14597,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -15074,8 +14677,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -15084,29 +14686,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -15118,27 +14708,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -15187,7 +14769,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -15222,9 +14804,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -15232,10 +14813,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -15275,24 +14855,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -15342,24 +14921,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -15377,12 +14955,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -15406,32 +14981,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -15471,9 +15045,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -15487,19 +15061,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -15568,19 +15133,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -15653,29 +15210,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -15687,27 +15234,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -15788,26 +15327,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -15837,25 +15379,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -15918,19 +15462,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -16017,19 +15552,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -16087,41 +15614,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -16151,7 +15674,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -16165,17 +15688,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -16183,7 +15699,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -16235,10 +15751,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -16265,12 +15781,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -16279,15 +15790,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -16306,33 +15815,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -16390,8 +15895,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -16400,29 +15904,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -16434,27 +15926,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -16553,29 +16037,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -16586,27 +16058,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -16639,51 +16101,26 @@ spec:
                                           headers.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                              If multiple entries specify equivalent header names, only the first
-                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                              entries with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-
-                                              When a header is repeated in an HTTP request, it is
-                                              implementation-specific behavior as to how this is represented.
-                                              Generally, proxies should follow the guidance from the RFC:
-                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                              processing a repeated header, with special handling for "Set-Cookie".
+                                            description: Name of the HTTP header to
+                                              match, case-insensitive. When names
+                                              are equivalent, only the first matching
+                                              entry is used
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           type:
                                             default: Exact
-                                            description: |-
-                                              Type specifies how to match against the value of the header.
-
-                                              Support: Core (Exact)
-
-                                              Support: Implementation-specific (RegularExpression)
-
-                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                              of regular expressions. Please read the implementation's documentation to
-                                              determine the supported dialect.
+                                            description: 'How to match against the
+                                              header value: `Exact` (default) or `RegularExpression`.
+                                              The regex dialect is implementation-specific'
                                             enum:
                                             - Exact
                                             - RegularExpression
                                             type: string
                                           value:
-                                            description: |-
-                                              Value is the value of HTTP Header to be matched.
-                                              <gateway:experimental:description>
-                                              Must consist of printable US-ASCII characters, optionally separated
-                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                              </gateway:experimental:description>
-
-                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                            description: Value of the HTTP header
+                                              to match
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -16729,7 +16166,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -16764,9 +16201,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -16774,10 +16210,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -16817,24 +16252,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -16884,24 +16318,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -16919,12 +16352,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -16948,32 +16378,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -17013,9 +16442,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -17029,19 +16458,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -17110,19 +16530,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -17195,29 +16607,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -17229,27 +16631,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -17330,26 +16724,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -17379,25 +16776,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -17460,19 +16859,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -17559,19 +16949,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -17629,41 +17011,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -17693,7 +17071,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -17707,17 +17085,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -17725,7 +17096,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -17777,10 +17148,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -17807,12 +17178,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -17821,15 +17187,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -17848,33 +17212,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -17932,8 +17292,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -17942,29 +17301,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -17976,27 +17323,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -18050,7 +17389,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -18085,9 +17424,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -18095,10 +17433,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -18138,24 +17475,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -18205,24 +17541,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -18240,12 +17575,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -18269,32 +17601,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -18334,9 +17665,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -18350,19 +17681,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -18431,19 +17753,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -18516,29 +17830,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -18550,27 +17854,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -18651,26 +17947,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -18700,25 +17999,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -18781,19 +18082,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -18880,19 +18172,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -18950,41 +18234,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -19014,7 +18294,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -19028,17 +18308,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -19046,7 +18319,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -19098,10 +18371,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -19128,12 +18401,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -19142,15 +18410,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -19169,33 +18435,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -19253,8 +18515,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -19263,29 +18524,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -19297,27 +18546,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -19429,29 +18670,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -19462,27 +18691,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -19515,51 +18734,26 @@ spec:
                                           headers.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                              If multiple entries specify equivalent header names, only the first
-                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                              entries with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-
-                                              When a header is repeated in an HTTP request, it is
-                                              implementation-specific behavior as to how this is represented.
-                                              Generally, proxies should follow the guidance from the RFC:
-                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                              processing a repeated header, with special handling for "Set-Cookie".
+                                            description: Name of the HTTP header to
+                                              match, case-insensitive. When names
+                                              are equivalent, only the first matching
+                                              entry is used
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           type:
                                             default: Exact
-                                            description: |-
-                                              Type specifies how to match against the value of the header.
-
-                                              Support: Core (Exact)
-
-                                              Support: Implementation-specific (RegularExpression)
-
-                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                              of regular expressions. Please read the implementation's documentation to
-                                              determine the supported dialect.
+                                            description: 'How to match against the
+                                              header value: `Exact` (default) or `RegularExpression`.
+                                              The regex dialect is implementation-specific'
                                             enum:
                                             - Exact
                                             - RegularExpression
                                             type: string
                                           value:
-                                            description: |-
-                                              Value is the value of HTTP Header to be matched.
-                                              <gateway:experimental:description>
-                                              Must consist of printable US-ASCII characters, optionally separated
-                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                              </gateway:experimental:description>
-
-                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                            description: Value of the HTTP header
+                                              to match
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -19655,7 +18849,7 @@ spec:
                       rule: '[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
                         >= 1'
                   auth:
-                    description: Settings for managing authentication to the backend.
+                    description: Settings for managing authentication to the backend
                     properties:
                       aws:
                         description: |-
@@ -19689,9 +18883,8 @@ spec:
                                 type: string
                               tags:
                                 description: |-
-                                  Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                  allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                  attribution. STS allows at most 50 session tags per role session.
+                                  Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                  & Usage Report, once activated. STS allows at most 50 per role session.
                                 items:
                                   description: |-
                                     AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -19699,10 +18892,9 @@ spec:
                                   properties:
                                     expression:
                                       description: |-
-                                        Expression is a CEL expression evaluated against each request to produce
-                                        the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                        expression does not produce a valid tag value at request time, the request
-                                        is rejected.
+                                        CEL expression evaluated against each request to produce the tag value,
+                                        for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                        tag values are rejected.
                                       maxLength: 16384
                                       minLength: 1
                                       type: string
@@ -19737,23 +18929,20 @@ spec:
                                 <= 1'
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing the AWS credentials. When using the default Secret
-                              resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                              optionally `sessionToken`.
+                              Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                              The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                              `sessionToken` keys.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -19799,23 +18988,20 @@ spec:
                             type: object
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing the Azure credentials. When using the default Secret
-                              resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                              `clientSecret`.
+                              Credential source for Azure credentials, defaulting to a Kubernetes
+                              `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                              `clientSecret` keys.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -19832,12 +19018,9 @@ spec:
                                 > 0)'
                           workloadIdentity:
                             description: |-
-                              Workload identity authentication settings. Uses the federated token
-                              projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                              `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                              environment variables) to authenticate. This is the recommended method
-                              when running on Azure Kubernetes Service (AKS) with Workload Identity
-                              enabled.
+                              Workload identity authentication settings. Uses the federated token and
+                              Azure env vars projected into the data plane pod. Recommended on AKS with
+                              Workload Identity enabled.
                             type: object
                         type: object
                         x-kubernetes-validations:
@@ -19860,31 +19043,27 @@ spec:
                             type: string
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing ADC-compatible Google credential JSON. When using
-                              the default Secret resolver, this must be stored in the `credentials.json`
-                              key by default; override via `secretRef.key`. When omitted, ambient
-                              credentials are used.
+                              Credential source for ADC-compatible Google credential JSON, defaulting to
+                              a Kubernetes `Secret`. By default, the value is read from
+                              `credentials.json`; set `secretRef.key` to override it. When omitted,
+                              ambient credentials are used.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               key:
-                                description: |-
-                                  The key in the referenced Secret whose value is used. If omitted, a
-                                  location-specific default key is used.
+                                description: Key in the referenced Secret. If omitted,
+                                  a location-specific default is used
                                 maxLength: 253
                                 minLength: 1
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -19921,9 +19100,9 @@ spec:
                         type: string
                       location:
                         description: |-
-                          Where backend credentials are inserted.
-                          If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                          This applies to `key`, `secretRef`, and `passthrough`.
+                          Where backend credentials are inserted. Defaults to the `Authorization`
+                          header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                          `passthrough`.
                         properties:
                           cookie:
                             properties:
@@ -19937,19 +19116,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -20012,19 +19180,9 @@ spec:
                                   header:
                                     properties:
                                       name:
-                                        description: |-
-                                          HTTPHeaderName is the name of an HTTP header.
-
-                                          Valid values include:
-
-                                          * "Authorization"
-                                          * "Set-Cookie"
-
-                                          Invalid values include:
-
-                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                              headers are not currently supported by this type.
-                                            - "/invalid" - "/ " is an invalid character
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
                                         maxLength: 256
                                         minLength: 1
                                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -20088,29 +19246,15 @@ spec:
                             properties:
                               group:
                                 default: ""
-                                description: |-
-                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                  When unspecified or empty string, core API group is inferred.
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
                                 default: Service
-                                description: |-
-                                  Kind is the Kubernetes resource kind of the referent. For example
-                                  "Service".
-
-                                  Defaults to "Service" when not specified.
-
-                                  ExternalName services can refer to CNAME DNS records that may live
-                                  outside of the cluster and as such are difficult to reason about in
-                                  terms of conformance. They also may not be safe to forward to (see
-                                  CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                  support ExternalName Services.
-
-                                  Support: Core (Services with a type other than ExternalName)
-
-                                  Support: Implementation-specific (Services with type ExternalName)
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -20121,27 +19265,16 @@ spec:
                                 minLength: 1
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of the backend. When unspecified, the local
-                                  namespace is inferred.
-
-                                  Note that when a namespace different than the local namespace is specified,
-                                  a ReferenceGrant object is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the ReferenceGrant
-                                  documentation for details.
-
-                                  Support: Core
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               port:
-                                description: |-
-                                  Port specifies the destination port number to use for this resource.
-                                  Port is required when the referent is a Kubernetes Service. In this
-                                  case, the port number is the service port number, not the target port.
-                                  For other resources, destination port might be derived from the referent
-                                  resource or this field.
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -20211,24 +19344,22 @@ spec:
                                       or EC private key; override the key name via `signingKeyRef.key`.
                                     properties:
                                       group:
-                                        description: |-
-                                          The API group of the referenced credential.
-                                          Empty selects the core API group.
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
                                         type: string
                                       key:
-                                        description: |-
-                                          The key in the referenced Secret whose value is used. If omitted, a
-                                          location-specific default key is used.
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
                                         maxLength: 253
                                         minLength: 1
                                         type: string
                                       kind:
-                                        description: |-
-                                          The kind of the referenced credential.
-                                          Empty defaults to `Secret`.
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
                                         type: string
                                       name:
-                                        description: The name of the referenced credential.
+                                        description: Name of the referenced credential
                                         maxLength: 253
                                         minLength: 1
                                         type: string
@@ -20254,24 +19385,21 @@ spec:
                                   is only valid with ClientSecretPost.
                                 properties:
                                   group:
-                                    description: |-
-                                      The API group of the referenced credential.
-                                      Empty selects the core API group.
+                                    description: API group of the referenced credential;
+                                      empty selects the core API group
                                     type: string
                                   key:
-                                    description: |-
-                                      The key in the referenced Secret whose value is used. If omitted, a
-                                      location-specific default key is used.
+                                    description: Key in the referenced Secret. If
+                                      omitted, a location-specific default is used
                                     maxLength: 253
                                     minLength: 1
                                     type: string
                                   kind:
-                                    description: |-
-                                      The kind of the referenced credential.
-                                      Empty defaults to `Secret`.
+                                    description: Kind of the referenced credential;
+                                      empty defaults to `Secret`
                                     type: string
                                   name:
-                                    description: The name of the referenced credential.
+                                    description: Name of the referenced credential
                                     maxLength: 253
                                     minLength: 1
                                     type: string
@@ -20324,19 +19452,8 @@ spec:
                               header:
                                 properties:
                                   name:
-                                    description: |-
-                                      HTTPHeaderName is the name of an HTTP header.
-
-                                      Valid values include:
-
-                                      * "Authorization"
-                                      * "Set-Cookie"
-
-                                      Invalid values include:
-
-                                        - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                          headers are not currently supported by this type.
-                                        - "/invalid" - "/ " is an invalid character
+                                    description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                      (names beginning with `:`) are not supported
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -20416,19 +19533,9 @@ spec:
                                   header:
                                     properties:
                                       name:
-                                        description: |-
-                                          HTTPHeaderName is the name of an HTTP header.
-
-                                          Valid values include:
-
-                                          * "Authorization"
-                                          * "Set-Cookie"
-
-                                          Invalid values include:
-
-                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                              headers are not currently supported by this type.
-                                            - "/invalid" - "/ " is an invalid character
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
                                         maxLength: 256
                                         minLength: 1
                                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -20480,40 +19587,33 @@ spec:
                             != ''IdJag'''
                       passthrough:
                         description: |-
-                          Passes through an existing token that has been sent by the
-                          client and validated. Other policies, like JWT and API key
-                          authentication, will strip the original client credentials. Passthrough backend authentication
-                          causes the original token to be added back into the request. If there are no client authentication policies on the
-                          request, the original token would be unchanged, so this would have no effect.
+                          Reuses a client token already validated by another policy. Those policies
+                          may strip client credentials; passthrough adds the original token back to
+                          the backend request. Without client auth policies, this has no effect.
                         type: object
                       secretRef:
                         description: |-
-                          Credential source, defaulting to a Kubernetes
-                          `Secret`, storing the key to use as the authorization value. When using
-                          the default Secret resolver, this must be stored in the `Authorization`
-                          key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                          stored value is stripped only when reading the default `Authorization`
-                          key.
+                          Credential source for the authorization value, defaulting to a Kubernetes
+                          `Secret`. By default, the value is read from the `Authorization` key; set
+                          `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                          the default `Authorization` key.
                         properties:
                           group:
-                            description: |-
-                              The API group of the referenced credential.
-                              Empty selects the core API group.
+                            description: API group of the referenced credential; empty
+                              selects the core API group
                             type: string
                           key:
-                            description: |-
-                              The key in the referenced Secret whose value is used. If omitted, a
-                              location-specific default key is used.
+                            description: Key in the referenced Secret. If omitted,
+                              a location-specific default is used
                             maxLength: 253
                             minLength: 1
                             type: string
                           kind:
-                            description: |-
-                              The kind of the referenced credential.
-                              Empty defaults to `Secret`.
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
                             type: string
                           name:
-                            description: The name of the referenced credential.
+                            description: Name of the referenced credential
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -20549,29 +19649,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -20582,27 +19668,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -20840,13 +19915,12 @@ spec:
                               rule: duration(self) >= duration('1s')
                           healthThreshold:
                             description: |-
-                              EWMA health score threshold, expressed as 0 to 100.
-                              When set, a backend is only evicted if its computed health drops below this value after an unhealthy response.
-                              For example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.
-                              Unlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average
-                              so a single success in a stream of failures can delay eviction.
-                              When both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.
-                              When neither is set, a single unhealthy response triggers eviction.
+                              EWMA health score threshold, from 0 to 100. When set, a backend is evicted
+                              only if its computed health drops below this value after an unhealthy
+                              response (e.g. 50 evicts when EWMA health falls below 50%). Unlike
+                              consecutiveFailures, this sliding-window average lets a single success delay
+                              eviction. If both are set, either condition evicts; if neither, a single
+                              unhealthy response evicts.
                             format: int32
                             maximum: 100
                             minimum: 0
@@ -20875,7 +19949,7 @@ spec:
                         type: string
                     type: object
                   http:
-                    description: Settings for managing HTTP requests to the backend.
+                    description: Settings for managing HTTP requests to the backend
                     properties:
                       requestTimeout:
                         description: Deadline for receiving a response from the backend.
@@ -20887,17 +19961,10 @@ spec:
                           rule: duration(self) >= duration('1ms')
                       version:
                         description: |-
-                          HTTP protocol version to use when connecting to
-                          the backend.
-                          If not specified, the version is automatically determined:
-                          * `Service` types can specify it with `appProtocol` on the `Service`
-                            port.
-                          * If traffic is identified as gRPC, `HTTP2` is used.
-                          * If the incoming traffic was plaintext HTTP, the original protocol will
-                            be used.
-                          * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                            because most clients will transparently upgrade HTTPS traffic to
-                            `HTTP2`, even if the backend doesn't support it.
+                          HTTP protocol version for backend connections. If unset, it is inferred:
+                          `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                          plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                          to HTTP/2 even when the backend does not support it.
                         enum:
                         - HTTP1
                         - HTTP2
@@ -20953,29 +20020,16 @@ spec:
                                 properties:
                                   group:
                                     default: ""
-                                    description: |-
-                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When unspecified or empty string, core API group is inferred.
+                                    description: Group of the referent, for example
+                                      `gateway.networking.k8s.io`. Empty selects the
+                                      core API group
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   kind:
                                     default: Service
-                                    description: |-
-                                      Kind is the Kubernetes resource kind of the referent. For example
-                                      "Service".
-
-                                      Defaults to "Service" when not specified.
-
-                                      ExternalName services can refer to CNAME DNS records that may live
-                                      outside of the cluster and as such are difficult to reason about in
-                                      terms of conformance. They also may not be safe to forward to (see
-                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                      support ExternalName Services.
-
-                                      Support: Core (Services with a type other than ExternalName)
-
-                                      Support: Implementation-specific (Services with type ExternalName)
+                                    description: Kubernetes resource kind of the referent,
+                                      for example `Service`. Defaults to `Service`
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -20986,27 +20040,16 @@ spec:
                                     minLength: 1
                                     type: string
                                   namespace:
-                                    description: |-
-                                      Namespace is the namespace of the backend. When unspecified, the local
-                                      namespace is inferred.
-
-                                      Note that when a namespace different than the local namespace is specified,
-                                      a ReferenceGrant object is required in the referent namespace to allow that
-                                      namespace's owner to accept the reference. See the ReferenceGrant
-                                      documentation for details.
-
-                                      Support: Core
+                                    description: Namespace of the referent. Defaults
+                                      to the local namespace. A cross-namespace reference
+                                      requires a ReferenceGrant in the referent namespace
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   port:
-                                    description: |-
-                                      Port specifies the destination port number to use for this resource.
-                                      Port is required when the referent is a Kubernetes Service. In this
-                                      case, the port number is the service port number, not the target port.
-                                      For other resources, destination port might be derived from the referent
-                                      resource or this field.
+                                    description: Destination port number. Required
+                                      when the referent is a Kubernetes `Service`
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -21187,29 +20230,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -21220,27 +20251,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -21318,7 +20339,7 @@ spec:
                       rule: '[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size()
                         >= 1'
                   tcp:
-                    description: Settings for managing TCP connections to the backend.
+                    description: Settings for managing TCP connections to the backend
                     properties:
                       connectTimeout:
                         description: |-
@@ -21367,10 +20388,10 @@ spec:
                     type: object
                   tls:
                     description: |-
-                      Settings for managing TLS connections to the backend.
+                      Settings for managing TLS connections to the backend
 
-                      If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                      validate the server, and the SNI will automatically be set based on the destination.
+                      When set, TLS is originated to the backend using the system trusted CA
+                      certificates, and SNI is inferred from the destination.
                     properties:
                       alpnProtocols:
                         description: |-
@@ -21397,12 +20418,7 @@ spec:
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: Name of the referent
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -21411,15 +20427,13 @@ spec:
                         x-kubernetes-list-type: atomic
                       insecureSkipVerify:
                         description: |-
-                          Originates TLS but skips verification of the backend's certificate.
-                          WARNING: This is an insecure option that should only be used if the risks are understood.
+                          Originates TLS but skips verification of the backend's certificate
+                          WARNING: insecure; only use if the risks are understood
 
-                          There are two modes:
-                          * `All` disables all TLS verification.
-                          * `Hostname` verifies the CA certificate is trusted, but ignores any
-                            mismatch of hostname or SANs. Note that this method is still insecure;
-                            prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                            if possible.
+                          Modes:
+                          * `All` disables all TLS verification
+                          * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                            Still insecure; prefer `verifySubjectAltNames` where possible.
                         enum:
                         - All
                         - Hostname
@@ -21438,32 +20452,26 @@ spec:
                         type: array
                       mtlsCertificateRef:
                         description: |-
-                          Enables mutual TLS to the backend, using the
-                          specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                          credential source, defaulting to a Kubernetes `Secret`.
-
-                          An optional `ca.cert` field, if present, will be used to verify the
-                          server certificate. If `caCertificateRefs` is also specified, the
-                          `caCertificateRefs` field takes priority.
-
-                          If unspecified, no client certificate will be used.
+                          Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                          referenced credential source (defaulting to a Kubernetes `Secret`). An
+                          optional `ca.cert`, if present, verifies the server certificate, but
+                          `caCertificateRefs` takes priority. If unspecified, no client certificate
+                          is used.
                         items:
                           description: |-
-                            References a same-namespace credential.
-                            Set only `name` to reference a Kubernetes Secret.
+                            References a same-namespace credential
+                            Set only `name` for a Kubernetes Secret
                           properties:
                             group:
-                              description: |-
-                                The API group of the referenced credential.
-                                Empty selects the core API group.
+                              description: API group of the referenced credential;
+                                empty selects the core API group
                               type: string
                             kind:
-                              description: |-
-                                The kind of the referenced credential.
-                                Empty defaults to `Secret`.
+                              description: Kind of the referenced credential; empty
+                                defaults to `Secret`
                               type: string
                             name:
-                              description: The name of the referenced credential.
+                              description: Name of the referenced credential
                               maxLength: 253
                               minLength: 1
                               type: string
@@ -21752,8 +20760,8 @@ spec:
                       rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
                         >= 1'
                   tunnel:
-                    description: Settings for managing tunnel connections, with behavior
-                      like `HTTPS_PROXY`, to the backend.
+                    description: Settings for managing tunnel connections to the backend,
+                      like `HTTPS_PROXY`
                     properties:
                       backendRef:
                         description: |-
@@ -21762,29 +20770,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -21795,27 +20789,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewayparameters.yaml
@@ -272,12 +272,7 @@ spec:
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: Name of the referent
                               type: string
                             optional:
                               description: Specify whether the ConfigMap or its key
@@ -374,12 +369,7 @@ spec:
                               type: string
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: Name of the referent
                               type: string
                             optional:
                               description: Specify whether the Secret or its key must

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -289,7 +289,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -324,9 +324,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -334,10 +333,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -377,24 +375,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -444,24 +441,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -479,12 +475,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -508,32 +501,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -573,9 +565,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -589,19 +581,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -670,19 +653,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -755,29 +730,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -789,27 +754,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -890,26 +847,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -939,25 +899,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -1020,19 +982,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1119,19 +1072,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1189,41 +1134,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -1253,7 +1194,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -1267,17 +1208,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -1285,7 +1219,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -1337,10 +1271,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -1367,12 +1301,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -1381,15 +1310,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -1408,33 +1335,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -1492,8 +1415,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -1502,29 +1424,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -1536,27 +1446,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -1610,7 +1512,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -1645,9 +1547,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -1655,10 +1556,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -1698,24 +1598,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -1765,24 +1664,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -1800,12 +1698,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -1829,32 +1724,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -1894,9 +1788,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -1910,19 +1804,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -1991,19 +1876,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -2076,29 +1953,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2110,27 +1977,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -2211,26 +2070,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -2260,25 +2122,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -2341,19 +2205,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -2440,19 +2295,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -2510,41 +2357,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -2574,7 +2417,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -2588,17 +2431,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -2606,7 +2442,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -2658,10 +2494,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -2688,12 +2524,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -2702,15 +2533,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -2729,33 +2558,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -2813,8 +2638,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -2823,29 +2647,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -2857,27 +2669,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -2926,7 +2730,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -2961,9 +2765,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -2971,10 +2774,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -3014,24 +2816,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -3081,24 +2882,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -3116,12 +2916,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -3145,32 +2942,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -3210,9 +3006,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -3226,19 +3022,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -3307,19 +3094,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -3392,29 +3171,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -3426,27 +3195,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -3527,26 +3288,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -3576,25 +3340,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -3657,19 +3423,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -3756,19 +3513,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -3826,41 +3575,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -3890,7 +3635,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -3904,17 +3649,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -3922,7 +3660,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -3974,10 +3712,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -4004,12 +3742,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -4018,15 +3751,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -4045,33 +3776,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -4129,8 +3856,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -4139,29 +3865,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -4173,27 +3887,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -4292,29 +3998,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -4325,27 +4019,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -4378,51 +4062,26 @@ spec:
                                           headers.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                              If multiple entries specify equivalent header names, only the first
-                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                              entries with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-
-                                              When a header is repeated in an HTTP request, it is
-                                              implementation-specific behavior as to how this is represented.
-                                              Generally, proxies should follow the guidance from the RFC:
-                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                              processing a repeated header, with special handling for "Set-Cookie".
+                                            description: Name of the HTTP header to
+                                              match, case-insensitive. When names
+                                              are equivalent, only the first matching
+                                              entry is used
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           type:
                                             default: Exact
-                                            description: |-
-                                              Type specifies how to match against the value of the header.
-
-                                              Support: Core (Exact)
-
-                                              Support: Implementation-specific (RegularExpression)
-
-                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                              of regular expressions. Please read the implementation's documentation to
-                                              determine the supported dialect.
+                                            description: 'How to match against the
+                                              header value: `Exact` (default) or `RegularExpression`.
+                                              The regex dialect is implementation-specific'
                                             enum:
                                             - Exact
                                             - RegularExpression
                                             type: string
                                           value:
-                                            description: |-
-                                              Value is the value of HTTP Header to be matched.
-                                              <gateway:experimental:description>
-                                              Must consist of printable US-ASCII characters, optionally separated
-                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                              </gateway:experimental:description>
-
-                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                            description: Value of the HTTP header
+                                              to match
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -4468,7 +4127,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -4503,9 +4162,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -4513,10 +4171,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -4556,24 +4213,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -4623,24 +4279,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -4658,12 +4313,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -4687,32 +4339,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -4752,9 +4403,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -4768,19 +4419,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -4849,19 +4491,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -4934,29 +4568,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -4968,27 +4592,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -5069,26 +4685,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -5118,25 +4737,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -5199,19 +4820,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -5298,19 +4910,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -5368,41 +4972,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -5432,7 +5032,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -5446,17 +5046,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -5464,7 +5057,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -5516,10 +5109,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -5546,12 +5139,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -5560,15 +5148,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -5587,33 +5173,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -5671,8 +5253,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -5681,29 +5262,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -5715,27 +5284,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -5789,7 +5350,7 @@ spec:
                                       properties:
                                         auth:
                                           description: Settings for managing authentication
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             aws:
                                               description: |-
@@ -5824,9 +5385,8 @@ spec:
                                                       type: string
                                                     tags:
                                                       description: |-
-                                                        Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                                        allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                                        attribution. STS allows at most 50 session tags per role session.
+                                                        Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                                        & Usage Report, once activated. STS allows at most 50 per role session.
                                                       items:
                                                         description: |-
                                                           AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -5834,10 +5394,9 @@ spec:
                                                         properties:
                                                           expression:
                                                             description: |-
-                                                              Expression is a CEL expression evaluated against each request to produce
-                                                              the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                                              expression does not produce a valid tag value at request time, the request
-                                                              is rejected.
+                                                              CEL expression evaluated against each request to produce the tag value,
+                                                              for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                                              tag values are rejected.
                                                             maxLength: 16384
                                                             minLength: 1
                                                             type: string
@@ -5877,24 +5436,23 @@ spec:
                                                       <= 1'
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the AWS credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                                                    optionally `sessionToken`.
+                                                    Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                                                    The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                                                    `sessionToken` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -5944,24 +5502,23 @@ spec:
                                                   type: object
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing the Azure credentials. When using the default Secret
-                                                    resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                                                    `clientSecret`.
+                                                    Credential source for Azure credentials, defaulting to a Kubernetes
+                                                    `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                                                    `clientSecret` keys.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -5979,12 +5536,9 @@ spec:
                                                       && size(self.kind) > 0)'
                                                 workloadIdentity:
                                                   description: |-
-                                                    Workload identity authentication settings. Uses the federated token
-                                                    projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                                                    `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                                                    environment variables) to authenticate. This is the recommended method
-                                                    when running on Azure Kubernetes Service (AKS) with Workload Identity
-                                                    enabled.
+                                                    Workload identity authentication settings. Uses the federated token and
+                                                    Azure env vars projected into the data plane pod. Recommended on AKS with
+                                                    Workload Identity enabled.
                                                   type: object
                                               type: object
                                               x-kubernetes-validations:
@@ -6008,32 +5562,31 @@ spec:
                                                   type: string
                                                 secretRef:
                                                   description: |-
-                                                    Credential source, defaulting to a Kubernetes
-                                                    `Secret`, containing ADC-compatible Google credential JSON. When using
-                                                    the default Secret resolver, this must be stored in the `credentials.json`
-                                                    key by default; override via `secretRef.key`. When omitted, ambient
-                                                    credentials are used.
+                                                    Credential source for ADC-compatible Google credential JSON, defaulting to
+                                                    a Kubernetes `Secret`. By default, the value is read from
+                                                    `credentials.json`; set `secretRef.key` to override it. When omitted,
+                                                    ambient credentials are used.
                                                   properties:
                                                     group:
-                                                      description: |-
-                                                        The API group of the referenced credential.
-                                                        Empty selects the core API group.
+                                                      description: API group of the
+                                                        referenced credential; empty
+                                                        selects the core API group
                                                       type: string
                                                     key:
-                                                      description: |-
-                                                        The key in the referenced Secret whose value is used. If omitted, a
-                                                        location-specific default key is used.
+                                                      description: Key in the referenced
+                                                        Secret. If omitted, a location-specific
+                                                        default is used
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
                                                     kind:
-                                                      description: |-
-                                                        The kind of the referenced credential.
-                                                        Empty defaults to `Secret`.
+                                                      description: Kind of the referenced
+                                                        credential; empty defaults
+                                                        to `Secret`
                                                       type: string
                                                     name:
-                                                      description: The name of the
-                                                        referenced credential.
+                                                      description: Name of the referenced
+                                                        credential
                                                       maxLength: 253
                                                       minLength: 1
                                                       type: string
@@ -6073,9 +5626,9 @@ spec:
                                               type: string
                                             location:
                                               description: |-
-                                                Where backend credentials are inserted.
-                                                If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                                                This applies to `key`, `secretRef`, and `passthrough`.
+                                                Where backend credentials are inserted. Defaults to the `Authorization`
+                                                header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                                                `passthrough`.
                                               properties:
                                                 cookie:
                                                   properties:
@@ -6089,19 +5642,10 @@ spec:
                                                 header:
                                                   properties:
                                                     name:
-                                                      description: |-
-                                                        HTTPHeaderName is the name of an HTTP header.
-
-                                                        Valid values include:
-
-                                                        * "Authorization"
-                                                        * "Set-Cookie"
-
-                                                        Invalid values include:
-
-                                                          - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                            headers are not currently supported by this type.
-                                                          - "/invalid" - "/ " is an invalid character
+                                                      description: Name of an HTTP
+                                                        header. HTTP/2 pseudo-headers
+                                                        (names beginning with `:`)
+                                                        are not supported
                                                       maxLength: 256
                                                       minLength: 1
                                                       pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6170,19 +5714,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6255,29 +5791,19 @@ spec:
                                                   properties:
                                                     group:
                                                       default: ""
-                                                      description: |-
-                                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                        When unspecified or empty string, core API group is inferred.
+                                                      description: Group of the referent,
+                                                        for example `gateway.networking.k8s.io`.
+                                                        Empty selects the core API
+                                                        group
                                                       maxLength: 253
                                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                       type: string
                                                     kind:
                                                       default: Service
-                                                      description: |-
-                                                        Kind is the Kubernetes resource kind of the referent. For example
-                                                        "Service".
-
-                                                        Defaults to "Service" when not specified.
-
-                                                        ExternalName services can refer to CNAME DNS records that may live
-                                                        outside of the cluster and as such are difficult to reason about in
-                                                        terms of conformance. They also may not be safe to forward to (see
-                                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                        support ExternalName Services.
-
-                                                        Support: Core (Services with a type other than ExternalName)
-
-                                                        Support: Implementation-specific (Services with type ExternalName)
+                                                      description: Kubernetes resource
+                                                        kind of the referent, for
+                                                        example `Service`. Defaults
+                                                        to `Service`
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -6289,27 +5815,19 @@ spec:
                                                       minLength: 1
                                                       type: string
                                                     namespace:
-                                                      description: |-
-                                                        Namespace is the namespace of the backend. When unspecified, the local
-                                                        namespace is inferred.
-
-                                                        Note that when a namespace different than the local namespace is specified,
-                                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                                        documentation for details.
-
-                                                        Support: Core
+                                                      description: Namespace of the
+                                                        referent. Defaults to the
+                                                        local namespace. A cross-namespace
+                                                        reference requires a ReferenceGrant
+                                                        in the referent namespace
                                                       maxLength: 63
                                                       minLength: 1
                                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                       type: string
                                                     port:
-                                                      description: |-
-                                                        Port specifies the destination port number to use for this resource.
-                                                        Port is required when the referent is a Kubernetes Service. In this
-                                                        case, the port number is the service port number, not the target port.
-                                                        For other resources, destination port might be derived from the referent
-                                                        resource or this field.
+                                                      description: Destination port
+                                                        number. Required when the
+                                                        referent is a Kubernetes `Service`
                                                       format: int32
                                                       maximum: 65535
                                                       minimum: 1
@@ -6390,26 +5908,29 @@ spec:
                                                             or EC private key; override the key name via `signingKeyRef.key`.
                                                           properties:
                                                             group:
-                                                              description: |-
-                                                                The API group of the referenced credential.
-                                                                Empty selects the core API group.
+                                                              description: API group
+                                                                of the referenced
+                                                                credential; empty
+                                                                selects the core API
+                                                                group
                                                               type: string
                                                             key:
-                                                              description: |-
-                                                                The key in the referenced Secret whose value is used. If omitted, a
-                                                                location-specific default key is used.
+                                                              description: Key in
+                                                                the referenced Secret.
+                                                                If omitted, a location-specific
+                                                                default is used
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
                                                             kind:
-                                                              description: |-
-                                                                The kind of the referenced credential.
-                                                                Empty defaults to `Secret`.
+                                                              description: Kind of
+                                                                the referenced credential;
+                                                                empty defaults to
+                                                                `Secret`
                                                               type: string
                                                             name:
-                                                              description: The name
-                                                                of the referenced
-                                                                credential.
+                                                              description: Name of
+                                                                the referenced credential
                                                               maxLength: 253
                                                               minLength: 1
                                                               type: string
@@ -6439,25 +5960,27 @@ spec:
                                                         is only valid with ClientSecretPost.
                                                       properties:
                                                         group:
-                                                          description: |-
-                                                            The API group of the referenced credential.
-                                                            Empty selects the core API group.
+                                                          description: API group of
+                                                            the referenced credential;
+                                                            empty selects the core
+                                                            API group
                                                           type: string
                                                         key:
-                                                          description: |-
-                                                            The key in the referenced Secret whose value is used. If omitted, a
-                                                            location-specific default key is used.
+                                                          description: Key in the
+                                                            referenced Secret. If
+                                                            omitted, a location-specific
+                                                            default is used
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
                                                         kind:
-                                                          description: |-
-                                                            The kind of the referenced credential.
-                                                            Empty defaults to `Secret`.
+                                                          description: Kind of the
+                                                            referenced credential;
+                                                            empty defaults to `Secret`
                                                           type: string
                                                         name:
-                                                          description: The name of
-                                                            the referenced credential.
+                                                          description: Name of the
+                                                            referenced credential
                                                           maxLength: 253
                                                           minLength: 1
                                                           type: string
@@ -6520,19 +6043,10 @@ spec:
                                                     header:
                                                       properties:
                                                         name:
-                                                          description: |-
-                                                            HTTPHeaderName is the name of an HTTP header.
-
-                                                            Valid values include:
-
-                                                            * "Authorization"
-                                                            * "Set-Cookie"
-
-                                                            Invalid values include:
-
-                                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                headers are not currently supported by this type.
-                                                              - "/invalid" - "/ " is an invalid character
+                                                          description: Name of an
+                                                            HTTP header. HTTP/2 pseudo-headers
+                                                            (names beginning with
+                                                            `:`) are not supported
                                                           maxLength: 256
                                                           minLength: 1
                                                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6619,19 +6133,11 @@ spec:
                                                         header:
                                                           properties:
                                                             name:
-                                                              description: |-
-                                                                HTTPHeaderName is the name of an HTTP header.
-
-                                                                Valid values include:
-
-                                                                * "Authorization"
-                                                                * "Set-Cookie"
-
-                                                                Invalid values include:
-
-                                                                  - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                                                    headers are not currently supported by this type.
-                                                                  - "/invalid" - "/ " is an invalid character
+                                                              description: Name of
+                                                                an HTTP header. HTTP/2
+                                                                pseudo-headers (names
+                                                                beginning with `:`)
+                                                                are not supported
                                                               maxLength: 256
                                                               minLength: 1
                                                               pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -6689,41 +6195,37 @@ spec:
                                                   || self.requestedTokenType != ''IdJag'''
                                             passthrough:
                                               description: |-
-                                                Passes through an existing token that has been sent by the
-                                                client and validated. Other policies, like JWT and API key
-                                                authentication, will strip the original client credentials. Passthrough backend authentication
-                                                causes the original token to be added back into the request. If there are no client authentication policies on the
-                                                request, the original token would be unchanged, so this would have no effect.
+                                                Reuses a client token already validated by another policy. Those policies
+                                                may strip client credentials; passthrough adds the original token back to
+                                                the backend request. Without client auth policies, this has no effect.
                                               type: object
                                             secretRef:
                                               description: |-
-                                                Credential source, defaulting to a Kubernetes
-                                                `Secret`, storing the key to use as the authorization value. When using
-                                                the default Secret resolver, this must be stored in the `Authorization`
-                                                key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                                                stored value is stripped only when reading the default `Authorization`
-                                                key.
+                                                Credential source for the authorization value, defaulting to a Kubernetes
+                                                `Secret`. By default, the value is read from the `Authorization` key; set
+                                                `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                                                the default `Authorization` key.
                                               properties:
                                                 group:
-                                                  description: |-
-                                                    The API group of the referenced credential.
-                                                    Empty selects the core API group.
+                                                  description: API group of the referenced
+                                                    credential; empty selects the
+                                                    core API group
                                                   type: string
                                                 key:
-                                                  description: |-
-                                                    The key in the referenced Secret whose value is used. If omitted, a
-                                                    location-specific default key is used.
+                                                  description: Key in the referenced
+                                                    Secret. If omitted, a location-specific
+                                                    default is used
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
                                                 kind:
-                                                  description: |-
-                                                    The kind of the referenced credential.
-                                                    Empty defaults to `Secret`.
+                                                  description: Kind of the referenced
+                                                    credential; empty defaults to
+                                                    `Secret`
                                                   type: string
                                                 name:
-                                                  description: The name of the referenced
-                                                    credential.
+                                                  description: Name of the referenced
+                                                    credential
                                                   maxLength: 253
                                                   minLength: 1
                                                   type: string
@@ -6753,7 +6255,7 @@ spec:
                                               == 1'
                                         http:
                                           description: Settings for managing HTTP
-                                            requests to the backend.
+                                            requests to the backend
                                           properties:
                                             requestTimeout:
                                               description: Deadline for receiving
@@ -6767,17 +6269,10 @@ spec:
                                                 rule: duration(self) >= duration('1ms')
                                             version:
                                               description: |-
-                                                HTTP protocol version to use when connecting to
-                                                the backend.
-                                                If not specified, the version is automatically determined:
-                                                * `Service` types can specify it with `appProtocol` on the `Service`
-                                                  port.
-                                                * If traffic is identified as gRPC, `HTTP2` is used.
-                                                * If the incoming traffic was plaintext HTTP, the original protocol will
-                                                  be used.
-                                                * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                                                  because most clients will transparently upgrade HTTPS traffic to
-                                                  `HTTP2`, even if the backend doesn't support it.
+                                                HTTP protocol version for backend connections. If unset, it is inferred:
+                                                `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                                                plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                                                to HTTP/2 even when the backend does not support it.
                                               enum:
                                               - HTTP1
                                               - HTTP2
@@ -6785,7 +6280,7 @@ spec:
                                           type: object
                                         tcp:
                                           description: Settings for managing TCP connections
-                                            to the backend.
+                                            to the backend
                                           properties:
                                             connectTimeout:
                                               description: |-
@@ -6837,10 +6332,10 @@ spec:
                                           type: object
                                         tls:
                                           description: |-
-                                            Settings for managing TLS connections to the backend.
+                                            Settings for managing TLS connections to the backend
 
-                                            If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                                            validate the server, and the SNI will automatically be set based on the destination.
+                                            When set, TLS is originated to the backend using the system trusted CA
+                                            certificates, and SNI is inferred from the destination.
                                           properties:
                                             alpnProtocols:
                                               description: |-
@@ -6867,12 +6362,7 @@ spec:
                                                 properties:
                                                   name:
                                                     default: ""
-                                                    description: |-
-                                                      Name of the referent.
-                                                      This field is effectively required, but due to backwards compatibility is
-                                                      allowed to be empty. Instances of this type with an empty value here are
-                                                      almost certainly wrong.
-                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    description: Name of the referent
                                                     type: string
                                                 type: object
                                                 x-kubernetes-map-type: atomic
@@ -6881,15 +6371,13 @@ spec:
                                               x-kubernetes-list-type: atomic
                                             insecureSkipVerify:
                                               description: |-
-                                                Originates TLS but skips verification of the backend's certificate.
-                                                WARNING: This is an insecure option that should only be used if the risks are understood.
+                                                Originates TLS but skips verification of the backend's certificate
+                                                WARNING: insecure; only use if the risks are understood
 
-                                                There are two modes:
-                                                * `All` disables all TLS verification.
-                                                * `Hostname` verifies the CA certificate is trusted, but ignores any
-                                                  mismatch of hostname or SANs. Note that this method is still insecure;
-                                                  prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                                                  if possible.
+                                                Modes:
+                                                * `All` disables all TLS verification
+                                                * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                                                  Still insecure; prefer `verifySubjectAltNames` where possible.
                                               enum:
                                               - All
                                               - Hostname
@@ -6908,33 +6396,29 @@ spec:
                                               type: array
                                             mtlsCertificateRef:
                                               description: |-
-                                                Enables mutual TLS to the backend, using the
-                                                specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                                                credential source, defaulting to a Kubernetes `Secret`.
-
-                                                An optional `ca.cert` field, if present, will be used to verify the
-                                                server certificate. If `caCertificateRefs` is also specified, the
-                                                `caCertificateRefs` field takes priority.
-
-                                                If unspecified, no client certificate will be used.
+                                                Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                                                referenced credential source (defaulting to a Kubernetes `Secret`). An
+                                                optional `ca.cert`, if present, verifies the server certificate, but
+                                                `caCertificateRefs` takes priority. If unspecified, no client certificate
+                                                is used.
                                               items:
                                                 description: |-
-                                                  References a same-namespace credential.
-                                                  Set only `name` to reference a Kubernetes Secret.
+                                                  References a same-namespace credential
+                                                  Set only `name` for a Kubernetes Secret
                                                 properties:
                                                   group:
-                                                    description: |-
-                                                      The API group of the referenced credential.
-                                                      Empty selects the core API group.
+                                                    description: API group of the
+                                                      referenced credential; empty
+                                                      selects the core API group
                                                     type: string
                                                   kind:
-                                                    description: |-
-                                                      The kind of the referenced credential.
-                                                      Empty defaults to `Secret`.
+                                                    description: Kind of the referenced
+                                                      credential; empty defaults to
+                                                      `Secret`
                                                     type: string
                                                   name:
-                                                    description: The name of the referenced
-                                                      credential.
+                                                    description: Name of the referenced
+                                                      credential
                                                     maxLength: 253
                                                     minLength: 1
                                                     type: string
@@ -6992,8 +6476,7 @@ spec:
                                               <= 1'
                                         tunnel:
                                           description: Settings for managing tunnel
-                                            connections, with behavior like `HTTPS_PROXY`,
-                                            to the backend.
+                                            connections to the backend, like `HTTPS_PROXY`
                                           properties:
                                             backendRef:
                                               description: |-
@@ -7002,29 +6485,17 @@ spec:
                                               properties:
                                                 group:
                                                   default: ""
-                                                  description: |-
-                                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                                    When unspecified or empty string, core API group is inferred.
+                                                  description: Group of the referent,
+                                                    for example `gateway.networking.k8s.io`.
+                                                    Empty selects the core API group
                                                   maxLength: 253
                                                   pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                                   type: string
                                                 kind:
                                                   default: Service
-                                                  description: |-
-                                                    Kind is the Kubernetes resource kind of the referent. For example
-                                                    "Service".
-
-                                                    Defaults to "Service" when not specified.
-
-                                                    ExternalName services can refer to CNAME DNS records that may live
-                                                    outside of the cluster and as such are difficult to reason about in
-                                                    terms of conformance. They also may not be safe to forward to (see
-                                                    CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                                    support ExternalName Services.
-
-                                                    Support: Core (Services with a type other than ExternalName)
-
-                                                    Support: Implementation-specific (Services with type ExternalName)
+                                                  description: Kubernetes resource
+                                                    kind of the referent, for example
+                                                    `Service`. Defaults to `Service`
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -7036,27 +6507,19 @@ spec:
                                                   minLength: 1
                                                   type: string
                                                 namespace:
-                                                  description: |-
-                                                    Namespace is the namespace of the backend. When unspecified, the local
-                                                    namespace is inferred.
-
-                                                    Note that when a namespace different than the local namespace is specified,
-                                                    a ReferenceGrant object is required in the referent namespace to allow that
-                                                    namespace's owner to accept the reference. See the ReferenceGrant
-                                                    documentation for details.
-
-                                                    Support: Core
+                                                  description: Namespace of the referent.
+                                                    Defaults to the local namespace.
+                                                    A cross-namespace reference requires
+                                                    a ReferenceGrant in the referent
+                                                    namespace
                                                   maxLength: 63
                                                   minLength: 1
                                                   pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                                   type: string
                                                 port:
-                                                  description: |-
-                                                    Port specifies the destination port number to use for this resource.
-                                                    Port is required when the referent is a Kubernetes Service. In this
-                                                    case, the port number is the service port number, not the target port.
-                                                    For other resources, destination port might be derived from the referent
-                                                    resource or this field.
+                                                  description: Destination port number.
+                                                    Required when the referent is
+                                                    a Kubernetes `Service`
                                                   format: int32
                                                   maximum: 65535
                                                   minimum: 1
@@ -7168,29 +6631,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -7201,27 +6652,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -7254,51 +6695,26 @@ spec:
                                           headers.
                                         properties:
                                           name:
-                                            description: |-
-                                              Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                              case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                              If multiple entries specify equivalent header names, only the first
-                                              entry with an equivalent name MUST be considered for a match. Subsequent
-                                              entries with an equivalent header name MUST be ignored. Due to the
-                                              case-insensitivity of header names, "foo" and "Foo" are considered
-                                              equivalent.
-
-                                              When a header is repeated in an HTTP request, it is
-                                              implementation-specific behavior as to how this is represented.
-                                              Generally, proxies should follow the guidance from the RFC:
-                                              https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
-                                              processing a repeated header, with special handling for "Set-Cookie".
+                                            description: Name of the HTTP header to
+                                              match, case-insensitive. When names
+                                              are equivalent, only the first matching
+                                              entry is used
                                             maxLength: 256
                                             minLength: 1
                                             pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                             type: string
                                           type:
                                             default: Exact
-                                            description: |-
-                                              Type specifies how to match against the value of the header.
-
-                                              Support: Core (Exact)
-
-                                              Support: Implementation-specific (RegularExpression)
-
-                                              Since RegularExpression HeaderMatchType has implementation-specific
-                                              conformance, implementations can support POSIX, PCRE or any other dialects
-                                              of regular expressions. Please read the implementation's documentation to
-                                              determine the supported dialect.
+                                            description: 'How to match against the
+                                              header value: `Exact` (default) or `RegularExpression`.
+                                              The regex dialect is implementation-specific'
                                             enum:
                                             - Exact
                                             - RegularExpression
                                             type: string
                                           value:
-                                            description: |-
-                                              Value is the value of HTTP Header to be matched.
-                                              <gateway:experimental:description>
-                                              Must consist of printable US-ASCII characters, optionally separated
-                                              by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                              </gateway:experimental:description>
-
-                                              <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                            description: Value of the HTTP header
+                                              to match
                                             maxLength: 4096
                                             minLength: 1
                                             type: string
@@ -7394,7 +6810,7 @@ spec:
                       rule: '[has(self.defaults),has(self.modelAliases),has(self.overrides),has(self.prompt),has(self.promptCaching),has(self.promptGuard),has(self.routes),has(self.transformations)].filter(x,x==true).size()
                         >= 1'
                   auth:
-                    description: Settings for managing authentication to the backend.
+                    description: Settings for managing authentication to the backend
                     properties:
                       aws:
                         description: |-
@@ -7428,9 +6844,8 @@ spec:
                                 type: string
                               tags:
                                 description: |-
-                                  Tags are session tags passed to STS AssumeRole. Once activated as cost
-                                  allocation tags, they appear in the AWS Cost & Usage Report for cost
-                                  attribution. STS allows at most 50 session tags per role session.
+                                  Session tags passed to STS AssumeRole for cost attribution in the AWS Cost
+                                  & Usage Report, once activated. STS allows at most 50 per role session.
                                 items:
                                   description: |-
                                     AwsSessionTag is an AWS STS session tag passed to AssumeRole for cost
@@ -7438,10 +6853,9 @@ spec:
                                   properties:
                                     expression:
                                       description: |-
-                                        Expression is a CEL expression evaluated against each request to produce
-                                        the tag value, for example `jwt.sub` or `request.headers["x-app"]`. If the
-                                        expression does not produce a valid tag value at request time, the request
-                                        is rejected.
+                                        CEL expression evaluated against each request to produce the tag value,
+                                        for example `jwt.sub` or `request.headers["x-app"]`. Requests with invalid
+                                        tag values are rejected.
                                       maxLength: 16384
                                       minLength: 1
                                       type: string
@@ -7476,23 +6890,20 @@ spec:
                                 <= 1'
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing the AWS credentials. When using the default Secret
-                              resolver, the `Secret` must have keys `accessKey`, `secretKey`, and
-                              optionally `sessionToken`.
+                              Credential source for AWS credentials, defaulting to a Kubernetes `Secret`.
+                              The default Secret resolver expects `accessKey`, `secretKey`, and optional
+                              `sessionToken` keys.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -7538,23 +6949,20 @@ spec:
                             type: object
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing the Azure credentials. When using the default Secret
-                              resolver, the `Secret` must have keys `clientID`, `tenantID`, and
-                              `clientSecret`.
+                              Credential source for Azure credentials, defaulting to a Kubernetes
+                              `Secret`. The default Secret resolver expects `clientID`, `tenantID`, and
+                              `clientSecret` keys.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -7571,12 +6979,9 @@ spec:
                                 > 0)'
                           workloadIdentity:
                             description: |-
-                              Workload identity authentication settings. Uses the federated token
-                              projected into the data plane pod (via the `AZURE_FEDERATED_TOKEN_FILE`,
-                              `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_AUTHORITY_HOST`
-                              environment variables) to authenticate. This is the recommended method
-                              when running on Azure Kubernetes Service (AKS) with Workload Identity
-                              enabled.
+                              Workload identity authentication settings. Uses the federated token and
+                              Azure env vars projected into the data plane pod. Recommended on AKS with
+                              Workload Identity enabled.
                             type: object
                         type: object
                         x-kubernetes-validations:
@@ -7599,31 +7004,27 @@ spec:
                             type: string
                           secretRef:
                             description: |-
-                              Credential source, defaulting to a Kubernetes
-                              `Secret`, containing ADC-compatible Google credential JSON. When using
-                              the default Secret resolver, this must be stored in the `credentials.json`
-                              key by default; override via `secretRef.key`. When omitted, ambient
-                              credentials are used.
+                              Credential source for ADC-compatible Google credential JSON, defaulting to
+                              a Kubernetes `Secret`. By default, the value is read from
+                              `credentials.json`; set `secretRef.key` to override it. When omitted,
+                              ambient credentials are used.
                             properties:
                               group:
-                                description: |-
-                                  The API group of the referenced credential.
-                                  Empty selects the core API group.
+                                description: API group of the referenced credential;
+                                  empty selects the core API group
                                 type: string
                               key:
-                                description: |-
-                                  The key in the referenced Secret whose value is used. If omitted, a
-                                  location-specific default key is used.
+                                description: Key in the referenced Secret. If omitted,
+                                  a location-specific default is used
                                 maxLength: 253
                                 minLength: 1
                                 type: string
                               kind:
-                                description: |-
-                                  The kind of the referenced credential.
-                                  Empty defaults to `Secret`.
+                                description: Kind of the referenced credential; empty
+                                  defaults to `Secret`
                                 type: string
                               name:
-                                description: The name of the referenced credential.
+                                description: Name of the referenced credential
                                 maxLength: 253
                                 minLength: 1
                                 type: string
@@ -7660,9 +7061,9 @@ spec:
                         type: string
                       location:
                         description: |-
-                          Where backend credentials are inserted.
-                          If omitted, credentials are written to the `Authorization` header with the `Bearer ` prefix.
-                          This applies to `key`, `secretRef`, and `passthrough`.
+                          Where backend credentials are inserted. Defaults to the `Authorization`
+                          header with the `Bearer ` prefix. Applies to `key`, `secretRef`, and
+                          `passthrough`.
                         properties:
                           cookie:
                             properties:
@@ -7676,19 +7077,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -7751,19 +7141,9 @@ spec:
                                   header:
                                     properties:
                                       name:
-                                        description: |-
-                                          HTTPHeaderName is the name of an HTTP header.
-
-                                          Valid values include:
-
-                                          * "Authorization"
-                                          * "Set-Cookie"
-
-                                          Invalid values include:
-
-                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                              headers are not currently supported by this type.
-                                            - "/invalid" - "/ " is an invalid character
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
                                         maxLength: 256
                                         minLength: 1
                                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -7827,29 +7207,15 @@ spec:
                             properties:
                               group:
                                 default: ""
-                                description: |-
-                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                  When unspecified or empty string, core API group is inferred.
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
                                 default: Service
-                                description: |-
-                                  Kind is the Kubernetes resource kind of the referent. For example
-                                  "Service".
-
-                                  Defaults to "Service" when not specified.
-
-                                  ExternalName services can refer to CNAME DNS records that may live
-                                  outside of the cluster and as such are difficult to reason about in
-                                  terms of conformance. They also may not be safe to forward to (see
-                                  CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                  support ExternalName Services.
-
-                                  Support: Core (Services with a type other than ExternalName)
-
-                                  Support: Implementation-specific (Services with type ExternalName)
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -7860,27 +7226,16 @@ spec:
                                 minLength: 1
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of the backend. When unspecified, the local
-                                  namespace is inferred.
-
-                                  Note that when a namespace different than the local namespace is specified,
-                                  a ReferenceGrant object is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the ReferenceGrant
-                                  documentation for details.
-
-                                  Support: Core
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               port:
-                                description: |-
-                                  Port specifies the destination port number to use for this resource.
-                                  Port is required when the referent is a Kubernetes Service. In this
-                                  case, the port number is the service port number, not the target port.
-                                  For other resources, destination port might be derived from the referent
-                                  resource or this field.
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -7950,24 +7305,22 @@ spec:
                                       or EC private key; override the key name via `signingKeyRef.key`.
                                     properties:
                                       group:
-                                        description: |-
-                                          The API group of the referenced credential.
-                                          Empty selects the core API group.
+                                        description: API group of the referenced credential;
+                                          empty selects the core API group
                                         type: string
                                       key:
-                                        description: |-
-                                          The key in the referenced Secret whose value is used. If omitted, a
-                                          location-specific default key is used.
+                                        description: Key in the referenced Secret.
+                                          If omitted, a location-specific default
+                                          is used
                                         maxLength: 253
                                         minLength: 1
                                         type: string
                                       kind:
-                                        description: |-
-                                          The kind of the referenced credential.
-                                          Empty defaults to `Secret`.
+                                        description: Kind of the referenced credential;
+                                          empty defaults to `Secret`
                                         type: string
                                       name:
-                                        description: The name of the referenced credential.
+                                        description: Name of the referenced credential
                                         maxLength: 253
                                         minLength: 1
                                         type: string
@@ -7993,24 +7346,21 @@ spec:
                                   is only valid with ClientSecretPost.
                                 properties:
                                   group:
-                                    description: |-
-                                      The API group of the referenced credential.
-                                      Empty selects the core API group.
+                                    description: API group of the referenced credential;
+                                      empty selects the core API group
                                     type: string
                                   key:
-                                    description: |-
-                                      The key in the referenced Secret whose value is used. If omitted, a
-                                      location-specific default key is used.
+                                    description: Key in the referenced Secret. If
+                                      omitted, a location-specific default is used
                                     maxLength: 253
                                     minLength: 1
                                     type: string
                                   kind:
-                                    description: |-
-                                      The kind of the referenced credential.
-                                      Empty defaults to `Secret`.
+                                    description: Kind of the referenced credential;
+                                      empty defaults to `Secret`
                                     type: string
                                   name:
-                                    description: The name of the referenced credential.
+                                    description: Name of the referenced credential
                                     maxLength: 253
                                     minLength: 1
                                     type: string
@@ -8063,19 +7413,8 @@ spec:
                               header:
                                 properties:
                                   name:
-                                    description: |-
-                                      HTTPHeaderName is the name of an HTTP header.
-
-                                      Valid values include:
-
-                                      * "Authorization"
-                                      * "Set-Cookie"
-
-                                      Invalid values include:
-
-                                        - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                          headers are not currently supported by this type.
-                                        - "/invalid" - "/ " is an invalid character
+                                    description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                      (names beginning with `:`) are not supported
                                     maxLength: 256
                                     minLength: 1
                                     pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -8155,19 +7494,9 @@ spec:
                                   header:
                                     properties:
                                       name:
-                                        description: |-
-                                          HTTPHeaderName is the name of an HTTP header.
-
-                                          Valid values include:
-
-                                          * "Authorization"
-                                          * "Set-Cookie"
-
-                                          Invalid values include:
-
-                                            - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                              headers are not currently supported by this type.
-                                            - "/invalid" - "/ " is an invalid character
+                                        description: Name of an HTTP header. HTTP/2
+                                          pseudo-headers (names beginning with `:`)
+                                          are not supported
                                         maxLength: 256
                                         minLength: 1
                                         pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -8219,40 +7548,33 @@ spec:
                             != ''IdJag'''
                       passthrough:
                         description: |-
-                          Passes through an existing token that has been sent by the
-                          client and validated. Other policies, like JWT and API key
-                          authentication, will strip the original client credentials. Passthrough backend authentication
-                          causes the original token to be added back into the request. If there are no client authentication policies on the
-                          request, the original token would be unchanged, so this would have no effect.
+                          Reuses a client token already validated by another policy. Those policies
+                          may strip client credentials; passthrough adds the original token back to
+                          the backend request. Without client auth policies, this has no effect.
                         type: object
                       secretRef:
                         description: |-
-                          Credential source, defaulting to a Kubernetes
-                          `Secret`, storing the key to use as the authorization value. When using
-                          the default Secret resolver, this must be stored in the `Authorization`
-                          key by default; override via `secretRef.key`. A `Bearer ` prefix on the
-                          stored value is stripped only when reading the default `Authorization`
-                          key.
+                          Credential source for the authorization value, defaulting to a Kubernetes
+                          `Secret`. By default, the value is read from the `Authorization` key; set
+                          `secretRef.key` to override it. A `Bearer ` prefix is stripped only from
+                          the default `Authorization` key.
                         properties:
                           group:
-                            description: |-
-                              The API group of the referenced credential.
-                              Empty selects the core API group.
+                            description: API group of the referenced credential; empty
+                              selects the core API group
                             type: string
                           key:
-                            description: |-
-                              The key in the referenced Secret whose value is used. If omitted, a
-                              location-specific default key is used.
+                            description: Key in the referenced Secret. If omitted,
+                              a location-specific default is used
                             maxLength: 253
                             minLength: 1
                             type: string
                           kind:
-                            description: |-
-                              The kind of the referenced credential.
-                              Empty defaults to `Secret`.
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
                             type: string
                           name:
-                            description: The name of the referenced credential.
+                            description: Name of the referenced credential
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -8288,29 +7610,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8321,27 +7629,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -8579,13 +7876,12 @@ spec:
                               rule: duration(self) >= duration('1s')
                           healthThreshold:
                             description: |-
-                              EWMA health score threshold, expressed as 0 to 100.
-                              When set, a backend is only evicted if its computed health drops below this value after an unhealthy response.
-                              For example, 50 means the backend is evicted when its EWMA health falls below 50% following failures.
-                              Unlike consecutiveFailures (which counts consecutive failures), this uses a sliding-window average
-                              so a single success in a stream of failures can delay eviction.
-                              When both consecutiveFailures and healthThreshold are set, the backend is evicted when either condition is met.
-                              When neither is set, a single unhealthy response triggers eviction.
+                              EWMA health score threshold, from 0 to 100. When set, a backend is evicted
+                              only if its computed health drops below this value after an unhealthy
+                              response (e.g. 50 evicts when EWMA health falls below 50%). Unlike
+                              consecutiveFailures, this sliding-window average lets a single success delay
+                              eviction. If both are set, either condition evicts; if neither, a single
+                              unhealthy response evicts.
                             format: int32
                             maximum: 100
                             minimum: 0
@@ -8614,7 +7910,7 @@ spec:
                         type: string
                     type: object
                   http:
-                    description: Settings for managing HTTP requests to the backend.
+                    description: Settings for managing HTTP requests to the backend
                     properties:
                       requestTimeout:
                         description: Deadline for receiving a response from the backend.
@@ -8626,17 +7922,10 @@ spec:
                           rule: duration(self) >= duration('1ms')
                       version:
                         description: |-
-                          HTTP protocol version to use when connecting to
-                          the backend.
-                          If not specified, the version is automatically determined:
-                          * `Service` types can specify it with `appProtocol` on the `Service`
-                            port.
-                          * If traffic is identified as gRPC, `HTTP2` is used.
-                          * If the incoming traffic was plaintext HTTP, the original protocol will
-                            be used.
-                          * If the incoming traffic was HTTPS, `HTTP1` will be used. This is
-                            because most clients will transparently upgrade HTTPS traffic to
-                            `HTTP2`, even if the backend doesn't support it.
+                          HTTP protocol version for backend connections. If unset, it is inferred:
+                          `Service` appProtocol, `HTTP2` for gRPC, the original protocol for
+                          plaintext HTTP, or `HTTP1` for HTTPS because clients often upgrade HTTPS
+                          to HTTP/2 even when the backend does not support it.
                         enum:
                         - HTTP1
                         - HTTP2
@@ -8692,29 +7981,16 @@ spec:
                                 properties:
                                   group:
                                     default: ""
-                                    description: |-
-                                      Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                      When unspecified or empty string, core API group is inferred.
+                                    description: Group of the referent, for example
+                                      `gateway.networking.k8s.io`. Empty selects the
+                                      core API group
                                     maxLength: 253
                                     pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                     type: string
                                   kind:
                                     default: Service
-                                    description: |-
-                                      Kind is the Kubernetes resource kind of the referent. For example
-                                      "Service".
-
-                                      Defaults to "Service" when not specified.
-
-                                      ExternalName services can refer to CNAME DNS records that may live
-                                      outside of the cluster and as such are difficult to reason about in
-                                      terms of conformance. They also may not be safe to forward to (see
-                                      CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                      support ExternalName Services.
-
-                                      Support: Core (Services with a type other than ExternalName)
-
-                                      Support: Implementation-specific (Services with type ExternalName)
+                                    description: Kubernetes resource kind of the referent,
+                                      for example `Service`. Defaults to `Service`
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8725,27 +8001,16 @@ spec:
                                     minLength: 1
                                     type: string
                                   namespace:
-                                    description: |-
-                                      Namespace is the namespace of the backend. When unspecified, the local
-                                      namespace is inferred.
-
-                                      Note that when a namespace different than the local namespace is specified,
-                                      a ReferenceGrant object is required in the referent namespace to allow that
-                                      namespace's owner to accept the reference. See the ReferenceGrant
-                                      documentation for details.
-
-                                      Support: Core
+                                    description: Namespace of the referent. Defaults
+                                      to the local namespace. A cross-namespace reference
+                                      requires a ReferenceGrant in the referent namespace
                                     maxLength: 63
                                     minLength: 1
                                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                     type: string
                                   port:
-                                    description: |-
-                                      Port specifies the destination port number to use for this resource.
-                                      Port is required when the referent is a Kubernetes Service. In this
-                                      case, the port number is the service port number, not the target port.
-                                      For other resources, destination port might be derived from the referent
-                                      resource or this field.
+                                    description: Destination port number. Required
+                                      when the referent is a Kubernetes `Service`
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
@@ -8926,29 +8191,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -8959,27 +8212,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -9057,7 +8300,7 @@ spec:
                       rule: '[has(self.authentication),has(self.authorization),has(self.guardrails)].filter(x,x==true).size()
                         >= 1'
                   tcp:
-                    description: Settings for managing TCP connections to the backend.
+                    description: Settings for managing TCP connections to the backend
                     properties:
                       connectTimeout:
                         description: |-
@@ -9106,10 +8349,10 @@ spec:
                     type: object
                   tls:
                     description: |-
-                      Settings for managing TLS connections to the backend.
+                      Settings for managing TLS connections to the backend
 
-                      If this field is set, TLS will be initiated to the backend; the system trusted CA certificates will be used to
-                      validate the server, and the SNI will automatically be set based on the destination.
+                      When set, TLS is originated to the backend using the system trusted CA
+                      certificates, and SNI is inferred from the destination.
                     properties:
                       alpnProtocols:
                         description: |-
@@ -9136,12 +8379,7 @@ spec:
                           properties:
                             name:
                               default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: Name of the referent
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
@@ -9150,15 +8388,13 @@ spec:
                         x-kubernetes-list-type: atomic
                       insecureSkipVerify:
                         description: |-
-                          Originates TLS but skips verification of the backend's certificate.
-                          WARNING: This is an insecure option that should only be used if the risks are understood.
+                          Originates TLS but skips verification of the backend's certificate
+                          WARNING: insecure; only use if the risks are understood
 
-                          There are two modes:
-                          * `All` disables all TLS verification.
-                          * `Hostname` verifies the CA certificate is trusted, but ignores any
-                            mismatch of hostname or SANs. Note that this method is still insecure;
-                            prefer setting `verifySubjectAltNames` to customize the valid hostnames
-                            if possible.
+                          Modes:
+                          * `All` disables all TLS verification
+                          * `Hostname` trusts the CA certificate but ignores hostname/SAN mismatches.
+                            Still insecure; prefer `verifySubjectAltNames` where possible.
                         enum:
                         - All
                         - Hostname
@@ -9177,32 +8413,26 @@ spec:
                         type: array
                       mtlsCertificateRef:
                         description: |-
-                          Enables mutual TLS to the backend, using the
-                          specified key (`tls.key`) and cert (`tls.crt`) from the referenced
-                          credential source, defaulting to a Kubernetes `Secret`.
-
-                          An optional `ca.cert` field, if present, will be used to verify the
-                          server certificate. If `caCertificateRefs` is also specified, the
-                          `caCertificateRefs` field takes priority.
-
-                          If unspecified, no client certificate will be used.
+                          Enables mutual TLS to the backend using `tls.key` and `tls.crt` from the
+                          referenced credential source (defaulting to a Kubernetes `Secret`). An
+                          optional `ca.cert`, if present, verifies the server certificate, but
+                          `caCertificateRefs` takes priority. If unspecified, no client certificate
+                          is used.
                         items:
                           description: |-
-                            References a same-namespace credential.
-                            Set only `name` to reference a Kubernetes Secret.
+                            References a same-namespace credential
+                            Set only `name` for a Kubernetes Secret
                           properties:
                             group:
-                              description: |-
-                                The API group of the referenced credential.
-                                Empty selects the core API group.
+                              description: API group of the referenced credential;
+                                empty selects the core API group
                               type: string
                             kind:
-                              description: |-
-                                The kind of the referenced credential.
-                                Empty defaults to `Secret`.
+                              description: Kind of the referenced credential; empty
+                                defaults to `Secret`
                               type: string
                             name:
-                              description: The name of the referenced credential.
+                              description: Name of the referenced credential
                               maxLength: 253
                               minLength: 1
                               type: string
@@ -9491,8 +8721,8 @@ spec:
                       rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
                         >= 1'
                   tunnel:
-                    description: Settings for managing tunnel connections, with behavior
-                      like `HTTPS_PROXY`, to the backend.
+                    description: Settings for managing tunnel connections to the backend,
+                      like `HTTPS_PROXY`
                     properties:
                       backendRef:
                         description: |-
@@ -9501,29 +8731,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -9534,27 +8750,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -9699,29 +8904,15 @@ spec:
                             properties:
                               group:
                                 default: ""
-                                description: |-
-                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                  When unspecified or empty string, core API group is inferred.
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
                                 default: Service
-                                description: |-
-                                  Kind is the Kubernetes resource kind of the referent. For example
-                                  "Service".
-
-                                  Defaults to "Service" when not specified.
-
-                                  ExternalName services can refer to CNAME DNS records that may live
-                                  outside of the cluster and as such are difficult to reason about in
-                                  terms of conformance. They also may not be safe to forward to (see
-                                  CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                  support ExternalName Services.
-
-                                  Support: Core (Services with a type other than ExternalName)
-
-                                  Support: Implementation-specific (Services with type ExternalName)
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -9732,27 +8923,16 @@ spec:
                                 minLength: 1
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of the backend. When unspecified, the local
-                                  namespace is inferred.
-
-                                  Note that when a namespace different than the local namespace is specified,
-                                  a ReferenceGrant object is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the ReferenceGrant
-                                  documentation for details.
-
-                                  Support: Core
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               port:
-                                description: |-
-                                  Port specifies the destination port number to use for this resource.
-                                  Port is required when the referent is a Kubernetes Service. In this
-                                  case, the port number is the service port number, not the target port.
-                                  For other resources, destination port might be derived from the referent
-                                  resource or this field.
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -10260,29 +9440,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -10293,27 +9459,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -10643,19 +9798,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -10713,17 +9857,15 @@ spec:
                           \     }\n\t    }"
                         properties:
                           group:
-                            description: |-
-                              The API group of the referenced credential.
-                              Empty selects the core API group.
+                            description: API group of the referenced credential; empty
+                              selects the core API group
                             type: string
                           kind:
-                            description: |-
-                              The kind of the referenced credential.
-                              Empty defaults to `Secret`.
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
                             type: string
                           name:
-                            description: The name of the referenced credential.
+                            description: Name of the referenced credential
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -10849,19 +9991,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -10914,24 +10045,21 @@ spec:
                           \   bob:$apr1$Ukb5LgRD$EPY2lIfY.A54jzLELNIId/"
                         properties:
                           group:
-                            description: |-
-                              The API group of the referenced credential.
-                              Empty selects the core API group.
+                            description: API group of the referenced credential; empty
+                              selects the core API group
                             type: string
                           key:
-                            description: |-
-                              The key in the referenced Secret whose value is used. If omitted, a
-                              location-specific default key is used.
+                            description: Key in the referenced Secret. If omitted,
+                              a location-specific default is used
                             maxLength: 253
                             minLength: 1
                             type: string
                           kind:
-                            description: |-
-                              The kind of the referenced credential.
-                              Empty defaults to `Secret`.
+                            description: Kind of the referenced credential; empty
+                              defaults to `Secret`
                             type: string
                           name:
-                            description: The name of the referenced credential.
+                            description: Name of the referenced credential
                             maxLength: 253
                             minLength: 1
                             type: string
@@ -11051,59 +10179,12 @@ spec:
                           Support: Extended
                         type: boolean
                       allowHeaders:
-                        description: |-
-                          AllowHeaders indicates which HTTP request headers are supported for
-                          accessing the requested resource.
-
-                          Header names are not case-sensitive.
-
-                          Multiple header names in the value of the `Access-Control-Allow-Headers`
-                          response header are separated by a comma (",").
-
-                          When the `allowHeaders` field is configured with one or more headers, the
-                          gateway must return the `Access-Control-Allow-Headers` response header
-                          which value is present in the `allowHeaders` field.
-
-                          If any header name in the `Access-Control-Request-Headers` request header
-                          is not included in the list of header names specified by the response
-                          header `Access-Control-Allow-Headers`, it will present an error on the
-                          client side.
-
-                          If any header name in the `Access-Control-Allow-Headers` response header
-                          does not recognize by the client, it will also occur an error on the
-                          client side.
-
-                          A wildcard indicates that the requests with all HTTP headers are allowed.
-
-                          If the configuration contains the wildcard `*` in `allowHeaders` and
-                          `allowCredentials` is set to `false`, the `Access-Control-Allow-Headers`
-                          response header may either contain the wildcard `*` or echo the value
-                          of the `Access-Control-Request-Headers` request header.
-
-                          If the configuration contains the wildcard `*` in `allowHeaders` and
-                          `allowCredentials` is set to `true`, the gateway must not return `*`
-                          in the `Access-Control-Allow-Headers` response header. Instead, it must
-                          return one or more header names matching the value of the
-                          `Access-Control-Request-Headers` request header.
-                          If the `Access-Control-Request-Headers` header is not present in the
-                          request, the gateway must omit the `Access-Control-Allow-Headers`
-                          response header.
-
-                          Support: Extended
+                        description: 'Request headers allowed when accessing the resource,
+                          or `*` for all. Sets `Access-Control-Allow-Headers`. Support:
+                          Extended'
                         items:
-                          description: |-
-                            HTTPHeaderName is the name of an HTTP header.
-
-                            Valid values include:
-
-                            * "Authorization"
-                            * "Set-Cookie"
-
-                            Invalid values include:
-
-                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                headers are not currently supported by this type.
-                              - "/invalid" - "/ " is an invalid character
+                          description: Name of an HTTP header. HTTP/2 pseudo-headers
+                            (names beginning with `:`) are not supported
                           maxLength: 256
                           minLength: 1
                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -11116,47 +10197,10 @@ spec:
                             methods
                           rule: '!(''*'' in self && self.size() > 1)'
                       allowMethods:
-                        description: |-
-                          AllowMethods indicates which HTTP methods are supported for accessing the
-                          requested resource.
-
-                          Valid values are any method defined by RFC9110, along with the special
-                          value `*`, which represents all HTTP methods are allowed.
-
-                          Method names are case-sensitive, so these values are also case-sensitive.
-                          (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
-
-                          Multiple method names in the value of the `Access-Control-Allow-Methods`
-                          response header are separated by a comma (",").
-
-                          A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
-                          (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
-                          CORS-safelisted methods are always allowed, regardless of whether they
-                          are specified in the `allowMethods` field.
-
-                          When the `allowMethods` field is configured with one or more methods, the
-                          gateway must return the `Access-Control-Allow-Methods` response header
-                          which value is present in the `allowMethods` field.
-
-                          If the HTTP method of the `Access-Control-Request-Method` request header
-                          is not included in the list of methods specified by the response header
-                          `Access-Control-Allow-Methods`, it will present an error on the client
-                          side.
-
-                          If the configuration contains the wildcard `*` in `allowMethods` and
-                          `allowCredentials` is set to `false`, the `Access-Control-Allow-Methods`
-                          response header may either contain the wildcard `*` or echo the value
-                          of the `Access-Control-Request-Method` request header.
-
-                          If the configuration contains the wildcard `*` in `allowMethods` and
-                          `allowCredentials` is set to `true`, the gateway must not return `*`
-                          in the `Access-Control-Allow-Methods` response header. Instead, it must
-                          return a single HTTP method matching the value of the
-                          `Access-Control-Request-Method` request header.
-                          If the `Access-Control-Request-Method` header is not present in the request,
-                          the gateway must omit the `Access-Control-Allow-Methods` response header.
-
-                          Support: Extended
+                        description: 'HTTP methods allowed for the resource, or `*`
+                          for all. CORS-safelisted methods (`GET`, `HEAD`, `POST`)
+                          are always allowed. Sets `Access-Control-Allow-Methods`.
+                          Support: Extended'
                         items:
                           enum:
                           - GET
@@ -11178,65 +10222,11 @@ spec:
                             methods
                           rule: '!(''*'' in self && self.size() > 1)'
                       allowOrigins:
-                        description: |-
-                          AllowOrigins indicates whether the response can be shared with requested
-                          resource from the given `Origin`.
-
-                          The `Origin` consists of a scheme and a host, with an optional port, and
-                          takes the form `<scheme>://<host>(:<port>)`.
-
-                          Valid values for scheme are: `http` and `https`.
-
-                          Valid values for port are any integer between 1 and 65535 (the list of
-                          available TCP/UDP ports). Note that, if not included, port `80` is
-                          assumed for `http` scheme origins, and port `443` is assumed for `https`
-                          origins. This may affect origin matching.
-
-                          The host part of the origin may contain the wildcard character `*`. These
-                          wildcard characters behave as follows:
-
-                          * `*` is a greedy match to the _left_, including any number of
-                            DNS labels to the left of its position. This also means that
-                            `*` will include any number of period `.` characters to the
-                            left of its position.
-                          * A wildcard by itself matches all hosts.
-
-                          An origin value that includes _only_ the `*` character indicates requests
-                          from all `Origin`s are allowed.
-
-                          When the `allowOrigins` field is configured with multiple origins, it
-                          means the server supports clients from multiple origins. If the request
-                          `Origin` matches the configured allowed origins, the gateway must return
-                          the given `Origin` and sets value of the header
-                          `Access-Control-Allow-Origin` same as the `Origin` header provided by the
-                          client.
-
-                          The status code of a successful response to a "preflight" request is
-                          always an OK status (i.e., 204 or 200).
-
-                          If the request `Origin` does not match the configured allowed origins,
-                          the gateway returns 204/200 response but doesn't set the relevant
-                          cross-origin response headers. Alternatively, the gateway responds with
-                          403 status to the "preflight" request is denied, coupled with omitting
-                          the CORS headers. The cross-origin request fails on the client side.
-                          Therefore, the client doesn't attempt the actual cross-origin request.
-
-                          Conversely, if the request `Origin` matches one of the configured
-                          allowed origins, the gateway sets the response header
-                          `Access-Control-Allow-Origin` to the same value as the `Origin`
-                          header provided by the client.
-
-                          If the configuration contains the wildcard `*` in `allowOrigins` and
-                          `allowCredentials` is set to `false`, the `Access-Control-Allow-Origin`
-                          response header may either contain the wildcard `*` or echo the value
-                          of the `Origin` request header.
-
-                          If the configuration contains the wildcard `*` in `allowOrigins` and
-                          `allowCredentials` is set to `true`, the gateway must not return `*`
-                          in the `Access-Control-Allow-Origin` response header. Instead, it must
-                          return a single origin matching the value of the `Origin` request header.
-
-                          Support: Extended
+                        description: 'Origins allowed to share the response, each
+                          as `<scheme>://<host>(:<port>)`; the host may use the `*`
+                          wildcard, and a bare `*` allows all origins. Sets `Access-Control-Allow-Origin`.
+                          When credentials are allowed, a specific origin is echoed
+                          instead of `*`. Support: Extended'
                         items:
                           description: |-
                             The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
@@ -11256,58 +10246,12 @@ spec:
                             origins
                           rule: '!(''*'' in self && self.size() > 1)'
                       exposeHeaders:
-                        description: |-
-                          ExposeHeaders indicates which HTTP response headers can be exposed
-                          to client-side scripts in response to a cross-origin request.
-
-                          A CORS-safelisted response header is an HTTP header in a CORS response
-                          that it is considered safe to expose to the client scripts.
-                          The CORS-safelisted response headers include the following headers:
-                          `Cache-Control`
-                          `Content-Language`
-                          `Content-Length`
-                          `Content-Type`
-                          `Expires`
-                          `Last-Modified`
-                          `Pragma`
-                          (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
-                          The CORS-safelisted response headers are exposed to client by default.
-
-                          When an HTTP header name is specified using the `exposeHeaders` field,
-                          this additional header will be exposed as part of the response to the
-                          client.
-
-                          Header names are not case-sensitive.
-
-                          Multiple header names in the value of the `Access-Control-Expose-Headers`
-                          response header are separated by a comma (",").
-
-                          A wildcard indicates that the responses with all HTTP headers are exposed
-                          to clients.
-
-                          If the configuration contains the wildcard `*` in `exposeHeaders` and
-                          `allowCredentials` is set to `false`, the `Access-Control-Expose-Headers`
-                          response header can contain the wildcard `*`.
-
-                          If the configuration contains the wildcard `*` in `exposeHeaders` and
-                          `allowCredentials` is set to `true`, the gateway cannot use the `*`
-                          in the `Access-Control-Expose-Headers` response header.
-
-                          Support: Extended
+                        description: 'Response headers exposed to client scripts,
+                          or `*` for all. Sets `Access-Control-Expose-Headers`. Support:
+                          Extended'
                         items:
-                          description: |-
-                            HTTPHeaderName is the name of an HTTP header.
-
-                            Valid values include:
-
-                            * "Authorization"
-                            * "Set-Cookie"
-
-                            Invalid values include:
-
-                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                headers are not currently supported by this type.
-                              - "/invalid" - "/ " is an invalid character
+                          description: Name of an HTTP header. HTTP/2 pseudo-headers
+                            (names beginning with `:`) are not supported
                           maxLength: 256
                           minLength: 1
                           pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -11521,29 +10465,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -11554,27 +10484,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -11658,29 +10577,17 @@ spec:
                                   properties:
                                     group:
                                       default: ""
-                                      description: |-
-                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                        When unspecified or empty string, core API group is inferred.
+                                      description: Group of the referent, for example
+                                        `gateway.networking.k8s.io`. Empty selects
+                                        the core API group
                                       maxLength: 253
                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     kind:
                                       default: Service
-                                      description: |-
-                                        Kind is the Kubernetes resource kind of the referent. For example
-                                        "Service".
-
-                                        Defaults to "Service" when not specified.
-
-                                        ExternalName services can refer to CNAME DNS records that may live
-                                        outside of the cluster and as such are difficult to reason about in
-                                        terms of conformance. They also may not be safe to forward to (see
-                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                        support ExternalName Services.
-
-                                        Support: Core (Services with a type other than ExternalName)
-
-                                        Support: Implementation-specific (Services with type ExternalName)
+                                      description: Kubernetes resource kind of the
+                                        referent, for example `Service`. Defaults
+                                        to `Service`
                                       maxLength: 63
                                       minLength: 1
                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -11691,27 +10598,17 @@ spec:
                                       minLength: 1
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of the backend. When unspecified, the local
-                                        namespace is inferred.
-
-                                        Note that when a namespace different than the local namespace is specified,
-                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                        documentation for details.
-
-                                        Support: Core
+                                      description: Namespace of the referent. Defaults
+                                        to the local namespace. A cross-namespace
+                                        reference requires a ReferenceGrant in the
+                                        referent namespace
                                       maxLength: 63
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                       type: string
                                     port:
-                                      description: |-
-                                        Port specifies the destination port number to use for this resource.
-                                        Port is required when the referent is a Kubernetes Service. In this
-                                        case, the port number is the service port number, not the target port.
-                                        For other resources, destination port might be derived from the referent
-                                        resource or this field.
+                                      description: Destination port number. Required
+                                        when the referent is a Kubernetes `Service`
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -12105,29 +11002,15 @@ spec:
                         properties:
                           group:
                             default: ""
-                            description: |-
-                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                              When unspecified or empty string, core API group is inferred.
+                            description: Group of the referent, for example `gateway.networking.k8s.io`.
+                              Empty selects the core API group
                             maxLength: 253
                             pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           kind:
                             default: Service
-                            description: |-
-                              Kind is the Kubernetes resource kind of the referent. For example
-                              "Service".
-
-                              Defaults to "Service" when not specified.
-
-                              ExternalName services can refer to CNAME DNS records that may live
-                              outside of the cluster and as such are difficult to reason about in
-                              terms of conformance. They also may not be safe to forward to (see
-                              CVE-2021-25740 for more information). Implementations SHOULD NOT
-                              support ExternalName Services.
-
-                              Support: Core (Services with a type other than ExternalName)
-
-                              Support: Implementation-specific (Services with type ExternalName)
+                            description: Kubernetes resource kind of the referent,
+                              for example `Service`. Defaults to `Service`
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -12138,27 +11021,16 @@ spec:
                             minLength: 1
                             type: string
                           namespace:
-                            description: |-
-                              Namespace is the namespace of the backend. When unspecified, the local
-                              namespace is inferred.
-
-                              Note that when a namespace different than the local namespace is specified,
-                              a ReferenceGrant object is required in the referent namespace to allow that
-                              namespace's owner to accept the reference. See the ReferenceGrant
-                              documentation for details.
-
-                              Support: Core
+                            description: Namespace of the referent. Defaults to the
+                              local namespace. A cross-namespace reference requires
+                              a ReferenceGrant in the referent namespace
                             maxLength: 63
                             minLength: 1
                             pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           port:
-                            description: |-
-                              Port specifies the destination port number to use for this resource.
-                              Port is required when the referent is a Kubernetes Service. In this
-                              case, the port number is the service port number, not the target port.
-                              For other resources, destination port might be derived from the referent
-                              resource or this field.
+                            description: Destination port number. Required when the
+                              referent is a Kubernetes `Service`
                             format: int32
                             maximum: 65535
                             minimum: 1
@@ -12194,29 +11066,17 @@ spec:
                                   properties:
                                     group:
                                       default: ""
-                                      description: |-
-                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                        When unspecified or empty string, core API group is inferred.
+                                      description: Group of the referent, for example
+                                        `gateway.networking.k8s.io`. Empty selects
+                                        the core API group
                                       maxLength: 253
                                       pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                     kind:
                                       default: Service
-                                      description: |-
-                                        Kind is the Kubernetes resource kind of the referent. For example
-                                        "Service".
-
-                                        Defaults to "Service" when not specified.
-
-                                        ExternalName services can refer to CNAME DNS records that may live
-                                        outside of the cluster and as such are difficult to reason about in
-                                        terms of conformance. They also may not be safe to forward to (see
-                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                        support ExternalName Services.
-
-                                        Support: Core (Services with a type other than ExternalName)
-
-                                        Support: Implementation-specific (Services with type ExternalName)
+                                      description: Kubernetes resource kind of the
+                                        referent, for example `Service`. Defaults
+                                        to `Service`
                                       maxLength: 63
                                       minLength: 1
                                       pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -12227,27 +11087,17 @@ spec:
                                       minLength: 1
                                       type: string
                                     namespace:
-                                      description: |-
-                                        Namespace is the namespace of the backend. When unspecified, the local
-                                        namespace is inferred.
-
-                                        Note that when a namespace different than the local namespace is specified,
-                                        a ReferenceGrant object is required in the referent namespace to allow that
-                                        namespace's owner to accept the reference. See the ReferenceGrant
-                                        documentation for details.
-
-                                        Support: Core
+                                      description: Namespace of the referent. Defaults
+                                        to the local namespace. A cross-namespace
+                                        reference requires a ReferenceGrant in the
+                                        referent namespace
                                       maxLength: 63
                                       minLength: 1
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                       type: string
                                     port:
-                                      description: |-
-                                        Port specifies the destination port number to use for this resource.
-                                        Port is required when the referent is a Kubernetes Service. In this
-                                        case, the port number is the service port number, not the target port.
-                                        For other resources, destination port might be derived from the referent
-                                        resource or this field.
+                                      description: Destination port number. Required
+                                        when the referent is a Kubernetes `Service`
                                       format: int32
                                       maximum: 65535
                                       minimum: 1
@@ -12557,28 +11407,13 @@ spec:
                                 and value as defined by RFC 7230.
                               properties:
                                 name:
-                                  description: |-
-                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                    If multiple entries specify equivalent header names, the first entry with
-                                    an equivalent name MUST be considered for a match. Subsequent entries
-                                    with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
+                                  description: Name of the HTTP header, case-insensitive
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 value:
-                                  description: |-
-                                    Value is the value of HTTP Header to be matched.
-                                    <gateway:experimental:description>
-                                    Must consist of printable US-ASCII characters, optionally separated
-                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                    </gateway:experimental:description>
-
-                                    <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                  description: Value for the HTTP header
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -12637,28 +11472,13 @@ spec:
                                 and value as defined by RFC 7230.
                               properties:
                                 name:
-                                  description: |-
-                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                    If multiple entries specify equivalent header names, the first entry with
-                                    an equivalent name MUST be considered for a match. Subsequent entries
-                                    with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
+                                  description: Name of the HTTP header, case-insensitive
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 value:
-                                  description: |-
-                                    Value is the value of HTTP Header to be matched.
-                                    <gateway:experimental:description>
-                                    Must consist of printable US-ASCII characters, optionally separated
-                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                    </gateway:experimental:description>
-
-                                    <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                  description: Value for the HTTP header
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -12698,28 +11518,13 @@ spec:
                                 and value as defined by RFC 7230.
                               properties:
                                 name:
-                                  description: |-
-                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                    If multiple entries specify equivalent header names, the first entry with
-                                    an equivalent name MUST be considered for a match. Subsequent entries
-                                    with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
+                                  description: Name of the HTTP header, case-insensitive
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 value:
-                                  description: |-
-                                    Value is the value of HTTP Header to be matched.
-                                    <gateway:experimental:description>
-                                    Must consist of printable US-ASCII characters, optionally separated
-                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                    </gateway:experimental:description>
-
-                                    <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                  description: Value for the HTTP header
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -12778,28 +11583,13 @@ spec:
                                 and value as defined by RFC 7230.
                               properties:
                                 name:
-                                  description: |-
-                                    Name is the name of the HTTP Header to be matched. Name matching MUST be
-                                    case-insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
-
-                                    If multiple entries specify equivalent header names, the first entry with
-                                    an equivalent name MUST be considered for a match. Subsequent entries
-                                    with an equivalent header name MUST be ignored. Due to the
-                                    case-insensitivity of header names, "foo" and "Foo" are considered
-                                    equivalent.
+                                  description: Name of the HTTP header, case-insensitive
                                   maxLength: 256
                                   minLength: 1
                                   pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
                                   type: string
                                 value:
-                                  description: |-
-                                    Value is the value of HTTP Header to be matched.
-                                    <gateway:experimental:description>
-                                    Must consist of printable US-ASCII characters, optionally separated
-                                    by single tabs or spaces. See: https://tools.ietf.org/html/rfc7230#section-3.2
-                                    </gateway:experimental:description>
-
-                                    <gateway:experimental:validation:Pattern=`^[!-~]+([\t ]?[!-~]+)*$`>
+                                  description: Value for the HTTP header
                                   maxLength: 4096
                                   minLength: 1
                                   type: string
@@ -12871,19 +11661,8 @@ spec:
                           header:
                             properties:
                               name:
-                                description: |-
-                                  HTTPHeaderName is the name of an HTTP header.
-
-                                  Valid values include:
-
-                                  * "Authorization"
-                                  * "Set-Cookie"
-
-                                  Invalid values include:
-
-                                    - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
-                                      headers are not currently supported by this type.
-                                    - "/invalid" - "/ " is an invalid character
+                                description: Name of an HTTP header. HTTP/2 pseudo-headers
+                                  (names beginning with `:`) are not supported
                                 maxLength: 256
                                 minLength: 1
                                 pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
@@ -12995,29 +11774,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -13028,27 +11795,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -13154,29 +11911,17 @@ spec:
                                       properties:
                                         group:
                                           default: ""
-                                          description: |-
-                                            Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                            When unspecified or empty string, core API group is inferred.
+                                          description: Group of the referent, for
+                                            example `gateway.networking.k8s.io`. Empty
+                                            selects the core API group
                                           maxLength: 253
                                           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                           type: string
                                         kind:
                                           default: Service
-                                          description: |-
-                                            Kind is the Kubernetes resource kind of the referent. For example
-                                            "Service".
-
-                                            Defaults to "Service" when not specified.
-
-                                            ExternalName services can refer to CNAME DNS records that may live
-                                            outside of the cluster and as such are difficult to reason about in
-                                            terms of conformance. They also may not be safe to forward to (see
-                                            CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                            support ExternalName Services.
-
-                                            Support: Core (Services with a type other than ExternalName)
-
-                                            Support: Implementation-specific (Services with type ExternalName)
+                                          description: Kubernetes resource kind of
+                                            the referent, for example `Service`. Defaults
+                                            to `Service`
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -13187,27 +11932,17 @@ spec:
                                           minLength: 1
                                           type: string
                                         namespace:
-                                          description: |-
-                                            Namespace is the namespace of the backend. When unspecified, the local
-                                            namespace is inferred.
-
-                                            Note that when a namespace different than the local namespace is specified,
-                                            a ReferenceGrant object is required in the referent namespace to allow that
-                                            namespace's owner to accept the reference. See the ReferenceGrant
-                                            documentation for details.
-
-                                            Support: Core
+                                          description: Namespace of the referent.
+                                            Defaults to the local namespace. A cross-namespace
+                                            reference requires a ReferenceGrant in
+                                            the referent namespace
                                           maxLength: 63
                                           minLength: 1
                                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                           type: string
                                         port:
-                                          description: |-
-                                            Port specifies the destination port number to use for this resource.
-                                            Port is required when the referent is a Kubernetes Service. In this
-                                            case, the port number is the service port number, not the target port.
-                                            For other resources, destination port might be derived from the referent
-                                            resource or this field.
+                                          description: Destination port number. Required
+                                            when the referent is a Kubernetes `Service`
                                           format: int32
                                           maximum: 65535
                                           minimum: 1
@@ -13381,29 +12116,15 @@ spec:
                             properties:
                               group:
                                 default: ""
-                                description: |-
-                                  Group is the group of the referent. For example, "gateway.networking.k8s.io".
-                                  When unspecified or empty string, core API group is inferred.
+                                description: Group of the referent, for example `gateway.networking.k8s.io`.
+                                  Empty selects the core API group
                                 maxLength: 253
                                 pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                 type: string
                               kind:
                                 default: Service
-                                description: |-
-                                  Kind is the Kubernetes resource kind of the referent. For example
-                                  "Service".
-
-                                  Defaults to "Service" when not specified.
-
-                                  ExternalName services can refer to CNAME DNS records that may live
-                                  outside of the cluster and as such are difficult to reason about in
-                                  terms of conformance. They also may not be safe to forward to (see
-                                  CVE-2021-25740 for more information). Implementations SHOULD NOT
-                                  support ExternalName Services.
-
-                                  Support: Core (Services with a type other than ExternalName)
-
-                                  Support: Implementation-specific (Services with type ExternalName)
+                                description: Kubernetes resource kind of the referent,
+                                  for example `Service`. Defaults to `Service`
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
@@ -13414,27 +12135,16 @@ spec:
                                 minLength: 1
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace is the namespace of the backend. When unspecified, the local
-                                  namespace is inferred.
-
-                                  Note that when a namespace different than the local namespace is specified,
-                                  a ReferenceGrant object is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the ReferenceGrant
-                                  documentation for details.
-
-                                  Support: Core
+                                description: Namespace of the referent. Defaults to
+                                  the local namespace. A cross-namespace reference
+                                  requires a ReferenceGrant in the referent namespace
                                 maxLength: 63
                                 minLength: 1
                                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                                 type: string
                               port:
-                                description: |-
-                                  Port specifies the destination port number to use for this resource.
-                                  Port is required when the referent is a Kubernetes Service. In this
-                                  case, the port number is the service port number, not the target port.
-                                  For other resources, destination port might be derived from the referent
-                                  resource or this field.
+                                description: Destination port number. Required when
+                                  the referent is a Kubernetes `Service`
                                 format: int32
                                 maximum: 65535
                                 minimum: 1
@@ -13608,43 +12318,10 @@ spec:
                         minimum: 1
                         type: integer
                       backoff:
-                        description: |-
-                          Backoff specifies the minimum duration a Gateway should wait between
-                          retry attempts and is represented in Gateway API Duration formatting.
-
-                          For example, setting the `rules[].retry.backoff` field to the value
-                          `100ms` will cause a backend request to first be retried approximately
-                          100 milliseconds after timing out or receiving a response code configured
-                          to be retriable.
-
-                          An implementation MAY use an exponential or alternative backoff strategy
-                          for subsequent retry attempts, MAY cap the maximum backoff duration to
-                          some amount greater than the specified minimum, and MAY add arbitrary
-                          jitter to stagger requests, as long as unsuccessful backend requests are
-                          not retried before the configured minimum duration.
-
-                          If a Request timeout (`rules[].timeouts.request`) is configured on the
-                          route, the entire duration of the initial request and any retry attempts
-                          MUST not exceed the Request timeout duration. If any retry attempts are
-                          still in progress when the Request timeout duration has been reached,
-                          these SHOULD be canceled if possible and the Gateway MUST immediately
-                          return a timeout error.
-
-                          If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
-                          configured on the route, any retry attempts which reach the configured
-                          BackendRequest timeout duration without a response SHOULD be canceled if
-                          possible and the Gateway should wait for at least the specified backoff
-                          duration before attempting to retry the backend request again.
-
-                          If a BackendRequest timeout is _not_ configured on the route, retry
-                          attempts MAY time out after an implementation default duration, or MAY
-                          remain pending until a configured Request timeout or implementation
-                          default duration for total request time is reached.
-
-                          When this field is unspecified, the time to wait between retry attempts
-                          is implementation-specific.
-
-                          Support: Extended
+                        description: 'Minimum duration to wait between retry attempts,
+                          in Gateway API Duration format. Implementations may add
+                          jitter or use exponential backoff, and must not exceed a
+                          configured request timeout. Support: Extended'
                         pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
                         type: string
                       codes:
@@ -14320,68 +12997,12 @@ spec:
             description: Current policy status.
             properties:
               ancestors:
-                description: |-
-                  Ancestors is a list of ancestor resources (usually Gateways) that are
-                  associated with the policy, and the status of the policy with respect to
-                  each ancestor. When this policy attaches to a parent, the controller that
-                  manages the parent and the ancestors MUST add an entry to this list when
-                  the controller first sees the policy and SHOULD update the entry as
-                  appropriate when the relevant ancestor is modified.
-
-                  Note that choosing the relevant ancestor is left to the Policy designers;
-                  an important part of Policy design is designing the right object level at
-                  which to namespace this status.
-
-                  Note also that implementations MUST ONLY populate ancestor status for
-                  the Ancestor resources they are responsible for. Implementations MUST
-                  use the ControllerName field to uniquely identify the entries in this list
-                  that they are responsible for.
-
-                  Note that to achieve this, the list of PolicyAncestorStatus structs
-                  MUST be treated as a map with a composite key, made up of the AncestorRef
-                  and ControllerName fields combined.
-
-                  A maximum of 16 ancestors will be represented in this list. An empty list
-                  means the Policy is not relevant for any ancestors.
-
-                  If this slice is full, implementations MUST NOT add further entries.
-                  Instead they MUST consider the policy unimplementable and signal that
-                  on any related resources such as the ancestor that would be referenced
-                  here. For example, if this list was full on BackendTLSPolicy, no
-                  additional Gateways would be able to reference the Service targeted by
-                  the BackendTLSPolicy.
+                description: Ancestor resources (usually Gateways) associated with
+                  the policy, with the policy's status for each. At most 16 entries;
+                  an empty list means the policy is not relevant to any ancestor
                 items:
-                  description: |-
-                    PolicyAncestorStatus describes the status of a route with respect to an
-                    associated Ancestor.
-
-                    Ancestors refer to objects that are either the Target of a policy or above it
-                    in terms of object hierarchy. For example, if a policy targets a Service, the
-                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
-                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
-                    useful object to place Policy status on, so we recommend that implementations
-                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
-                    have a _very_ good reason otherwise.
-
-                    In the context of policy attachment, the Ancestor is used to distinguish which
-                    resource results in a distinct application of this policy. For example, if a policy
-                    targets a Service, it may have a distinct result per attached Gateway.
-
-                    Policies targeting the same resource may have different effects depending on the
-                    ancestors of those resources. For example, different Gateways targeting the same
-                    Service may have different capabilities, especially if they have different underlying
-                    implementations.
-
-                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
-                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
-                    In this case, the relevant object for status is the Gateway, and that is the
-                    ancestor object referred to in this status.
-
-                    Note that a parent is also an ancestor, so for objects where the parent is the
-                    relevant object for status, this struct SHOULD still be used.
-
-                    This struct is intended to be used in a slice that's effectively a map,
-                    with a composite key made up of the AncestorRef and the ControllerName.
+                  description: Status of a policy with respect to an associated ancestor
+                    resource, usually a Gateway
                   properties:
                     ancestorRef:
                       description: |-
@@ -14424,95 +13045,26 @@ spec:
                           minLength: 1
                           type: string
                         namespace:
-                          description: |-
-                            Namespace is the namespace of the referent. When unspecified, this refers
-                            to the local namespace of the Route.
-
-                            Note that there are specific rules for ParentRefs which cross namespace
-                            boundaries. Cross-namespace references are only valid if they are explicitly
-                            allowed by something in the namespace they are referring to. For example:
-                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-                            generic way to enable any other kind of cross-namespace reference.
-
-                            <gateway:experimental:description>
-                            ParentRefs from a Route to a Service in the same namespace are "producer"
-                            routes, which apply default routing rules to inbound connections from
-                            any namespace to the Service.
-
-                            ParentRefs from a Route to a Service in a different namespace are
-                            "consumer" routes, and these routing rules are only applied to outbound
-                            connections originating from the same namespace as the Route, for which
-                            the intended destination of the connections are a Service targeted as a
-                            ParentRef of the Route.
-                            </gateway:experimental:description>
-
-                            Support: Core
+                          description: 'Namespace of the referent. Defaults to the
+                            Route''s local namespace. Cross-namespace references must
+                            be explicitly allowed, for example via ReferenceGrant.
+                            Support: Core'
                           maxLength: 63
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
-                          description: |-
-                            Port is the network port this Route targets. It can be interpreted
-                            differently based on the type of parent resource.
-
-                            When the parent resource is a Gateway, this targets all listeners
-                            listening on the specified port that also support this kind of Route(and
-                            select this Route). It's not recommended to set `Port` unless the
-                            networking behaviors specified in a Route must apply to a specific port
-                            as opposed to a listener(s) whose port(s) may be changed. When both Port
-                            and SectionName are specified, the name and port of the selected listener
-                            must match both specified values.
-
-                            <gateway:experimental:description>
-                            When the parent resource is a Service, this targets a specific port in the
-                            Service spec. When both Port (experimental) and SectionName are specified,
-                            the name and port of the selected port must match both specified values.
-                            </gateway:experimental:description>
-
-                            Implementations MAY choose to support other parent resources.
-                            Implementations supporting other types of parent resources MUST clearly
-                            document how/if Port is interpreted.
-
-                            For the purpose of status, an attachment is considered successful as
-                            long as the parent resource accepts it partially. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                            from the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route,
-                            the Route MUST be considered detached from the Gateway.
-
-                            Support: Extended
+                          description: 'Port this Route targets on the parent, interpreted
+                            per parent kind (for example a Gateway listener port or
+                            Service port). Support: Extended'
                           format: int32
                           maximum: 65535
                           minimum: 1
                           type: integer
                         sectionName:
-                          description: |-
-                            SectionName is the name of a section within the target resource. In the
-                            following resources, SectionName is interpreted as the following:
-
-                            * Gateway: Listener name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-                            * Service: Port name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-
-                            Implementations MAY choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName is
-                            interpreted.
-
-                            When unspecified (empty string), this will reference the entire resource.
-                            For the purpose of status, an attachment is considered successful if at
-                            least one section in the parent resource accepts it. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
-                            the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route, the
-                            Route MUST be considered detached from the Gateway.
-
-                            Support: Core
+                          description: 'Name of a section within the target resource,
+                            for example a Gateway Listener name or Service port name.
+                            Empty references the entire resource. Support: Core'
                           maxLength: 253
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
@@ -14521,38 +13073,8 @@ spec:
                       - name
                       type: object
                     conditions:
-                      description: |-
-                        Conditions describes the status of the Policy with respect to the given Ancestor.
-
-                        <gateway:util:excludeFromCRD>
-
-                        Notes for implementors:
-
-                        Conditions are a listType `map`, which means that they function like a
-                        map with a key of the `type` field _in the k8s apiserver_.
-
-                        This means that implementations must obey some rules when updating this
-                        section.
-
-                        * Implementations MUST perform a read-modify-write cycle on this field
-                          before modifying it. That is, when modifying this field, implementations
-                          must be confident they have fetched the most recent version of this field,
-                          and ensure that changes they make are on that recent version.
-                        * Implementations MUST NOT remove or reorder Conditions that they are not
-                          directly responsible for. For example, if an implementation sees a Condition
-                          with type `special.io/SomeField`, it MUST NOT remove, change or update that
-                          Condition.
-                        * Implementations MUST always _merge_ changes into Conditions of the same Type,
-                          rather than creating more than one Condition of the same Type.
-                        * Implementations MUST always update the `observedGeneration` field of the
-                          Condition to the `metadata.generation` of the Gateway at the time of update creation.
-                        * If the `observedGeneration` of a Condition is _greater than_ the value the
-                          implementation knows about, then it MUST NOT perform the update on that Condition,
-                          but must wait for a future reconciliation and status update. (The assumption is that
-                          the implementation's copy of the object is stale and an update will be re-triggered
-                          if relevant.)
-
-                        </gateway:util:excludeFromCRD>
+                      description: Conditions describing the status of the policy
+                        for this ancestor
                       items:
                         description: Condition contains details for one aspect of
                           the current state of this API Resource.


### PR DESCRIPTION
Shorten selected high-repeat CRD descriptions to reduce the packaged Helm CRD size and give us more headroom under install-time size limits.

This keeps the Go API types and generated schema structure unchanged. First-party API comments are shortened at the source, while verbose imported Gateway API/Kubernetes descriptions are overridden during CRD generation before the schemas are emitted.

---

**Raw generated CRD YAML:**
  - Before: 2,689,637 bytes
  - After: 2,490,299 bytes
  - Delta: -199,338 bytes
  - Reduction: 7.41%

**Packaged Helm CRD chart:**
  - Before: 271,413 bytes
  - After: 230,804 bytes
  - Delta: -40,609 bytes
  - Reduction: 14.96%