### PR TITLE
mcp: multi-target subscriptions/listen

### DIFF
--- a/crates/agentgateway/src/mcp/README.md
+++ b/crates/agentgateway/src/mcp/README.md
@@ -48,7 +48,8 @@ negotiation, so modern clients fall back before a listen request is forwarded.
 
 For multiplexed `subscriptions/listen`, Agentgateway waits for selected upstream ACKs before
 emitting one downstream ACK. The ACK includes only accepted filters; resource URIs keep the
-client's `service+` form. Later notifications are limited to the filters accepted by their source
+client's `service+` form. Resource subscriptions may span upstreams; each target receives only
+the URIs it owns. Later notifications are limited to the filters accepted by their source
 upstream.
 Like other MCP fanout requests, setup waits for every selected upstream before the gateway can
 construct its response.

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -26,6 +26,7 @@ use crate::mcp::mergestream::{MergeFn, Messages};
 use crate::mcp::rbac::{CelExecWrapper, McpAuthorizationSet};
 use crate::mcp::router::McpBackendGroup;
 use crate::mcp::streamablehttp::{RequestProtocol, ServerSseMessage};
+use crate::mcp::subscriptions::ResourceSubscription;
 use crate::mcp::upstream::{IncomingRequestContext, UpstreamError};
 use crate::mcp::{ClientError, FailureMode, MCPInfo, apps, mergestream, rbac, upstream};
 use crate::proxy::httpproxy::PolicyClient;
