### PR TITLE
standalone: support writing config to database

### DIFF
--- a/crates/agentgateway-app/src/commands/run.rs
+++ b/crates/agentgateway-app/src/commands/run.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use agent_core::{strng, telemetry, version};
 use agentgateway::app::Bound;
 use agentgateway::types::agent::ListenerTarget;
-use agentgateway::{BackendConfig, Config, LoggingFormat, client, serdes};
+use agentgateway::{BackendConfig, Config, ConfigStoreMode, LoggingFormat, client, serdes};
 use tracing::{error, info};
 
 use crate::{RunArgs, read_config_contents};
@@ -46,22 +46,29 @@ pub(crate) fn execute(args: RunArgs) -> anyhow::Result<()> {
 				&config.logging.level,
 				config.logging.format == LoggingFormat::Json,
 			);
-			info!("version: {}", version::BuildInfo::new());
-			info!(
-				"running with config: {}",
-				serdes::yamlviajson::to_string(&config)?
-			);
+			let config_resource_store = if config.config_store.mode == ConfigStoreMode::Hybrid {
+				let database = config
+					.database
+					.as_ref()
+					.expect("hybrid config store requires config.database");
+				Some(agentgateway::config_store::setup(database).await?)
+			} else {
+				None
+			};
 			let request_log_store = match config.database.as_ref() {
-				Some(cfg) => match agentgateway::telemetry::log_store::setup(cfg).await {
-					Ok(store) => Some(store),
-					Err(err) => {
-						error!(?err, "failed to initialize request log database");
-						return Err(err);
-					},
+				Some(cfg) => {
+					let sqlite_pool = config_resource_store.as_ref().map(|store| store.pool());
+					match agentgateway::telemetry::log_store::setup_with_sqlite_pool(cfg, sqlite_pool).await {
+						Ok(store) => Some(store),
+						Err(err) => {
+							error!(?err, "failed to initialize request log database");
+							return Err(err);
+						},
+					}
 				},
 				None => None,
 			};
-			let result = proxy(Arc::new(config)).await;
+			let result = proxy(Arc::new(config), config_resource_store).await;
 			if let Some(request_log_store) = request_log_store {
 				request_log_store.shutdown_and_wait().await;
 			}
@@ -149,8 +156,16 @@ fn spawn_readiness(bound: &Bound) {
 	}
 }
 