@@ -1011,15 +1012,14 @@ impl Relay {
 
 	/// Handles `subscriptions/listen` with an ACK derived from every selected upstream.
 	///
-	/// `client_filter` keeps service+ URIs for the downstream ACK. `upstream_filter` has rewritten
-	/// upstream URIs for request routing and matching `ResourceUpdated` notifications.
+	/// `client_filter` keeps service+ URIs for the downstream ACK. `resource_subs` carries the
+	/// owning target and rewritten upstream URI for each of them.
 	pub async fn send_subscriptions_listen(
 		&self,
 		r: JsonRpcRequest<ClientRequest>,
 		mut ctx: IncomingRequestContext,
 		client_filter: SubscriptionFilter,
-		upstream_filter: SubscriptionFilter,
-		resource_target: Option<String>,
+		resource_subs: Vec<ResourceSubscription>,
 	) -> Result<Response, UpstreamError> {
 		use futures_util::StreamExt;
 
@@ -1028,19 +1028,25 @@ impl Relay {
 			synthesize_listen_ack,
 		};
 		let id = r.id.clone();
-		let has_global_filter = upstream_filter.tools_list_changed == Some(true)
-			|| upstream_filter.prompts_list_changed == Some(true)
-			|| upstream_filter.resources_list_changed == Some(true);
-		let targets = resource_target
-			.as_ref()
-			.filter(|_| !has_global_filter)
-			.map(|target| vec![target.clone()]);
+		let has_global_filter = client_filter.tools_list_changed == Some(true)
+			|| client_filter.prompts_list_changed == Some(true)
+			|| client_filter.resources_list_changed == Some(true);
+		// Resource-only listens go to just the owning targets; any global filter widens the
+		// fanout to every upstream (non-owners then get a filter without resource URIs).
+		let targets = (!has_global_filter && !resource_subs.is_empty()).then(|| {
+			resource_subs.iter().fold(Vec::new(), |mut targets, sub| {
+				if !targets.contains(&sub.owner) {
+					targets.push(sub.owner.clone());
+				}
+				targets
+			})
+		});
 		let (streams, service_names) = self
 			.fanout_open_streams(&r, &mut ctx, targets, |target, r| {
 				let mut r = r.clone();
 				if let ClientRequest::SubscriptionsListenRequest(slr) = &mut r.request {
 					slr.params.notifications =
-						listen_filter_for_target(&upstream_filter, resource_target.as_deref(), target);
+						listen_filter_for_target(&client_filter, &resource_subs, target);
 				}
 				r
 			})
@@ -1049,8 +1055,7 @@ impl Relay {
 		let prepared_inputs = streams
 			.into_iter()
 			.map(|(name, stream)| {
-				let filter =
-					listen_filter_for_target(&upstream_filter, resource_target.as_deref(), name.as_str());
+				let filter = listen_filter_for_target(&client_filter, &resource_subs, name.as_str());
 				(name, stream, filter)
 			})
 			.collect();
@@ -1070,7 +1075,7 @@ impl Relay {
 			};
 
 		let ack_filter =
-			client_filter_from_accepted(&client_filter, &upstream_filter, &accepted_filter);
+			client_filter_from_accepted(&client_filter, &resource_subs, &accepted_filter, &prepared);
 		let ack = synthesize_listen_ack(id.clone(), ack_filter);
 		let pipelines = prepared
 			.into_iter()
@@ -1455,14 +1460,17 @@ pub(crate) fn ctx_downstream_modern(ctx: &IncomingRequestContext) -> bool {
 }
 
 fn listen_filter_for_target(
-	upstream_filter: &SubscriptionFilter,
-	resource_target: Option<&str>,
+	client_filter: &SubscriptionFilter,
+	resource_subs: &[ResourceSubscription],
 	target: &str,
 ) -> SubscriptionFilter {
-	let mut filter = upstream_filter.clone();
-	if resource_target.is_some_and(|resource_target| resource_target != target) {
-		filter.resource_subscriptions = None;
-	}
+	let mut filter = client_filter.clone();
+	let mine = resource_subs
+		.iter()
+		.filter(|sub| sub.owner == target)
+		.map(|sub| sub.upstream_uri.clone())
+		.collect::<Vec<_>>();
+	filter.resource_subscriptions = (!mine.is_empty()).then_some(mine);
 	filter
 }
 

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -2433,6 +2433,105 @@ async fn resource_scoped_listen_preserves_global_filters_for_other_backends() {
 	);
 }
 
+#[tokio::test]
+async fn listen_resource_subscriptions_span_multiple_upstreams() {
+	use wiremock::{Mock, ResponseTemplate};
+
+	// `a` accepts its one URI; `b` accepts only b1 of its two. The downstream ack must
+	// combine per-owner accepted URIs in client form, and each upstream must receive
+	// only the URIs it owns.
+	let a = wiremock::MockServer::start().await;
+	let b = wiremock::MockServer::start().await;
+	Mock::given(wiremock::matchers::method("POST"))
+		.respond_with(ResponseTemplate::new(200).set_body_raw(
+			"data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/subscriptions/acknowledged\",\"params\":{\"notifications\":{\"resourceSubscriptions\":[\"https://example.com/a\"]}}}\n\n",
+			"text/event-stream",
+		))
+		.mount(&a)
+		.await;
+	Mock::given(wiremock::matchers::method("POST"))
+		.respond_with(ResponseTemplate::new(200).set_body_raw(
+			"data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/subscriptions/acknowledged\",\"params\":{\"notifications\":{\"resourceSubscriptions\":[\"https://example.com/b1\"]}}}\n\n",
+			"text/event-stream",
+		))
+		.mount(&b)
+		.await;
+
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("a", *a.address(), false), ("b", *b.address(), false)],
+			true,
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::new("/mcp")));
+	let io = t.serve_real_listener(BIND_KEY).await;
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+	let listen = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 2,
+		"method": "subscriptions/listen",
+		"params": {
+			"_meta": modern_meta(),
+			"notifications": {
+				"resourceSubscriptions": [
+					"a+https://example.com/a",
+					"b+https://example.com/b1",
+					"b+https://example.com/b2"
+				]
+			}
+		}
+	});
+	let response = mcp_json_post(&client, &url, &listen)
+		.header("mcp-protocol-version", "2026-07-28")
+		.header("mcp-method", "subscriptions/listen")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(response.status(), reqwest::StatusCode::OK);
+	let frames = response
+		.text()
+		.await
+		.unwrap()
+		.lines()
+		.filter_map(|line| line.strip_prefix("data:"))
+		.map(|data| serde_json::from_str::<serde_json::Value>(data.trim()).unwrap())
+		.collect::<Vec<_>>();
+	assert_eq!(
+		frames[0]["method"],
+		"notifications/subscriptions/acknowledged"
+	);
+	assert_eq!(
+		frames[0]["params"]["notifications"],
+		serde_json::json!({
+			"resourceSubscriptions": ["a+https://example.com/a", "b+https://example.com/b1"]
+		})
+	);
+
+	for (server, expected) in [
+		(&a, serde_json::json!(["https://example.com/a"])),
+		(
+			&b,
+			serde_json::json!(["https://example.com/b1", "https://example.com/b2"]),
+		),
+	] {
+		let listen_request = server
+			.received_requests()
+			.await
+			.unwrap()
+			.iter()
+			.map(|request| serde_json::from_slice::<serde_json::Value>(&request.body).unwrap())
+			.find(|request| request["method"] == "subscriptions/listen")
+			.expect("each owner should receive a listen request");
+		assert_eq!(
+			listen_request["params"]["notifications"],
+			serde_json::json!({ "resourceSubscriptions": expected })
+		);
+	}
+}
+
 /// Test that a deny policy using request.headers correctly filters tools per-agent.
 /// This exercises the router.rs fix that registers authorization policies on the log's
 /// CEL context so the request snapshot includes headers needed by CEL expressions.

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -25,6 +25,7 @@ use crate::http::Response;
 use crate::mcp::handler::{Relay, RelayInputs, ResolveKind};
 use crate::mcp::mergestream::Messages;
 use crate::mcp::streamablehttp::{ServerSseMessage, StreamableHttpPostResponse};
+use crate::mcp::subscriptions::ResourceSubscription;
 use crate::mcp::upstream::{IncomingRequestContext, UpstreamError};
 use crate::mcp::{ClientError, rbac};
 use crate::proxy::ProxyError;
@@ -490,49 +491,37 @@ impl Session {
 						Box::pin(self.relay.send_fanout(r, ctx, self.relay.merge_empty())).await
 					},
 					ClientRequest::SubscriptionsListenRequest(slr) => {
-						// Snapshot the client's filter (URIs still in service+ form) for the ack before the
-						// loop below rewrites them to upstream form for matching forwarded notifications.
+						// Per-target upstream filters are rebuilt from resource_subs, so the request's
+						// URIs stay in the client's service+ form and are never sent upstream as-is.
 						let client_filter = slr.params.notifications.clone();
-						let target_name = if let Some(resource_subscriptions) =
-							&mut slr.params.notifications.resource_subscriptions
+						let mut resource_subs = Vec::new();
+						for uri in slr
+							.params
+							.notifications
+							.resource_subscriptions
+							.as_deref()
+							.unwrap_or_default()
 						{
-							let mut target_name = None;
-							for uri in resource_subscriptions.iter_mut() {
-								let requested_uri = uri.clone();
-								let (service_name, original_uri) = self.relay.parse_resource_uri(&requested_uri)?;
-								if let Some(target_name) = &target_name
-									&& target_name != service_name
-								{
-									return Err(UpstreamError::InvalidRequest(
-										"subscriptions/listen resourceSubscriptions must target one upstream"
-											.to_string(),
-									));
-								}
-								self.authorize_resource_request(
-									service_name,
-									&original_uri,
-									&method,
-									&mut span,
-									&log,
-									&cel,
-								)?;
-								target_name = Some(service_name.to_string());
-								*uri = original_uri;
-							}
-							target_name
-						} else {
-							None
-						};
-						// URIs in this filter were rewritten to upstream form in the loop above; it matches
-						// forwarded ResourceUpdated frames before their URIs are rewritten back to service+ form.
-						let upstream_filter = slr.params.notifications.clone();
-						Box::pin(self.relay.send_subscriptions_listen(
-							r,
-							ctx,
-							client_filter,
-							upstream_filter,
-							target_name,
-						))
+							let (service_name, upstream_uri) = self.relay.parse_resource_uri(uri)?;
+							self.authorize_resource_request(
+								service_name,
+								&upstream_uri,
+								&method,
+								&mut span,
+								&log,
+								&cel,
+							)?;
+							resource_subs.push(ResourceSubscription {
+								owner: service_name.to_string(),
+								client_uri: uri.clone(),
+								upstream_uri,
+							});
+						}
+						Box::pin(
+							self
+								.relay
+								.send_subscriptions_listen(r, ctx, client_filter, resource_subs),
+						)
 						.await
 					},
 					ClientRequest::ListPromptsRequest(_) => {

--- a/crates/agentgateway/src/mcp/subscriptions.rs
+++ b/crates/agentgateway/src/mcp/subscriptions.rs
@@ -226,10 +226,17 @@ pub(super) async fn prepare_listen_streams(
 	Ok((prepared, accepted))
 }
 
+pub(super) struct ResourceSubscription {
+	pub owner: String,
+	pub client_uri: String,
+	pub upstream_uri: String,
+}
+
 pub(super) fn client_filter_from_accepted(
 	client_filter: &SubscriptionFilter,
-	upstream_filter: &SubscriptionFilter,
+	resource_subs: &[ResourceSubscription],
 	accepted_filter: &SubscriptionFilter,
+	prepared: &[PreparedListenStream],
 ) -> SubscriptionFilter {
 	let mut filter = SubscriptionFilter::new();
 	filter.tools_list_changed = (client_filter.tools_list_changed == Some(true)
@@ -241,22 +248,20 @@ pub(super) fn client_filter_from_accepted(
 	filter.resources_list_changed = (client_filter.resources_list_changed == Some(true)
 		&& accepted_filter.resources_list_changed == Some(true))
 	.then_some(true);
-	let accepted_uris = accepted_filter
-		.resource_subscriptions
-		.as_deref()
-		.unwrap_or_default();
-	let uris = client_filter
-		.resource_subscriptions
-		.as_deref()
-		.unwrap_or_default()
+	let uris = resource_subs
 		.iter()
-		.zip(
-			upstream_filter
-				.resource_subscriptions
-				.as_deref()
-				.unwrap_or_default(),
-		)
-		.filter_map(|(client, upstream)| accepted_uris.contains(upstream).then_some(client.clone()))
+		.filter(|sub| {
+			prepared.iter().any(|stream| {
+				stream.target.as_str() == sub.owner
+					&& stream
+						.accepted_filter
+						.resource_subscriptions
+						.as_deref()
+						.unwrap_or_default()
+						.contains(&sub.upstream_uri)
+			})
+		})
+		.map(|sub| sub.client_uri.clone())
 		.fold(Vec::new(), |mut uris, uri| {
 			if !uris.contains(&uri) {
 				uris.push(uri);
@@ -406,9 +411,26 @@ mod tests {
 		)
 		.await
 		.unwrap();
+		let resource_subs = client_filter
+			.resource_subscriptions
+			.as_deref()
+			.unwrap_or_default()
+			.iter()
+			.zip(
+				upstream_filter
+					.resource_subscriptions
+					.as_deref()
+					.unwrap_or_default(),
+			)
+			.map(|(client_uri, upstream_uri)| ResourceSubscription {
+				owner: target.to_string(),
+				client_uri: client_uri.clone(),
+				upstream_uri: upstream_uri.clone(),
+			})
+			.collect::<Vec<_>>();
 		let ack = synthesize_listen_ack(
 			id.clone(),
-			client_filter_from_accepted(&client_filter, &upstream_filter, &accepted_filter),
+			client_filter_from_accepted(&client_filter, &resource_subs, &accepted_filter, &prepared),
 		);
 		let PreparedListenStream {
 			target: target_name,
@@ -510,24 +532,60 @@ mod tests {
 		);
 	}
 
+	fn prepared_with_accepted(
+		target: &str,
+		accepted_filter: SubscriptionFilter,
+	) -> PreparedListenStream {
+		PreparedListenStream {
+			target: agent_core::strng::new(target),
+			stream: Messages::from_results(Vec::new()),
+			accepted_filter,
+		}
+	}
+
+	fn resource_sub(owner: &str, uri: &str) -> ResourceSubscription {
+		ResourceSubscription {
+			owner: owner.to_string(),
+			client_uri: format!("{owner}+{uri}"),
+			upstream_uri: uri.to_string(),
+		}
+	}
+
 	#[test]
 	fn client_filter_from_accepted_restores_resource_uri_order() {
-		let client = SubscriptionFilter::new().with_resource_subscriptions(vec![
-			"svc+https://example.com/a".to_string(),
-			"svc+https://example.com/b".to_string(),
-			"svc+https://example.com/a".to_string(),
-		]);
-		let upstream = SubscriptionFilter::new().with_resource_subscriptions(vec![
-			"https://example.com/a".to_string(),
-			"https://example.com/b".to_string(),
-			"https://example.com/a".to_string(),
-		]);
+		let subs = vec![
+			resource_sub("svc", "https://example.com/a"),
+			resource_sub("svc", "https://example.com/b"),
+			resource_sub("svc", "https://example.com/a"),
+		];
 		let accepted = SubscriptionFilter::new()
 			.with_resource_subscriptions(vec!["https://example.com/a".to_string()]);
+		let prepared = [prepared_with_accepted("svc", accepted.clone())];
 		assert_eq!(
-			client_filter_from_accepted(&client, &upstream, &accepted),
+			client_filter_from_accepted(&SubscriptionFilter::new(), &subs, &accepted, &prepared),
 			SubscriptionFilter::new()
 				.with_resource_subscriptions(vec!["svc+https://example.com/a".to_string()])
+		);
+	}
+
+	#[test]
+	fn client_filter_from_accepted_distinguishes_same_uri_across_targets() {
+		// Both targets were asked for the same upstream-form URI; only `a` accepted it.
+		// The ack must keep a's client URI and drop b's.
+		let subs = vec![
+			resource_sub("a", "https://example.com/r"),
+			resource_sub("b", "https://example.com/r"),
+		];
+		let accepted_a = SubscriptionFilter::new()
+			.with_resource_subscriptions(vec!["https://example.com/r".to_string()]);
+		let prepared = [
+			prepared_with_accepted("a", accepted_a.clone()),
+			prepared_with_accepted("b", SubscriptionFilter::new()),
+		];
+		assert_eq!(
+			client_filter_from_accepted(&SubscriptionFilter::new(), &subs, &accepted_a, &prepared),
+			SubscriptionFilter::new()
+				.with_resource_subscriptions(vec!["a+https://example.com/r".to_string()])
 		);
 	}
 


### PR DESCRIPTION
```json
{ "id": 2, "method": "subscriptions/listen",
  "params": { "notifications": { "resourceSubscriptions": [
      "a+https://example.com/a",
      "b+https://example.com/b1",
      "b+https://example.com/b2" ] } } }
```

When a client issues a subscriptions/listen that includes resource URLs for multiple backends, we fan out to the unique set of referenced backends