-async fn proxy(cfg: Arc<Config>) -> anyhow::Result<()> {
-	let bound = agentgateway::app::run(cfg).await?;
+async fn proxy(
+	cfg: Arc<Config>,
+	config_resource_store: Option<agentgateway::config_store::ConfigResourceStore>,
+) -> anyhow::Result<()> {
+	info!("version: {}", version::BuildInfo::new());
+	info!(
+		"running with config: {}",
+		serdes::yamlviajson::to_string(&cfg)?
+	);
+	let bound = agentgateway::app::run(cfg, config_resource_store).await?;
 	spawn_readiness(&bound);
 	bound.wait_termination().await
 }

--- a/crates/agentgateway-app/src/commands/run.rs
+++ b/crates/agentgateway-app/src/commands/run.rs
@@ -46,6 +46,11 @@ pub(crate) fn execute(args: RunArgs) -> anyhow::Result<()> {
 				&config.logging.level,
 				config.logging.format == LoggingFormat::Json,
 			);
+			info!("version: {}", version::BuildInfo::new());
+			info!(
+				"running with config: {}",
+				serdes::yamlviajson::to_string(&config)?
+			);
 			let config_resource_store = if config.config_store.mode == ConfigStoreMode::Hybrid {
 				let database = config
 					.database
@@ -57,8 +62,8 @@ pub(crate) fn execute(args: RunArgs) -> anyhow::Result<()> {
 			};
 			let request_log_store = match config.database.as_ref() {
 				Some(cfg) => {
-					let sqlite_pool = config_resource_store.as_ref().map(|store| store.pool());
-					match agentgateway::telemetry::log_store::setup_with_sqlite_pool(cfg, sqlite_pool).await {
+					let pool = config_resource_store.as_ref().map(|store| store.pool());
+					match agentgateway::telemetry::log_store::setup_with_pool(cfg, pool).await {
 						Ok(store) => Some(store),
 						Err(err) => {
 							error!(?err, "failed to initialize request log database");
@@ -160,11 +165,6 @@ async fn proxy(
 	cfg: Arc<Config>,
 	config_resource_store: Option<agentgateway::config_store::ConfigResourceStore>,
 ) -> anyhow::Result<()> {
-	info!("version: {}", version::BuildInfo::new());
-	info!(
-		"running with config: {}",
-		serdes::yamlviajson::to_string(&cfg)?
-	);
 	let bound = agentgateway::app::run(cfg, config_resource_store).await?;
 	spawn_readiness(&bound);
 	bound.wait_termination().await

--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -9,9 +9,12 @@ use tokio::task::JoinSet;
 
 use crate::control::caclient;
 use crate::telemetry::trc;
-use crate::{Config, ProxyInputs, client, mcp, proxy, state_manager};
+use crate::{Config, ProxyInputs, client, config_store, mcp, proxy, state_manager};
 
-pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
+pub async fn run(
+	config: Arc<Config>,
+	config_resource_store: Option<config_store::ConfigResourceStore>,
+) -> anyhow::Result<Bound> {
 	crate::transport::tls::warn_if_key_log_enabled();
 	let (data_plane_handle, data_plane_pool) = new_data_plane_pool(config.num_worker_threads);
 
@@ -85,6 +88,7 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 		control_client.clone(),
 		Arc::new(xds_metrics),
 		xds_tx,
+		config_resource_store.clone(),
 	)
 	.await?;
 	let stores = state_mgr.stores();
@@ -92,7 +96,17 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 
 	state_manager::start_self_workload_resolution(&config, stores.clone(), &ready);
 
-	let model_catalog = crate::llm::cost::ModelCatalog::new(config.model_catalog.sources.clone())?;
+	let mut model_catalog_sources = if let Some(store) = &config_resource_store {
+		config_store::model_catalog_sources(
+			&store
+				.list(Some(config_store::ConfigResourceKind::ModelCatalog))
+				.await?,
+		)?
+	} else {
+		Vec::new()
+	};
+	model_catalog_sources.extend(config.model_catalog.sources.clone());
+	let model_catalog = crate::llm::cost::ModelCatalog::new(model_catalog_sources)?;
 
 	let mut xds_rx_for_task = xds_rx.clone();
 	tokio::spawn(async move {
@@ -106,6 +120,7 @@ pub async fn run(config: Arc<Config>) -> anyhow::Result<Bound> {
 	let admin_server = crate::management::admin::Service::new(
 		config.clone(),
 		model_catalog.clone(),
+		config_resource_store,
 		stores.clone(),
 		resource_manager,
 		shutdown.trigger(),

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -15,8 +15,9 @@ use crate::telemetry::trc;
 use crate::types::discovery::{Identity, WaypointIdentity};
 use crate::util::ErrorContext;
 use crate::{
-	Address, Config, ConfigSource, DnsLookupFamily, NestedRawConfig, RawLoggingFields,
-	RawLoggingLevel, StringOrInt, ThreadingMode, XDSConfig, cel, client, serdes, telemetry, types,
+	Address, Config, ConfigSource, ConfigStoreConfig, ConfigStoreMode, DnsLookupFamily,
+	NestedRawConfig, RawLoggingFields, RawLoggingLevel, StringOrInt, ThreadingMode, XDSConfig, cel,
+	client, serdes, telemetry, types,
 };
 
 const DEFAULT_UI_USER_ATTRIBUTE: &str = r#"coalesce(apiKey.user, apiKey.name, apiKey.owner, jwt.sub, jwt.email, basicAuth.username, source.identity.namespace + "/" + source.identity.serviceAccount, source.subjectCn, null)"#;
@@ -359,10 +360,16 @@ pub fn parse_config(
 		})
 		.or(raw.model_catalog)
 		.unwrap_or_default();
-	let database = raw
-		.database
+	let shared_database = raw.database.clone();
+	let database = shared_database
 		.clone()
 		.or_else(|| raw.logging.as_ref().and_then(|l| l.database.clone()));
+	let config_store = ConfigStoreConfig {
+		mode: raw.config_store.clone().unwrap_or_default().mode,
+	};
+	if config_store.mode == ConfigStoreMode::Hybrid && shared_database.is_none() {
+		anyhow::bail!("configStore.mode=hybrid requires config.database.url");
+	}
 
 	Ok(crate::Config {
 		ipv6_enabled,
@@ -550,6 +557,7 @@ pub fn parse_config(
 			sources: model_catalog_sources,
 		},
 		database,
+		config_store,
 		session_encoder,
 		oidc_cookie_encoder,
 			hbone: Arc::new(agent_hbone::Config {
@@ -1224,6 +1232,75 @@ config:
 			err
 				.to_string()
 				.contains("config.tracing requires otlpEndpoint"),
+			"unexpected error: {err}"
+		);
+	}
+
+	#[test]
+	fn config_store_defaults_to_file_mode() {
+		let config = parse_config("{}".to_string(), None).expect("config should parse");
+
+		assert_eq!(config.config_store.mode, ConfigStoreMode::File);
+		assert!(config.database.is_none());
+	}
+
+	#[test]
+	fn config_store_hybrid_uses_shared_database_url() {
+		let config = parse_config(
+			r#"
+config:
+  database:
+    url: "sqlite::memory:"
+  configStore:
+    mode: hybrid
+"#
+			.to_string(),
+			None,
+		)
+		.expect("hybrid config should parse with primary database");
+
+		assert_eq!(config.config_store.mode, ConfigStoreMode::Hybrid);
+		assert_eq!(
+			config.database.as_ref().map(|db| db.url.as_str()),
+			Some("sqlite::memory:")
+		);
+
+		let err = parse_config(
+			r#"
+config:
+  configStore:
+    mode: hybrid
+"#
+			.to_string(),
+			None,
+		)
+		.expect_err("hybrid config without database should fail");
+
+		assert!(
+			err
+				.to_string()
+				.contains("configStore.mode=hybrid requires config.database.url"),
+			"unexpected error: {err}"
+		);
+
+		let err = parse_config(
+			r#"
+config:
+  logging:
+    database:
+      url: "sqlite::memory:"
+  configStore:
+    mode: hybrid
+"#
+			.to_string(),
+			None,
+		)
+		.expect_err("hybrid config should require top-level database");
+
+		assert!(
+			err
+				.to_string()
+				.contains("configStore.mode=hybrid requires config.database.url"),
 			"unexpected error: {err}"
 		);
 	}

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -1238,6 +1238,7 @@ config:
 
 	#[test]
 	fn config_store_defaults_to_file_mode() {
+		let _env_lock = lock_env();
 		let config = parse_config("{}".to_string(), None).expect("config should parse");
 
 		assert_eq!(config.config_store.mode, ConfigStoreMode::File);
@@ -1246,6 +1247,7 @@ config:
 
 	#[test]
 	fn config_store_hybrid_uses_shared_database_url() {
+		let _env_lock = lock_env();
 		let config = parse_config(
 			r#"
 config:

--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -1,20 +1,19 @@
 use std::fmt;
 use std::str::FromStr;
-use std::time::Duration;
 
-use anyhow::Context;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
-use sqlx::{Row, SqlitePool};
+use sqlx::types::Json;
+use sqlx::{PgPool, Row, SqlitePool};
 use tokio::sync::watch;
 
+use crate::database::DatabasePool;
 use crate::telemetry::log_store;
 
 #[derive(Clone, Debug)]
 pub struct ConfigResourceStore {
-	pool: SqlitePool,
+	pool: DatabasePool,
 	change_tx: watch::Sender<()>,
 }
 
@@ -96,34 +95,28 @@ pub struct ConfigResourceUpsert {
 }
 
 pub async fn setup(cfg: &log_store::Config) -> anyhow::Result<ConfigResourceStore> {
-	ConfigResourceStore::connect(cfg).await
+	ConfigResourceStore::connect(&cfg.url).await
 }
 
 impl ConfigResourceStore {
-	async fn connect(cfg: &log_store::Config) -> anyhow::Result<Self> {
-		if cfg.url.starts_with("postgres://") || cfg.url.starts_with("postgresql://") {
-			anyhow::bail!("configStore.mode=hybrid currently supports only SQLite config.database.url");
-		}
+	async fn connect(url: &str) -> anyhow::Result<Self> {
+		Self::from_pool(DatabasePool::connect(url).await?).await
+	}
 
-		let options = cfg
-			.url
-			.parse::<SqliteConnectOptions>()
-			.context("failed to parse config store sqlite database URL")?
-			.create_if_missing(true)
-			.journal_mode(SqliteJournalMode::Wal)
-			.synchronous(SqliteSynchronous::Normal)
-			.busy_timeout(Duration::from_secs(5));
-		let pool = SqlitePoolOptions::new()
-			.max_connections(5)
-			.connect_with(options)
-			.await
-			.context("failed to connect config store sqlite database")?;
-		sqlx::raw_sql(SCHEMA).execute(&pool).await?;
+	async fn from_pool(pool: DatabasePool) -> anyhow::Result<Self> {
+		match &pool {
+			DatabasePool::Sqlite(pool) => {
+				sqlx::raw_sql(SQLITE_SCHEMA).execute(pool).await?;
+			},
+			DatabasePool::Postgres(pool) => {
+				sqlx::raw_sql(POSTGRES_SCHEMA).execute(pool).await?;
+			},
+		};
 		let (change_tx, _) = watch::channel(());
 		Ok(Self { pool, change_tx })
 	}
 
-	pub fn pool(&self) -> SqlitePool {
+	pub fn pool(&self) -> DatabasePool {
 		self.pool.clone()
 	}
 
@@ -135,28 +128,10 @@ impl ConfigResourceStore {
 		&self,
 		kind: Option<ConfigResourceKind>,
 	) -> anyhow::Result<Vec<ConfigResource>> {
-		if let Some(kind) = kind {
-			let rows = sqlx::query(
-				"SELECT kind, id, value_json, revision, created_at, updated_at \
-				 FROM agw_config_resources \
-				 WHERE deleted_at IS NULL AND kind = ? \
-				 ORDER BY id",
-			)
-			.bind(kind.as_str())
-			.fetch_all(&self.pool)
-			.await?;
-			return rows.into_iter().map(row_to_resource).collect();
+		match &self.pool {
+			DatabasePool::Sqlite(pool) => list_sqlite(pool, kind).await,
+			DatabasePool::Postgres(pool) => list_postgres(pool, kind).await,
 		}
-
-		let rows = sqlx::query(
-			"SELECT kind, id, value_json, revision, created_at, updated_at \
-			 FROM agw_config_resources \
-			 WHERE deleted_at IS NULL \
-			 ORDER BY kind, id",
-		)
-		.fetch_all(&self.pool)
-		.await?;
-		rows.into_iter().map(row_to_resource).collect()
 	}
 
 	#[cfg_attr(not(feature = "ui"), allow(dead_code))]
@@ -164,38 +139,10 @@ impl ConfigResourceStore {
 		&self,
 		prepared: Vec<PreparedResource>,
 	) -> anyhow::Result<ConfigResourcesResponse> {
-		let mut tx = self.pool.begin().await?;
-		let mut changed = Vec::with_capacity(prepared.len());
-		for PreparedResource { kind, id, value } in prepared {
-			validate_id(&id)?;
-			let now = now();
-			sqlx::query(
-				"INSERT INTO agw_config_resources \
-					(kind, id, value_json, revision, created_at, updated_at, deleted_at) \
-				 VALUES (?, ?, ?, 1, ?, ?, NULL) \
-				 ON CONFLICT(kind, id) DO UPDATE SET \
-					value_json = excluded.value_json, \
-					revision = agw_config_resources.revision + 1, \
-					updated_at = excluded.updated_at, \
-					deleted_at = NULL",
-			)
-			.bind(kind.as_str())
-			.bind(&id)
-			.bind(serde_json::to_string(&value)?)
-			.bind(&now)
-			.bind(&now)
-			.execute(&mut *tx)
-			.await?;
-			changed.push((kind, id));
-		}
-
-		let mut resources = Vec::with_capacity(changed.len());
-		for (kind, id) in changed {
-			if let Some(resource) = fetch_resource(&mut tx, kind, &id).await? {
-				resources.push(resource);
-			}
-		}
-		tx.commit().await?;
+		let resources = match &self.pool {
+			DatabasePool::Sqlite(pool) => upsert_sqlite(pool, prepared).await?,
+			DatabasePool::Postgres(pool) => upsert_postgres(pool, prepared).await?,
+		};
 		if !resources.is_empty() {
 			self.notify_changed();
 		}
@@ -204,19 +151,11 @@ impl ConfigResourceStore {
 
 	pub async fn delete(&self, kind: ConfigResourceKind, id: &str) -> anyhow::Result<()> {
 		validate_id(id)?;
-		let now = now();
-		let result = sqlx::query(
-			"UPDATE agw_config_resources \
-			 SET revision = revision + 1, updated_at = ?, deleted_at = ? \
-			 WHERE kind = ? AND id = ? AND deleted_at IS NULL",
-		)
-		.bind(&now)
-		.bind(&now)
-		.bind(kind.as_str())
-		.bind(id)
-		.execute(&self.pool)
-		.await?;
-		if result.rows_affected() == 0 {
+		let deleted = match &self.pool {
+			DatabasePool::Sqlite(pool) => delete_sqlite(pool, kind, id).await?,
+			DatabasePool::Postgres(pool) => delete_postgres(pool, kind, id).await?,
+		};
+		if !deleted {
 			anyhow::bail!("config resource not found: {kind}/{id}");
 		}
 		self.notify_changed();
@@ -537,12 +476,178 @@ fn string_field(
 		.ok_or_else(|| anyhow::anyhow!(error()))
 }
 
-fn now() -> String {
-	Utc::now().to_rfc3339()
+async fn list_sqlite(
+	pool: &SqlitePool,
+	kind: Option<ConfigResourceKind>,
+) -> anyhow::Result<Vec<ConfigResource>> {
+	let rows = if let Some(kind) = kind {
+		sqlx::query(
+			"SELECT kind, id, value_json, revision, created_at, updated_at \
+			 FROM agw_config_resources \
+			 WHERE deleted_at IS NULL AND kind = ? \
+			 ORDER BY id",
+		)
+		.bind(kind.as_str())
+		.fetch_all(pool)
+		.await?
+	} else {
+		sqlx::query(
+			"SELECT kind, id, value_json, revision, created_at, updated_at \
+			 FROM agw_config_resources \
+			 WHERE deleted_at IS NULL \
+			 ORDER BY kind, id",
+		)
+		.fetch_all(pool)
+		.await?
+	};
+	rows.into_iter().map(sqlite_row_to_resource).collect()
+}
+
+async fn list_postgres(
+	pool: &PgPool,
+	kind: Option<ConfigResourceKind>,
+) -> anyhow::Result<Vec<ConfigResource>> {
+	let rows = if let Some(kind) = kind {
+		sqlx::query(
+			"SELECT kind, id, value_json, revision, created_at, updated_at \
+			 FROM agw_config_resources \
+			 WHERE deleted_at IS NULL AND kind = $1 \
+			 ORDER BY id",
+		)
+		.bind(kind.as_str())
+		.fetch_all(pool)
+		.await?
+	} else {
+		sqlx::query(
+			"SELECT kind, id, value_json, revision, created_at, updated_at \
+			 FROM agw_config_resources \
+			 WHERE deleted_at IS NULL \
+			 ORDER BY kind, id",
+		)
+		.fetch_all(pool)
+		.await?
+	};
+	rows.into_iter().map(postgres_row_to_resource).collect()
+}
+
+async fn upsert_sqlite(
+	pool: &SqlitePool,
+	prepared: Vec<PreparedResource>,
+) -> anyhow::Result<Vec<ConfigResource>> {
+	let mut tx = pool.begin().await?;
+	let mut changed = Vec::with_capacity(prepared.len());
+	for PreparedResource { kind, id, value } in prepared {
+		validate_id(&id)?;
+		let now = Utc::now().to_rfc3339();
+		sqlx::query(
+			"INSERT INTO agw_config_resources \
+			 (kind, id, value_json, revision, created_at, updated_at, deleted_at) \
+			 VALUES (?, ?, ?, 1, ?, ?, NULL) \
+			 ON CONFLICT(kind, id) DO UPDATE SET \
+				value_json = excluded.value_json, \
+				revision = agw_config_resources.revision + 1, \
+				updated_at = excluded.updated_at, \
+				deleted_at = NULL",
+		)
+		.bind(kind.as_str())
+		.bind(&id)
+		.bind(serde_json::to_string(&value)?)
+		.bind(&now)
+		.bind(&now)
+		.execute(&mut *tx)
+		.await?;
+		changed.push((kind, id));
+	}
+
+	let mut resources = Vec::with_capacity(changed.len());
+	for (kind, id) in changed {
+		if let Some(resource) = fetch_sqlite_resource(&mut tx, kind, &id).await? {
+			resources.push(resource);
+		}
+	}
+	tx.commit().await?;
+	Ok(resources)
+}
+
+async fn upsert_postgres(
+	pool: &PgPool,
+	prepared: Vec<PreparedResource>,
+) -> anyhow::Result<Vec<ConfigResource>> {
+	let mut tx = pool.begin().await?;
+	let mut changed = Vec::with_capacity(prepared.len());
+	for PreparedResource { kind, id, value } in prepared {
+		validate_id(&id)?;
+		let now = Utc::now();
+		sqlx::query(
+			"INSERT INTO agw_config_resources \
+			 (kind, id, value_json, revision, created_at, updated_at, deleted_at) \
+			 VALUES ($1, $2, $3, 1, $4, $4, NULL) \
+			 ON CONFLICT(kind, id) DO UPDATE SET \
+				value_json = excluded.value_json, \
+				revision = agw_config_resources.revision + 1, \
+				updated_at = excluded.updated_at, \
+				deleted_at = NULL",
+		)
+		.bind(kind.as_str())
+		.bind(&id)
+		.bind(Json(value))
+		.bind(now)
+		.execute(&mut *tx)
+		.await?;
+		changed.push((kind, id));
+	}
+
+	let mut resources = Vec::with_capacity(changed.len());
+	for (kind, id) in changed {
+		if let Some(resource) = fetch_postgres_resource(&mut tx, kind, &id).await? {
+			resources.push(resource);
+		}
+	}
+	tx.commit().await?;
+	Ok(resources)
+}
+
+async fn delete_sqlite(
+	pool: &SqlitePool,
+	kind: ConfigResourceKind,
+	id: &str,
+) -> anyhow::Result<bool> {
+	let now = Utc::now().to_rfc3339();
+	let result = sqlx::query(
+		"UPDATE agw_config_resources \
+		 SET revision = revision + 1, updated_at = ?, deleted_at = ? \
+		 WHERE kind = ? AND id = ? AND deleted_at IS NULL",
+	)
+	.bind(&now)
+	.bind(&now)
+	.bind(kind.as_str())
+	.bind(id)
+	.execute(pool)
+	.await?;
+	Ok(result.rows_affected() > 0)
+}
+
+async fn delete_postgres(
+	pool: &PgPool,
+	kind: ConfigResourceKind,
+	id: &str,
+) -> anyhow::Result<bool> {
+	let now = Utc::now();
+	let result = sqlx::query(
+		"UPDATE agw_config_resources \
+		 SET revision = revision + 1, updated_at = $1, deleted_at = $1 \
+		 WHERE kind = $2 AND id = $3 AND deleted_at IS NULL",
+	)
+	.bind(now)
+	.bind(kind.as_str())
+	.bind(id)
+	.execute(pool)
+	.await?;
+	Ok(result.rows_affected() > 0)
 }
 
 #[cfg_attr(not(feature = "ui"), allow(dead_code))]
-async fn fetch_resource(
+async fn fetch_sqlite_resource(
 	tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
 	kind: ConfigResourceKind,
 	id: &str,
@@ -556,11 +661,30 @@ async fn fetch_resource(
 	.bind(id)
 	.fetch_optional(&mut **tx)
 	.await?
-	.map(row_to_resource)
+	.map(sqlite_row_to_resource)
 	.transpose()
 }
 
-fn row_to_resource(row: sqlx::sqlite::SqliteRow) -> anyhow::Result<ConfigResource> {
+#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+async fn fetch_postgres_resource(
+	tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+	kind: ConfigResourceKind,
+	id: &str,
+) -> anyhow::Result<Option<ConfigResource>> {
+	sqlx::query(
+		"SELECT kind, id, value_json, revision, created_at, updated_at \
+		 FROM agw_config_resources \
+		 WHERE kind = $1 AND id = $2 AND deleted_at IS NULL",
+	)
+	.bind(kind.as_str())
+	.bind(id)
+	.fetch_optional(&mut **tx)
+	.await?
+	.map(postgres_row_to_resource)
+	.transpose()
+}
+
+fn sqlite_row_to_resource(row: sqlx::sqlite::SqliteRow) -> anyhow::Result<ConfigResource> {
 	let value_json: String = row.try_get("value_json")?;
 	let kind: String = row.try_get("kind")?;
 	let created_at: String = row.try_get("created_at")?;
@@ -575,7 +699,20 @@ fn row_to_resource(row: sqlx::sqlite::SqliteRow) -> anyhow::Result<ConfigResourc
 	})
 }
 
-const SCHEMA: &str = r#"
+fn postgres_row_to_resource(row: sqlx::postgres::PgRow) -> anyhow::Result<ConfigResource> {
+	let kind: String = row.try_get("kind")?;
+	let Json(value) = row.try_get("value_json")?;
+	Ok(ConfigResource {
+		kind: kind.parse()?,
+		id: row.try_get("id")?,
+		value,
+		revision: row.try_get("revision")?,
+		created_at: row.try_get("created_at")?,
+		updated_at: row.try_get("updated_at")?,
+	})
+}
+
+const SQLITE_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS agw_config_resources (
 	kind TEXT NOT NULL,
 	id TEXT NOT NULL,
@@ -584,6 +721,22 @@ CREATE TABLE IF NOT EXISTS agw_config_resources (
 	created_at TEXT NOT NULL,
 	updated_at TEXT NOT NULL,
 	deleted_at TEXT,
+	PRIMARY KEY (kind, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agw_config_resources_kind_updated
+	ON agw_config_resources(kind, updated_at);
+"#;
+
+const POSTGRES_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS agw_config_resources (
+	kind TEXT NOT NULL,
+	id TEXT NOT NULL,
+	value_json JSONB NOT NULL,
+	revision BIGINT NOT NULL DEFAULT 1,
+	created_at TIMESTAMPTZ NOT NULL,
+	updated_at TIMESTAMPTZ NOT NULL,
+	deleted_at TIMESTAMPTZ,
 	PRIMARY KEY (kind, id)
 );
 

--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -301,7 +301,7 @@ pub(crate) fn materialize_config(
 ) -> anyhow::Result<String> {
 	let mut config: Value = crate::yamlviajson::from_str(base)?;
 	overlay_config_resources(&mut config, resources)?;
-	crate::yamlviajson::to_string(&config).map_err(Into::into)
+	crate::yamlviajson::to_string(&config)
 }
 
 fn overlay_config_resources(

--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -1,0 +1,747 @@
+use std::fmt;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
+use sqlx::{Row, SqlitePool};
+use tokio::sync::watch;
+
+use crate::telemetry::log_store;
+
+#[derive(Clone, Debug)]
+pub struct ConfigResourceStore {
+	pool: SqlitePool,
+	change_tx: watch::Sender<()>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigResource {
+	pub kind: ConfigResourceKind,
+	pub id: String,
+	pub value: Value,
+	pub revision: i64,
+	pub created_at: DateTime<Utc>,
+	pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigResourcesResponse {
+	pub resources: Vec<ConfigResource>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum ConfigResourceKind {
+	#[serde(rename = "modelCatalog")]
+	ModelCatalog,
+	#[serde(rename = "llm.provider")]
+	LlmProvider,
+	#[serde(rename = "llm.model")]
+	LlmModel,
+	#[serde(rename = "llm.virtualModel")]
+	LlmVirtualModel,
+	#[serde(rename = "llm.apiKey")]
+	LlmApiKey,
+}
+
+impl ConfigResourceKind {
+	pub const fn as_str(self) -> &'static str {
+		match self {
+			Self::ModelCatalog => "modelCatalog",
+			Self::LlmProvider => "llm.provider",
+			Self::LlmModel => "llm.model",
+			Self::LlmVirtualModel => "llm.virtualModel",
+			Self::LlmApiKey => "llm.apiKey",
+		}
+	}
+}
+
+impl fmt::Display for ConfigResourceKind {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.write_str(self.as_str())
+	}
+}
+
+impl FromStr for ConfigResourceKind {
+	type Err = anyhow::Error;
+
+	fn from_str(kind: &str) -> Result<Self, Self::Err> {
+		match kind {
+			"modelCatalog" => Ok(Self::ModelCatalog),
+			"llm.provider" => Ok(Self::LlmProvider),
+			"llm.model" => Ok(Self::LlmModel),
+			"llm.virtualModel" => Ok(Self::LlmVirtualModel),
+			"llm.apiKey" => Ok(Self::LlmApiKey),
+			_ => anyhow::bail!("unsupported config resource kind: {kind}"),
+		}
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigResourceUpsertRequest {
+	#[serde(default)]
+	pub resources: Vec<ConfigResourceUpsert>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigResourceUpsert {
+	pub value: Value,
+}
+
+pub async fn setup(cfg: &log_store::Config) -> anyhow::Result<ConfigResourceStore> {
+	ConfigResourceStore::connect(cfg).await
+}
+
+impl ConfigResourceStore {
+	async fn connect(cfg: &log_store::Config) -> anyhow::Result<Self> {
+		if cfg.url.starts_with("postgres://") || cfg.url.starts_with("postgresql://") {
+			anyhow::bail!("configStore.mode=hybrid currently supports only SQLite config.database.url");
+		}
+
+		let options = cfg
+			.url
+			.parse::<SqliteConnectOptions>()
+			.context("failed to parse config store sqlite database URL")?
+			.create_if_missing(true)
+			.journal_mode(SqliteJournalMode::Wal)
+			.synchronous(SqliteSynchronous::Normal)
+			.busy_timeout(Duration::from_secs(5));
+		let pool = SqlitePoolOptions::new()
+			.max_connections(5)
+			.connect_with(options)
+			.await
+			.context("failed to connect config store sqlite database")?;
+		sqlx::raw_sql(SCHEMA).execute(&pool).await?;
+		let (change_tx, _) = watch::channel(());
+		Ok(Self { pool, change_tx })
+	}
+
+	pub fn pool(&self) -> SqlitePool {
+		self.pool.clone()
+	}
+
+	pub fn subscribe_changes(&self) -> watch::Receiver<()> {
+		self.change_tx.subscribe()
+	}
+
+	pub async fn list(
+		&self,
+		kind: Option<ConfigResourceKind>,
+	) -> anyhow::Result<Vec<ConfigResource>> {
+		if let Some(kind) = kind {
+			let rows = sqlx::query(
+				"SELECT kind, id, value_json, revision, created_at, updated_at \
+				 FROM agw_config_resources \
+				 WHERE deleted_at IS NULL AND kind = ? \
+				 ORDER BY id",
+			)
+			.bind(kind.as_str())
+			.fetch_all(&self.pool)
+			.await?;
+			return rows.into_iter().map(row_to_resource).collect();
+		}
+
+		let rows = sqlx::query(
+			"SELECT kind, id, value_json, revision, created_at, updated_at \
+			 FROM agw_config_resources \
+			 WHERE deleted_at IS NULL \
+			 ORDER BY kind, id",
+		)
+		.fetch_all(&self.pool)
+		.await?;
+		rows.into_iter().map(row_to_resource).collect()
+	}
+
+	#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+	pub(crate) async fn upsert_prepared(
+		&self,
+		prepared: Vec<PreparedResource>,
+	) -> anyhow::Result<ConfigResourcesResponse> {
+		let mut tx = self.pool.begin().await?;
+		let mut changed = Vec::with_capacity(prepared.len());
+		for PreparedResource { kind, id, value } in prepared {
+			validate_id(&id)?;
+			let now = now();
+			sqlx::query(
+				"INSERT INTO agw_config_resources \
+					(kind, id, value_json, revision, created_at, updated_at, deleted_at) \
+				 VALUES (?, ?, ?, 1, ?, ?, NULL) \
+				 ON CONFLICT(kind, id) DO UPDATE SET \
+					value_json = excluded.value_json, \
+					revision = agw_config_resources.revision + 1, \
+					updated_at = excluded.updated_at, \
+					deleted_at = NULL",
+			)
+			.bind(kind.as_str())
+			.bind(&id)
+			.bind(serde_json::to_string(&value)?)
+			.bind(&now)
+			.bind(&now)
+			.execute(&mut *tx)
+			.await?;
+			changed.push((kind, id));
+		}
+
+		let mut resources = Vec::with_capacity(changed.len());
+		for (kind, id) in changed {
+			if let Some(resource) = fetch_resource(&mut tx, kind, &id).await? {
+				resources.push(resource);
+			}
+		}
+		tx.commit().await?;
+		if !resources.is_empty() {
+			self.notify_changed();
+		}
+		Ok(ConfigResourcesResponse { resources })
+	}
+
+	pub async fn delete(&self, kind: ConfigResourceKind, id: &str) -> anyhow::Result<()> {
+		validate_id(id)?;
+		let now = now();
+		let result = sqlx::query(
+			"UPDATE agw_config_resources \
+			 SET revision = revision + 1, updated_at = ?, deleted_at = ? \
+			 WHERE kind = ? AND id = ? AND deleted_at IS NULL",
+		)
+		.bind(&now)
+		.bind(&now)
+		.bind(kind.as_str())
+		.bind(id)
+		.execute(&self.pool)
+		.await?;
+		if result.rows_affected() == 0 {
+			anyhow::bail!("config resource not found: {kind}/{id}");
+		}
+		self.notify_changed();
+		Ok(())
+	}
+
+	fn notify_changed(&self) {
+		let _ = self.change_tx.send(());
+	}
+}
+
+fn validate_id(id: &str) -> anyhow::Result<()> {
+	if id.is_empty() {
+		anyhow::bail!("config resource id cannot be empty");
+	}
+	Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedResource {
+	pub kind: ConfigResourceKind,
+	pub id: String,
+	pub value: Value,
+}
+
+#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+pub(crate) fn prepare_resources(
+	kind: ConfigResourceKind,
+	request: ConfigResourceUpsertRequest,
+) -> anyhow::Result<Vec<PreparedResource>> {
+	request
+		.resources
+		.into_iter()
+		.map(|resource| prepare_resource(kind, resource.value))
+		.collect()
+}
+
+#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+pub(crate) fn prepare_api_key_update(
+	id: String,
+	mut value: Value,
+) -> anyhow::Result<PreparedResource> {
+	validate_id(&id)?;
+	ensure_no_api_key_id(&value)?;
+	set_api_key_id(&mut value, id.clone())?;
+	Ok(PreparedResource {
+		kind: ConfigResourceKind::LlmApiKey,
+		id,
+		value,
+	})
+}
+
+pub fn model_catalog_sources(
+	resources: &[ConfigResource],
+) -> anyhow::Result<Vec<crate::ModelCatalogSource>> {
+	let Some(resource) = resources
+		.iter()
+		.find(|resource| resource.kind == ConfigResourceKind::ModelCatalog)
+	else {
+		return Ok(Vec::new());
+	};
+	let value = resource
+		.value
+		.as_object()
+		.ok_or_else(|| anyhow::anyhow!("modelCatalog resource must be an object"))?;
+	["base", "custom"]
+		.into_iter()
+		.filter_map(|field| value.get(field))
+		.map(|inline| {
+			Ok(crate::ModelCatalogSource::InlineCatalog {
+				inline: serde_json::from_value(inline.clone())?,
+			})
+		})
+		.collect()
+}
+
+#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+pub(crate) fn apply_prepared_upsert(
+	mut resources: Vec<ConfigResource>,
+	prepared: &[PreparedResource],
+) -> anyhow::Result<Vec<ConfigResource>> {
+	for prepared in prepared {
+		validate_id(&prepared.id)?;
+		if let Some(existing) = resources
+			.iter_mut()
+			.find(|resource| resource.kind == prepared.kind && resource.id == prepared.id)
+		{
+			existing.value = prepared.value.clone();
+			continue;
+		}
+		resources.push(ConfigResource {
+			kind: prepared.kind,
+			id: prepared.id.clone(),
+			value: prepared.value.clone(),
+			revision: 1,
+			created_at: Utc::now(),
+			updated_at: Utc::now(),
+		});
+	}
+	Ok(resources)
+}
+
+#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+pub(crate) fn apply_delete(
+	resources: Vec<ConfigResource>,
+	kind: ConfigResourceKind,
+	id: &str,
+) -> Vec<ConfigResource> {
+	resources
+		.into_iter()
+		.filter(|resource| !(resource.kind == kind && resource.id == id))
+		.collect()
+}
+
+pub async fn materialize_hybrid_config(
+	source: &crate::ConfigSource,
+	store: &ConfigResourceStore,
+) -> anyhow::Result<String> {
+	let base = source.read_to_string().await?;
+	let resources = store.list(None).await?;
+	materialize_config(base.as_str(), &resources)
+}
+
+pub(crate) fn materialize_config(
+	base: &str,
+	resources: &[ConfigResource],
+) -> anyhow::Result<String> {
+	let mut config: Value = crate::yamlviajson::from_str(base)?;
+	overlay_config_resources(&mut config, resources)?;
+	crate::yamlviajson::to_string(&config).map_err(Into::into)
+}
+
+fn overlay_config_resources(
+	config: &mut Value,
+	resources: &[ConfigResource],
+) -> anyhow::Result<()> {
+	let has_llm_resources = resources.iter().any(|resource| {
+		matches!(
+			resource.kind,
+			ConfigResourceKind::LlmProvider
+				| ConfigResourceKind::LlmModel
+				| ConfigResourceKind::LlmVirtualModel
+				| ConfigResourceKind::LlmApiKey
+		)
+	});
+	if !has_llm_resources {
+		return Ok(());
+	}
+
+	let Some(root) = config.as_object_mut() else {
+		anyhow::bail!("local config root must be a JSON object");
+	};
+	let llm = root
+		.entry("llm")
+		.or_insert_with(|| Value::Object(serde_json::Map::new()));
+	let Some(llm) = llm.as_object_mut() else {
+		anyhow::bail!("local config llm must be a JSON object");
+	};
+
+	append_llm_kind(llm, resources, ConfigResourceKind::LlmProvider, "providers")?;
+	append_llm_kind(llm, resources, ConfigResourceKind::LlmModel, "models")?;
+	append_llm_kind(
+		llm,
+		resources,
+		ConfigResourceKind::LlmVirtualModel,
+		"virtualModels",
+	)?;
+	append_api_keys(llm, resources)?;
+	Ok(())
+}
+
+fn append_api_keys(
+	llm: &mut serde_json::Map<String, Value>,
+	resources: &[ConfigResource],
+) -> anyhow::Result<()> {
+	let Some(db_resources) = non_empty_resources(resources, ConfigResourceKind::LlmApiKey) else {
+		return Ok(());
+	};
+	let policies = llm
+		.get_mut("policies")
+		.ok_or_else(|| {
+			anyhow::anyhow!("DB-backed API keys require llm.policies.apiKey in the file config")
+		})?
+		.as_object_mut()
+		.ok_or_else(|| anyhow::anyhow!("local config llm.policies must be an object"))?;
+	let policy = policies
+		.get_mut("apiKey")
+		.ok_or_else(|| {
+			anyhow::anyhow!("DB-backed API keys require llm.policies.apiKey in the file config")
+		})?
+		.as_object_mut()
+		.ok_or_else(|| anyhow::anyhow!("local config llm.policies.apiKey must be an object"))?;
+	let keys = policy
+		.entry("keys")
+		.or_insert_with(|| Value::Array(Vec::new()))
+		.as_array_mut()
+		.ok_or_else(|| anyhow::anyhow!("local config llm.policies.apiKey.keys must be an array"))?;
+
+	keys.extend(
+		db_resources
+			.into_iter()
+			.map(|resource| resource.value.clone()),
+	);
+	Ok(())
+}
+
+fn append_llm_kind(
+	llm: &mut serde_json::Map<String, Value>,
+	resources: &[ConfigResource],
+	kind: ConfigResourceKind,
+	field: &str,
+) -> anyhow::Result<()> {
+	let Some(db_resources) = non_empty_resources(resources, kind) else {
+		return Ok(());
+	};
+
+	let values = llm.entry(field).or_insert_with(|| Value::Array(Vec::new()));
+	let Some(values) = values.as_array_mut() else {
+		anyhow::bail!("local config llm.{field} must be an array");
+	};
+
+	for existing in values.iter() {
+		let id = resource_id(kind, existing)?;
+		if db_resources.iter().any(|resource| resource.id == id) {
+			anyhow::bail!("config resource {kind}/{id} conflicts with file-owned resource");
+		}
+	}
+
+	for resource in db_resources {
+		values.push(resource.value.clone());
+	}
+	Ok(())
+}
+
+fn non_empty_resources(
+	resources: &[ConfigResource],
+	kind: ConfigResourceKind,
+) -> Option<Vec<&ConfigResource>> {
+	let resources = resources
+		.iter()
+		.filter(|resource| resource.kind == kind)
+		.collect::<Vec<_>>();
+	(!resources.is_empty()).then_some(resources)
+}
+
+#[cfg_attr(not(any(feature = "ui", test)), allow(dead_code))]
+fn prepare_resource(
+	kind: ConfigResourceKind,
+	mut value: Value,
+) -> anyhow::Result<PreparedResource> {
+	let id = match kind {
+		ConfigResourceKind::LlmApiKey => {
+			ensure_no_api_key_id(&value)?;
+			let id = uuid::Uuid::new_v4().to_string();
+			set_api_key_id(&mut value, id.clone())?;
+			id
+		},
+		_ => resource_id(kind, &value)?,
+	};
+	Ok(PreparedResource { kind, id, value })
+}
+
+fn resource_id(kind: ConfigResourceKind, value: &Value) -> anyhow::Result<String> {
+	match kind {
+		ConfigResourceKind::ModelCatalog => Ok("default".to_string()),
+		ConfigResourceKind::LlmProvider | ConfigResourceKind::LlmVirtualModel => {
+			string_field(value, "name", || {
+				format!("{kind} resources require value.name")
+			})
+		},
+		ConfigResourceKind::LlmModel => string_field(value, "id", || {
+			"llm.model resources require value.id or value.name".to_string()
+		})
+		.or_else(|_| {
+			string_field(value, "name", || {
+				"llm.model resources require value.id or value.name".to_string()
+			})
+		}),
+		ConfigResourceKind::LlmApiKey => value
+			.pointer("/metadata/id")
+			.and_then(Value::as_str)
+			.map(ToString::to_string)
+			.ok_or_else(|| anyhow::anyhow!("llm.apiKey resources require value.metadata.id")),
+	}
+}
+
+fn ensure_no_api_key_id(value: &Value) -> anyhow::Result<()> {
+	if value.pointer("/metadata/id").is_some() {
+		anyhow::bail!("llm.apiKey resources must not include value.metadata.id");
+	}
+	Ok(())
+}
+
+fn set_api_key_id(value: &mut Value, id: String) -> anyhow::Result<()> {
+	let Some(object) = value.as_object_mut() else {
+		anyhow::bail!("llm.apiKey resources must be JSON objects");
+	};
+	let metadata = object
+		.entry("metadata")
+		.or_insert_with(|| Value::Object(serde_json::Map::new()));
+	let Some(metadata) = metadata.as_object_mut() else {
+		anyhow::bail!("llm.apiKey resources require value.metadata to be an object");
+	};
+	metadata.insert("id".to_string(), Value::String(id));
+	Ok(())
+}
+
+fn string_field(
+	value: &Value,
+	field: &str,
+	error: impl FnOnce() -> String,
+) -> anyhow::Result<String> {
+	value
+		.get(field)
+		.and_then(Value::as_str)
+		.filter(|value| !value.is_empty())
+		.map(ToString::to_string)
+		.ok_or_else(|| anyhow::anyhow!(error()))
+}
+
+fn now() -> String {
+	Utc::now().to_rfc3339()
+}
+
+#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+async fn fetch_resource(
+	tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+	kind: ConfigResourceKind,
+	id: &str,
+) -> anyhow::Result<Option<ConfigResource>> {
+	sqlx::query(
+		"SELECT kind, id, value_json, revision, created_at, updated_at \
+		 FROM agw_config_resources \
+		 WHERE kind = ? AND id = ? AND deleted_at IS NULL",
+	)
+	.bind(kind.as_str())
+	.bind(id)
+	.fetch_optional(&mut **tx)
+	.await?
+	.map(row_to_resource)
+	.transpose()
+}
+
+fn row_to_resource(row: sqlx::sqlite::SqliteRow) -> anyhow::Result<ConfigResource> {
+	let value_json: String = row.try_get("value_json")?;
+	let kind: String = row.try_get("kind")?;
+	let created_at: String = row.try_get("created_at")?;
+	let updated_at: String = row.try_get("updated_at")?;
+	Ok(ConfigResource {
+		kind: kind.parse()?,
+		id: row.try_get("id")?,
+		value: serde_json::from_str(&value_json)?,
+		revision: row.try_get("revision")?,
+		created_at: created_at.parse()?,
+		updated_at: updated_at.parse()?,
+	})
+}
+
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS agw_config_resources (
+	kind TEXT NOT NULL,
+	id TEXT NOT NULL,
+	value_json TEXT NOT NULL CHECK (json_valid(value_json)),
+	revision INTEGER NOT NULL DEFAULT 1,
+	created_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	deleted_at TEXT,
+	PRIMARY KEY (kind, id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agw_config_resources_kind_updated
+	ON agw_config_resources(kind, updated_at);
+"#;
+
+#[cfg(test)]
+mod tests {
+	use serde_json::json;
+
+	use super::*;
+
+	fn test_resource(kind: ConfigResourceKind, id: &str, value: Value) -> ConfigResource {
+		ConfigResource {
+			kind,
+			id: id.to_string(),
+			value,
+			revision: 1,
+			created_at: Utc::now(),
+			updated_at: Utc::now(),
+		}
+	}
+
+	#[test]
+	fn derives_resource_ids_and_manages_api_key_ids() {
+		let err = "traffic.listener"
+			.parse::<ConfigResourceKind>()
+			.expect_err("unsupported kind should fail");
+		assert!(err.to_string().contains("unsupported config resource kind"));
+		assert_eq!(
+			resource_id(ConfigResourceKind::LlmProvider, &json!({"name": "openai"}))
+				.expect("provider id"),
+			"openai"
+		);
+		assert_eq!(
+			resource_id(ConfigResourceKind::LlmModel, &json!({"name": "fast"})).expect("model id"),
+			"fast"
+		);
+		assert_eq!(
+			resource_id(
+				ConfigResourceKind::LlmModel,
+				&json!({"id": "model_01", "name": "fast"})
+			)
+			.expect("stable model id"),
+			"model_01"
+		);
+		assert_eq!(
+			resource_id(
+				ConfigResourceKind::LlmVirtualModel,
+				&json!({"name": "router"})
+			)
+			.expect("virtual model id"),
+			"router"
+		);
+
+		let created = prepare_resource(
+			ConfigResourceKind::LlmApiKey,
+			json!({"metadata": {"name": "ci"}}),
+		)
+		.expect("api key id");
+		uuid::Uuid::parse_str(&created.id).expect("UUID v4");
+		assert_eq!(
+			created.value.pointer("/metadata/id"),
+			Some(&Value::String(created.id))
+		);
+		assert!(
+			prepare_resource(
+				ConfigResourceKind::LlmApiKey,
+				json!({"metadata": {"id": "client-id"}}),
+			)
+			.is_err()
+		);
+	}
+
+	#[test]
+	fn materializes_llm_resources_into_base_config() {
+		let base = r#"
+llm:
+  models:
+  - name: file-model
+    provider:
+      openAI:
+        model: gpt-4o-mini
+  policies:
+    apiKey:
+      keys: []
+      mode: strict
+"#;
+		let resources = vec![
+			test_resource(
+				ConfigResourceKind::LlmProvider,
+				"openai",
+				json!({"name": "openai", "provider": "openAI", "params": {"model": "gpt-4o"}}),
+			),
+			test_resource(
+				ConfigResourceKind::LlmModel,
+				"model_01",
+				json!({"id": "model_01", "name": "db-model", "provider": {"reference": "openai"}}),
+			),
+			test_resource(
+				ConfigResourceKind::LlmVirtualModel,
+				"router",
+				json!({"name": "router", "routing": {"weighted": {"targets": [{"model": "db-model"}]}}}),
+			),
+			test_resource(
+				ConfigResourceKind::LlmApiKey,
+				"key_01",
+				json!({"key": "agw_sk_test", "metadata": {"id": "key_01", "name": "test"}}),
+			),
+		];
+
+		let materialized = materialize_config(base, &resources).expect("materialize");
+		let value: Value = crate::yamlviajson::from_str(&materialized).expect("parse materialized");
+
+		assert_eq!(
+			value.pointer("/llm/providers/0/name"),
+			Some(&json!("openai"))
+		);
+		assert_eq!(
+			value.pointer("/llm/models/0/name"),
+			Some(&json!("file-model"))
+		);
+		assert_eq!(
+			value.pointer("/llm/policies/apiKey/keys/0/key"),
+			Some(&json!("agw_sk_test"))
+		);
+		assert_eq!(
+			value.pointer("/llm/models/1/name"),
+			Some(&json!("db-model"))
+		);
+		assert_eq!(value.pointer("/llm/models/1/id"), Some(&json!("model_01")));
+		assert_eq!(
+			value.pointer("/llm/virtualModels/0/name"),
+			Some(&json!("router"))
+		);
+	}
+
+	#[test]
+	fn materialization_rejects_file_owned_identity_conflicts() {
+		let base = r#"
+llm:
+  providers:
+  - name: openai
+    provider: openAI
+"#;
+		let resources = vec![test_resource(
+			ConfigResourceKind::LlmProvider,
+			"openai",
+			json!({"name": "openai", "provider": "openAI"}),
+		)];
+
+		let err = materialize_config(base, &resources).expect_err("conflict should fail");
+		assert!(
+			err
+				.to_string()
+				.contains("conflicts with file-owned resource"),
+			"unexpected error: {err}"
+		);
+	}
+}

--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -34,6 +34,16 @@ pub struct ConfigResourcesResponse {
 	pub resources: Vec<ConfigResource>,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigResourceError {
+	#[error("{0}")]
+	InvalidRequest(String),
+	#[error("{0}")]
+	Conflict(String),
+	#[error("{0}")]
+	NotFound(String),
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ConfigResourceKind {
 	#[serde(rename = "modelCatalog")]
@@ -67,7 +77,7 @@ impl fmt::Display for ConfigResourceKind {
 }
 
 impl FromStr for ConfigResourceKind {
-	type Err = anyhow::Error;
+	type Err = ConfigResourceError;
 
 	fn from_str(kind: &str) -> Result<Self, Self::Err> {
 		match kind {
@@ -76,7 +86,9 @@ impl FromStr for ConfigResourceKind {
 			"llm.model" => Ok(Self::LlmModel),
 			"llm.virtualModel" => Ok(Self::LlmVirtualModel),
 			"llm.apiKey" => Ok(Self::LlmApiKey),
-			_ => anyhow::bail!("unsupported config resource kind: {kind}"),
+			_ => Err(ConfigResourceError::InvalidRequest(format!(
+				"unsupported config resource kind: {kind}"
+			))),
 		}
 	}
 }
@@ -156,7 +168,9 @@ impl ConfigResourceStore {
 			DatabasePool::Postgres(pool) => delete_postgres(pool, kind, id).await?,
 		};
 		if !deleted {
-			anyhow::bail!("config resource not found: {kind}/{id}");
+			return Err(
+				ConfigResourceError::NotFound(format!("config resource not found: {kind}/{id}")).into(),
+			);
 		}
 		self.notify_changed();
 		Ok(())
@@ -169,7 +183,9 @@ impl ConfigResourceStore {
 
 fn validate_id(id: &str) -> anyhow::Result<()> {
 	if id.is_empty() {
-		anyhow::bail!("config resource id cannot be empty");
+		return Err(
+			ConfigResourceError::InvalidRequest("config resource id cannot be empty".to_string()).into(),
+		);
 	}
 	Ok(())
 }
@@ -337,14 +353,18 @@ fn append_api_keys(
 	let policies = llm
 		.get_mut("policies")
 		.ok_or_else(|| {
-			anyhow::anyhow!("DB-backed API keys require llm.policies.apiKey in the file config")
+			ConfigResourceError::Conflict(
+				"DB-backed API keys require llm.policies.apiKey in the file config".to_string(),
+			)
 		})?
 		.as_object_mut()
 		.ok_or_else(|| anyhow::anyhow!("local config llm.policies must be an object"))?;
 	let policy = policies
 		.get_mut("apiKey")
 		.ok_or_else(|| {
-			anyhow::anyhow!("DB-backed API keys require llm.policies.apiKey in the file config")
+			ConfigResourceError::Conflict(
+				"DB-backed API keys require llm.policies.apiKey in the file config".to_string(),
+			)
 		})?
 		.as_object_mut()
 		.ok_or_else(|| anyhow::anyhow!("local config llm.policies.apiKey must be an object"))?;
@@ -380,7 +400,12 @@ fn append_llm_kind(
 	for existing in values.iter() {
 		let id = resource_id(kind, existing)?;
 		if db_resources.iter().any(|resource| resource.id == id) {
-			anyhow::bail!("config resource {kind}/{id} conflicts with file-owned resource");
+			return Err(
+				ConfigResourceError::Conflict(format!(
+					"config resource {kind}/{id} conflicts with file-owned resource"
+				))
+				.into(),
+			);
 		}
 	}
 
@@ -438,26 +463,44 @@ fn resource_id(kind: ConfigResourceKind, value: &Value) -> anyhow::Result<String
 			.pointer("/metadata/id")
 			.and_then(Value::as_str)
 			.map(ToString::to_string)
-			.ok_or_else(|| anyhow::anyhow!("llm.apiKey resources require value.metadata.id")),
+			.ok_or_else(|| {
+				ConfigResourceError::InvalidRequest(
+					"llm.apiKey resources require value.metadata.id".to_string(),
+				)
+				.into()
+			}),
 	}
 }
 
 fn ensure_no_api_key_id(value: &Value) -> anyhow::Result<()> {
 	if value.pointer("/metadata/id").is_some() {
-		anyhow::bail!("llm.apiKey resources must not include value.metadata.id");
+		return Err(
+			ConfigResourceError::InvalidRequest(
+				"llm.apiKey resources must not include value.metadata.id".to_string(),
+			)
+			.into(),
+		);
 	}
 	Ok(())
 }
 
 fn set_api_key_id(value: &mut Value, id: String) -> anyhow::Result<()> {
 	let Some(object) = value.as_object_mut() else {
-		anyhow::bail!("llm.apiKey resources must be JSON objects");
+		return Err(
+			ConfigResourceError::InvalidRequest("llm.apiKey resources must be JSON objects".to_string())
+				.into(),
+		);
 	};
 	let metadata = object
 		.entry("metadata")
 		.or_insert_with(|| Value::Object(serde_json::Map::new()));
 	let Some(metadata) = metadata.as_object_mut() else {
-		anyhow::bail!("llm.apiKey resources require value.metadata to be an object");
+		return Err(
+			ConfigResourceError::InvalidRequest(
+				"llm.apiKey resources require value.metadata to be an object".to_string(),
+			)
+			.into(),
+		);
 	};
 	metadata.insert("id".to_string(), Value::String(id));
 	Ok(())
@@ -473,7 +516,7 @@ fn string_field(
 		.and_then(Value::as_str)
 		.filter(|value| !value.is_empty())
 		.map(ToString::to_string)
-		.ok_or_else(|| anyhow::anyhow!(error()))
+		.ok_or_else(|| ConfigResourceError::InvalidRequest(error()).into())
 }
 
 async fn list_sqlite(

--- a/crates/agentgateway/src/database.rs
+++ b/crates/agentgateway/src/database.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
+use sqlx::{PgPool, SqlitePool};
+
+#[derive(Clone, Debug)]
+pub enum DatabasePool {
+	Sqlite(SqlitePool),
+	Postgres(PgPool),
+}
+
+impl DatabasePool {
+	pub async fn connect(url: &str) -> anyhow::Result<Self> {
+		if url.starts_with("postgres://") || url.starts_with("postgresql://") {
+			let pool = PgPoolOptions::new()
+				.max_connections(5)
+				.connect(url)
+				.await
+				.context("failed to connect postgres database")?;
+			return Ok(Self::Postgres(pool));
+		}
+
+		let options = url
+			.parse::<SqliteConnectOptions>()
+			.context("failed to parse sqlite database URL")?
+			.create_if_missing(true)
+			.journal_mode(SqliteJournalMode::Wal)
+			.synchronous(SqliteSynchronous::Normal)
+			.busy_timeout(Duration::from_secs(5));
+		let pool = SqlitePoolOptions::new()
+			.max_connections(5)
+			.connect_with(options)
+			.await
+			.context("failed to connect sqlite database")?;
+		Ok(Self::Sqlite(pool))
+	}
+}

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -27,6 +27,7 @@ pub mod aws;
 pub mod cel;
 pub mod client;
 pub mod config;
+pub mod config_store;
 pub mod control;
 pub mod http;
 pub mod json;
@@ -158,6 +159,8 @@ pub struct RawConfig {
 	model_catalog: Option<Vec<ModelCatalogSource>>,
 	/// Primary database used by local runtime features.
 	database: Option<telemetry::log_store::Config>,
+	/// Controls whether UI-managed configuration is written to the config file or a DB overlay.
+	config_store: Option<RawConfigStoreConfig>,
 
 	/// Address of the Certificate Authority used to issue SPIFFE certificates.
 	ca_address: Option<String>,
@@ -405,6 +408,23 @@ pub struct RawLogging {
 }
 
 #[apply(schema_de!)]
+#[derive(Default)]
+pub struct RawConfigStoreConfig {
+	#[serde(default)]
+	mode: ConfigStoreMode,
+}
+
+#[apply(schema!)]
+#[derive(Default, Eq, PartialEq, Copy)]
+pub enum ConfigStoreMode {
+	/// Store all UI-managed configuration in the local config file.
+	#[default]
+	File,
+	/// Read a file baseline and store UI-managed overlay resources in the configured database.
+	Hybrid,
+}
+
+#[apply(schema_de!)]
 #[serde(untagged)]
 pub enum RawLoggingLevel {
 	Single(String),
@@ -594,6 +614,7 @@ pub struct Config {
 	pub metrics: crate::telemetry::log::MetricsConfig,
 	pub logging: crate::telemetry::log::Config,
 	pub database: Option<telemetry::log_store::Config>,
+	pub config_store: ConfigStoreConfig,
 
 	pub dns: client::Config,
 	pub proxy_metadata: ProxyMetadata,
@@ -615,6 +636,12 @@ pub struct Config {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ModelCatalogConfig {
 	pub sources: Vec<ModelCatalogSource>,
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConfigStoreConfig {
+	pub mode: ConfigStoreMode,
 }
 
 /// A source of model cost catalog data.

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -29,6 +29,7 @@ pub mod client;
 pub mod config;
 pub mod config_store;
 pub mod control;
+pub mod database;
 pub mod http;
 pub mod json;
 pub mod llm;

--- a/crates/agentgateway/src/llm/cost/mod.rs
+++ b/crates/agentgateway/src/llm/cost/mod.rs
@@ -23,6 +23,7 @@ const TRACE_POLICY_KIND: &str = "llm_cost";
 
 pub struct ModelCatalog {
 	snapshot: ArcSwap<CatalogSnapshot>,
+	sources: ArcSwap<Vec<ModelCatalogSource>>,
 }
 
 impl fmt::Debug for ModelCatalog {
@@ -37,6 +38,7 @@ impl Default for ModelCatalog {
 	fn default() -> Self {
 		Self {
 			snapshot: ArcSwap::from_pointee(CatalogSnapshot::empty()),
+			sources: ArcSwap::from_pointee(Vec::new()),
 		}
 	}
 }
@@ -55,23 +57,17 @@ impl ModelCatalog {
 				ModelCatalogSource::InlineCatalog { .. } => None,
 			})
 			.collect();
+		catalog.sources.store(Arc::new(sources));
 		tokio::spawn({
-			let sources = sources.clone();
 			let catalog = catalog.clone();
 			async move {
-				match load_sources(&sources).await {
-					Ok(loaded) => {
-						log_loaded_catalog("loaded model catalog", &loaded);
-						catalog.snapshot.store(Arc::new(loaded.snapshot));
-					},
-					Err(e) => {
-						warn!("model catalog load failed; will load when the files become valid: {e:#}")
-					},
+				if let Err(e) = catalog.reload().await {
+					warn!("model catalog load failed; will load when the files become valid: {e:#}")
 				}
 			}
 		});
 		if !file_paths.is_empty() {
-			watch_catalog_files(file_paths, sources, catalog.clone())?;
+			watch_catalog_files(file_paths, catalog.clone())?;
 		}
 		Ok(catalog)
 	}
@@ -88,8 +84,24 @@ impl ModelCatalog {
 		self.snapshot.load().list_models()
 	}
 
-	pub fn replace(&self, snapshot: CatalogSnapshot) {
-		self.snapshot.store(Arc::new(snapshot));
+	pub async fn replace_sources(&self, sources: Vec<ModelCatalogSource>) -> anyhow::Result<()> {
+		if sources.is_empty() {
+			self.sources.store(Arc::new(sources));
+			self.snapshot.store(Arc::new(CatalogSnapshot::empty()));
+			return Ok(());
+		}
+		let loaded = load_sources(&sources).await?;
+		log_loaded_catalog("model catalog reloaded", &loaded);
+		self.sources.store(Arc::new(sources));
+		self.snapshot.store(Arc::new(loaded.snapshot));
+		Ok(())
+	}
+
+	pub(super) async fn reload(&self) -> anyhow::Result<()> {
+		let loaded = load_sources(&self.sources.load_full()).await?;
+		log_loaded_catalog("model catalog loaded", &loaded);
+		self.snapshot.store(Arc::new(loaded.snapshot));
+		Ok(())
 	}
 
 	pub fn project(&self, info: &LLMInfo) -> CostProjection {
@@ -518,11 +530,7 @@ fn log_loaded_catalog(message: &'static str, loaded: &LoadedCatalog) {
 	}
 }
 
-fn watch_catalog_files(
-	file_paths: Vec<PathBuf>,
-	all_sources: Vec<ModelCatalogSource>,
-	catalog: Arc<ModelCatalog>,
-) -> anyhow::Result<()> {
+fn watch_catalog_files(file_paths: Vec<PathBuf>, catalog: Arc<ModelCatalog>) -> anyhow::Result<()> {
 	let mut watched = crate::util::watch_files_with_options(
 		file_paths,
 		crate::util::WatchFilesOptions::default().reload_on_disappearance(true),
@@ -533,14 +541,8 @@ fn watch_catalog_files(
 	);
 	tokio::task::spawn(async move {
 		while watched.changed().await {
-			match load_sources(&all_sources).await {
-				Ok(loaded) => {
-					log_loaded_catalog("model catalog reloaded", &loaded);
-					catalog.snapshot.store(Arc::new(loaded.snapshot));
-				},
-				Err(e) => {
-					error!("failed to reload model catalog; keeping last valid catalog: {e:#}")
-				},
+			if let Err(e) = catalog.reload().await {
+				error!("failed to reload model catalog; keeping last valid catalog: {e:#}")
 			}
 		}
 	});
@@ -657,6 +659,7 @@ mod tests {
 	fn model_catalog(json: &str) -> ModelCatalog {
 		ModelCatalog {
 			snapshot: ArcSwap::from_pointee(CatalogSnapshot::parse(json).unwrap()),
+			..Default::default()
 		}
 	}
 

--- a/crates/agentgateway/src/llm/cost/mod.rs
+++ b/crates/agentgateway/src/llm/cost/mod.rs
@@ -22,14 +22,19 @@ pub mod refresh;
 const TRACE_POLICY_KIND: &str = "llm_cost";
 
 pub struct ModelCatalog {
-	snapshot: ArcSwap<CatalogSnapshot>,
-	sources: ArcSwap<Vec<ModelCatalogSource>>,
+	state: ArcSwap<ModelCatalogState>,
+}
+
+struct ModelCatalogState {
+	snapshot: Arc<CatalogSnapshot>,
+	sources: Vec<ModelCatalogSource>,
 }
 
 impl fmt::Debug for ModelCatalog {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let state = self.state.load();
 		f.debug_struct("ModelCatalog")
-			.field("snapshot", &*self.snapshot.load())
+			.field("snapshot", &state.snapshot)
 			.finish()
 	}
 }
@@ -37,8 +42,10 @@ impl fmt::Debug for ModelCatalog {
 impl Default for ModelCatalog {
 	fn default() -> Self {
 		Self {
-			snapshot: ArcSwap::from_pointee(CatalogSnapshot::empty()),
-			sources: ArcSwap::from_pointee(Vec::new()),
+			state: ArcSwap::from_pointee(ModelCatalogState {
+				snapshot: Arc::new(CatalogSnapshot::empty()),
+				sources: Vec::new(),
+			}),
 		}
 	}
 }
@@ -57,7 +64,10 @@ impl ModelCatalog {
 				ModelCatalogSource::InlineCatalog { .. } => None,
 			})
 			.collect();
-		catalog.sources.store(Arc::new(sources));
+		catalog.state.store(Arc::new(ModelCatalogState {
+			snapshot: Arc::new(CatalogSnapshot::empty()),
+			sources,
+		}));
 		tokio::spawn({
 			let catalog = catalog.clone();
 			async move {
@@ -77,36 +87,50 @@ impl ModelCatalog {
 	}
 
 	pub fn snapshot(&self) -> Arc<CatalogSnapshot> {
-		self.snapshot.load_full()
+		self.state.load().snapshot.clone()
 	}
 
 	pub fn list_models(&self) -> ModelCatalogModels {
-		self.snapshot.load().list_models()
+		self.state.load().snapshot.list_models()
 	}
 
 	pub async fn replace_sources(&self, sources: Vec<ModelCatalogSource>) -> anyhow::Result<()> {
 		if sources.is_empty() {
-			self.sources.store(Arc::new(sources));
-			self.snapshot.store(Arc::new(CatalogSnapshot::empty()));
+			self.state.store(Arc::new(ModelCatalogState {
+				snapshot: Arc::new(CatalogSnapshot::empty()),
+				sources,
+			}));
 			return Ok(());
 		}
 		let loaded = load_sources(&sources).await?;
-		log_loaded_catalog("model catalog reloaded", &loaded);
-		self.sources.store(Arc::new(sources));
-		self.snapshot.store(Arc::new(loaded.snapshot));
+		log_loaded_catalog("model catalog reloaded", &loaded.snapshot, &loaded.missing);
+		self.state.store(Arc::new(ModelCatalogState {
+			snapshot: Arc::new(loaded.snapshot),
+			sources,
+		}));
 		Ok(())
 	}
 
 	pub(super) async fn reload(&self) -> anyhow::Result<()> {
-		let loaded = load_sources(&self.sources.load_full()).await?;
-		log_loaded_catalog("model catalog loaded", &loaded);
-		self.snapshot.store(Arc::new(loaded.snapshot));
-		Ok(())
+		loop {
+			let current = self.state.load_full();
+			let loaded = load_sources(&current.sources).await?;
+			let next = Arc::new(ModelCatalogState {
+				snapshot: Arc::new(loaded.snapshot),
+				sources: current.sources.clone(),
+			});
+			let previous = self.state.compare_and_swap(&current, next.clone());
+			if Arc::ptr_eq(&previous, &current) {
+				log_loaded_catalog("model catalog loaded", &next.snapshot, &loaded.missing);
+				return Ok(());
+			}
+		}
 	}
 
 	pub fn project(&self, info: &LLMInfo) -> CostProjection {
 		let provider = info.request.provider.as_str();
-		let snapshot = self.snapshot.load();
+		let state = self.state.load();
+		let snapshot = &state.snapshot;
 		if let Some(provider_model) = &info.response.provider_model {
 			let projection = snapshot.project_with_missing_trace(
 				provider,
@@ -518,15 +542,15 @@ async fn load_sources(sources: &[ModelCatalogSource]) -> anyhow::Result<LoadedCa
 	})
 }
 
-fn log_loaded_catalog(message: &'static str, loaded: &LoadedCatalog) {
-	let catalog = loaded.snapshot.catalog.as_ref();
+fn log_loaded_catalog(message: &'static str, snapshot: &CatalogSnapshot, missing: &[PathBuf]) {
+	let catalog = snapshot.catalog.as_ref();
 	let providers = catalog.map_or(0, |catalog| catalog.providers.len());
 	let models = catalog.map_or(0, |catalog| {
 		catalog.providers.values().map(|p| p.models.len()).sum()
 	});
 	info!(providers, models, "{}", message);
-	if !loaded.missing.is_empty() {
-		debug!(files = ?loaded.missing, "{} configured but missing", message);
+	if !missing.is_empty() {
+		debug!(files = ?missing, "{} configured but missing", message);
 	}
 }
 
@@ -658,8 +682,10 @@ mod tests {
 
 	fn model_catalog(json: &str) -> ModelCatalog {
 		ModelCatalog {
-			snapshot: ArcSwap::from_pointee(CatalogSnapshot::parse(json).unwrap()),
-			..Default::default()
+			state: ArcSwap::from_pointee(ModelCatalogState {
+				snapshot: Arc::new(CatalogSnapshot::parse(json).unwrap()),
+				sources: Vec::new(),
+			}),
 		}
 	}
 

--- a/crates/agentgateway/src/llm/cost/refresh.rs
+++ b/crates/agentgateway/src/llm/cost/refresh.rs
@@ -6,19 +6,33 @@ use anyhow::{Context, bail};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-use crate::llm::cost::{CatalogSnapshot, ModelCatalog, catalog};
+use crate::llm::cost::{ModelCatalog, catalog};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RefreshBaseCatalogResponse {
 	pub providers: usize,
 	pub models: usize,
+	#[serde(skip_serializing)]
+	pub catalog: catalog::Catalog,
 }
 
 pub async fn refresh_models_dev_base_catalog(
 	file: &Path,
 	model_catalog: &ModelCatalog,
 ) -> anyhow::Result<RefreshBaseCatalogResponse> {
+	let refreshed = fetch_models_dev_base_catalog().await?;
+	let catalog = refreshed.catalog.clone();
+	let json = serde_json::to_vec_pretty(&catalog).context("marshal models.dev catalog")?;
+	if let Some(parent) = file.parent() {
+		fs_err::tokio::create_dir_all(parent).await?;
+	}
+	fs_err::tokio::write(file, &json).await?;
+	model_catalog.reload().await?;
+	Ok(refreshed)
+}
+
+pub async fn fetch_models_dev_base_catalog() -> anyhow::Result<RefreshBaseCatalogResponse> {
 	let catalog = fetch_models_dev_catalog().await?;
 	let providers = catalog.providers.len();
 	let models = catalog
@@ -26,15 +40,11 @@ pub async fn refresh_models_dev_base_catalog(
 		.values()
 		.map(|provider| provider.models.len())
 		.sum();
-	let json = serde_json::to_vec_pretty(&catalog).context("marshal models.dev catalog")?;
-	if let Some(parent) = file.parent() {
-		fs_err::tokio::create_dir_all(parent).await?;
-	}
-	fs_err::tokio::write(file, &json).await?;
-	model_catalog.replace(CatalogSnapshot {
-		catalog: Some(catalog),
-	});
-	Ok(RefreshBaseCatalogResponse { providers, models })
+	Ok(RefreshBaseCatalogResponse {
+		providers,
+		models,
+		catalog,
+	})
 }
 
 async fn fetch_models_dev_catalog() -> anyhow::Result<crate::llm::cost::catalog::Catalog> {

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -18,6 +18,8 @@ use crate::{apply, cel, llm, schema_enum};
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ModelRoute {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub id: Option<String>,
 	pub name: String,
 	pub visibility: ModelVisibility,
 	pub header_matches: Vec<Vec<HeaderMatch>>,

--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -67,6 +67,8 @@ struct AdminState {
 	config: Arc<Config>,
 	#[cfg_attr(not(feature = "ui"), allow(dead_code))]
 	model_catalog: Arc<crate::llm::cost::ModelCatalog>,
+	#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+	config_resource_store: Option<crate::config_store::ConfigResourceStore>,
 	shutdown_trigger: signal::ShutdownTrigger,
 	#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 	dataplane_handle: Handle,
@@ -114,6 +116,7 @@ impl Service {
 	pub async fn new(
 		config: Arc<Config>,
 		model_catalog: Arc<crate::llm::cost::ModelCatalog>,
+		config_resource_store: Option<crate::config_store::ConfigResourceStore>,
 		stores: crate::store::Stores,
 		resource_manager: crate::resource_manager::ResourceManager,
 		shutdown_trigger: signal::ShutdownTrigger,
@@ -123,6 +126,7 @@ impl Service {
 		let state = Arc::new(AdminState {
 			config,
 			model_catalog,
+			config_resource_store,
 			stores,
 			resource_manager,
 			shutdown_trigger,
@@ -186,6 +190,7 @@ fn admin_router(state: Arc<AdminState>) -> Router {
 	let router = router.merge(crate::ui::router(
 		state.config.clone(),
 		state.model_catalog.clone(),
+		state.config_resource_store.clone(),
 		state.resource_manager.clone(),
 	));
 	#[cfg(not(feature = "ui"))]

--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -113,6 +113,7 @@ pub struct CertsDump {
 }
 
 impl Service {
+	#[allow(clippy::too_many_arguments)]
 	pub async fn new(
 		config: Arc<Config>,
 		model_catalog: Arc<crate::llm::cost::ModelCatalog>,

--- a/crates/agentgateway/src/management/admin_tests.rs
+++ b/crates/agentgateway/src/management/admin_tests.rs
@@ -16,6 +16,7 @@ async fn spawn_admin(cfg: &str) -> (SocketAddr, agent_core::drain::DrainTrigger)
 	let svc = Service::new(
 		config,
 		crate::llm::cost::ModelCatalog::empty(),
+		None,
 		stores,
 		resource_manager,
 		shutdown.trigger(),

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -902,7 +902,7 @@ impl Gateway {
 					dtrace::DebugTracer::maybe_scope(req, |req| async move {
 						proxy.proxy(connection, req).map(Ok::<_, Infallible>).await
 					})
-					.assert_size::<{ 16 * 1024 }>(),
+					.assert_size::<{ 17 * 1024 }>(),
 				)
 			}),
 		);

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -10,7 +10,7 @@ use crate::types::agent::ListenerTarget;
 use crate::types::discovery::SelfIdentitySource;
 use crate::types::proto::agent::Resource as ADPResource;
 use crate::types::proto::workload::Address as XdsAddress;
-use crate::{ConfigSource, client, control, store};
+use crate::{ConfigSource, ConfigStoreMode, client, config_store, control, store};
 
 #[derive(serde::Serialize)]
 pub struct StateManager {
@@ -36,6 +36,7 @@ impl StateManager {
 		client: client::Client,
 		config_metrics: Arc<agent_xds::Metrics>,
 		awaiting_ready: tokio::sync::watch::Sender<()>,
+		config_resource_store: Option<config_store::ConfigResourceStore>,
 	) -> anyhow::Result<Self> {
 		let xds = &config.xds;
 		let stores = Stores::new_with_dynamic_ca_cert_cache(
@@ -72,6 +73,7 @@ impl StateManager {
 				config: config.clone(),
 				stores: stores.clone(),
 				cfg: cfg.clone(),
+				config_resource_store: config_resource_store.clone(),
 				client,
 				resource_manager: resource_manager.clone(),
 				gateway: ListenerTarget {
@@ -112,6 +114,7 @@ impl StateManager {
 pub struct LocalClient {
 	config: Arc<crate::Config>,
 	pub cfg: ConfigSource,
+	pub config_resource_store: Option<config_store::ConfigResourceStore>,
 	pub stores: Stores,
 	pub client: Client,
 	pub resource_manager: crate::resource_manager::ResourceManager,
@@ -144,6 +147,10 @@ impl LocalClient {
 		let lc: LocalClient = self.to_owned();
 		let path = path.to_path_buf();
 		let mut resource_changes = lc.resource_manager.subscribe_changes();
+		let mut config_store_changes = lc
+			.config_resource_store
+			.as_ref()
+			.map(config_store::ConfigResourceStore::subscribe_changes);
 		tokio::task::spawn(async move {
 			loop {
 				tokio::select! {
@@ -170,6 +177,18 @@ impl LocalClient {
 						info!(resource, "resource changed, reloading");
 						next_state = lc.reload_config_after_change(next_state).await;
 					}
+					changed = async {
+						match &mut config_store_changes {
+							Some(changes) => changes.changed().await,
+							None => std::future::pending().await,
+						}
+					} => {
+						if changed.is_err() {
+							break;
+						}
+						info!("config resource changed, reloading");
+						next_state = lc.reload_config_after_change(next_state).await;
+					}
 				}
 			}
 		});
@@ -180,17 +199,40 @@ impl LocalClient {
 	fn watch_resource_changes(&self, mut next_state: PreviousState) {
 		let lc = self.clone();
 		let mut resource_changes = self.resource_manager.subscribe_changes();
+		let mut config_store_changes = self
+			.config_resource_store
+			.as_ref()
+			.map(config_store::ConfigResourceStore::subscribe_changes);
 		tokio::task::spawn(async move {
-			while resource_changes.changed().await.is_ok() {
-				let resource = resource_changes.borrow().resource.clone();
-				info!(resource, "resource changed, reloading");
-				next_state = lc.reload_config_after_change(next_state).await;
+			loop {
+				tokio::select! {
+					changed = resource_changes.changed() => {
+						if changed.is_err() {
+							break;
+						}
+						let resource = resource_changes.borrow().resource.clone();
+						info!(resource, "resource changed, reloading");
+						next_state = lc.reload_config_after_change(next_state).await;
+					}
+					changed = async {
+						match &mut config_store_changes {
+							Some(changes) => changes.changed().await,
+							None => std::future::pending().await,
+						}
+					} => {
+						if changed.is_err() {
+							break;
+						}
+						info!("config resource changed, reloading");
+						next_state = lc.reload_config_after_change(next_state).await;
+					}
+				}
 			}
 		});
 	}
 
 	async fn reload_config(&self, prev: PreviousState) -> anyhow::Result<PreviousState> {
-		let config_content = self.cfg.read_to_string().await?;
+		let config_content = self.config_content().await?;
 		let resources =
 			crate::resource_manager::ResourceFetcher::managed(self.resource_manager.clone());
 		let config = crate::types::local::NormalizedLocalConfig::from(
@@ -222,6 +264,15 @@ impl LocalClient {
 			binds: next_binds,
 			discovery: next_discovery,
 		})
+	}
+
+	async fn config_content(&self) -> anyhow::Result<String> {
+		if self.config.config_store.mode == ConfigStoreMode::Hybrid
+			&& let Some(store) = &self.config_resource_store
+		{
+			return config_store::materialize_hybrid_config(&self.cfg, store).await;
+		}
+		self.cfg.read_to_string().await
 	}
 
 	async fn reload_config_after_change(&self, prev: PreviousState) -> PreviousState {
@@ -512,6 +563,7 @@ frontendPolicies:
 		let local_client = LocalClient {
 			config: config.clone(),
 			cfg: ConfigSource::File(path.clone()),
+			config_resource_store: None,
 			stores: stores.clone(),
 			client,
 			resource_manager,

--- a/crates/agentgateway/src/telemetry/log_store.rs
+++ b/crates/agentgateway/src/telemetry/log_store.rs
@@ -54,16 +54,16 @@ impl RequestLogStore {
 }
 
 pub async fn setup(cfg: &Config) -> anyhow::Result<RequestLogStoreGuard> {
-	setup_with_sqlite_pool(cfg, None).await
+	setup_with_pool(cfg, None).await
 }
 
-pub async fn setup_with_sqlite_pool(
+pub async fn setup_with_pool(
 	cfg: &Config,
-	sqlite_pool: Option<sqlx::SqlitePool>,
+	pool: Option<crate::database::DatabasePool>,
 ) -> anyhow::Result<RequestLogStoreGuard> {
 	let (tx, rx) = crossbeam::channel::unbounded();
 	let (ready_tx, ready_rx) = oneshot::channel();
-	let writer = LogStoreWorker::new(rx, cfg.clone(), sqlite_pool, ready_tx)
+	let writer = LogStoreWorker::new(rx, cfg.clone(), pool, ready_tx)
 		.worker_thread("request-log-db-writer".to_string())?;
 	ready_rx
 		.await
@@ -179,7 +179,7 @@ type QueryResponse<T> = oneshot::Sender<anyhow::Result<T>>;
 struct LogStoreWorker {
 	receiver: Receiver<LogStoreMsg>,
 	cfg: Config,
-	sqlite_pool: Option<sqlx::SqlitePool>,
+	pool: Option<crate::database::DatabasePool>,
 	ready_tx: Option<oneshot::Sender<anyhow::Result<()>>>,
 }
 
@@ -187,13 +187,13 @@ impl LogStoreWorker {
 	fn new(
 		receiver: Receiver<LogStoreMsg>,
 		cfg: Config,
-		sqlite_pool: Option<sqlx::SqlitePool>,
+		pool: Option<crate::database::DatabasePool>,
 		ready_tx: oneshot::Sender<anyhow::Result<()>>,
 	) -> Self {
 		Self {
 			receiver,
 			cfg,
-			sqlite_pool,
+			pool,
 			ready_tx: Some(ready_tx),
 		}
 	}
@@ -235,7 +235,7 @@ impl LogStoreWorker {
 				return;
 			},
 		};
-		let backend = match Backend::connect(&self.cfg, self.sqlite_pool.take()).await {
+		let backend = match Backend::connect(&self.cfg, self.pool.take()).await {
 			Ok(backend) => backend,
 			Err(err) => {
 				self.notify_ready(Err(err));
@@ -680,20 +680,21 @@ enum Backend {
 }
 
 impl Backend {
-	async fn connect(cfg: &Config, sqlite_pool: Option<sqlx::SqlitePool>) -> anyhow::Result<Self> {
-		if cfg.url.starts_with("postgres://") || cfg.url.starts_with("postgresql://") {
-			if sqlite_pool.is_some() {
-				anyhow::bail!("cannot use a SQLite pool with request log Postgres database URL");
-			}
-			Ok(Self::Postgres(
-				postgres::PostgresLogStore::connect(&cfg.url).await?,
-			))
-		} else if let Some(pool) = sqlite_pool {
-			Ok(Self::Sqlite(sqlite::SqliteLogStore::from_pool(pool).await?))
-		} else {
-			Ok(Self::Sqlite(
-				sqlite::SqliteLogStore::connect(&cfg.url).await?,
-			))
+	async fn connect(
+		cfg: &Config,
+		pool: Option<crate::database::DatabasePool>,
+	) -> anyhow::Result<Self> {
+		let pool = match pool {
+			Some(pool) => pool,
+			None => crate::database::DatabasePool::connect(&cfg.url).await?,
+		};
+		match pool {
+			crate::database::DatabasePool::Sqlite(pool) => {
+				Ok(Self::Sqlite(sqlite::SqliteLogStore::from_pool(pool).await?))
+			},
+			crate::database::DatabasePool::Postgres(pool) => Ok(Self::Postgres(
+				postgres::PostgresLogStore::from_pool(pool).await?,
+			)),
 		}
 	}
 

--- a/crates/agentgateway/src/telemetry/log_store.rs
+++ b/crates/agentgateway/src/telemetry/log_store.rs
@@ -54,9 +54,16 @@ impl RequestLogStore {
 }
 
 pub async fn setup(cfg: &Config) -> anyhow::Result<RequestLogStoreGuard> {
+	setup_with_sqlite_pool(cfg, None).await
+}
+
+pub async fn setup_with_sqlite_pool(
+	cfg: &Config,
+	sqlite_pool: Option<sqlx::SqlitePool>,
+) -> anyhow::Result<RequestLogStoreGuard> {
 	let (tx, rx) = crossbeam::channel::unbounded();
 	let (ready_tx, ready_rx) = oneshot::channel();
-	let writer = LogStoreWorker::new(rx, cfg.clone(), ready_tx)
+	let writer = LogStoreWorker::new(rx, cfg.clone(), sqlite_pool, ready_tx)
 		.worker_thread("request-log-db-writer".to_string())?;
 	ready_rx
 		.await
@@ -172,6 +179,7 @@ type QueryResponse<T> = oneshot::Sender<anyhow::Result<T>>;
 struct LogStoreWorker {
 	receiver: Receiver<LogStoreMsg>,
 	cfg: Config,
+	sqlite_pool: Option<sqlx::SqlitePool>,
 	ready_tx: Option<oneshot::Sender<anyhow::Result<()>>>,
 }
 
@@ -179,11 +187,13 @@ impl LogStoreWorker {
 	fn new(
 		receiver: Receiver<LogStoreMsg>,
 		cfg: Config,
+		sqlite_pool: Option<sqlx::SqlitePool>,
 		ready_tx: oneshot::Sender<anyhow::Result<()>>,
 	) -> Self {
 		Self {
 			receiver,
 			cfg,
+			sqlite_pool,
 			ready_tx: Some(ready_tx),
 		}
 	}
@@ -225,7 +235,7 @@ impl LogStoreWorker {
 				return;
 			},
 		};
-		let backend = match Backend::connect(&self.cfg).await {
+		let backend = match Backend::connect(&self.cfg, self.sqlite_pool.take()).await {
 			Ok(backend) => backend,
 			Err(err) => {
 				self.notify_ready(Err(err));
@@ -670,11 +680,16 @@ enum Backend {
 }
 
 impl Backend {
-	async fn connect(cfg: &Config) -> anyhow::Result<Self> {
+	async fn connect(cfg: &Config, sqlite_pool: Option<sqlx::SqlitePool>) -> anyhow::Result<Self> {
 		if cfg.url.starts_with("postgres://") || cfg.url.starts_with("postgresql://") {
+			if sqlite_pool.is_some() {
+				anyhow::bail!("cannot use a SQLite pool with request log Postgres database URL");
+			}
 			Ok(Self::Postgres(
 				postgres::PostgresLogStore::connect(&cfg.url).await?,
 			))
+		} else if let Some(pool) = sqlite_pool {
+			Ok(Self::Sqlite(sqlite::SqliteLogStore::from_pool(pool).await?))
 		} else {
 			Ok(Self::Sqlite(
 				sqlite::SqliteLogStore::connect(&cfg.url).await?,

--- a/crates/agentgateway/src/telemetry/log_store/postgres.rs
+++ b/crates/agentgateway/src/telemetry/log_store/postgres.rs
@@ -1,8 +1,6 @@
 use std::fmt::Display;
 
-use anyhow::Context;
 use serde_json::Value;
-use sqlx::postgres::PgPoolOptions;
 use sqlx::types::Json;
 use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 
@@ -21,12 +19,7 @@ pub struct PostgresLogStore {
 const ANALYTICS_FILTER_OPTION_LIMIT: i64 = 500;
 
 impl PostgresLogStore {
-	pub async fn connect(url: &str) -> anyhow::Result<Self> {
-		let pool = PgPoolOptions::new()
-			.max_connections(5)
-			.connect(url)
-			.await
-			.context("failed to connect request log postgres database")?;
+	pub async fn from_pool(pool: PgPool) -> anyhow::Result<Self> {
 		sqlx::raw_sql(SCHEMA).execute(&pool).await?;
 		Ok(Self { pool })
 	}

--- a/crates/agentgateway/src/telemetry/log_store/sqlite.rs
+++ b/crates/agentgateway/src/telemetry/log_store/sqlite.rs
@@ -1,8 +1,4 @@
-use std::time::Duration;
-
-use anyhow::Context;
 use serde_json::Value;
-use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sqlx::types::Json;
 use sqlx::{QueryBuilder, Row, Sqlite, SqlitePool, query_builder};
 
@@ -75,22 +71,6 @@ fn push_request_log_payload_row(
 }
 
 impl SqliteLogStore {
-	pub async fn connect(url: &str) -> anyhow::Result<Self> {
-		let options = url
-			.parse::<SqliteConnectOptions>()
-			.context("failed to parse request log sqlite database URL")?
-			.create_if_missing(true)
-			.journal_mode(SqliteJournalMode::Wal)
-			.synchronous(SqliteSynchronous::Normal)
-			.busy_timeout(Duration::from_secs(5));
-		let pool = SqlitePoolOptions::new()
-			.max_connections(5)
-			.connect_with(options)
-			.await
-			.context("failed to connect request log sqlite database")?;
-		Self::from_pool(pool).await
-	}
-
 	pub async fn from_pool(pool: SqlitePool) -> anyhow::Result<Self> {
 		sqlx::raw_sql(SCHEMA).execute(&pool).await?;
 		Ok(Self { pool })

--- a/crates/agentgateway/src/telemetry/log_store/sqlite.rs
+++ b/crates/agentgateway/src/telemetry/log_store/sqlite.rs
@@ -88,6 +88,10 @@ impl SqliteLogStore {
 			.connect_with(options)
 			.await
 			.context("failed to connect request log sqlite database")?;
+		Self::from_pool(pool).await
+	}
+
+	pub async fn from_pool(pool: SqlitePool) -> anyhow::Result<Self> {
 		sqlx::raw_sql(SCHEMA).execute(&pool).await?;
 		Ok(Self { pool })
 	}

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -734,6 +734,9 @@ impl LocalRateLimitPolicy {
 
 #[apply(schema_de!)]
 pub struct LocalLLMModels {
+	/// id is a stable identity for this model config entry. The name field remains the model match pattern.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	id: Option<String>,
 	/// name is the name of the model we are matching from a users request. If params.model is set, that
 	/// will be used in the request to the LLM provider. If not, the incoming model is used.
 	name: String,
@@ -3908,8 +3911,17 @@ impl LocalLLMModelRegistry {
 	}
 
 	fn validate_model_patterns(&self) -> anyhow::Result<()> {
+		let mut ids = HashSet::new();
 		for model in &self.models {
 			validate_llm_model_pattern(&model.name)?;
+			if let Some(id) = model.id.as_ref() {
+				if id.is_empty() {
+					bail!("llm.models model id cannot be empty");
+				}
+				if !ids.insert(id) {
+					bail!("llm.models contains duplicate model id: {id}");
+				}
+			}
 		}
 		Ok(())
 	}
@@ -4155,8 +4167,11 @@ async fn convert_llm_config(
 		model_config.apply_provider_defaults();
 		model_config.apply_base_url()?;
 		let model_name = strng::new(&model_config.name);
-		// Index is needed because the same name can be used with different match criteria
-		let backend_key = strng::format!("llm:model:{}:{idx}", model_config.name);
+		// Index is needed when the same model pattern without an ID has different match criteria.
+		let backend_key = match &model_config.id {
+			Some(id) => strng::format!("llm:model:{id}"),
+			None => strng::format!("llm:model:{}:{idx}", model_config.name),
+		};
 		let p = model_config.params.clone();
 		let model = p.model;
 		let llm_routes = llm_route_types(model_config.passthrough.as_ref());
@@ -4425,6 +4440,7 @@ async fn convert_llm_config(
 		});
 
 		router_models.push(llm::model_router::ModelRoute {
+			id: model_config.id.clone(),
 			name: model_config.name.clone(),
 			visibility: model_config.visibility,
 			header_matches: model_config

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -582,6 +582,66 @@ llm:
 }
 
 #[tokio::test]
+async fn test_llm_model_accepts_stable_id() {
+	normalize_test_config(
+		r#"
+llm:
+  models:
+  - id: 4f8572ff-20c4-49c1-b7c3-d1519ad1e860
+    name: ollama/*
+    provider: ollama
+"#,
+	)
+	.await
+	.expect("model id should be accepted");
+}
+
+#[tokio::test]
+async fn test_llm_model_rejects_duplicate_id() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - id: shared
+    name: ollama/*
+    provider: ollama
+  - id: shared
+    name: openai/*
+    provider: openAI
+"#,
+	)
+	.await
+	.expect_err("duplicate model id should fail");
+	assert!(
+		err
+			.to_string()
+			.contains("llm.models contains duplicate model id: shared"),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
+async fn test_llm_model_rejects_empty_id() {
+	let err = normalize_test_config(
+		r#"
+llm:
+  models:
+  - id: ""
+    name: ollama/*
+    provider: ollama
+"#,
+	)
+	.await
+	.expect_err("empty model id should fail");
+	assert!(
+		err
+			.to_string()
+			.contains("llm.models model id cannot be empty"),
+		"{err:?}"
+	);
+}
+
+#[tokio::test]
 async fn test_llm_weighted_virtual_model_allows_authorized_target() {
 	let normalized = normalize_test_config(
 		r#"

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -19,7 +19,8 @@ use tower_serve_static::ServeDir;
 
 use crate::cel::{self, ExecutorSerde};
 use crate::config_store::{
-	ConfigResourceKind, ConfigResourceStore, ConfigResourceUpsertRequest, ConfigResourcesResponse,
+	ConfigResourceError, ConfigResourceKind, ConfigResourceStore, ConfigResourceUpsertRequest,
+	ConfigResourcesResponse,
 };
 use crate::llm::cost::ModelCatalog;
 use crate::{Config, ConfigSource, ConfigStoreMode, yamlviajson};
@@ -325,8 +326,8 @@ async fn update_config_resource(
 		.parse::<ConfigResourceKind>()
 		.map_err(resource_api_error)?;
 	if kind != ConfigResourceKind::LlmApiKey {
-		return Err(resource_api_error(anyhow::anyhow!(
-			"item updates are only supported for llm.apiKey resources"
+		return Err(resource_api_error(ConfigResourceError::InvalidRequest(
+			"item updates are only supported for llm.apiKey resources".to_string(),
 		)));
 	}
 	let resources = store.list(None).await.map_err(resource_api_error)?;
@@ -334,9 +335,9 @@ async fn update_config_resource(
 		.iter()
 		.any(|resource| resource.kind == kind && resource.id == id)
 	{
-		return Err(resource_api_error(anyhow::anyhow!(
+		return Err(resource_api_error(ConfigResourceError::NotFound(format!(
 			"config resource not found: {kind}/{id}"
-		)));
+		))));
 	}
 	let prepared = vec![
 		crate::config_store::prepare_api_key_update(id, resource.value).map_err(resource_api_error)?,
@@ -364,9 +365,9 @@ async fn delete_config_resource(
 		.iter()
 		.any(|resource| resource.kind == kind && resource.id == id)
 	{
-		return Err(resource_api_error(anyhow::anyhow!(
+		return Err(resource_api_error(ConfigResourceError::NotFound(format!(
 			"config resource not found: {kind}/{id}"
-		)));
+		))));
 	}
 	let candidate = crate::config_store::apply_delete(resources, kind, &id);
 	validate_materialized_config(&app, &candidate).await?;
@@ -413,24 +414,14 @@ async fn validate_materialized_config(
 	Ok(())
 }
 
-fn resource_api_error(err: anyhow::Error) -> ErrorResponse {
+fn resource_api_error(err: impl Into<anyhow::Error>) -> ErrorResponse {
+	let err = err.into();
 	let message = err.to_string();
-	let status = if message.contains("unsupported config resource kind")
-		|| message.contains("config resource id cannot be empty")
-		|| message.contains("item updates are only supported")
-		|| message.contains("resources require value.")
-		|| message.contains("must be JSON objects")
-		|| message.contains("must not include value.metadata.id")
-	{
-		StatusCode::BAD_REQUEST
-	} else if message.contains("conflicts with file-owned resource")
-		|| message.contains("DB-backed API keys require")
-	{
-		StatusCode::CONFLICT
-	} else if message.contains("config resource not found") {
-		StatusCode::NOT_FOUND
-	} else {
-		StatusCode::INTERNAL_SERVER_ERROR
+	let status = match err.downcast_ref::<ConfigResourceError>() {
+		Some(ConfigResourceError::InvalidRequest(_)) => StatusCode::BAD_REQUEST,
+		Some(ConfigResourceError::Conflict(_)) => StatusCode::CONFLICT,
+		Some(ConfigResourceError::NotFound(_)) => StatusCode::NOT_FOUND,
+		None => StatusCode::INTERNAL_SERVER_ERROR,
 	};
 	ErrorResponse::Status(status, message)
 }

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use agent_core::version::BuildInfo;
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::http::{StatusCode, Uri};
 use axum::response::sse::Event;
 use axum::response::{IntoResponse, Redirect, Response, Sse};
-use axum::routing::{get, post};
+use axum::routing::{get, post, put};
 use axum::{Json, Router};
 use chrono::Utc;
 use include_dir::{Dir, include_dir};
@@ -18,8 +18,11 @@ use tower::ServiceExt;
 use tower_serve_static::ServeDir;
 
 use crate::cel::{self, ExecutorSerde};
+use crate::config_store::{
+	ConfigResourceKind, ConfigResourceStore, ConfigResourceUpsertRequest, ConfigResourcesResponse,
+};
 use crate::llm::cost::ModelCatalog;
-use crate::{Config, ConfigSource, yamlviajson};
+use crate::{Config, ConfigSource, ConfigStoreMode, yamlviajson};
 
 const BASE_COSTS_FILE: &str = "base-costs.json";
 const CONFIG_SCHEMA_HEADER: &str =
@@ -28,6 +31,7 @@ const CONFIG_SCHEMA_HEADER: &str =
 #[derive(Clone, Debug)]
 struct App {
 	state: Arc<Config>,
+	config_resource_store: Option<ConfigResourceStore>,
 	resource_manager: crate::resource_manager::ResourceManager,
 	model_catalog: Arc<ModelCatalog>,
 }
@@ -41,6 +45,19 @@ impl App {
 			.clone()
 			.ok_or(ErrorResponse::String("local config not setup".to_string()))
 	}
+
+	fn config_resource_store(&self) -> Result<ConfigResourceStore, ErrorResponse> {
+		if self.state.config_store.mode != ConfigStoreMode::Hybrid {
+			return Err(ErrorResponse::Status(
+				StatusCode::FORBIDDEN,
+				"config resource APIs require configStore.mode=hybrid".to_string(),
+			));
+		}
+		self
+			.config_resource_store
+			.clone()
+			.ok_or_else(|| ErrorResponse::String("config resource store was not initialized".to_string()))
+	}
 }
 
 lazy_static::lazy_static! {
@@ -50,6 +67,7 @@ lazy_static::lazy_static! {
 pub fn router(
 	cfg: Arc<Config>,
 	model_catalog: Arc<ModelCatalog>,
+	config_resource_store: Option<ConfigResourceStore>,
 	resource_manager: crate::resource_manager::ResourceManager,
 ) -> Router {
 	let ui_service = tower::service_fn(move |req| serve_ui_asset(req, &ASSETS_DIR));
@@ -57,6 +75,15 @@ pub fn router(
 		// Redirect to the UI
 		.route("/api/runtime", get(get_runtime))
 		.route("/api/config", get(get_config).post(write_config))
+		.route("/api/config/resources", get(list_config_resources))
+		.route(
+			"/api/config/resources/{kind}",
+			get(list_config_resources_by_kind).put(upsert_config_resources_by_kind),
+		)
+		.route(
+			"/api/config/resources/{kind}/{id}",
+			put(update_config_resource).delete(delete_config_resource),
+		)
 		// Legacy path
 		.route("/cel", axum::routing::post(handle_cel))
 		.route("/api/cel", axum::routing::post(handle_cel))
@@ -70,6 +97,7 @@ pub fn router(
 		.route("/", get(|| async { Redirect::permanent("/ui") }))
 		.with_state(App {
 			state: cfg.clone(),
+			config_resource_store,
 			resource_manager,
 			model_catalog,
 		})
@@ -96,6 +124,7 @@ struct RuntimeBuildInfo {
 #[serde(rename_all = "camelCase")]
 struct RuntimeUiInfo {
 	gateway_mode: GatewayRuntimeMode,
+	config_store_mode: ConfigStoreMode,
 }
 
 #[derive(Serialize)]
@@ -121,6 +150,7 @@ async fn get_runtime(State(app): State<App>) -> Json<RuntimeInfo> {
 			} else {
 				GatewayRuntimeMode::Standalone
 			},
+			config_store_mode: app.state.config_store.mode,
 		},
 	})
 }
@@ -159,6 +189,8 @@ fn request_with_path<B>(mut req: http::Request<B>, path: &str) -> http::Request<
 enum ErrorResponse {
 	#[error("{0}")]
 	String(String),
+	#[error("{1}")]
+	Status(StatusCode, String),
 	#[error("{0}")]
 	Anyhow(#[from] anyhow::Error),
 }
@@ -174,7 +206,11 @@ impl Serialize for ErrorResponse {
 
 impl IntoResponse for ErrorResponse {
 	fn into_response(self) -> Response {
-		(StatusCode::INTERNAL_SERVER_ERROR, Json(self)).into_response()
+		let status = match &self {
+			Self::Status(status, _) => *status,
+			Self::String(_) | Self::Anyhow(_) => StatusCode::INTERNAL_SERVER_ERROR,
+		};
+		(status, Json(self)).into_response()
 	}
 }
 
@@ -226,23 +262,238 @@ async fn write_config(
 	))
 }
 
-async fn refresh_base_costs(State(app): State<App>) -> Result<Json<Value>, ErrorResponse> {
-	let config_source = app.cfg()?;
-	let file_path = match &config_source {
-		ConfigSource::File(path) => path,
-		ConfigSource::Static(_) => {
-			return Err(ErrorResponse::String(
-				"Cannot refresh base costs for static config".to_string(),
-			));
-		},
+async fn list_config_resources(
+	State(app): State<App>,
+) -> Result<Json<ConfigResourcesResponse>, ErrorResponse> {
+	let store = app.config_resource_store()?;
+	let resources = store.list(None).await.map_err(resource_api_error)?;
+	Ok(Json(ConfigResourcesResponse { resources }))
+}
+
+async fn list_config_resources_by_kind(
+	State(app): State<App>,
+	Path(kind): Path<String>,
+) -> Result<Json<ConfigResourcesResponse>, ErrorResponse> {
+	let store = app.config_resource_store()?;
+	let kind = kind
+		.parse::<ConfigResourceKind>()
+		.map_err(resource_api_error)?;
+	let resources = store.list(Some(kind)).await.map_err(resource_api_error)?;
+	Ok(Json(ConfigResourcesResponse { resources }))
+}
+
+async fn upsert_config_resources_by_kind(
+	State(app): State<App>,
+	Path(kind): Path<String>,
+	Json(request): Json<ConfigResourceUpsertRequest>,
+) -> Result<Json<ConfigResourcesResponse>, ErrorResponse> {
+	let kind = kind
+		.parse::<ConfigResourceKind>()
+		.map_err(resource_api_error)?;
+	upsert_config_resources(&app, kind, request).await.map(Json)
+}
+
+async fn upsert_config_resources(
+	app: &App,
+	kind: ConfigResourceKind,
+	request: ConfigResourceUpsertRequest,
+) -> Result<ConfigResourcesResponse, ErrorResponse> {
+	let store = app.config_resource_store()?;
+	let prepared =
+		crate::config_store::prepare_resources(kind, request).map_err(resource_api_error)?;
+	let resources = store.list(None).await.map_err(resource_api_error)?;
+	let candidate =
+		crate::config_store::apply_prepared_upsert(resources, &prepared).map_err(resource_api_error)?;
+	validate_materialized_config(app, &candidate).await?;
+	let response = store
+		.upsert_prepared(prepared)
+		.await
+		.map_err(resource_api_error)?;
+	if kind == ConfigResourceKind::ModelCatalog {
+		reload_model_catalog(app, &candidate).await?;
+	}
+	Ok(response)
+}
+
+async fn update_config_resource(
+	State(app): State<App>,
+	Path((kind, id)): Path<(String, String)>,
+	Json(resource): Json<crate::config_store::ConfigResourceUpsert>,
+) -> Result<Json<ConfigResourcesResponse>, ErrorResponse> {
+	let store = app.config_resource_store()?;
+	let kind = kind
+		.parse::<ConfigResourceKind>()
+		.map_err(resource_api_error)?;
+	if kind != ConfigResourceKind::LlmApiKey {
+		return Err(resource_api_error(anyhow::anyhow!(
+			"item updates are only supported for llm.apiKey resources"
+		)));
+	}
+	let resources = store.list(None).await.map_err(resource_api_error)?;
+	if !resources
+		.iter()
+		.any(|resource| resource.kind == kind && resource.id == id)
+	{
+		return Err(resource_api_error(anyhow::anyhow!(
+			"config resource not found: {kind}/{id}"
+		)));
+	}
+	let prepared = vec![
+		crate::config_store::prepare_api_key_update(id, resource.value).map_err(resource_api_error)?,
+	];
+	let candidate =
+		crate::config_store::apply_prepared_upsert(resources, &prepared).map_err(resource_api_error)?;
+	validate_materialized_config(&app, &candidate).await?;
+	store
+		.upsert_prepared(prepared)
+		.await
+		.map(Json)
+		.map_err(resource_api_error)
+}
+
+async fn delete_config_resource(
+	State(app): State<App>,
+	Path((kind, id)): Path<(String, String)>,
+) -> Result<Json<Value>, ErrorResponse> {
+	let store = app.config_resource_store()?;
+	let kind = kind
+		.parse::<ConfigResourceKind>()
+		.map_err(resource_api_error)?;
+	let resources = store.list(None).await.map_err(resource_api_error)?;
+	if !resources
+		.iter()
+		.any(|resource| resource.kind == kind && resource.id == id)
+	{
+		return Err(resource_api_error(anyhow::anyhow!(
+			"config resource not found: {kind}/{id}"
+		)));
+	}
+	let candidate = crate::config_store::apply_delete(resources, kind, &id);
+	validate_materialized_config(&app, &candidate).await?;
+	store.delete(kind, &id).await.map_err(resource_api_error)?;
+	if kind == ConfigResourceKind::ModelCatalog {
+		reload_model_catalog(&app, &candidate).await?;
+	}
+	Ok(Json(
+		serde_json::json!({"status": "success", "message": "Configuration resource deleted successfully"}),
+	))
+}
+
+async fn reload_model_catalog(
+	app: &App,
+	resources: &[crate::config_store::ConfigResource],
+) -> Result<(), ErrorResponse> {
+	let mut sources =
+		crate::config_store::model_catalog_sources(resources).map_err(resource_api_error)?;
+	sources.extend(app.state.model_catalog.sources.clone());
+	app
+		.model_catalog
+		.replace_sources(sources)
+		.await
+		.map_err(resource_api_error)
+}
+
+async fn validate_materialized_config(
+	app: &App,
+	resources: &[crate::config_store::ConfigResource],
+) -> Result<(), ErrorResponse> {
+	let base = app.cfg()?.read_to_string().await?;
+	let config_content = crate::config_store::materialize_config(base.as_str(), resources)
+		.map_err(resource_api_error)?;
+	let resources =
+		crate::resource_manager::ResourceFetcher::cached_or_direct(app.resource_manager.clone());
+	crate::types::local::NormalizedLocalConfig::from(
+		&app.state,
+		&resources,
+		app.state.gateway(),
+		config_content.as_str(),
+	)
+	.await
+	.map_err(|err| ErrorResponse::Status(StatusCode::UNPROCESSABLE_ENTITY, err.to_string()))?;
+	Ok(())
+}
+
+fn resource_api_error(err: anyhow::Error) -> ErrorResponse {
+	let message = err.to_string();
+	let status = if message.contains("unsupported config resource kind")
+		|| message.contains("config resource id cannot be empty")
+		|| message.contains("item updates are only supported")
+		|| message.contains("resources require value.")
+		|| message.contains("must be JSON objects")
+		|| message.contains("must not include value.metadata.id")
+	{
+		StatusCode::BAD_REQUEST
+	} else if message.contains("conflicts with file-owned resource")
+		|| message.contains("DB-backed API keys require")
+	{
+		StatusCode::CONFLICT
+	} else if message.contains("config resource not found") {
+		StatusCode::NOT_FOUND
+	} else {
+		StatusCode::INTERNAL_SERVER_ERROR
 	};
-	let dir = file_path.parent().ok_or_else(|| {
-		ErrorResponse::String(format!(
-			"config file has no parent: {}",
-			file_path.display()
-		))
-	})?;
-	let base_costs_file = dir.join(BASE_COSTS_FILE);
+	ErrorResponse::Status(status, message)
+}
+
+async fn refresh_base_costs(State(app): State<App>) -> Result<Json<Value>, ErrorResponse> {
+	let configured_file = app.state.model_catalog.sources.iter().find_map(|source| {
+		if let crate::ModelCatalogSource::File { file } = source {
+			Some(file)
+		} else {
+			None
+		}
+	});
+	if configured_file.is_none() && app.state.config_store.mode == ConfigStoreMode::Hybrid {
+		let refreshed = crate::llm::cost::refresh::fetch_models_dev_base_catalog().await?;
+		let resources = app
+			.config_resource_store()?
+			.list(None)
+			.await
+			.map_err(resource_api_error)?;
+		let mut value = resources
+			.iter()
+			.find(|resource| resource.kind == ConfigResourceKind::ModelCatalog)
+			.map(|resource| resource.value.clone())
+			.unwrap_or_else(|| serde_json::json!({}));
+		let object = value.as_object_mut().ok_or_else(|| {
+			resource_api_error(anyhow::anyhow!("modelCatalog resource must be an object"))
+		})?;
+		object.insert(
+			"base".to_string(),
+			serde_json::to_value(&refreshed.catalog).map_err(|err| ErrorResponse::Anyhow(err.into()))?,
+		);
+		upsert_config_resources(
+			&app,
+			ConfigResourceKind::ModelCatalog,
+			ConfigResourceUpsertRequest {
+				resources: vec![crate::config_store::ConfigResourceUpsert { value }],
+			},
+		)
+		.await?;
+		return serde_json::to_value(refreshed)
+			.map(Json)
+			.map_err(|err| ErrorResponse::Anyhow(err.into()));
+	}
+	let base_costs_file = if let Some(file) = configured_file {
+		file.clone()
+	} else {
+		let config_source = app.cfg()?;
+		let file_path = match &config_source {
+			ConfigSource::File(path) => path,
+			ConfigSource::Static(_) => {
+				return Err(ErrorResponse::String(
+					"Cannot refresh base costs for static config".to_string(),
+				));
+			},
+		};
+		let dir = file_path.parent().ok_or_else(|| {
+			ErrorResponse::String(format!(
+				"config file has no parent: {}",
+				file_path.display()
+			))
+		})?;
+		dir.join(BASE_COSTS_FILE)
+	};
 
 	let refreshed = crate::llm::cost::refresh::refresh_models_dev_base_catalog(
 		&base_costs_file,
@@ -252,7 +503,9 @@ async fn refresh_base_costs(State(app): State<App>) -> Result<Json<Value>, Error
 
 	let mut response =
 		serde_json::to_value(refreshed).map_err(|e| ErrorResponse::Anyhow(e.into()))?;
-	if let Value::Object(fields) = &mut response {
+	if configured_file.is_none()
+		&& let Value::Object(fields) = &mut response
+	{
 		fields.insert(
 			"file".to_string(),
 			Value::String(base_costs_file.to_string_lossy().to_string()),

--- a/crates/agentgateway/tests/common/gateway.rs
+++ b/crates/agentgateway/tests/common/gateway.rs
@@ -72,10 +72,25 @@ impl AgentGateway {
 		let (port_tx, port_rx) = tokio::sync::oneshot::channel::<u16>();
 
 		let task = tokio::task::spawn(async move {
-			let config =
+			let config = Arc::new(
 				agentgateway::config::parse_config(js, Some(agentgateway::ConfigSource::File(config)))
-					.unwrap();
-			let app = agentgateway::app::run(Arc::new(config)).await.unwrap();
+					.unwrap(),
+			);
+			let config_resource_store =
+				if config.config_store.mode == agentgateway::ConfigStoreMode::Hybrid {
+					Some(
+						agentgateway::config_store::setup(
+							config.database.as_ref().expect("hybrid database config"),
+						)
+						.await
+						.unwrap(),
+					)
+				} else {
+					None
+				};
+			let app = agentgateway::app::run(config, config_resource_store)
+				.await
+				.unwrap();
 
 			// Report the actual bound port back to the test.
 			let addrs = app.bind_addresses();
@@ -102,7 +117,7 @@ impl AgentGateway {
 			.timer(TokioTimer::new())
 			.build_http();
 		Ok(Self {
-			_temp_dirs: Vec::new(),
+			_temp_dirs: temp_dirs,
 			port,
 			task,
 			client,
@@ -129,11 +144,20 @@ impl AgentGateway {
 	}
 
 	pub async fn send_request_json(&self, url: &str, body: serde_json::Value) -> Response {
+		self.send_request_json_method(Method::POST, url, body).await
+	}
+
+	pub async fn send_request_json_method(
+		&self,
+		method: Method,
+		url: &str,
+		body: serde_json::Value,
+	) -> Response {
 		let id = generate_id();
 		let mut url = Url::parse(url).unwrap();
 		url.set_port(Some(self.port)).unwrap();
 		let body = serde_json::to_vec_pretty(&body).unwrap();
-		let mut resp = RequestBuilder::new(Method::POST, url.as_str())
+		let mut resp = RequestBuilder::new(method, url.as_str())
 			.header("x-test-id", id.clone())
 			.header("Content-Type", "application/json")
 			.body(body)

--- a/crates/agentgateway/tests/tests/config_store.rs
+++ b/crates/agentgateway/tests/tests/config_store.rs
@@ -1,0 +1,136 @@
+use std::time::{Duration, Instant};
+
+use http::{Method, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::{Value, json};
+
+use crate::common::gateway::AgentGateway;
+
+#[tokio::test]
+async fn hybrid_resources_reload_and_survive_restart() -> anyhow::Result<()> {
+	let dir = tempfile::tempdir()?;
+	let database_url = format!("sqlite://{}", dir.path().join("config.db").display());
+	let config = hybrid_config(&database_url);
+
+	let gateway = AgentGateway::new(config.clone()).await?;
+	put_model(&gateway, "db-model").await?;
+	wait_for_models(&gateway, &["db-model"]).await?;
+	gateway.shutdown().await;
+
+	let gateway = AgentGateway::new(config).await?;
+	assert_resource(&gateway, "db-model").await?;
+	wait_for_models(&gateway, &["db-model"]).await?;
+
+	put_model(&gateway, "renamed-model").await?;
+	assert_resource(&gateway, "renamed-model").await?;
+	wait_for_models(&gateway, &["renamed-model"]).await?;
+
+	let response = gateway
+		.send_request(
+			Method::DELETE,
+			"http://localhost/api/config/resources/llm.model/model-e2e",
+		)
+		.await;
+	assert_eq!(response.status(), StatusCode::OK);
+	wait_for_models(&gateway, &[]).await?;
+
+	Ok(())
+}
+
+fn hybrid_config(database_url: &str) -> String {
+	format!(
+		r#"
+config:
+  database:
+    url: {database_url}
+  configStore:
+    mode: hybrid
+gateways:
+  default:
+    port: $PORT
+ui:
+  gateways: default
+llm:
+  gateways: default
+  models: []
+"#,
+	)
+}
+
+async fn put_model(gateway: &AgentGateway, name: &str) -> anyhow::Result<()> {
+	let response = gateway
+		.send_request_json_method(
+			Method::PUT,
+			"http://localhost/api/config/resources/llm.model",
+			json!({
+				"resources": [{
+					"value": {
+						"id": "model-e2e",
+						"name": name,
+						"provider": "ollama",
+						"params": {"model": "llama3"}
+					}
+				}]
+			}),
+		)
+		.await;
+	let status = response.status();
+	let body = response.into_body().collect().await?.to_bytes();
+	anyhow::ensure!(
+		status == StatusCode::OK,
+		"model upsert failed ({status}): {}",
+		String::from_utf8_lossy(&body)
+	);
+	Ok(())
+}
+
+async fn assert_resource(gateway: &AgentGateway, expected_name: &str) -> anyhow::Result<()> {
+	let response = gateway
+		.send_request(
+			Method::GET,
+			"http://localhost/api/config/resources/llm.model",
+		)
+		.await;
+	anyhow::ensure!(
+		response.status() == StatusCode::OK,
+		"resource list failed: {}",
+		response.status()
+	);
+	let body = response.into_body().collect().await?.to_bytes();
+	let value: Value = serde_json::from_slice(&body)?;
+	anyhow::ensure!(
+		value["resources"].as_array().is_some_and(|resources| {
+			resources.len() == 1
+				&& resources[0]["id"] == "model-e2e"
+				&& resources[0]["value"]["name"] == expected_name
+		}),
+		"persisted resource did not match model-e2e/{expected_name}: {value}"
+	);
+	Ok(())
+}
+
+async fn wait_for_models(gateway: &AgentGateway, expected: &[&str]) -> anyhow::Result<()> {
+	let deadline = Instant::now() + Duration::from_secs(5);
+	loop {
+		let response = gateway
+			.send_request(Method::GET, "http://localhost/v1/models")
+			.await;
+		if response.status() == StatusCode::OK {
+			let body = response.into_body().collect().await?.to_bytes();
+			let value: Value = serde_json::from_slice(&body)?;
+			let models = value["data"]
+				.as_array()
+				.into_iter()
+				.flatten()
+				.filter_map(|model| model["id"].as_str())
+				.collect::<Vec<_>>();
+			if models == expected {
+				return Ok(());
+			}
+		}
+		if Instant::now() >= deadline {
+			anyhow::bail!("timed out waiting for models {expected:?}");
+		}
+		tokio::time::sleep(Duration::from_millis(50)).await;
+	}
+}

--- a/crates/agentgateway/tests/tests/mod.rs
+++ b/crates/agentgateway/tests/tests/mod.rs
@@ -1,6 +1,8 @@
 mod auth;
 mod auto_protocol;
 mod basic;
+#[cfg(feature = "ui")]
+mod config_store;
 mod connect;
 mod cors;
 mod dfp;

--- a/schema/config.json
+++ b/schema/config.json
@@ -171,6 +171,17 @@
             }
           ]
         },
+        "configStore": {
+          "description": "Controls whether UI-managed configuration is written to the config file or a DB overlay.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RawConfigStoreConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "caAddress": {
           "description": "Address of the Certificate Authority used to issue SPIFFE certificates.",
           "type": [
@@ -660,6 +671,30 @@
       "additionalProperties": false,
       "required": [
         "url"
+      ]
+    },
+    "RawConfigStoreConfig": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "$ref": "#/$defs/ConfigStoreMode",
+          "default": "file"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ConfigStoreMode": {
+      "oneOf": [
+        {
+          "description": "Store all UI-managed configuration in the local config file.",
+          "type": "string",
+          "const": "file"
+        },
+        {
+          "description": "Read a file baseline and store UI-managed overlay resources in the configured database.",
+          "type": "string",
+          "const": "hybrid"
+        }
       ]
     },
     "RawStandardAttributes": {
@@ -10536,6 +10571,13 @@
     "LocalLLMModels": {
       "type": "object",
       "properties": {
+        "id": {
+          "description": "id is a stable identity for this model config entry. The name field remains the model match pattern.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "name": {
           "description": "name is the name of the model we are matching from a users request. If params.model is set, that\nwill be used in the request to the LLM provider. If not, the incoming model is used.",
           "type": "string"

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -1,5 +1,6 @@
 export * from "./api/celApi";
 export * from "./api/configApi";
+export * from "./api/configResourcesApi";
 export * from "./api/configDumpApi";
 export * from "./api/costsApi";
 export * from "./api/logsApi";

--- a/ui/src/api/configResourcesApi.ts
+++ b/ui/src/api/configResourcesApi.ts
@@ -1,0 +1,92 @@
+import type {
+  LlmModel,
+  LlmProvider,
+  LlmVirtualModel,
+  VirtualApiKey,
+} from "../types";
+import { requestJson } from "./base";
+
+export type ConfigResourceKind =
+  | "modelCatalog"
+  | "llm.provider"
+  | "llm.model"
+  | "llm.virtualModel"
+  | "llm.apiKey";
+
+export type ConfigResourceValue<K extends ConfigResourceKind> =
+  K extends "modelCatalog"
+    ? { base?: unknown; custom?: unknown }
+    : K extends "llm.provider"
+      ? LlmProvider
+      : K extends "llm.model"
+        ? LlmModel
+        : K extends "llm.virtualModel"
+          ? LlmVirtualModel
+          : K extends "llm.apiKey"
+            ? VirtualApiKey
+            : unknown;
+
+export interface ConfigResource<
+  K extends ConfigResourceKind = ConfigResourceKind,
+> {
+  kind: K;
+  id: string;
+  value: ConfigResourceValue<K>;
+  revision: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ConfigResourcesResponse<
+  K extends ConfigResourceKind = ConfigResourceKind,
+> {
+  resources: ConfigResource<K>[];
+}
+
+export function listConfigResources() {
+  return requestJson<ConfigResourcesResponse>("/api/config/resources");
+}
+
+export function listConfigResourcesByKind<K extends ConfigResourceKind>(
+  kind: K,
+) {
+  return requestJson<ConfigResourcesResponse<K>>(
+    `/api/config/resources/${encodeURIComponent(kind)}`,
+  );
+}
+
+export function putConfigResources<K extends ConfigResourceKind>(
+  kind: K,
+  resources: ConfigResourceValue<K>[],
+) {
+  return requestJson<ConfigResourcesResponse<K>>(
+    `/api/config/resources/${encodeURIComponent(kind)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        resources: resources.map((value) => ({ value })),
+      }),
+    },
+  );
+}
+
+export function updateConfigResource<K extends ConfigResourceKind>(
+  kind: K,
+  id: string,
+  value: ConfigResourceValue<K>,
+) {
+  return requestJson<ConfigResourcesResponse<K>>(
+    `/api/config/resources/${encodeURIComponent(kind)}/${encodeURIComponent(id)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({ value }),
+    },
+  );
+}
+
+export function deleteConfigResource(kind: ConfigResourceKind, id: string) {
+  return requestJson<{ status: string; message: string }>(
+    `/api/config/resources/${encodeURIComponent(kind)}/${encodeURIComponent(id)}`,
+    { method: "DELETE" },
+  );
+}

--- a/ui/src/api/costsApi.ts
+++ b/ui/src/api/costsApi.ts
@@ -1,7 +1,7 @@
 import { requestJson } from "./base";
 
 export interface RefreshBaseCostsResponse {
-  file: string;
+  file?: string;
   providers: number;
   models: number;
 }

--- a/ui/src/api/runtimeApi.ts
+++ b/ui/src/api/runtimeApi.ts
@@ -10,6 +10,7 @@ export interface RuntimeInfo {
   };
   ui: {
     gatewayMode: "standalone" | "xds";
+    configStoreMode: "file" | "hybrid";
   };
 }
 

--- a/ui/src/components/ConfigDiffDrawer.tsx
+++ b/ui/src/components/ConfigDiffDrawer.tsx
@@ -1,12 +1,64 @@
 import "../monacoWorkers";
 import { DiffEditor } from "@monaco-editor/react";
 import { FileText, Save } from "lucide-react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { configureConfigYamlMonaco } from "../configMonaco";
 import { cloneConfig } from "../config";
+import {
+  allowNextHybridFileWrite,
+  useHybridFileWriteOverrideKeys,
+  useRuntimeInfo,
+} from "../hooks";
 import { toYamlText } from "../policies/policyUtils";
 import type { GatewayConfig } from "../types";
-import { Drawer } from "./Primitives";
+import { Drawer, Tooltip } from "./Primitives";
+
+const hybridFileWriteMessage =
+  "File configuration is read-only in hybrid mode. Copy this diff and update the configuration file directly.";
+const hybridFileWriteOverrideMessage =
+  "Override active. Click to write this change to the configuration file.";
+
+export function ConfigSaveButton(props: {
+  children: ReactNode;
+  disabled?: boolean;
+  allowHybridWrite?: boolean;
+  hybridFileWriteMessage?: string;
+  onClick: () => void;
+}) {
+  const runtime = useRuntimeInfo();
+  const overrideKeysActive = useHybridFileWriteOverrideKeys();
+  const fileWriteDisabled =
+    runtime.data?.ui.configStoreMode === "hybrid" && !props.allowHybridWrite;
+  const button = (
+    <button
+      className={`button primary${fileWriteDisabled ? " hybrid-write-disabled" : ""}${fileWriteDisabled && overrideKeysActive ? " hybrid-write-override" : ""}`}
+      type="button"
+      disabled={props.disabled}
+      aria-disabled={fileWriteDisabled}
+      onClick={(event) => {
+        if (fileWriteDisabled) {
+          if (!event.ctrlKey || !event.shiftKey) return;
+          allowNextHybridFileWrite();
+        }
+        props.onClick();
+      }}
+    >
+      {props.children}
+    </button>
+  );
+  if (!fileWriteDisabled) return button;
+  return (
+    <Tooltip
+      content={
+        overrideKeysActive
+          ? hybridFileWriteOverrideMessage
+          : (props.hybridFileWriteMessage ?? hybridFileWriteMessage)
+      }
+    >
+      {button}
+    </Tooltip>
+  );
+}
 
 const configTopLevelOrder = [
   "config",
@@ -29,9 +81,20 @@ export function ConfigDiffDrawer(props: {
   original: string;
   modified: string;
   saving?: boolean;
+  allowHybridWrite?: boolean;
   onClose: () => void;
   onSave?: () => void;
 }) {
+  const saveButton = props.onSave ? (
+    <ConfigSaveButton
+      disabled={props.saving}
+      allowHybridWrite={props.allowHybridWrite}
+      onClick={props.onSave}
+    >
+      <Save size={16} />
+      Save
+    </ConfigSaveButton>
+  ) : null;
   return (
     <Drawer
       title={props.title}
@@ -42,17 +105,7 @@ export function ConfigDiffDrawer(props: {
           <button className="button" type="button" onClick={props.onClose}>
             Close
           </button>
-          {props.onSave ? (
-            <button
-              className="button primary"
-              type="button"
-              disabled={props.saving}
-              onClick={props.onSave}
-            >
-              <Save size={16} />
-              Save
-            </button>
-          ) : null}
+          {saveButton}
         </div>
       }
     >
@@ -62,6 +115,10 @@ export function ConfigDiffDrawer(props: {
           language="yaml"
           original={props.original}
           modified={props.modified}
+          originalModelPath={`inmemory://config-diff/${encodeURIComponent(props.title)}/original.yaml`}
+          modifiedModelPath={`inmemory://config-diff/${encodeURIComponent(props.title)}/modified.yaml`}
+          keepCurrentOriginalModel
+          keepCurrentModifiedModel
           theme={
             document.documentElement.dataset.theme === "dark"
               ? "vs-dark"
@@ -95,6 +152,7 @@ export function ConfigDiffDrawer(props: {
 
 export function ConfigDiffSaveActions(props: {
   config?: GatewayConfig | null;
+  resourceDiff?: { original: unknown; modified: unknown };
   diffTitle: string;
   saveLabel: string;
   saving?: boolean;
@@ -111,8 +169,21 @@ export function ConfigDiffSaveActions(props: {
   } | null>(null);
 
   function viewDiff() {
-    if (!props.config || props.diffDisabled || props.saveDisabled) return;
+    if (
+      (!props.config && !props.resourceDiff) ||
+      props.diffDisabled ||
+      props.saveDisabled
+    )
+      return;
     if (props.beforeDiff && !props.beforeDiff()) return;
+    if (props.resourceDiff) {
+      setDiff({
+        original: toYamlText(props.resourceDiff.original),
+        modified: toYamlText(props.resourceDiff.modified),
+      });
+      return;
+    }
+    if (!props.config) return;
     const modified = cloneConfig(props.config);
     props.applyDiff(modified);
     setDiff(configDiffText(props.config, modified));
@@ -131,7 +202,7 @@ export function ConfigDiffSaveActions(props: {
           type="button"
           disabled={
             props.saving ||
-            !props.config ||
+            (!props.config && !props.resourceDiff) ||
             props.diffDisabled ||
             props.saveDisabled
           }
@@ -140,15 +211,14 @@ export function ConfigDiffSaveActions(props: {
           <FileText size={16} />
           View diff
         </button>
-        <button
-          className="button primary"
-          type="button"
+        <ConfigSaveButton
           disabled={props.saving || props.saveDisabled}
+          allowHybridWrite={Boolean(props.resourceDiff)}
           onClick={props.onSave}
         >
           <Save size={16} />
           {props.saveLabel}
-        </button>
+        </ConfigSaveButton>
       </div>
       {diff ? (
         <ConfigDiffDrawer
@@ -156,8 +226,12 @@ export function ConfigDiffSaveActions(props: {
           original={diff.original}
           modified={diff.modified}
           saving={props.saving}
+          allowHybridWrite={Boolean(props.resourceDiff)}
           onClose={() => setDiff(null)}
-          onSave={props.onSave}
+          onSave={() => {
+            setDiff(null);
+            props.onSave();
+          }}
         />
       ) : null}
     </>

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -13,6 +13,10 @@ import type {
   ProviderName,
   VirtualApiKey,
 } from "./types";
+import type {
+  ConfigResource,
+  ConfigResourceKind,
+} from "./api/configResourcesApi";
 import { keyValue } from "./credentialDisplay";
 
 const promptLogKey = "gen_ai.prompt";
@@ -127,15 +131,6 @@ export function ensureLlm(config: GatewayConfig): LlmConfig {
     config.llm = { models: [] };
     ensureLlmFrontendDefaults(config);
   }
-  if (!Array.isArray(config.llm.models)) {
-    config.llm.models = [];
-  }
-  if (!Array.isArray(config.llm.providers)) {
-    config.llm.providers = [];
-  }
-  if (!Array.isArray(config.llm.virtualModels)) {
-    config.llm.virtualModels = [];
-  }
   return config.llm;
 }
 
@@ -204,11 +199,12 @@ export function usesUiGateways(config: GatewayConfig | undefined) {
 export function upsertModel(
   config: GatewayConfig,
   model: LlmModel,
-  previousName?: string,
+  previousId?: string,
 ) {
   const llm = ensureLlm(config);
+  llm.models ??= [];
   const index = llm.models.findIndex(
-    (item) => item.name === (previousName ?? model.name),
+    (item) => modelIdentity(item) === (previousId ?? modelIdentity(model)),
   );
   if (index >= 0) {
     llm.models[index] = model;
@@ -217,9 +213,15 @@ export function upsertModel(
   }
 }
 
-export function removeModel(config: GatewayConfig, name: string) {
-  const llm = ensureLlm(config);
-  llm.models = llm.models.filter((model) => model.name !== name);
+export function removeModel(config: GatewayConfig, id: string) {
+  if (!config.llm?.models) return;
+  config.llm.models = config.llm.models.filter(
+    (model) => modelIdentity(model) !== id,
+  );
+}
+
+export function modelIdentity(model: LlmModel): string {
+  return model.id || model.name;
 }
 
 export function upsertVirtualModel(
@@ -228,6 +230,7 @@ export function upsertVirtualModel(
   previousName?: string,
 ) {
   const llm = ensureLlm(config);
+  llm.virtualModels ??= [];
   const index =
     llm.virtualModels?.findIndex(
       (item) => item.name === (previousName ?? model.name),
@@ -240,8 +243,8 @@ export function upsertVirtualModel(
 }
 
 export function removeVirtualModel(config: GatewayConfig, name: string) {
-  const llm = ensureLlm(config);
-  llm.virtualModels = (llm.virtualModels ?? []).filter(
+  if (!config.llm?.virtualModels) return;
+  config.llm.virtualModels = config.llm.virtualModels.filter(
     (model) => model.name !== name,
   );
 }
@@ -252,6 +255,7 @@ export function upsertLlmProvider(
   previousName?: string,
 ) {
   const llm = ensureLlm(config);
+  llm.providers ??= [];
   const index =
     llm.providers?.findIndex(
       (item) => item.name === (previousName ?? provider.name),
@@ -264,10 +268,53 @@ export function upsertLlmProvider(
 }
 
 export function removeLlmProvider(config: GatewayConfig, name: string) {
-  const llm = ensureLlm(config);
-  llm.providers = (llm.providers ?? []).filter(
+  if (!config.llm?.providers) return;
+  config.llm.providers = config.llm.providers.filter(
     (provider) => provider.name !== name,
   );
+}
+
+export function llmProviderResources(
+  resources: ConfigResource<ConfigResourceKind>[] | undefined,
+): LlmProvider[] {
+  return llmResourceValues(resources, "llm.provider");
+}
+
+export function llmModelResources(
+  resources: ConfigResource<ConfigResourceKind>[] | undefined,
+): LlmModel[] {
+  return llmResourceValues(resources, "llm.model");
+}
+
+export function llmVirtualModelResources(
+  resources: ConfigResource<ConfigResourceKind>[] | undefined,
+): LlmVirtualModel[] {
+  return llmResourceValues(resources, "llm.virtualModel");
+}
+
+export function llmApiKeyResources(
+  resources: ConfigResource<ConfigResourceKind>[] | undefined,
+): VirtualApiKey[] {
+  return llmResourceValues(resources, "llm.apiKey");
+}
+
+export function isDatabaseConfigResource(
+  resources: ConfigResource<ConfigResourceKind>[] | undefined,
+  kind: ConfigResourceKind,
+  id: string,
+) {
+  return (resources ?? []).some(
+    (resource) => resource.kind === kind && resource.id === id,
+  );
+}
+
+function llmResourceValues<K extends ConfigResourceKind>(
+  resources: ConfigResource<ConfigResourceKind>[] | undefined,
+  kind: K,
+) {
+  return (resources ?? [])
+    .filter((resource) => resource.kind === kind)
+    .map((resource) => resource.value) as ConfigResource<K>["value"][];
 }
 
 type LlmPolicyWithGuardrails = NonNullable<LlmConfig["policies"]> & {
@@ -466,12 +513,22 @@ export function configWarnings(config: GatewayConfig): string[] {
   const models = config.llm?.models ?? [];
   const mcpTargets = config.mcp?.targets ?? [];
   const duplicateNames = models
+    .filter((model) => !model.id)
     .map((model) => model.name)
     .filter((name, index, names) => names.indexOf(name) !== index);
   if (duplicateNames.length > 0)
     warnings.push(
-      `Duplicate model names: ${Array.from(new Set(duplicateNames)).join(", ")}.`,
+      `Duplicate model names may be ambiguous: ${Array.from(new Set(duplicateNames)).join(", ")}.`,
     );
+  const duplicateIds = models
+    .map((model) => model.id)
+    .filter((id): id is string => Boolean(id))
+    .filter((id, index, ids) => ids.indexOf(id) !== index);
+  if (duplicateIds.length > 0) {
+    warnings.push(
+      `Duplicate model IDs: ${Array.from(new Set(duplicateIds)).join(", ")}.`,
+    );
+  }
   const apiPolicy = config.llm?.policies?.apiKey;
   if (apiPolicy?.mode && apiPolicy.mode !== "strict") {
     warnings.push(
@@ -533,4 +590,10 @@ export function makeEmptyMcpTarget(): McpTarget {
       path: "/mcp",
     },
   };
+}
+
+export function enableTrafficConfig(config: GatewayConfig) {
+  if (!("gateways" in config)) {
+    config.gateways = { public: { port: 8080 } };
+  }
 }

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -592,8 +592,8 @@ export function makeEmptyMcpTarget(): McpTarget {
   };
 }
 
-export function enableTrafficConfig(config: GatewayConfig) {
+export function enableTrafficConfig(config: GatewayConfig, port = 8080) {
   if (!("gateways" in config)) {
-    config.gateways = { public: { port: 8080 } };
+    config.gateways = { public: { port } };
   }
 }

--- a/ui/src/costs.ts
+++ b/ui/src/costs.ts
@@ -27,8 +27,9 @@ export async function refreshBaseCostsAndConfigure(updateConfig: {
   ) => Promise<unknown>;
 }) {
   const refreshed = await refreshBaseCosts();
-  await updateConfig.mutateAsync((next) =>
-    addBaseCostSource(next, refreshed.file),
-  );
+  if (refreshed.file) {
+    const file = refreshed.file;
+    await updateConfig.mutateAsync((next) => addBaseCostSource(next, file));
+  }
   return refreshed;
 }

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -1,11 +1,55 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getConfig, writeConfig } from "./api/configApi";
+import {
+  deleteConfigResource,
+  listConfigResources,
+  putConfigResources,
+  updateConfigResource,
+  type ConfigResourceKind,
+  type ConfigResourceValue,
+} from "./api/configResourcesApi";
 import { getConfigDump } from "./api/configDumpApi";
 import { getRuntimeInfo } from "./api/runtimeApi";
-import { cloneConfig } from "./config";
+import {
+  cloneConfig,
+  llmApiKeyResources,
+  llmModelResources,
+  llmProviderResources,
+  llmVirtualModelResources,
+} from "./config";
 import { validateGatewayConfig } from "./configValidation";
 import type { GatewayConfig } from "./types";
+
+let hybridFileWriteOverride = false;
+
+export function allowNextHybridFileWrite() {
+  hybridFileWriteOverride = true;
+}
+
+export function takeHybridFileWriteOverride() {
+  const active = hybridFileWriteOverride;
+  hybridFileWriteOverride = false;
+  return active;
+}
+
+export function useHybridFileWriteOverrideKeys() {
+  const [active, setActive] = useState(false);
+  useEffect(() => {
+    const update = (event: KeyboardEvent) =>
+      setActive(event.ctrlKey && event.shiftKey);
+    const clear = () => setActive(false);
+    window.addEventListener("keydown", update);
+    window.addEventListener("keyup", update);
+    window.addEventListener("blur", clear);
+    return () => {
+      window.removeEventListener("keydown", update);
+      window.removeEventListener("keyup", update);
+      window.removeEventListener("blur", clear);
+    };
+  }, []);
+  return active;
+}
 
 export function useGatewayConfig(options?: { enabled?: boolean }) {
   return useQuery({
@@ -14,6 +58,77 @@ export function useGatewayConfig(options?: { enabled?: boolean }) {
     enabled: options?.enabled ?? true,
     retry: false,
   });
+}
+
+export function useRuntimeInfo() {
+  return useQuery({
+    queryKey: ["runtime"],
+    queryFn: getRuntimeInfo,
+    retry: false,
+  });
+}
+
+export function useConfigResources(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ["configResources"],
+    queryFn: listConfigResources,
+    enabled: options?.enabled ?? true,
+    retry: false,
+  });
+}
+
+export function useLlmConfigData(options?: { enabled?: boolean }) {
+  const enabled = options?.enabled ?? true;
+  const config = useGatewayConfig({ enabled });
+  const runtime = useRuntimeInfo();
+  const hybrid = runtime.data?.ui.configStoreMode === "hybrid";
+  const configResources = useConfigResources({ enabled: enabled && hybrid });
+  const resources = configResources.data?.resources;
+  const models = useMemo(
+    () => [
+      ...(config.data?.llm?.models ?? []),
+      ...(hybrid ? llmModelResources(resources) : []),
+    ],
+    [config.data, hybrid, resources],
+  );
+  const virtualModels = useMemo(
+    () => [
+      ...(config.data?.llm?.virtualModels ?? []),
+      ...(hybrid ? llmVirtualModelResources(resources) : []),
+    ],
+    [config.data, hybrid, resources],
+  );
+  const providers = useMemo(
+    () => [
+      ...(config.data?.llm?.providers ?? []),
+      ...(hybrid ? llmProviderResources(resources) : []),
+    ],
+    [config.data, hybrid, resources],
+  );
+  const apiKeys = useMemo(
+    () => [
+      ...(config.data?.llm?.policies?.apiKey?.keys ?? []),
+      ...(hybrid ? llmApiKeyResources(resources) : []),
+    ],
+    [config.data, hybrid, resources],
+  );
+
+  return {
+    config,
+    runtime,
+    hybrid,
+    configResources,
+    resources,
+    models,
+    virtualModels,
+    providers,
+    apiKeys,
+    isLoading:
+      config.isLoading ||
+      runtime.isLoading ||
+      (hybrid && configResources.isLoading),
+    error: config.error ?? (hybrid ? configResources.error : null),
+  };
 }
 
 export function useConfigDumpMode() {
@@ -35,12 +150,30 @@ export function useConfigDumpMode() {
   });
 }
 
+function invalidateConfigViews(queryClient: ReturnType<typeof useQueryClient>) {
+  void queryClient.invalidateQueries({ queryKey: ["configResources"] });
+  void queryClient.invalidateQueries({ queryKey: ["config"] });
+  void queryClient.invalidateQueries({ queryKey: ["runtime"] });
+  void queryClient.invalidateQueries({ queryKey: ["config_dump"] });
+  void queryClient.invalidateQueries({ queryKey: ["config_dump_mode"] });
+}
+
 export function useUpdateConfig() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (
       updater: (config: GatewayConfig) => GatewayConfig | void,
     ) => {
+      const runtime =
+        queryClient.getQueryData<Awaited<ReturnType<typeof getRuntimeInfo>>>([
+          "runtime",
+        ]) ?? (await getRuntimeInfo());
+      const overrideHybridFileWrite = takeHybridFileWriteOverride();
+      if (runtime.ui.configStoreMode === "hybrid" && !overrideHybridFileWrite) {
+        throw new Error(
+          "File configuration is read-only in hybrid mode. Copy the diff and update the configuration file directly.",
+        );
+      }
       const current =
         queryClient.getQueryData<GatewayConfig>(["config"]) ??
         (await getConfig());
@@ -53,12 +186,65 @@ export function useUpdateConfig() {
     },
     onSuccess: (next) => {
       queryClient.setQueryData(["config"], next);
-      void queryClient.invalidateQueries({ queryKey: ["config"] });
-      void queryClient.invalidateQueries({ queryKey: ["runtime"] });
-      void queryClient.invalidateQueries({ queryKey: ["config_dump"] });
-      void queryClient.invalidateQueries({ queryKey: ["config_dump_mode"] });
+      invalidateConfigViews(queryClient);
     },
   });
+}
+
+export function useUpsertConfigResource() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: UpsertConfigResourceInput) => {
+      if (input.kind === "llm.apiKey" && input.previousId) {
+        await updateConfigResource(input.kind, input.previousId, input.value);
+        return;
+      }
+      await putConfigResources(input.kind, [input.value]);
+      if (input.kind === "llm.apiKey") return;
+      const id = configResourceId(input.kind, input.value);
+      if (input.previousId && input.previousId !== id) {
+        await deleteConfigResource(input.kind, input.previousId);
+      }
+    },
+    onSuccess: () => invalidateConfigViews(queryClient),
+  });
+}
+
+type UpsertConfigResourceInput = {
+  [K in ConfigResourceKind]: {
+    kind: K;
+    value: ConfigResourceValue<K>;
+    previousId?: string;
+  };
+}[ConfigResourceKind];
+
+export function useDeleteConfigResource() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { kind: ConfigResourceKind; id: string }) =>
+      deleteConfigResource(input.kind, input.id),
+    onSuccess: () => invalidateConfigViews(queryClient),
+  });
+}
+
+export function configResourceId<K extends ConfigResourceKind>(
+  kind: K,
+  value: ConfigResourceValue<K>,
+) {
+  if (
+    kind === "llm.provider" ||
+    kind === "llm.model" ||
+    kind === "llm.virtualModel"
+  ) {
+    const name =
+      (value as { id?: string; name?: string }).id ??
+      (value as { name?: string }).name;
+    if (name) return name;
+  }
+  if (kind === "modelCatalog") return "default";
+  const apiKeyId = (value as { metadata?: { id?: string } })?.metadata?.id;
+  if (apiKeyId) return apiKeyId;
+  throw new Error(`Cannot derive config resource id for ${kind}`);
 }
 
 export function useStoredStringState(key: string, defaultValue: string) {

--- a/ui/src/pages/ClientSetup.tsx
+++ b/ui/src/pages/ClientSetup.tsx
@@ -405,7 +405,7 @@ function clientRecipes(args: {
   const requiredApiKey = args.apiKey || "dummy_key";
   const continuation = "\\";
   const curlAuthorization = args.apiKey
-    ? `  -H "Authorization: Bearer ${args.apiKey}" ${continuation}\n`
+    ? `  -H ${JSON.stringify(`Authorization: Bearer ${args.apiKey}`)} ${continuation}\n`
     : "";
   const openCodeApiKey = args.apiKey
     ? `,
@@ -414,7 +414,7 @@ function clientRecipes(args: {
   const openCodeApiKeyExport = args.apiKey
     ? `
 
-export AGENTGATEWAY_API_KEY='${args.apiKey}'  # Alternatively, type /connect to enter your API key.`
+export AGENTGATEWAY_API_KEY=${JSON.stringify(args.apiKey)}  # Alternatively, type /connect to enter your API key.`
     : "";
   return [
     {
@@ -440,10 +440,10 @@ ${curlAuthorization}  -H "Content-Type: application/json" ${continuation}
         "Use the gateway URL and key with Claude-compatible model routes when configured.",
       icon: "claude",
       language: "bash",
-      code: `export ANTHROPIC_AUTH_TOKEN="${requiredApiKey}"
-export ANTHROPIC_BASE_URL="${base}"
+      code: `export ANTHROPIC_AUTH_TOKEN=${JSON.stringify(requiredApiKey)}
+export ANTHROPIC_BASE_URL=${JSON.stringify(base)}
 
-claude --model "${args.model}"`,
+claude --model ${JSON.stringify(args.model)}`,
     },
     {
       id: "claude-desktop",
@@ -482,7 +482,7 @@ API Key: ${requiredApiKey}`,
         "Use OpenAI-compatible environment variables when running Codex against the gateway.",
       icon: "codex",
       language: "bash",
-      code: `export OPENAI_API_KEY='${requiredApiKey}'
+      code: `export OPENAI_API_KEY=${JSON.stringify(requiredApiKey)}
 # If Codex has an existing login it can impact functionality. Better if it's logged out.
 # If you don't want to override your Codex configuration, you can set up a new dedicated configuration file.
 export CODEX_HOME=/tmp/codex-gateway-home && mkdir -p $CODEX_HOME # optional

--- a/ui/src/pages/ClientSetup.tsx
+++ b/ui/src/pages/ClientSetup.tsx
@@ -21,7 +21,7 @@ import { claudeSubscriptionWarning } from "../claudeSubscription";
 import { providerLabel } from "../config";
 import { hasKeyValue, keyLabel, maskKey } from "../credentialDisplay";
 import { llmGatewayOrigin } from "../gatewayUrls";
-import { useGatewayConfig } from "../hooks";
+import { useLlmConfigData } from "../hooks";
 import {
   isWildcardModelName,
   modelProviderLabel,
@@ -68,16 +68,16 @@ type RequestModelOption =
   | { kind: "virtual"; name: string; icon: ReactNode; searchText: string };
 
 export function ClientSetupPage() {
-  const config = useGatewayConfig();
-  const models = useMemo(() => config.data?.llm?.models ?? [], [config.data]);
-  const virtualModels = useMemo(
-    () => config.data?.llm?.virtualModels ?? [],
-    [config.data],
-  );
-  const providers = useMemo(
-    () => config.data?.llm?.providers ?? [],
-    [config.data],
-  );
+  const {
+    config,
+    hybrid,
+    configResources,
+    models,
+    virtualModels,
+    providers,
+    apiKeys,
+    isLoading: modelsLoading,
+  } = useLlmConfigData();
   const modelOptions = useMemo(
     () => [
       ...models.map((item) => ({
@@ -100,14 +100,7 @@ export function ClientSetupPage() {
     ],
     [models, providers, virtualModels],
   );
-  const virtualKeys = useMemo(
-    () => config.data?.llm?.policies?.apiKey?.keys ?? [],
-    [config.data],
-  );
-  const rawVirtualKeys = useMemo(
-    () => virtualKeys.filter(hasKeyValue),
-    [virtualKeys],
-  );
+  const rawVirtualKeys = useMemo(() => apiKeys.filter(hasKeyValue), [apiKeys]);
   const derivedBaseUrl = llmGatewayOrigin(config.data);
   const [baseUrl, setBaseUrl] = useState(derivedBaseUrl);
   const [baseUrlTouched, setBaseUrlTouched] = useState(false);
@@ -158,7 +151,7 @@ export function ClientSetupPage() {
   const recipes = clientRecipes({
     baseUrl: effectiveBaseUrl,
     model: requestModel || "model",
-    apiKey: apiKey || "agw_sk_...",
+    apiKey,
   });
   const activeRecipe =
     recipes.find((recipe) => recipe.id === selectedIntegration) ?? recipes[0];
@@ -169,12 +162,12 @@ export function ClientSetupPage() {
         title="Client Setup"
         description="Generate connection settings and snippets for OpenAI-compatible LLM clients."
       />
-      {config.isError ? (
+      {config.isError || (hybrid && configResources.isError) ? (
         <StatusBanner state="bad" title="Configuration API unavailable">
-          {config.error.message}
+          {config.error?.message ?? configResources.error?.message}
         </StatusBanner>
       ) : null}
-      {modelOptions.length === 0 && !config.isLoading ? (
+      {modelOptions.length === 0 && !modelsLoading ? (
         <StatusBanner state="warn" title="No models configured">
           Create an LLM model before wiring clients to the gateway.
         </StatusBanner>
@@ -292,9 +285,7 @@ export function ClientSetupPage() {
             </div>
             <div>
               <span>Auth</span>
-              <code>
-                Authorization: Bearer {apiKey ? maskKey(apiKey) : "..."}
-              </code>
+              <code>{apiKey ? `Bearer ${maskKey(apiKey)}` : "None"}</code>
             </div>
           </div>
         </Panel>
@@ -411,6 +402,20 @@ function clientRecipes(args: {
   const base = args.baseUrl.replace(/\/$/, "");
   const v1 = `${base}/v1`;
   const completions = `${v1}/chat/completions`;
+  const requiredApiKey = args.apiKey || "dummy_key";
+  const continuation = "\\";
+  const curlAuthorization = args.apiKey
+    ? `  -H "Authorization: Bearer ${args.apiKey}" ${continuation}\n`
+    : "";
+  const openCodeApiKey = args.apiKey
+    ? `,
+        "apiKey": "{env:AGENTGATEWAY_API_KEY}"`
+    : "";
+  const openCodeApiKeyExport = args.apiKey
+    ? `
+
+export AGENTGATEWAY_API_KEY='${args.apiKey}'  # Alternatively, type /connect to enter your API key.`
+    : "";
   return [
     {
       id: "curl",
@@ -419,9 +424,8 @@ function clientRecipes(args: {
         "Minimal raw HTTP request for debugging client connectivity.",
       icon: "curl",
       language: "bash",
-      code: `curl ${JSON.stringify(completions)} \\
-  -H "Authorization: Bearer ${args.apiKey}" \\
-  -H "Content-Type: application/json" \\
+      code: `curl ${JSON.stringify(completions)} ${continuation}
+${curlAuthorization}  -H "Content-Type: application/json" ${continuation}
   -d '{
     "model": "${args.model}",
     "messages": [
@@ -436,7 +440,7 @@ function clientRecipes(args: {
         "Use the gateway URL and key with Claude-compatible model routes when configured.",
       icon: "claude",
       language: "bash",
-      code: `export ANTHROPIC_AUTH_TOKEN="${args.apiKey}"
+      code: `export ANTHROPIC_AUTH_TOKEN="${requiredApiKey}"
 export ANTHROPIC_BASE_URL="${base}"
 
 claude --model "${args.model}"`,
@@ -469,7 +473,7 @@ claude --model "${args.model}"`,
       ],
       language: "text",
       code: `Gateway URL: ${base}
-API Key: ${args.apiKey}`,
+API Key: ${requiredApiKey}`,
     },
     {
       id: "codex",
@@ -478,7 +482,7 @@ API Key: ${args.apiKey}`,
         "Use OpenAI-compatible environment variables when running Codex against the gateway.",
       icon: "codex",
       language: "bash",
-      code: `export OPENAI_API_KEY='${args.apiKey}'
+      code: `export OPENAI_API_KEY='${requiredApiKey}'
 # If Codex has an existing login it can impact functionality. Better if it's logged out.
 # If you don't want to override your Codex configuration, you can set up a new dedicated configuration file.
 export CODEX_HOME=/tmp/codex-gateway-home && mkdir -p $CODEX_HOME # optional
@@ -514,8 +518,7 @@ cat > opencode.json <<'EOF'
       "npm": "@ai-sdk/openai-compatible",
       "name": "Agentgateway",
       "options": {
-        "baseURL": "${v1}",
-        "apiKey": "{env:AGENTGATEWAY_API_KEY}"
+        "baseURL": "${v1}"${openCodeApiKey}
       },
       "models": {
         "${args.model}": {
@@ -526,8 +529,7 @@ cat > opencode.json <<'EOF'
   }
 }
 EOF
-
-export AGENTGATEWAY_API_KEY='${args.apiKey}'  # Alternatively, type /connect to enter your API key.
+${openCodeApiKeyExport}
 opencode`,
     },
     {
@@ -551,7 +553,7 @@ opencode`,
       ],
       language: "text",
       code: `Override OpenAI Base URL: ${base}
-OpenAI API Key: ${args.apiKey}
+OpenAI API Key: ${requiredApiKey}
 Custom model: ${args.model}`,
     },
     {
@@ -608,7 +610,7 @@ Custom model: ${args.model}`,
       code: `import OpenAI from "openai";
 
 const client = new OpenAI({
-  apiKey: "${args.apiKey}",
+  apiKey: "${requiredApiKey}",
   baseURL: "${v1}",
 });
 
@@ -629,7 +631,7 @@ console.log(response.choices[0]?.message?.content);`,
       code: `from openai import OpenAI
 
 client = OpenAI(
-    api_key="${args.apiKey}",
+    api_key="${requiredApiKey}",
     base_url="${v1}",
 )
 

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -11,7 +11,14 @@ import {
   StatusBanner,
   formatNumber,
 } from "../components/Primitives";
-import { useGatewayConfig, useUpdateConfig } from "../hooks";
+import { ConfigSaveButton } from "../components/ConfigDiffDrawer";
+import {
+  takeHybridFileWriteOverride,
+  useLlmConfigData,
+  useUpdateConfig,
+  useUpsertConfigResource,
+} from "../hooks";
+import type { ConfigResource } from "../api/configResourcesApi";
 import type { GatewayConfig } from "../types";
 import { useEffect, useMemo, useState } from "react";
 
@@ -24,14 +31,46 @@ type CustomCostRow = {
   cacheWrite: string;
 };
 
+type DisplayCostSource = CostCatalogSource & {
+  storage: "Database" | "File";
+  label: string;
+};
+
 export function CostsPage() {
-  const config = useGatewayConfig();
+  const { config, hybrid, resources, configResources } = useLlmConfigData();
   const updateConfig = useUpdateConfig();
+  const upsertResource = useUpsertConfigResource();
   const [refreshing, setRefreshing] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const sources = configuredCostSources(config.data);
-  const customRows = useMemo(() => inlineCostRows(sources), [sources]);
+  const databaseCatalog = useMemo(
+    () => modelCatalogResource(resources),
+    [resources],
+  );
+  const sources = useMemo(
+    () => [
+      ...databaseCostSources(databaseCatalog),
+      ...configuredCostSources(config.data).map(fileCostSource),
+    ],
+    [config.data, databaseCatalog],
+  );
+  const baseFile = useMemo(
+    () =>
+      configuredCostSources(config.data).find((source) => source.file)?.file,
+    [config.data],
+  );
+  const customRows = useMemo(
+    () =>
+      inlineCostRows(
+        hybrid
+          ? databaseCatalog.custom === undefined
+            ? []
+            : [{ inline: databaseCatalog.custom }]
+          : sources,
+      ),
+    [databaseCatalog, hybrid, sources],
+  );
+  const saving = updateConfig.isPending || upsertResource.isPending;
   const [editingCustom, setEditingCustom] = useState(false);
   const [customDraft, setCustomDraft] = useState<CustomCostRow[]>(customRows);
   const [customError, setCustomError] = useState<string | null>(null);
@@ -41,11 +80,13 @@ export function CostsPage() {
   }, [customRows, editingCustom]);
 
   async function refreshCosts() {
+    if (hybrid && baseFile) takeHybridFileWriteOverride();
     setRefreshing(true);
     setError(null);
     setMessage(null);
     try {
       const refreshed = await refreshBaseCostsAndConfigure(updateConfig);
+      if (hybrid) await configResources.refetch();
       setMessage(
         `Base cost catalog refreshed: ${formatNumber(refreshed.models)} models from ${formatNumber(refreshed.providers)} providers.`,
       );
@@ -66,15 +107,15 @@ export function CostsPage() {
         title="LLM Costs"
         description="Manage model cost catalogs used for analytics and request cost attribution."
         actions={
-          <button
-            className="button primary"
-            type="button"
-            disabled={refreshing || updateConfig.isPending}
+          <ConfigSaveButton
+            disabled={refreshing || saving}
+            allowHybridWrite={!baseFile}
+            hybridFileWriteMessage={`Base costs are stored in ${baseFile}. File writes are disabled in hybrid mode.`}
             onClick={() => void refreshCosts()}
           >
             <RefreshCw size={16} />
             Refresh base costs
-          </button>
+          </ConfigSaveButton>
         }
       />
       {error ? (
@@ -88,8 +129,8 @@ export function CostsPage() {
           <div>
             <h3>Catalog sources</h3>
             <p>
-              Sources are merged in order. Later sources override earlier
-              entries.
+              Sources are merged in order. Database sources load first, and
+              later file sources override them.
             </p>
           </div>
         </div>
@@ -98,6 +139,7 @@ export function CostsPage() {
             <table className="data-table">
               <thead>
                 <tr>
+                  <th>Storage</th>
                   <th>Source</th>
                   <th>Type</th>
                 </tr>
@@ -106,7 +148,10 @@ export function CostsPage() {
                 {sources.map((source, index) => (
                   <tr key={index}>
                     <td>
-                      <code>{sourceLabel(source)}</code>
+                      <span className="badge">{source.storage}</span>
+                    </td>
+                    <td>
+                      <code>{source.label}</code>
                     </td>
                     <td>{sourceType(source)}</td>
                   </tr>
@@ -136,7 +181,7 @@ export function CostsPage() {
                 <button
                   className="button"
                   type="button"
-                  disabled={updateConfig.isPending}
+                  disabled={saving}
                   onClick={() => {
                     setCustomDraft(customRows);
                     setCustomError(null);
@@ -148,7 +193,7 @@ export function CostsPage() {
                 <button
                   className="button primary"
                   type="button"
-                  disabled={updateConfig.isPending}
+                  disabled={saving}
                   onClick={() => void saveCustomCosts()}
                 >
                   Save
@@ -345,9 +390,19 @@ export function CostsPage() {
       return;
     }
     try {
-      await updateConfig.mutateAsync((next) =>
-        setInlineCostRows(next, customDraft),
-      );
+      if (hybrid) {
+        await upsertResource.mutateAsync({
+          kind: "modelCatalog",
+          value: {
+            ...databaseCatalog,
+            custom: inlineCatalog(customDraft),
+          },
+        });
+      } else {
+        await updateConfig.mutateAsync((next) =>
+          setInlineCostRows(next, customDraft),
+        );
+      }
       setEditingCustom(false);
     } catch (err) {
       setCustomError(
@@ -355,6 +410,46 @@ export function CostsPage() {
       );
     }
   }
+}
+
+function modelCatalogResource(resources: ConfigResource[] | undefined): {
+  base?: unknown;
+  custom?: unknown;
+} {
+  const value = resources?.find(
+    (resource) => resource.kind === "modelCatalog",
+  )?.value;
+  return record(value) as { base?: unknown; custom?: unknown };
+}
+
+function databaseCostSources(catalog: {
+  base?: unknown;
+  custom?: unknown;
+}): DisplayCostSource[] {
+  const sources: DisplayCostSource[] = [];
+  if (catalog.base !== undefined) {
+    sources.push({
+      inline: catalog.base,
+      storage: "Database",
+      label: "Base catalog",
+    });
+  }
+  if (catalog.custom !== undefined) {
+    sources.push({
+      inline: catalog.custom,
+      storage: "Database",
+      label: "Custom overrides",
+    });
+  }
+  return sources;
+}
+
+function fileCostSource(source: CostCatalogSource): DisplayCostSource {
+  return {
+    ...source,
+    storage: "File",
+    label: sourceLabel(source),
+  };
 }
 
 function sourceType(source: CostCatalogSource) {

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -80,6 +80,7 @@ export function CostsPage() {
   }, [customRows, editingCustom]);
 
   async function refreshCosts() {
+    // ConfigSaveButton records file overrides for useUpdateConfig, but this endpoint writes the catalog directly.
     if (hybrid && baseFile) takeHybridFileWriteOverride();
     setRefreshing(true);
     setError(null);

--- a/ui/src/pages/GetStarted.tsx
+++ b/ui/src/pages/GetStarted.tsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from "@tanstack/react-router";
 import { Bot, Network, Server } from "lucide-react";
 import { useEffect, useState } from "react";
 import {
+  enableTrafficConfig,
   ensureLlmFrontendDefaults,
   startupLlmConfig,
   startupMcpConfig,
@@ -116,12 +117,8 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
               next,
               parsePort(port, defaultSurfacePort(props.surface)),
             );
-        } else if (!("gateways" in next)) {
-          next.gateways = {
-            default: {
-              port: parsePort(port, defaultSurfacePort(props.surface)),
-            },
-          };
+        } else {
+          enableTrafficConfig(next);
         }
       });
       void navigate({ to: surface.destination });
@@ -228,5 +225,6 @@ function parsePort(value: string, fallback: number) {
 
 function defaultSurfacePort(surface: SurfaceKind) {
   if (surface === "llm") return 4000;
+  if (surface === "traffic") return 8080;
   return 3000;
 }

--- a/ui/src/pages/GetStarted.tsx
+++ b/ui/src/pages/GetStarted.tsx
@@ -118,7 +118,10 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
               parsePort(port, defaultSurfacePort(props.surface)),
             );
         } else {
-          enableTrafficConfig(next);
+          enableTrafficConfig(
+            next,
+            parsePort(port, defaultSurfacePort(props.surface)),
+          );
         }
       });
       void navigate({ to: surface.destination });

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { Bot, Network, Server, Settings } from "lucide-react";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import {
+  enableTrafficConfig,
   configWarnings,
   ensureLlm,
   ensureLlmFrontendDefaults,
@@ -11,7 +12,7 @@ import {
   startupMcpConfig,
 } from "../config";
 import { refreshBaseCostsAndConfigure } from "../costs";
-import { useConfigDumpMode, useGatewayConfig, useUpdateConfig } from "../hooks";
+import { useConfigDumpMode, useLlmConfigData, useUpdateConfig } from "../hooks";
 import { PageHeader, StatusBanner } from "../components/Primitives";
 import { trafficStats } from "../traffic";
 import {
@@ -35,7 +36,7 @@ const uiAuthPolicyKeys = [
 export function HomePage() {
   const mode = useConfigDumpMode();
   const dumpMode = mode.data?.mode === "dump";
-  const config = useGatewayConfig({
+  const { config, models, virtualModels, providers } = useLlmConfigData({
     enabled: Boolean(mode.data && mode.data.mode !== "dump"),
   });
   const update = useUpdateConfig();
@@ -43,7 +44,12 @@ export function HomePage() {
   const [locallyEnabled, setLocallyEnabled] = useState<Set<StartupSurface>>(
     () => new Set(),
   );
-  const hasLlm = Boolean(config.data?.llm);
+  const hasLlm = Boolean(
+    config.data?.llm ||
+    models.length ||
+    virtualModels.length ||
+    providers.length,
+  );
   const hasMcp = Boolean(config.data?.mcp);
   const hasTraffic = Boolean(
     config.data &&
@@ -53,8 +59,6 @@ export function HomePage() {
       "tcpRoutes" in config.data),
   );
   const hasBinds = Boolean(config.data?.binds?.length);
-  const models = config.data?.llm?.models ?? [];
-  const virtualModels = config.data?.llm?.virtualModels ?? [];
   const mcpServers = config.data?.mcp?.targets ?? [];
   const warnings = config.data ? configWarnings(config.data) : [];
   const uiGatewayNeedsAuthWarning = uiExposedWithoutAuth(config.data);
@@ -91,7 +95,7 @@ export function HomePage() {
         } else if (surface === "mcp") {
           next.mcp = startupMcpConfig(next, 3000);
         } else {
-          next.gateways ??= { default: { port: 8080 } };
+          enableTrafficConfig(next);
         }
       });
       setLocallyEnabled((current) => new Set(current).add(surface));
@@ -278,7 +282,7 @@ export function HomePage() {
           overview={[
             `${models.length} ${models.length === 1 ? "model" : "models"}`,
             `${virtualModels.length} virtual ${virtualModels.length === 1 ? "model" : "models"}`,
-            `${config.data?.llm?.providers?.length ?? 0} shared ${config.data?.llm?.providers?.length === 1 ? "provider" : "providers"}`,
+            `${providers.length} shared ${providers.length === 1 ? "provider" : "providers"}`,
             surfaceEndpointLabel(
               config.data?.llm?.gateways,
               config.data?.llm?.port ?? 4000,

--- a/ui/src/pages/Keys.tsx
+++ b/ui/src/pages/Keys.tsx
@@ -21,7 +21,13 @@ import { ConfigDiffSaveActions } from "../components/ConfigDiffDrawer";
 import { EnumSelector } from "../components/EnumSelector";
 import { hasKeyValue, keyValue, maskKey } from "../credentialDisplay";
 import { useStickyQueryParam } from "../drawerRouteState";
-import { useGatewayConfig, useUpdateConfig } from "../hooks";
+import {
+  useDeleteConfigResource,
+  useLlmConfigData,
+  useUpdateConfig,
+  useUpsertConfigResource,
+} from "../hooks";
+import { isDatabaseConfigResource } from "../config";
 import {
   ConfirmDialog,
   Drawer,
@@ -45,14 +51,15 @@ import type { GatewayConfig, LlmApiKeyPolicy, VirtualApiKey } from "../types";
 import type { AuthorizationLocation } from "../gateway-config";
 
 export function KeysPage() {
-  const config = useGatewayConfig();
+  const { config, hybrid, resources, apiKeys: keys } = useLlmConfigData();
   const update = useUpdateConfig();
+  const upsertResource = useUpsertConfigResource();
+  const deleteResource = useDeleteConfigResource();
   const help = useSchemaHelp();
   const policy = useMemo(
     () => config.data?.llm?.policies?.apiKey,
     [config.data],
   );
-  const keys = policy?.keys ?? [];
   const [editing, setEditing] = useState<{
     previousKey?: string;
     key: VirtualApiKey;
@@ -63,12 +70,61 @@ export function KeysPage() {
   const linkedKey = linkedVirtualKey(keyDrawer, keys);
   const activeEditing =
     editing ??
-    (keyDrawer === "new"
+    (keyDrawer === "new" && policy
       ? { key: newVirtualKey() }
       : linkedKey
         ? { previousKey: keyValue(linkedKey), key: structuredClone(linkedKey) }
         : null);
   const advancedOpen = keyDrawer === "settings";
+  const saving =
+    update.isPending || upsertResource.isPending || deleteResource.isPending;
+  const saveError =
+    update.error?.message ??
+    upsertResource.error?.message ??
+    deleteResource.error?.message ??
+    null;
+
+  function databaseKeyId(key: VirtualApiKey) {
+    const id = keyId(key);
+    return hybrid && id && isDatabaseConfigResource(resources, "llm.apiKey", id)
+      ? id
+      : undefined;
+  }
+
+  function saveKey(key: VirtualApiKey, previousKey?: string) {
+    const previous = previousKey
+      ? keys.find((item) => keyValue(item) === previousKey)
+      : undefined;
+    const previousId = previous ? databaseKeyId(previous) : undefined;
+    if (hybrid && (!previous || previousId)) {
+      const value = structuredClone(key);
+      if (value.metadata && typeof value.metadata === "object") {
+        delete value.metadata.id;
+      }
+      upsertResource.mutate(
+        { kind: "llm.apiKey", value, previousId },
+        { onSuccess: closeKeyDrawer },
+      );
+      return;
+    }
+    update.mutate((next) => upsertVirtualKey(next, key, previousKey), {
+      onSuccess: closeKeyDrawer,
+    });
+  }
+
+  function removeKey(key: VirtualApiKey) {
+    const id = databaseKeyId(key);
+    if (id) {
+      deleteResource.mutate(
+        { kind: "llm.apiKey", id },
+        { onSuccess: () => setDeleteKey(null) },
+      );
+      return;
+    }
+    update.mutate((next) => removeVirtualKey(next, keyValue(key)), {
+      onSuccess: () => setDeleteKey(null),
+    });
+  }
 
   function openNewKey() {
     setEditing(null);
@@ -98,29 +154,42 @@ export function KeysPage() {
         description="Provision incoming credentials and metadata for callers."
         actions={
           <div className="button-row">
-            <button
-              className="button"
-              type="button"
-              onClick={() => setKeyDrawer("settings")}
-            >
-              <SlidersHorizontal size={16} />
-              Settings
-            </button>
-            <button
-              className="button primary"
-              type="button"
-              onClick={openNewKey}
-            >
-              <Plus size={16} />
-              New key
-            </button>
+            {policy ? (
+              <>
+                <button
+                  className="button"
+                  type="button"
+                  onClick={() => setKeyDrawer("settings")}
+                >
+                  <SlidersHorizontal size={16} />
+                  Settings
+                </button>
+                <button
+                  className="button primary"
+                  type="button"
+                  onClick={openNewKey}
+                >
+                  <Plus size={16} />
+                  New key
+                </button>
+              </>
+            ) : (
+              <button
+                className="button primary"
+                type="button"
+                onClick={() => setKeyDrawer("settings")}
+              >
+                <KeyRound size={16} />
+                Enable API key auth
+              </button>
+            )}
           </div>
         }
       />
 
-      {update.isError ? (
+      {saveError ? (
         <StatusBanner state="bad" title="Save failed">
-          {update.error.message}
+          {saveError}
         </StatusBanner>
       ) : null}
       {policy?.mode && policy.mode !== "strict" ? (
@@ -139,23 +208,36 @@ export function KeysPage() {
           <StatusBanner state="bad" title="Configuration API unavailable">
             {config.error.message}
           </StatusBanner>
+        ) : !policy ? (
+          <EmptyState
+            title="API key authentication is disabled"
+            description="Enable API key authentication before provisioning virtual keys."
+            action={
+              <button
+                className="button primary"
+                type="button"
+                onClick={() => setKeyDrawer("settings")}
+              >
+                <KeyRound size={16} />
+                Enable API key auth
+              </button>
+            }
+          />
         ) : keys.length === 0 ? (
           <EmptyState
             title="No virtual API keys"
             description="Create a key so callers can authenticate without exposing provider credentials."
             action={
               <div className="button-row">
-                {policy ? (
-                  <button
-                    className="button danger"
-                    type="button"
-                    disabled={update.isPending}
-                    onClick={() => setDisablePolicyOpen(true)}
-                  >
-                    <X size={16} />
-                    Disable API Key Policy
-                  </button>
-                ) : null}
+                <button
+                  className="button danger"
+                  type="button"
+                  disabled={update.isPending}
+                  onClick={() => setDisablePolicyOpen(true)}
+                >
+                  <X size={16} />
+                  Disable API Key Policy
+                </button>
                 <button
                   className="button primary"
                   type="button"
@@ -232,14 +314,15 @@ export function KeysPage() {
           previousKey={activeEditing.previousKey}
           help={help}
           existingKeys={keys}
-          saving={update.isPending}
-          saveError={update.isError ? update.error.message : null}
-          onCancel={closeKeyDrawer}
-          onSave={(key, previousKey) =>
-            update.mutate((next) => upsertVirtualKey(next, key, previousKey), {
-              onSuccess: closeKeyDrawer,
-            })
+          databaseBacked={
+            hybrid &&
+            (!activeEditing.previousKey ||
+              Boolean(databaseKeyId(activeEditing.key)))
           }
+          saving={saving}
+          saveError={saveError}
+          onCancel={closeKeyDrawer}
+          onSave={saveKey}
         />
       ) : null}
       {deleteKey ? (
@@ -247,13 +330,10 @@ export function KeysPage() {
           title="Delete virtual API key?"
           destructive
           confirmLabel="Delete key"
-          confirmDisabled={update.isPending}
+          confirmDisabled={saving}
           onCancel={() => setDeleteKey(null)}
           onConfirm={() => {
-            const value = keyValue(deleteKey);
-            update.mutate((next) => removeVirtualKey(next, value), {
-              onSuccess: () => setDeleteKey(null),
-            });
+            removeKey(deleteKey);
           }}
         >
           <p>
@@ -323,7 +403,10 @@ function AdvancedSettingsDrawer(props: {
   onSave: (policy: Partial<LlmApiKeyPolicy>) => void;
 }) {
   return (
-    <Drawer title="Settings" onClose={props.onClose}>
+    <Drawer
+      title={props.policy ? "Settings" : "Enable API key auth"}
+      onClose={props.onClose}
+    >
       <PolicyControls
         policy={props.policy}
         config={props.config}
@@ -379,12 +462,11 @@ function PolicyControls(props: {
         <EnumSelector
           ariaLabel="Validation mode"
           value={mode}
-          schema={props.help.node(["$defs", "Mode3"])}
-          labels={{
-            strict: "Strict",
-            optional: "Optional",
-            permissive: "Permissive",
-          }}
+          options={[
+            { value: "strict", label: "Strict" },
+            { value: "optional", label: "Optional" },
+            { value: "permissive", label: "Permissive" },
+          ]}
           onChange={(value) =>
             setMode(value as "strict" | "optional" | "permissive")
           }
@@ -419,8 +501,12 @@ function PolicyControls(props: {
       ) : null}
       <ConfigDiffSaveActions
         config={props.config}
-        diffTitle="API key policy config diff"
-        saveLabel="Save policy"
+        diffTitle={
+          props.policy
+            ? "API key policy config diff"
+            : "Enable API key authentication"
+        }
+        saveLabel={props.policy ? "Save policy" : "Enable API key auth"}
         saving={props.saving}
         onSave={() => props.onSave(patch)}
         applyDiff={(next) => {
@@ -527,6 +613,7 @@ function KeyEditor(props: {
   previousKey?: string;
   help: SchemaHelp;
   existingKeys: VirtualApiKey[];
+  databaseBacked: boolean;
   saving: boolean;
   saveError?: string | null;
   onCancel: () => void;
@@ -560,9 +647,7 @@ function KeyEditor(props: {
     ? duplicateKeyName(name, props.existingKeys)
     : false;
 
-  function nextVirtualKey() {
-    setSubmitted(true);
-    if (nameRequired) return null;
+  function virtualKey() {
     const metadataId =
       typeof initialMetadata.id === "string" && initialMetadata.id.trim()
         ? initialMetadata.id.trim()
@@ -584,6 +669,11 @@ function KeyEditor(props: {
       : { ...props.initial, metadata };
   }
 
+  function nextVirtualKey() {
+    setSubmitted(true);
+    return nameRequired ? null : virtualKey();
+  }
+
   function save() {
     const virtualKey = nextVirtualKey();
     if (!virtualKey) return;
@@ -599,7 +689,21 @@ function KeyEditor(props: {
       footer={(requestClose) => (
         <ConfigDiffSaveActions
           config={props.config}
-          diffTitle="Virtual API key config diff"
+          resourceDiff={
+            props.databaseBacked
+              ? {
+                  original: props.previousKey
+                    ? keyResourceForDisplay(props.initial)
+                    : {},
+                  modified: keyResourceForDisplay(virtualKey()),
+                }
+              : undefined
+          }
+          diffTitle={
+            props.databaseBacked
+              ? "Virtual API key resource diff"
+              : "Virtual API key config diff"
+          }
           saveLabel="Save key"
           saving={props.saving}
           saveDisabled={keyMode === "custom" && !key.trim()}
@@ -754,6 +858,14 @@ function keyId(key: VirtualApiKey) {
   return typeof metadata.id === "string" && metadata.id.trim()
     ? metadata.id.trim()
     : "";
+}
+
+function keyResourceForDisplay(key: VirtualApiKey) {
+  const value = structuredClone(key);
+  if (value.metadata && typeof value.metadata === "object") {
+    delete value.metadata.id;
+  }
+  return value;
 }
 
 function virtualKeyUrlRef(key: VirtualApiKey, index: number) {

--- a/ui/src/pages/Logs.tsx
+++ b/ui/src/pages/Logs.tsx
@@ -44,7 +44,7 @@ import {
   uiLogAttributeExpressions,
 } from "../config";
 import { queryParam, useStickyQueryParam } from "../drawerRouteState";
-import { useGatewayConfig, useUpdateConfig } from "../hooks";
+import { useLlmConfigData, useUpdateConfig } from "../hooks";
 import {
   Drawer,
   EmptyState,
@@ -87,11 +87,21 @@ import type {
 
 export function LogsPage() {
   const navigate = useNavigate({ from: "/llm/logs" });
-  const config = useGatewayConfig();
+  const {
+    config,
+    models: configuredModels,
+    virtualModels,
+    providers,
+  } = useLlmConfigData();
   const updateConfig = useUpdateConfig();
   const models = useMemo(
-    () => llmModelOptions(config.data?.llm),
-    [config.data],
+    () =>
+      llmModelOptions({
+        models: configuredModels,
+        virtualModels,
+        providers,
+      }),
+    [configuredModels, providers, virtualModels],
   );
   const promptLoggingEnabled = promptCompletionLoggingEnabled(config.data);
   const [settings, setSettings] = useStickyQueryParam("settings");

--- a/ui/src/pages/Models.tsx
+++ b/ui/src/pages/Models.tsx
@@ -14,8 +14,10 @@ import {
 } from "lucide-react";
 import {
   invalidProviderApiKey,
+  isDatabaseConfigResource,
   makeEmptyModel,
   makeEmptyVirtualModel,
+  modelIdentity,
   modelWarnings,
   providerDisplayName,
   providerLabel,
@@ -25,7 +27,12 @@ import {
   upsertModel,
   upsertVirtualModel,
 } from "../config";
-import { useGatewayConfig, useUpdateConfig } from "../hooks";
+import {
+  useDeleteConfigResource,
+  useLlmConfigData,
+  useUpdateConfig,
+  useUpsertConfigResource,
+} from "../hooks";
 import { MiniMonacoEditor } from "../components/MiniMonacoEditor";
 import { ConfigDiffSaveActions } from "../components/ConfigDiffDrawer";
 import { CatalogModelSelector } from "../components/CatalogModelSelector";
@@ -109,20 +116,21 @@ type ConditionalVirtualTarget = NonNullable<
 >["targets"][number];
 
 export function ModelsPage() {
-  const config = useGatewayConfig();
+  const {
+    config,
+    hybrid,
+    configResources,
+    resources,
+    models,
+    virtualModels,
+    providers,
+  } = useLlmConfigData();
   const update = useUpdateConfig();
+  const upsertResource = useUpsertConfigResource();
+  const deleteResource = useDeleteConfigResource();
   const help = useSchemaHelp();
-  const models = useMemo(() => config.data?.llm?.models ?? [], [config.data]);
-  const virtualModels = useMemo(
-    () => config.data?.llm?.virtualModels ?? [],
-    [config.data],
-  );
-  const providers = useMemo(
-    () => config.data?.llm?.providers ?? [],
-    [config.data],
-  );
   const [editing, setEditing] = useState<{
-    previousName?: string;
+    previousId?: string;
     model: LlmModel;
   } | null>(() => {
     const provider = providerFromUrl();
@@ -134,6 +142,7 @@ export function ModelsPage() {
   } | null>(null);
   const [deleting, setDeleting] = useState<{
     kind: "model" | "virtual model";
+    id: string;
     name: string;
   } | null>(null);
   const [modelHash, setModelHashState] = useState<ModelHash | null>(() =>
@@ -141,7 +150,9 @@ export function ModelsPage() {
   );
   const hashEditModel =
     modelHash?.kind === "edit"
-      ? (models.find((model) => model.name === modelHash.modelName) ?? null)
+      ? (models.find((model) => modelIdentity(model) === modelHash.modelId) ??
+        models.find((model) => model.name === modelHash.modelId) ??
+        null)
       : null;
   const activeEditing =
     editing ??
@@ -150,7 +161,7 @@ export function ModelsPage() {
       : null) ??
     (hashEditModel
       ? {
-          previousName: hashEditModel.name,
+          previousId: modelIdentity(hashEditModel),
           model: structuredClone(hashEditModel),
         }
       : null);
@@ -159,6 +170,26 @@ export function ModelsPage() {
     (modelHash?.kind === "add" && modelHash.type === "virtual"
       ? { model: makeEmptyVirtualModel() }
       : null);
+  const editingDatabaseModel = Boolean(
+    hybrid &&
+    activeEditing &&
+    (!activeEditing.previousId ||
+      isDatabaseConfigResource(
+        resources,
+        "llm.model",
+        activeEditing.previousId,
+      )),
+  );
+  const editingDatabaseVirtualModel = Boolean(
+    hybrid &&
+    activeVirtualEditing &&
+    (!activeVirtualEditing.previousName ||
+      isDatabaseConfigResource(
+        resources,
+        "llm.virtualModel",
+        activeVirtualEditing.previousName,
+      )),
+  );
   const modelRows = useMemo(
     () => [
       ...models.map((model) => ({ kind: "model" as const, model })),
@@ -170,6 +201,8 @@ export function ModelsPage() {
   useEffect(() => {
     function syncSelectedFromUrl() {
       update.reset();
+      upsertResource.reset();
+      deleteResource.reset();
       setEditing(null);
       setEditingVirtual(null);
       setModelHashState(modelHashFromUrl());
@@ -180,17 +213,27 @@ export function ModelsPage() {
       window.removeEventListener("hashchange", syncSelectedFromUrl);
       window.removeEventListener("popstate", syncSelectedFromUrl);
     };
-  }, [update]);
+  }, [deleteResource, update, upsertResource]);
+
+  const saving =
+    update.isPending || upsertResource.isPending || deleteResource.isPending;
+  const saveError =
+    update.error?.message ??
+    upsertResource.error?.message ??
+    deleteResource.error?.message ??
+    null;
+  const saved =
+    update.isSuccess || upsertResource.isSuccess || deleteResource.isSuccess;
 
   function openModelEditor(model: LlmModel) {
-    update.reset();
+    resetSaves();
     setEditing(null);
-    setModelHashState({ kind: "edit", modelName: model.name });
-    setModelHash({ kind: "edit", modelName: model.name }, "push");
+    setModelHashState({ kind: "edit", modelId: modelIdentity(model) });
+    setModelHash({ kind: "edit", modelId: modelIdentity(model) }, "push");
   }
 
   function openNewModel() {
-    update.reset();
+    resetSaves();
     clearModelSearch();
     setModelHashState(null);
     setEditing(null);
@@ -199,7 +242,7 @@ export function ModelsPage() {
   }
 
   function openNewVirtualModel() {
-    update.reset();
+    resetSaves();
     clearModelSearch();
     setEditingVirtual(null);
     setModelHashState({ kind: "add", type: "virtual" });
@@ -207,7 +250,7 @@ export function ModelsPage() {
   }
 
   function closeModelEditor() {
-    update.reset();
+    resetSaves();
     setEditing(null);
     clearModelSearch();
     if (
@@ -220,12 +263,82 @@ export function ModelsPage() {
   }
 
   function closeVirtualModelEditor() {
-    update.reset();
+    resetSaves();
     setEditingVirtual(null);
     if (modelHash?.kind === "add" && modelHash.type === "virtual") {
       setModelHashState(null);
       setModelHash(null, "replace");
     }
+  }
+
+  function resetSaves() {
+    update.reset();
+    upsertResource.reset();
+    deleteResource.reset();
+  }
+
+  function saveModel(model: LlmModel, previousId?: string) {
+    if (
+      hybrid &&
+      (!previousId ||
+        isDatabaseConfigResource(resources, "llm.model", previousId))
+    ) {
+      model.id ??= crypto.randomUUID();
+      upsertResource.mutate(
+        { kind: "llm.model", value: model, previousId },
+        { onSuccess: closeModelEditor },
+      );
+      return;
+    }
+    update.mutate((next) => upsertModel(next, model, previousId), {
+      onSuccess: closeModelEditor,
+    });
+  }
+
+  function deleteModel(id: string) {
+    if (hybrid && isDatabaseConfigResource(resources, "llm.model", id)) {
+      deleteResource.mutate(
+        { kind: "llm.model", id },
+        { onSuccess: () => setDeleting(null) },
+      );
+      return;
+    }
+    update.mutate((next) => removeModel(next, id), {
+      onSuccess: () => setDeleting(null),
+    });
+  }
+
+  function saveVirtualModel(model: LlmVirtualModel, previousName?: string) {
+    if (
+      hybrid &&
+      (!previousName ||
+        isDatabaseConfigResource(resources, "llm.virtualModel", previousName))
+    ) {
+      upsertResource.mutate(
+        { kind: "llm.virtualModel", value: model, previousId: previousName },
+        { onSuccess: closeVirtualModelEditor },
+      );
+      return;
+    }
+    update.mutate((next) => upsertVirtualModel(next, model, previousName), {
+      onSuccess: closeVirtualModelEditor,
+    });
+  }
+
+  function deleteVirtualModel(name: string) {
+    if (
+      hybrid &&
+      isDatabaseConfigResource(resources, "llm.virtualModel", name)
+    ) {
+      deleteResource.mutate(
+        { kind: "llm.virtualModel", id: name },
+        { onSuccess: () => setDeleting(null) },
+      );
+      return;
+    }
+    update.mutate((next) => removeVirtualModel(next, name), {
+      onSuccess: () => setDeleting(null),
+    });
   }
 
   return (
@@ -255,21 +368,19 @@ export function ModelsPage() {
         }
       />
 
-      {update.isError ? (
+      {saveError ? (
         <StatusBanner state="bad" title="Save failed">
-          {update.error.message}
+          {saveError}
         </StatusBanner>
       ) : null}
-      {update.isSuccess ? (
-        <StatusBanner state="ok" title="Configuration saved" />
-      ) : null}
+      {saved ? <StatusBanner state="ok" title="Configuration saved" /> : null}
 
       <Panel>
-        {config.isLoading ? (
+        {config.isLoading || (hybrid && configResources.isLoading) ? (
           <StatusBanner state="loading" title="Loading models" />
-        ) : config.isError ? (
+        ) : config.isError || (hybrid && configResources.isError) ? (
           <StatusBanner state="bad" title="Configuration API unavailable">
-            {config.error.message}
+            {config.error?.message ?? configResources.error?.message}
           </StatusBanner>
         ) : modelRows.length === 0 ? (
           <EmptyState
@@ -302,6 +413,7 @@ export function ModelsPage() {
               <thead>
                 <tr>
                   <th>Name</th>
+                  {hybrid ? <th>Source</th> : null}
                   <th>Provider</th>
                   <th>Outgoing model</th>
                   <th>Policy state</th>
@@ -315,6 +427,19 @@ export function ModelsPage() {
                     return (
                       <tr key={`virtual:${model.name}`}>
                         <td className="strong">{model.name}</td>
+                        {hybrid ? (
+                          <td>
+                            <span className="badge">
+                              {isDatabaseConfigResource(
+                                resources,
+                                "llm.virtualModel",
+                                model.name,
+                              )
+                                ? "Database"
+                                : "File"}
+                            </span>
+                          </td>
+                        ) : null}
                         <td>
                           <span className="badge">
                             <GitBranch size={14} /> Virtual
@@ -357,10 +482,11 @@ export function ModelsPage() {
                               className="icon-button danger"
                               aria-label="Delete model"
                               type="button"
-                              disabled={update.isPending}
+                              disabled={saving}
                               onClick={() =>
                                 setDeleting({
                                   kind: "virtual model",
+                                  id: model.name,
                                   name: model.name,
                                 })
                               }
@@ -375,8 +501,21 @@ export function ModelsPage() {
                   const model = row.model;
                   const warnings = modelWarnings(model);
                   return (
-                    <tr key={`model:${model.name}`}>
+                    <tr key={`model:${modelIdentity(model)}`}>
                       <td className="strong">{model.name}</td>
+                      {hybrid ? (
+                        <td>
+                          <span className="badge">
+                            {isDatabaseConfigResource(
+                              resources,
+                              "llm.model",
+                              modelIdentity(model),
+                            )
+                              ? "Database"
+                              : "File"}
+                          </span>
+                        </td>
+                      ) : null}
                       <td>
                         <ModelProviderBadge
                           model={model}
@@ -416,9 +555,13 @@ export function ModelsPage() {
                             className="icon-button danger"
                             aria-label="Delete model"
                             type="button"
-                            disabled={update.isPending}
+                            disabled={saving}
                             onClick={() =>
-                              setDeleting({ kind: "model", name: model.name })
+                              setDeleting({
+                                kind: "model",
+                                id: modelIdentity(model),
+                                name: model.name,
+                              })
                             }
                           >
                             <Trash2 size={16} />
@@ -436,20 +579,17 @@ export function ModelsPage() {
 
       {activeEditing ? (
         <ModelEditor
-          key={activeEditing.previousName ?? "new"}
-          previousName={activeEditing.previousName}
+          key={activeEditing.previousId ?? "new"}
+          previousId={activeEditing.previousId}
           initial={activeEditing.model}
           config={config.data}
+          databaseBacked={editingDatabaseModel}
           providers={providers}
           help={help}
-          saving={update.isPending}
-          saveError={update.isError ? update.error.message : null}
+          saving={saving}
+          saveError={saveError}
           onCancel={closeModelEditor}
-          onSave={(model, previousName) => {
-            update.mutate((next) => upsertModel(next, model, previousName), {
-              onSuccess: closeModelEditor,
-            });
-          }}
+          onSave={saveModel}
         />
       ) : null}
       {activeVirtualEditing ? (
@@ -458,20 +598,14 @@ export function ModelsPage() {
           previousName={activeVirtualEditing.previousName}
           initial={activeVirtualEditing.model}
           config={config.data}
+          databaseBacked={editingDatabaseVirtualModel}
           baseModels={models}
           providers={providers}
           help={help}
-          saving={update.isPending}
-          saveError={update.isError ? update.error.message : null}
+          saving={saving}
+          saveError={saveError}
           onCancel={closeVirtualModelEditor}
-          onSave={(model, previousName) =>
-            update.mutate(
-              (next) => upsertVirtualModel(next, model, previousName),
-              {
-                onSuccess: closeVirtualModelEditor,
-              },
-            )
-          }
+          onSave={saveVirtualModel}
         />
       ) : null}
       {deleting ? (
@@ -479,16 +613,12 @@ export function ModelsPage() {
           title={`Delete ${deleting.kind}?`}
           destructive
           confirmLabel={`Delete ${deleting.kind}`}
-          confirmDisabled={update.isPending}
+          confirmDisabled={saving}
           onCancel={() => setDeleting(null)}
           onConfirm={() =>
-            update.mutate(
-              (next) =>
-                deleting.kind === "virtual model"
-                  ? removeVirtualModel(next, deleting.name)
-                  : removeModel(next, deleting.name),
-              { onSuccess: () => setDeleting(null) },
-            )
+            deleting.kind === "virtual model"
+              ? deleteVirtualModel(deleting.id)
+              : deleteModel(deleting.id)
           }
         >
           <p>
@@ -503,13 +633,14 @@ export function ModelsPage() {
 function ModelEditor(props: {
   initial: LlmModel;
   config?: GatewayConfig;
+  databaseBacked: boolean;
   providers: LlmProvider[];
-  previousName?: string;
+  previousId?: string;
   help: SchemaHelp;
   saving: boolean;
   saveError?: string | null;
   onCancel: () => void;
-  onSave: (model: LlmModel, previousName?: string) => void;
+  onSave: (model: LlmModel, previousId?: string) => void;
 }) {
   const [model, setModel] = useState<LlmModel>(() => {
     if (props.initial.name || !props.initial.provider) return props.initial;
@@ -609,7 +740,7 @@ function ModelEditor(props: {
       return;
     }
     setPolicyError(null);
-    props.onSave(preview ?? model, props.previousName);
+    props.onSave(preview ?? model, props.previousId);
   }
 
   function validateBeforeDiff() {
@@ -626,14 +757,26 @@ function ModelEditor(props: {
 
   return (
     <Drawer
-      title={props.previousName ? "Edit model" : "Add model"}
+      title={props.previousId ? "Edit model" : "Add model"}
       onClose={props.onCancel}
       dirty={draft !== initialDraft}
       saving={props.saving}
       footer={(requestClose) => (
         <ConfigDiffSaveActions
           config={props.config}
-          diffTitle="Model config diff"
+          resourceDiff={
+            props.databaseBacked
+              ? {
+                  original: props.previousId
+                    ? modelConfigForDisplay(props.initial)
+                    : {},
+                  modified: modelConfigForDisplay(preview),
+                }
+              : undefined
+          }
+          diffTitle={
+            props.databaseBacked ? "Model resource diff" : "Model config diff"
+          }
           saveLabel="Save model"
           saving={props.saving}
           saveDisabled={!model.name.trim() || !preview?.provider}
@@ -641,7 +784,7 @@ function ModelEditor(props: {
           onSave={save}
           beforeDiff={validateBeforeDiff}
           applyDiff={(next) =>
-            upsertModel(next, preview ?? model, props.previousName)
+            upsertModel(next, preview ?? model, props.previousId)
           }
         />
       )}
@@ -716,7 +859,7 @@ function ModelEditor(props: {
               current.name === currentDefault;
             if (shouldUseDefault) setAutoModelMatch(true);
             if (
-              !props.previousName &&
+              !props.previousId &&
               shouldUseDefault &&
               stripPrefixCandidate(nextDefault)
             )
@@ -816,7 +959,7 @@ function ModelEditor(props: {
       {providerSelected ? (
         <details>
           <summary>Generated model config</summary>
-          <YamlBlock value={preview ?? {}} />
+          <YamlBlock value={modelConfigForDisplay(preview)} />
         </details>
       ) : null}
     </Drawer>
@@ -1173,6 +1316,7 @@ function modelPolicySummary(model: Partial<LlmModel>) {
 function VirtualModelEditor(props: {
   initial: LlmVirtualModel;
   config?: GatewayConfig;
+  databaseBacked: boolean;
   previousName?: string;
   baseModels: LlmModel[];
   providers: LlmProvider[];
@@ -1320,7 +1464,19 @@ function VirtualModelEditor(props: {
       footer={(requestClose) => (
         <ConfigDiffSaveActions
           config={props.config}
-          diffTitle="Virtual model config diff"
+          resourceDiff={
+            props.databaseBacked
+              ? {
+                  original: props.previousName ? props.initial : {},
+                  modified: preview ?? {},
+                }
+              : undefined
+          }
+          diffTitle={
+            props.databaseBacked
+              ? "Virtual model resource diff"
+              : "Virtual model config diff"
+          }
           saveLabel="Save virtual model"
           saving={props.saving}
           saveDisabled={saveDisabled}
@@ -1869,6 +2025,12 @@ function optionalMappingYamlText(
   value: Record<string, unknown> | null | undefined,
 ) {
   return value && Object.keys(value).length ? toYamlText(value) : "";
+}
+
+function modelConfigForDisplay(model: LlmModel | undefined) {
+  if (!model) return {};
+  const { id: _id, ...config } = model;
+  return config;
 }
 
 function initialUpstreamMode(model: LlmModel): UpstreamModelMode {

--- a/ui/src/pages/Playground.tsx
+++ b/ui/src/pages/Playground.tsx
@@ -19,7 +19,7 @@ import { applyPlaygroundCors, corsNeedsUpdate, currentOrigin } from "../cors";
 import { hasKeyValue, keyLabel } from "../credentialDisplay";
 import { llmPlaygroundEndpoint, mcpPlaygroundEndpoint } from "../gatewayUrls";
 import {
-  useGatewayConfig,
+  useLlmConfigData,
   useStoredStringState,
   useUpdateConfig,
 } from "../hooks";
@@ -97,8 +97,7 @@ type RunStep = {
 };
 
 type RequestModelOption =
-  | { kind: "model"; config: LlmModel }
-  | { kind: "virtual" };
+  { kind: "model"; config: LlmModel } | { kind: "virtual" };
 
 const storageKeys = {
   model: "playgroundModel",
@@ -115,17 +114,9 @@ const legacySecretStorageKeys = [
 ];
 
 export function PlaygroundPage() {
-  const config = useGatewayConfig();
+  const { config, models, virtualModels, providers, apiKeys } =
+    useLlmConfigData();
   const updateConfig = useUpdateConfig();
-  const models = useMemo(() => config.data?.llm?.models ?? [], [config.data]);
-  const virtualModels = useMemo(
-    () => config.data?.llm?.virtualModels ?? [],
-    [config.data],
-  );
-  const providers = useMemo(
-    () => config.data?.llm?.providers ?? [],
-    [config.data],
-  );
   const modelOptions = useMemo(
     () => [
       ...models.map((item) => ({
@@ -149,14 +140,7 @@ export function PlaygroundPage() {
     ],
     [models, providers, virtualModels],
   );
-  const virtualKeys = useMemo(
-    () => config.data?.llm?.policies?.apiKey?.keys ?? [],
-    [config.data],
-  );
-  const rawVirtualKeys = useMemo(
-    () => virtualKeys.filter(hasKeyValue),
-    [virtualKeys],
-  );
+  const rawVirtualKeys = useMemo(() => apiKeys.filter(hasKeyValue), [apiKeys]);
   const [storedModel, setStoredModel] = useStoredStringState(
     storageKeys.model,
     "",
@@ -1081,8 +1065,7 @@ function extractToolCalls(response: unknown): ToolCall[] {
   const choices = (response as { choices?: unknown }).choices;
   if (!Array.isArray(choices)) return [];
   const first = choices[0] as
-    | { message?: { tool_calls?: unknown } }
-    | undefined;
+    { message?: { tool_calls?: unknown } } | undefined;
   const calls = first?.message?.tool_calls;
   if (!Array.isArray(calls)) return [];
   return calls.filter((call): call is ToolCall =>

--- a/ui/src/pages/Playground.tsx
+++ b/ui/src/pages/Playground.tsx
@@ -97,7 +97,8 @@ type RunStep = {
 };
 
 type RequestModelOption =
-  { kind: "model"; config: LlmModel } | { kind: "virtual" };
+  | { kind: "model"; config: LlmModel }
+  | { kind: "virtual" };
 
 const storageKeys = {
   model: "playgroundModel",
@@ -1065,7 +1066,8 @@ function extractToolCalls(response: unknown): ToolCall[] {
   const choices = (response as { choices?: unknown }).choices;
   if (!Array.isArray(choices)) return [];
   const first = choices[0] as
-    { message?: { tool_calls?: unknown } } | undefined;
+    | { message?: { tool_calls?: unknown } }
+    | undefined;
   const calls = first?.message?.tool_calls;
   if (!Array.isArray(calls)) return [];
   return calls.filter((call): call is ToolCall =>

--- a/ui/src/pages/Providers.tsx
+++ b/ui/src/pages/Providers.tsx
@@ -1,8 +1,9 @@
 import { Link } from "@tanstack/react-router";
 import { Bot, Pencil, Plus, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import {
   invalidProviderApiKey,
+  isDatabaseConfigResource,
   makeEmptyLlmProvider,
   providerDisplayName,
   providerLabel,
@@ -23,7 +24,12 @@ import {
 } from "../components/Primitives";
 import { useStickyQueryParam } from "../drawerRouteState";
 import { ProviderIcon } from "../components/ProviderIcon";
-import { useGatewayConfig, useUpdateConfig } from "../hooks";
+import {
+  useDeleteConfigResource,
+  useLlmConfigData,
+  useUpdateConfig,
+  useUpsertConfigResource,
+} from "../hooks";
 import { cleanEmpty } from "../policies/policyUtils";
 import { useSchemaHelp, type SchemaHelp } from "../schemaHelp";
 import type {
@@ -35,14 +41,12 @@ import type {
 import { ProviderConfigEditor } from "./models/ProviderConfigEditor";
 
 export function ProvidersPage() {
-  const config = useGatewayConfig();
+  const { config, hybrid, configResources, resources, models, providers } =
+    useLlmConfigData();
   const update = useUpdateConfig();
+  const upsertResource = useUpsertConfigResource();
+  const deleteResource = useDeleteConfigResource();
   const help = useSchemaHelp();
-  const providers = useMemo(
-    () => config.data?.llm?.providers ?? [],
-    [config.data],
-  );
-  const models = useMemo(() => config.data?.llm?.models ?? [], [config.data]);
   const [editing, setEditing] = useState<{
     previousName?: string;
     provider: LlmProvider;
@@ -63,20 +67,79 @@ export function ProvidersPage() {
             provider: structuredClone(linkedProvider),
           }
         : null);
+  const editingDatabaseProvider = Boolean(
+    hybrid &&
+    activeEditing &&
+    (!activeEditing.previousName ||
+      isDatabaseConfigResource(
+        resources,
+        "llm.provider",
+        activeEditing.previousName,
+      )),
+  );
 
   function openNewProvider() {
+    resetSaves();
     setEditing(null);
     setProviderDrawer("new");
   }
 
   function openEditProvider(provider: LlmProvider) {
+    resetSaves();
     setEditing(null);
     setProviderDrawer(provider.name);
   }
 
   function closeProviderEditor() {
+    resetSaves();
     setEditing(null);
     setProviderDrawer(null, "replace");
+  }
+
+  const saving =
+    update.isPending || upsertResource.isPending || deleteResource.isPending;
+  const saveError =
+    update.error?.message ??
+    upsertResource.error?.message ??
+    deleteResource.error?.message ??
+    null;
+  const saved =
+    update.isSuccess || upsertResource.isSuccess || deleteResource.isSuccess;
+
+  function resetSaves() {
+    update.reset();
+    upsertResource.reset();
+    deleteResource.reset();
+  }
+
+  function saveProvider(provider: LlmProvider, previousName?: string) {
+    if (
+      hybrid &&
+      (!previousName ||
+        isDatabaseConfigResource(resources, "llm.provider", previousName))
+    ) {
+      upsertResource.mutate(
+        { kind: "llm.provider", value: provider, previousId: previousName },
+        { onSuccess: closeProviderEditor },
+      );
+      return;
+    }
+    update.mutate((next) => upsertLlmProvider(next, provider, previousName), {
+      onSuccess: closeProviderEditor,
+    });
+  }
+
+  function deleteProvider(name: string) {
+    if (hybrid && isDatabaseConfigResource(resources, "llm.provider", name)) {
+      deleteResource.mutate(
+        { kind: "llm.provider", id: name },
+        { onSuccess: () => setDeletingProvider(null) },
+      );
+      return;
+    }
+    update.mutate((next) => removeLlmProvider(next, name), {
+      onSuccess: () => setDeletingProvider(null),
+    });
   }
 
   return (
@@ -96,21 +159,19 @@ export function ProvidersPage() {
         }
       />
 
-      {update.isError ? (
+      {saveError ? (
         <StatusBanner state="bad" title="Save failed">
-          {update.error.message}
+          {saveError}
         </StatusBanner>
       ) : null}
-      {update.isSuccess ? (
-        <StatusBanner state="ok" title="Configuration saved" />
-      ) : null}
+      {saved ? <StatusBanner state="ok" title="Configuration saved" /> : null}
 
       <Panel>
-        {config.isLoading ? (
+        {config.isLoading || (hybrid && configResources.isLoading) ? (
           <StatusBanner state="loading" title="Loading providers" />
-        ) : config.isError ? (
+        ) : config.isError || (hybrid && configResources.isError) ? (
           <StatusBanner state="bad" title="Configuration API unavailable">
-            {config.error.message}
+            {config.error?.message ?? configResources.error?.message}
           </StatusBanner>
         ) : providers.length === 0 ? (
           <EmptyState
@@ -133,6 +194,7 @@ export function ProvidersPage() {
               <thead>
                 <tr>
                   <th>Name</th>
+                  {hybrid ? <th>Source</th> : null}
                   <th>Provider</th>
                   <th>Upstream model</th>
                   <th>Used by</th>
@@ -145,6 +207,19 @@ export function ProvidersPage() {
                   return (
                     <tr key={provider.name}>
                       <td className="strong">{provider.name}</td>
+                      {hybrid ? (
+                        <td>
+                          <span className="badge">
+                            {isDatabaseConfigResource(
+                              resources,
+                              "llm.provider",
+                              provider.name,
+                            )
+                              ? "Database"
+                              : "File"}
+                          </span>
+                        </td>
+                      ) : null}
                       <td>
                         <ProviderBadge
                           provider={
@@ -195,7 +270,7 @@ export function ProvidersPage() {
                             className="icon-button danger"
                             aria-label="Delete provider"
                             type="button"
-                            disabled={usage.length > 0 || update.isPending}
+                            disabled={usage.length > 0 || saving}
                             onClick={() => setDeletingProvider(provider.name)}
                           >
                             <Trash2 size={16} />
@@ -216,18 +291,12 @@ export function ProvidersPage() {
           key={activeEditing.previousName ?? "new"}
           initial={activeEditing.provider}
           config={config.data}
+          databaseBacked={editingDatabaseProvider}
           previousName={activeEditing.previousName}
           help={help}
-          saving={update.isPending}
+          saving={saving}
           onCancel={closeProviderEditor}
-          onSave={(provider, previousName) =>
-            update.mutate(
-              (next) => upsertLlmProvider(next, provider, previousName),
-              {
-                onSuccess: closeProviderEditor,
-              },
-            )
-          }
+          onSave={saveProvider}
         />
       ) : null}
       {deletingProvider ? (
@@ -235,13 +304,9 @@ export function ProvidersPage() {
           title="Delete provider?"
           destructive
           confirmLabel="Delete provider"
-          confirmDisabled={update.isPending}
+          confirmDisabled={saving}
           onCancel={() => setDeletingProvider(null)}
-          onConfirm={() =>
-            update.mutate((next) => removeLlmProvider(next, deletingProvider), {
-              onSuccess: () => setDeletingProvider(null),
-            })
-          }
+          onConfirm={() => deleteProvider(deletingProvider)}
         >
           <p>
             Delete <strong>{deletingProvider}</strong>? This cannot be undone.
@@ -255,6 +320,7 @@ export function ProvidersPage() {
 function ProviderEditor(props: {
   initial: LlmProvider;
   config?: GatewayConfig;
+  databaseBacked: boolean;
   previousName?: string;
   help: SchemaHelp;
   saving: boolean;
@@ -291,7 +357,19 @@ function ProviderEditor(props: {
       footer={(requestClose) => (
         <ConfigDiffSaveActions
           config={props.config}
-          diffTitle="Provider config diff"
+          resourceDiff={
+            props.databaseBacked
+              ? {
+                  original: props.previousName ? props.initial : {},
+                  modified: preview ?? {},
+                }
+              : undefined
+          }
+          diffTitle={
+            props.databaseBacked
+              ? "Provider resource diff"
+              : "Provider config diff"
+          }
           saveLabel="Save provider"
           saving={props.saving}
           saveDisabled={!provider.name.trim()}

--- a/ui/src/pages/RawConfig.tsx
+++ b/ui/src/pages/RawConfig.tsx
@@ -269,6 +269,11 @@ function DatabaseResourcesPanel(props: {
   const [deleting, setDeleting] = useState<ConfigResource | null>(null);
   const deleteResource = useDeleteConfigResource();
   const dangerousActionsVisible = useHybridFileWriteOverrideKeys();
+
+  useEffect(() => {
+    if (!dangerousActionsVisible && deleting) setDeleting(null);
+  }, [dangerousActionsVisible, deleting]);
+
   return (
     <>
       <Panel>
@@ -359,9 +364,10 @@ function DatabaseResourcesPanel(props: {
           title="Delete database resource?"
           destructive
           confirmLabel="Delete resource"
-          confirmDisabled={deleteResource.isPending}
+          confirmDisabled={deleteResource.isPending || !dangerousActionsVisible}
           onCancel={() => setDeleting(null)}
           onConfirm={() => {
+            if (!dangerousActionsVisible) return;
             const key = `${deleting.kind}:${deleting.id}`;
             deleteResource.mutate(
               { kind: deleting.kind, id: deleting.id },

--- a/ui/src/pages/RawConfig.tsx
+++ b/ui/src/pages/RawConfig.tsx
@@ -1,11 +1,46 @@
 import { useNavigate } from "@tanstack/react-router";
-import { Clipboard, Download, FileText, Save, RotateCcw } from "lucide-react";
-import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Clipboard,
+  Download,
+  FileText,
+  Save,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
+import {
+  Fragment,
+  lazy,
+  Suspense,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { validateGatewayConfig } from "../configValidation";
-import { ConfigDiffDrawer } from "../components/ConfigDiffDrawer";
-import { PageHeader, Panel, StatusBanner } from "../components/Primitives";
-import { useConfigDumpMode, useGatewayConfig, useUpdateConfig } from "../hooks";
+import {
+  ConfigDiffDrawer,
+  ConfigSaveButton,
+} from "../components/ConfigDiffDrawer";
+import {
+  ConfirmDialog,
+  PageHeader,
+  Panel,
+  JsonBlock,
+  StatusBanner,
+  Tooltip,
+} from "../components/Primitives";
+import {
+  useConfigDumpMode,
+  useDeleteConfigResource,
+  useGatewayConfig,
+  useHybridFileWriteOverrideKeys,
+  useConfigResources,
+  useRuntimeInfo,
+  useUpdateConfig,
+} from "../hooks";
 import { parseYamlText, toYamlText } from "../policies/policyUtils";
+import { maskKey } from "../credentialDisplay";
+import type { ConfigResource } from "../api/configResourcesApi";
 import type { GatewayConfig } from "../types";
 
 const LazyRawConfigEditor = lazy(() =>
@@ -35,6 +70,10 @@ export function RawConfigPage() {
 
 function RawConfigEditorPage() {
   const config = useGatewayConfig();
+  const runtime = useRuntimeInfo();
+  const hybrid = runtime.data?.ui.configStoreMode === "hybrid";
+  const resources = useConfigResources({ enabled: hybrid });
+  const [view, setView] = useState<"file" | "database">("file");
   const update = useUpdateConfig();
   const initialText = useMemo(
     () => (config.data ? toYamlText(config.data) : ""),
@@ -87,89 +126,127 @@ function RawConfigEditorPage() {
     <div className="page-stack">
       <PageHeader
         title="Raw Configuration"
-        description="Edit the full gateway YAML."
+        description={
+          view === "file"
+            ? "Edit the full gateway YAML."
+            : "Inspect configuration resources stored in the database."
+        }
         actions={
-          <div className="button-row">
-            <button
-              className="button"
-              type="button"
-              disabled={!text}
-              onClick={() => void copyConfig(text)}
-            >
-              <Clipboard size={16} />
-              Copy
-            </button>
-            <button
-              className="button"
-              type="button"
-              disabled={!text}
-              onClick={() => downloadConfig(text)}
-            >
-              <Download size={16} />
-              Download
-            </button>
-            <button
-              className="button"
-              type="button"
-              disabled={!dirty || update.isPending}
-              onClick={() => updateText(initialText)}
-            >
-              <RotateCcw size={16} />
-              Reset
-            </button>
-            <button
-              className="button"
-              type="button"
-              disabled={!dirty || update.isPending}
-              onClick={() => setDiffOpen(true)}
-            >
-              <FileText size={16} />
-              View diff
-            </button>
-            <button
-              className="button primary"
-              type="button"
-              disabled={!dirty || update.isPending}
-              onClick={() => void save()}
-            >
-              <Save size={16} />
-              Save
-            </button>
-          </div>
+          view === "file" ? (
+            <div className="button-row">
+              <button
+                className="button"
+                type="button"
+                disabled={!text}
+                onClick={() => void copyConfig(text)}
+              >
+                <Clipboard size={16} />
+                Copy
+              </button>
+              <button
+                className="button"
+                type="button"
+                disabled={!text}
+                onClick={() => downloadConfig(text)}
+              >
+                <Download size={16} />
+                Download
+              </button>
+              <button
+                className="button"
+                type="button"
+                disabled={!dirty || update.isPending}
+                onClick={() => updateText(initialText)}
+              >
+                <RotateCcw size={16} />
+                Reset
+              </button>
+              <button
+                className="button"
+                type="button"
+                disabled={!dirty || update.isPending}
+                onClick={() => setDiffOpen(true)}
+              >
+                <FileText size={16} />
+                View diff
+              </button>
+              <ConfigSaveButton
+                disabled={!dirty || update.isPending}
+                onClick={() => void save()}
+              >
+                <Save size={16} />
+                Save
+              </ConfigSaveButton>
+            </div>
+          ) : null
         }
       />
 
-      {config.isError ? (
+      {hybrid ? (
+        <div
+          className="segmented-control compact raw-config-view-tabs"
+          role="tablist"
+        >
+          <button
+            className={view === "file" ? "active" : ""}
+            type="button"
+            role="tab"
+            aria-selected={view === "file"}
+            onClick={() => setView("file")}
+          >
+            File
+          </button>
+          <button
+            className={view === "database" ? "active" : ""}
+            type="button"
+            role="tab"
+            aria-selected={view === "database"}
+            onClick={() => setView("database")}
+          >
+            Database
+          </button>
+        </div>
+      ) : null}
+
+      {view === "file" && config.isError ? (
         <StatusBanner state="bad" title="Configuration API unavailable">
           {config.error.message}
         </StatusBanner>
       ) : null}
-      {error ? (
+      {view === "file" && error ? (
         <StatusBanner state="bad" title="Save failed">
           {error}
         </StatusBanner>
       ) : null}
-      {showSaved ? (
+      {view === "file" && showSaved ? (
         <StatusBanner state="ok" title="Configuration saved" />
       ) : null}
 
-      <Panel>
-        <Suspense
-          fallback={
-            <div className="editor-wrap raw-config-editor loading-panel">
-              Loading editor...
-            </div>
-          }
-        >
-          <LazyRawConfigEditor
-            invalid={Boolean(error)}
-            value={text}
-            onChange={updateText}
-            onSave={() => void save()}
-          />
-        </Suspense>
-      </Panel>
-      {diffOpen ? (
+      {view === "file" ? (
+        <Panel>
+          <Suspense
+            fallback={
+              <div className="editor-wrap raw-config-editor loading-panel">
+                Loading editor...
+              </div>
+            }
+          >
+            <LazyRawConfigEditor
+              invalid={Boolean(error)}
+              value={text}
+              onChange={updateText}
+              onSave={() => void save()}
+            />
+          </Suspense>
+        </Panel>
+      ) : (
+        <DatabaseResourcesPanel
+          loading={resources.isLoading}
+          error={resources.error?.message}
+          resources={resources.data?.resources ?? []}
+        />
+      )}
+      {view === "file" && diffOpen ? (
         <ConfigDiffDrawer
           title="Raw configuration diff"
           original={initialText}
@@ -181,6 +258,138 @@ function RawConfigEditorPage() {
       ) : null}
     </div>
   );
+}
+
+function DatabaseResourcesPanel(props: {
+  loading: boolean;
+  error?: string;
+  resources: ConfigResource[];
+}) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState<ConfigResource | null>(null);
+  const deleteResource = useDeleteConfigResource();
+  const dangerousActionsVisible = useHybridFileWriteOverrideKeys();
+  return (
+    <>
+      <Panel>
+        {deleteResource.isError ? (
+          <StatusBanner state="bad" title="Delete failed">
+            {deleteResource.error.message}
+          </StatusBanner>
+        ) : null}
+        {props.loading ? (
+          <StatusBanner state="loading" title="Loading database resources" />
+        ) : props.error ? (
+          <StatusBanner state="bad" title="Configuration database unavailable">
+            {props.error}
+          </StatusBanner>
+        ) : props.resources.length === 0 ? (
+          <StatusBanner state="info" title="No database resources" />
+        ) : (
+          <div className="table-wrap">
+            <table className="data-table raw-config-resource-table">
+              <thead>
+                <tr>
+                  <th>Kind</th>
+                  <th>ID</th>
+                  <th>Revision</th>
+                  <th>Updated</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {props.resources.map((resource) => {
+                  const key = `${resource.kind}:${resource.id}`;
+                  const open = expanded === key;
+                  return (
+                    <Fragment key={key}>
+                      <tr>
+                        <td>
+                          <code>{resource.kind}</code>
+                        </td>
+                        <td>
+                          <code>{resource.id}</code>
+                        </td>
+                        <td>{resource.revision}</td>
+                        <td>{new Date(resource.updatedAt).toLocaleString()}</td>
+                        <td>
+                          <div className="button-row compact">
+                            <button
+                              className="button compact"
+                              type="button"
+                              aria-expanded={open}
+                              onClick={() => setExpanded(open ? null : key)}
+                            >
+                              {open ? "Hide JSON" : "View JSON"}
+                            </button>
+                            {dangerousActionsVisible ? (
+                              <Tooltip content="Delete database resource">
+                                <button
+                                  className="icon-button danger"
+                                  type="button"
+                                  aria-label="Delete database resource"
+                                  onClick={() => setDeleting(resource)}
+                                >
+                                  <Trash2 size={15} />
+                                </button>
+                              </Tooltip>
+                            ) : null}
+                          </div>
+                        </td>
+                      </tr>
+                      {open ? (
+                        <tr className="raw-config-resource-detail">
+                          <td colSpan={5}>
+                            <JsonBlock
+                              value={redactedResourceValue(resource)}
+                            />
+                          </td>
+                        </tr>
+                      ) : null}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Panel>
+      {deleting ? (
+        <ConfirmDialog
+          title="Delete database resource?"
+          destructive
+          confirmLabel="Delete resource"
+          confirmDisabled={deleteResource.isPending}
+          onCancel={() => setDeleting(null)}
+          onConfirm={() => {
+            const key = `${deleting.kind}:${deleting.id}`;
+            deleteResource.mutate(
+              { kind: deleting.kind, id: deleting.id },
+              {
+                onSuccess: () => {
+                  if (expanded === key) setExpanded(null);
+                  setDeleting(null);
+                },
+              },
+            );
+          }}
+        >
+          <p>
+            Delete <strong>{deleting.kind}</strong>/
+            <strong>{deleting.id}</strong>? This cannot be undone.
+          </p>
+        </ConfirmDialog>
+      ) : null}
+    </>
+  );
+}
+
+function redactedResourceValue(resource: ConfigResource) {
+  if (resource.kind !== "llm.apiKey") return resource.value;
+  const value = structuredClone(resource.value) as Record<string, unknown>;
+  if (typeof value.key === "string") value.key = maskKey(value.key);
+  if (typeof value.keyHash === "string") value.keyHash = maskKey(value.keyHash);
+  return value;
 }
 
 async function copyConfig(value: string) {

--- a/ui/src/pages/TrafficGateways.tsx
+++ b/ui/src/pages/TrafficGateways.tsx
@@ -388,6 +388,9 @@ function GatewayEditor(props: {
   onSave: (draft: GatewayEditorState) => void;
 }) {
   const [name, setName] = useState(props.initial.name);
+  const [defaultGateway, setDefaultGateway] = useState(
+    props.initial.name === "default",
+  );
   const [gateway, setGateway] = useState<TrafficGateway>(
     structuredClone(props.initial.gateway),
   );
@@ -400,6 +403,16 @@ function GatewayEditor(props: {
   const protocol = effectiveGatewayProtocol(gateway);
   const hasTls = protocol === "HTTPS" || protocol === "TLS";
   const canEnableMultipleListeners = !hasTls && policyCount === 0;
+  const anotherDefaultGateway = Boolean(
+    props.config?.gateways?.default && props.initial.previousName !== "default",
+  );
+  const defaultTraffic = defaultGatewayTraffic(props.config);
+  const invalidDefaultName = !defaultGateway && name.trim() === "default";
+  const duplicateName = Boolean(
+    name.trim() &&
+    name.trim() !== props.initial.previousName &&
+    props.config?.gateways?.[name.trim()],
+  );
   const preview: TrafficGateway = cleanGateway({
     ...(multipleListeners ? withoutGatewayPolicies(gateway) : gateway),
     listeners: multipleListeners
@@ -425,7 +438,7 @@ function GatewayEditor(props: {
           diffTitle="Gateway config diff"
           saveLabel="Save gateway"
           saving={props.saving}
-          saveDisabled={!name.trim()}
+          saveDisabled={!name.trim() || invalidDefaultName || duplicateName}
           onCancel={props.onCancel}
           onSave={() =>
             props.onSave({
@@ -447,13 +460,14 @@ function GatewayEditor(props: {
         />
       }
     >
-      <div className="form-grid">
+      <div className="form-grid gateway-identity-grid">
         <Field
           label="Name"
           tooltip="Features and routes reference this gateway by name."
         >
           <input
             value={name}
+            disabled={defaultGateway}
             onChange={(event) => setName(event.target.value)}
             placeholder="public"
           />
@@ -473,7 +487,58 @@ function GatewayEditor(props: {
             placeholder="443"
           />
         </Field>
-        {!multipleListeners ? (
+      </div>
+
+      <div className="gateway-default-option">
+        <label className="config-option-row">
+          <input
+            type="checkbox"
+            checked={defaultGateway}
+            disabled={anotherDefaultGateway}
+            onChange={(event) => {
+              const checked = event.target.checked;
+              setDefaultGateway(checked);
+              setName(
+                checked
+                  ? "default"
+                  : availableGatewayName(
+                      props.config?.gateways,
+                      props.initial.previousName,
+                    ),
+              );
+            }}
+          />
+          <span>
+            <strong>Default gateway</strong>
+            <small>
+              {anotherDefaultGateway
+                ? "Another gateway is already the default gateway."
+                : "Use this gateway for enabled traffic without an explicit gateway selection."}
+            </small>
+          </span>
+        </label>
+
+        {invalidDefaultName ? (
+          <StatusBanner state="bad" title="Default name is reserved">
+            Select Default gateway to use the name <code>default</code>.
+          </StatusBanner>
+        ) : duplicateName ? (
+          <StatusBanner state="bad" title="Gateway name already exists">
+            Choose a unique gateway name.
+          </StatusBanner>
+        ) : null}
+
+        {defaultGateway ? (
+          <StatusBanner state="warn" title="Default gateway">
+            This will make the gateway the default gateway. This will impact{" "}
+            {defaultTraffic.length ? defaultTraffic.join(", ") : "no enabled"}{" "}
+            traffic.
+          </StatusBanner>
+        ) : null}
+      </div>
+
+      {!multipleListeners ? (
+        <div className="form-grid">
           <Field
             label="Protocol"
             tooltip={props.help.field<TrafficGateway>(
@@ -502,8 +567,8 @@ function GatewayEditor(props: {
               }}
             />
           </Field>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
 
       <div className="form-grid">
         <label className="config-option-row">
@@ -570,6 +635,28 @@ function GatewayEditor(props: {
       </details>
     </Drawer>
   );
+}
+
+function defaultGatewayTraffic(config: GatewayConfig | undefined) {
+  const traffic: string[] = [];
+  if (config?.llm) traffic.push("LLM");
+  if (config && Object.prototype.hasOwnProperty.call(config, "ui")) {
+    traffic.push("UI");
+  }
+  if (config?.mcp) traffic.push("MCP");
+  return traffic;
+}
+
+function availableGatewayName(
+  gateways: Record<string, TrafficGateway> | undefined,
+  currentName: string | undefined,
+) {
+  const names = new Set(Object.keys(gateways ?? {}));
+  if (currentName) names.delete(currentName);
+  if (!names.has("public")) return "public";
+  let suffix = 2;
+  while (names.has(`public-${suffix}`)) suffix += 1;
+  return `public-${suffix}`;
 }
 
 function GatewayTLSFields(props: {

--- a/ui/src/pages/models/modelRouteState.ts
+++ b/ui/src/pages/models/modelRouteState.ts
@@ -2,29 +2,29 @@ import { makeEmptyModel } from "../../config";
 import type { LlmModel } from "../../types";
 
 export type ModelHash =
-  | { kind: "edit"; modelName: string }
+  | { kind: "edit"; modelId: string }
   | { kind: "add"; type: "model" | "virtual" };
 
 export function modelHashFromUrl(): ModelHash | null {
   const raw = decodeURIComponent(window.location.hash.replace(/^#/, ""));
   if (!raw) return null;
   if (raw.startsWith("edit=")) {
-    const modelName = raw.slice("edit=".length);
-    return modelName ? { kind: "edit", modelName } : null;
+    const modelId = raw.slice("edit=".length);
+    return modelId ? { kind: "edit", modelId } : null;
   }
   if (raw === "add=model") return { kind: "add", type: "model" };
   if (raw === "add=virtual") return { kind: "add", type: "virtual" };
   if (raw.startsWith("policies=")) {
-    const modelName = raw.slice("policies=".length);
-    return modelName ? { kind: "edit", modelName } : null;
+    const modelId = raw.slice("policies=".length);
+    return modelId ? { kind: "edit", modelId } : null;
   }
   if (raw.startsWith("model=")) {
-    const modelName = raw.slice("model=".length);
-    return modelName ? { kind: "edit", modelName } : null;
+    const modelId = raw.slice("model=".length);
+    return modelId ? { kind: "edit", modelId } : null;
   }
   if (raw.startsWith("modelPolicy=")) {
-    const modelName = raw.slice("modelPolicy=".length);
-    return modelName ? { kind: "edit", modelName } : null;
+    const modelId = raw.slice("modelPolicy=".length);
+    return modelId ? { kind: "edit", modelId } : null;
   }
   return null;
 }
@@ -35,7 +35,7 @@ export function setModelHash(
 ) {
   const hash = value
     ? value.kind === "edit"
-      ? `#edit=${encodeURIComponent(value.modelName)}`
+      ? `#edit=${encodeURIComponent(value.modelId)}`
       : `#add=${value.type}`
     : "";
   const nextUrl = `${window.location.pathname}${window.location.search}${hash}`;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -127,6 +127,16 @@ button:disabled {
   opacity: 0.6;
 }
 
+button.hybrid-write-disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+button.hybrid-write-disabled.hybrid-write-override {
+  cursor: pointer;
+  opacity: 1;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -3382,6 +3392,50 @@ tbody tr:hover {
   margin-bottom: 14px;
 }
 
+.gateway-identity-grid {
+  margin-bottom: 0;
+}
+
+.gateway-default-option {
+  display: grid;
+  gap: 10px;
+  margin: 4px 0 22px;
+}
+
+.raw-config-view-tabs {
+  width: fit-content;
+  margin-bottom: 14px;
+}
+
+.raw-config-resource-table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.raw-config-resource-table th:nth-child(1),
+.raw-config-resource-table th:nth-child(2) {
+  width: 22%;
+}
+
+.raw-config-resource-table th:nth-child(3) {
+  width: 10%;
+}
+
+.raw-config-resource-table th:nth-child(4) {
+  width: 28%;
+}
+
+.raw-config-resource-table th:nth-child(5) {
+  width: 18%;
+}
+
+.raw-config-resource-detail .json-block {
+  width: 100%;
+  max-height: 360px;
+  margin: 0;
+  overflow: auto;
+}
+
 .field {
   display: flex;
   flex-direction: column;
@@ -3507,6 +3561,15 @@ input::placeholder,
 textarea::placeholder {
   color: var(--placeholder);
   opacity: 1;
+}
+
+input:disabled:not([type="checkbox"]),
+select:disabled,
+textarea:disabled {
+  cursor: not-allowed;
+  border-color: var(--line);
+  background: var(--surface-2);
+  color: var(--muted);
 }
 
 input:focus,

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -56,7 +56,7 @@ test("onboards all surfaces from a completely empty config", async ({
 
   await expect.poll(() => gateway.postedConfigs.length).toBe(1);
   expect(gateway.postedConfigs[0].gateways).toMatchObject({
-    default: { port: 8080 },
+    public: { port: 8080 },
   });
   await expect(
     page.getByRole("heading", { name: "Welcome to Agentgateway" }),
@@ -91,6 +91,163 @@ test("onboards all surfaces from a completely empty config", async ({
   await expect(
     page.getByRole("heading", { name: "Gateway Overview" }),
   ).toBeVisible();
+});
+
+test("enables traffic consistently from get started", async ({ page }) => {
+  const gateway = await mockGateway(page, {});
+  await page.goto("/traffic/get-started");
+
+  await page.getByRole("button", { name: "Enable", exact: true }).click();
+
+  await expect.poll(() => gateway.postedConfigs.length).toBe(1);
+  expect(gateway.postedConfigs[0].gateways).toEqual({
+    public: { port: 8080 },
+  });
+});
+
+test("controls the reserved default gateway name", async ({ page }) => {
+  await mockGateway(page, {
+    gateways: { public: { port: 8080 } },
+    llm: { models: [], providers: [], virtualModels: [] },
+    mcp: { targets: [] },
+    ui: {},
+  });
+  await page.goto("/traffic/gateways");
+  await page.getByRole("button", { name: "Add gateway" }).click();
+
+  const defaultGateway = page.getByRole("checkbox", {
+    name: /Default gateway/,
+  });
+  const name = page.getByRole("textbox", { name: /^Name/ });
+  await defaultGateway.check();
+  await expect(name).toHaveValue("default");
+  await expect(name).toBeDisabled();
+  await expect(page.getByText(/impact LLM, UI, MCP traffic/)).toBeVisible();
+
+  await defaultGateway.uncheck();
+  await expect(name).toHaveValue("public-2");
+  await name.fill("default");
+  await expect(page.getByText("Default name is reserved")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Save gateway" }),
+  ).toBeDisabled();
+});
+
+test("does not allow a second default gateway", async ({ page }) => {
+  await mockGateway(page, {
+    gateways: { default: { port: 8080 } },
+  });
+  await page.goto("/traffic/gateways");
+  await page.getByRole("button", { name: "Add gateway" }).click();
+
+  await expect(
+    page.getByRole("checkbox", { name: /Default gateway/ }),
+  ).toBeDisabled();
+  await expect(
+    page.getByText("Another gateway is already the default gateway."),
+  ).toBeVisible();
+});
+
+test("hybrid settings shows file diff without applying it", async ({
+  page,
+}) => {
+  const gateway = await mockGateway(page, {
+    gateways: { public: { port: 8080 } },
+  });
+  await page.route("**/api/runtime", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        build: {},
+        ui: { gatewayMode: "standalone", configStoreMode: "hybrid" },
+      }),
+    }),
+  );
+  await page.goto("/settings");
+
+  await page.getByRole("combobox", { name: "Public UI gateway" }).click();
+  await page.getByRole("option", { name: /public/ }).click();
+  const apply = page.getByRole("button", { name: "Save UI gateway" });
+  await expect(apply).toBeDisabled();
+
+  await page.getByRole("button", { name: "View diff" }).click();
+  const diff = page.locator(".drawer.nested");
+  await expect(diff).toBeVisible();
+  const save = diff.getByRole("button", { name: "Save" });
+  await expect(save).toBeDisabled();
+  await save.hover({ force: true });
+  await expect(
+    page.getByRole("tooltip").getByText(/read-only in hybrid mode/),
+  ).toBeVisible();
+  expect(gateway.postedConfigs).toHaveLength(0);
+
+  await page.keyboard.down("Control");
+  await page.keyboard.down("Shift");
+  await expect(
+    page.getByRole("tooltip").getByText(/Override active/),
+  ).toBeVisible();
+  await save.click({ force: true });
+  await page.keyboard.up("Shift");
+  await page.keyboard.up("Control");
+  await expect.poll(() => gateway.postedConfigs.length).toBe(1);
+  await expect(diff).not.toBeVisible();
+});
+
+test("raw configuration lists hybrid database resources with masked keys", async ({
+  page,
+}) => {
+  await mockGateway(page, {});
+  await page.route("**/api/runtime", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        build: {},
+        ui: { gatewayMode: "standalone", configStoreMode: "hybrid" },
+      }),
+    }),
+  );
+  await page.route("**/api/config/resources", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        resources: [
+          {
+            kind: "llm.model",
+            id: "model-id",
+            value: { id: "model-id", name: "test-model" },
+            revision: 2,
+            createdAt: "2026-07-10T00:00:00Z",
+            updatedAt: "2026-07-10T01:00:00Z",
+          },
+          {
+            kind: "llm.apiKey",
+            id: "key-id",
+            value: {
+              key: "agw_sk_supersecret123",
+              metadata: { id: "key-id", name: "Test key" },
+            },
+            revision: 1,
+            createdAt: "2026-07-10T00:00:00Z",
+            updatedAt: "2026-07-10T01:00:00Z",
+          },
+        ],
+      }),
+    }),
+  );
+  await page.goto("/raw-config");
+  await page.getByRole("tab", { name: "Database" }).click();
+
+  await expect(page.getByRole("cell", { name: "llm.model" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "llm.apiKey" })).toBeVisible();
+  await page
+    .getByRole("row", { name: /llm.apiKey/ })
+    .getByText("View JSON")
+    .click();
+  await expect(page.getByText("agw_sk_...t123")).toBeVisible();
+  await expect(page.locator("body")).not.toContainText("agw_sk_supersecret123");
 });
 
 test("onboards LLM and MCP onto the UI gateway when present", async ({
@@ -360,6 +517,148 @@ test("creates a weighted virtual model with a concrete wildcard target", async (
       },
     },
   });
+});
+
+test("hybrid model edits use the resource's owning store", async ({ page }) => {
+  const config = emptyConfig();
+  const llm = config.llm as { models: Array<Record<string, unknown>> };
+  llm.models = [
+    {
+      name: "file-model",
+      provider: "openai",
+      params: { model: "gpt-file" },
+    },
+  ];
+  delete (llm as Record<string, unknown>).providers;
+  delete (llm as Record<string, unknown>).virtualModels;
+  const gateway = await mockGateway(page, config);
+  const resourceWrites: Array<Record<string, unknown>> = [];
+  const dbResource = {
+    kind: "llm.model",
+    id: "db-model-id",
+    value: {
+      id: "db-model-id",
+      name: "db-model",
+      provider: "openai",
+      params: { model: "gpt-db" },
+    },
+    revision: 1,
+    createdAt: "2026-07-10T00:00:00Z",
+    updatedAt: "2026-07-10T00:00:00Z",
+  };
+
+  await page.route("**/api/runtime", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        build: {
+          version: "test",
+          gitRevision: "test",
+          rustVersion: "test",
+          buildProfile: "test",
+          buildTarget: "test",
+        },
+        ui: { gatewayMode: "standalone", configStoreMode: "hybrid" },
+      }),
+    }),
+  );
+  await page.route("**/api/config/resources**", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ resources: [dbResource] }),
+      });
+      return;
+    }
+    if (route.request().method() === "PUT") {
+      const request = route.request().postDataJSON() as {
+        resources: Array<{ value: Record<string, unknown> }>;
+      };
+      const value = request.resources[0].value;
+      resourceWrites.push(value);
+      dbResource.value = value as typeof dbResource.value;
+      dbResource.revision += 1;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ resources: [dbResource] }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.goto("/llm/models");
+
+  const fileRow = page.getByRole("row", { name: /file-model/ });
+  const databaseRow = page.getByRole("row", { name: /db-model/ });
+  await expect(fileRow.getByText("File", { exact: true })).toBeVisible();
+  await expect(
+    databaseRow.getByText("Database", { exact: true }),
+  ).toBeVisible();
+
+  await fileRow.getByRole("button", { name: "Edit model" }).click();
+  await page.getByLabel("Incoming model match").fill("file-model-renamed");
+  await page.getByRole("button", { name: "View diff" }).click();
+  const diffDrawer = page.locator(".drawer.nested");
+  await expect(
+    diffDrawer.getByRole("heading", { name: "Model config diff" }),
+  ).toBeVisible();
+  await diffDrawer.getByRole("button", { name: "Close" }).first().click();
+  await page.getByRole("button", { name: "Save model" }).click();
+
+  await expect.poll(() => gateway.postedConfigs.length).toBe(1);
+  expect(resourceWrites).toHaveLength(0);
+  const savedFileConfig = gateway.postedConfigs[0] as {
+    llm?: {
+      models?: Array<{ name: string }>;
+      providers?: unknown;
+      virtualModels?: unknown;
+    };
+  };
+  expect(savedFileConfig.llm?.models?.[0]).toMatchObject({
+    name: "file-model-renamed",
+  });
+  expect(savedFileConfig.llm?.models?.[0]).not.toHaveProperty("id");
+  expect(savedFileConfig.llm).not.toHaveProperty("providers");
+  expect(savedFileConfig.llm).not.toHaveProperty("virtualModels");
+
+  await databaseRow.getByRole("button", { name: "Edit model" }).click();
+  await page.getByLabel("Incoming model match").fill("db-model-renamed");
+  await page.getByRole("button", { name: "View diff" }).click();
+  await expect(
+    diffDrawer.getByRole("heading", { name: "Model resource diff" }),
+  ).toBeVisible();
+  await diffDrawer.getByRole("button", { name: "Close" }).first().click();
+  await page.getByRole("button", { name: "Save model" }).click();
+
+  await expect.poll(() => resourceWrites.length).toBe(1);
+  expect(gateway.postedConfigs).toHaveLength(1);
+  expect(resourceWrites[0]).toMatchObject({
+    id: "db-model-id",
+    name: "db-model-renamed",
+  });
+
+  await page.goto("/llm/client-setup");
+  await page.getByRole("combobox", { name: "Model" }).click();
+  await expect(
+    page.getByRole("option", { name: "db-model-renamed" }),
+  ).toBeVisible();
+  await page.getByRole("option", { name: "db-model-renamed" }).click();
+  const clientRecipe = page.locator(".client-recipe-card");
+  await expect(clientRecipe).not.toContainText("Authorization: Bearer");
+  await expect(clientRecipe).not.toContainText("agw_sk_...");
+  await page.getByRole("combobox", { name: "Integration" }).click();
+  await page.getByRole("option", { name: "OpenAI JavaScript SDK" }).click();
+  await expect(clientRecipe).toContainText("dummy_key");
+
+  await page.goto("/llm/playground");
+  await page.getByRole("combobox", { name: "Model" }).click();
+  await expect(
+    page.getByRole("option", { name: "db-model-renamed" }),
+  ).toBeVisible();
 });
 
 test("reveals a virtual API key explicitly", async ({ page }) => {


### PR DESCRIPTION
This PR adds hybrid configuration storage, using the file configuration as a stable baseline while allowing UI-managed resources to be stored in the existing SQLite database.

- Supports DB-backed LLM models, providers, virtual models, API keys, and cost catalogs.
- Merges database resources before file configuration, keeping file values authoritative.
- Adds stable model IDs and server-generated API key IDs.
- Updates UI workflows, diffs, client setup, and playgrounds to use merged resources.
- Adds database resource inspection
- Keeps API-key policy enablement file-owned while allowing keys themselves in the database.
- Supports refreshing and editing cost catalogs according to their configured storage source.

We do NOT support policies in the database, at least at the moment. probably a good followup