### PR TITLE
Add initial extensible standalone configuration importer

### DIFF
--- a/crates/agentgateway-app/src/commands/import.rs
+++ b/crates/agentgateway-app/src/commands/import.rs
@@ -10,7 +10,10 @@ pub(crate) fn execute(args: ImportArgs) -> anyhow::Result<()> {
 
 fn import_file(path: PathBuf, output: Option<PathBuf>, source: &str) -> anyhow::Result<()> {
 	let contents = read_input(&path)?;
-	let result = agentgateway::import::import_config(source, &contents)?;
+	let options = agentgateway::import::ImportOptions {
+		database_url: import_database_url(output.as_deref()),
+	};
+	let result = agentgateway::import::import_config_with_options(source, &contents, &options)?;
 	let imported = agentgateway::yamlviajson::to_string(&result.config)?;
 	for finding in result.findings {
 		eprintln!(
@@ -30,6 +33,16 @@ fn import_file(path: PathBuf, output: Option<PathBuf>, source: &str) -> anyhow::
 	Ok(())
 }
 
+fn import_database_url(output: Option<&Path>) -> String {
+	let database_path = output
+		.filter(|path| *path != Path::new("-"))
+		.and_then(Path::parent)
+		.filter(|parent| !parent.as_os_str().is_empty())
+		.map(|parent| parent.join("data.db"))
+		.unwrap_or_else(|| PathBuf::from("data.db"));
+	format!("sqlite://{}", database_path.display())
+}
+
 fn read_input(path: &Path) -> anyhow::Result<String> {
 	if path != Path::new("-") {
 		return Ok(fs_err::read_to_string(path)?);
@@ -37,4 +50,22 @@ fn read_input(path: &Path) -> anyhow::Result<String> {
 	let mut contents = String::new();
 	std::io::stdin().read_to_string(&mut contents)?;
 	Ok(contents)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn places_database_beside_generated_config() {
+		assert_eq!(
+			import_database_url(Some(Path::new("/tmp/imported/config.yaml"))),
+			"sqlite:///tmp/imported/data.db"
+		);
+		assert_eq!(
+			import_database_url(Some(Path::new("config.yaml"))),
+			"sqlite://data.db"
+		);
+		assert_eq!(import_database_url(None), "sqlite://data.db");
+	}
 }

--- a/crates/agentgateway-app/src/commands/import.rs
+++ b/crates/agentgateway-app/src/commands/import.rs
@@ -40,7 +40,10 @@ fn import_database_url(output: Option<&Path>) -> String {
 		.filter(|parent| !parent.as_os_str().is_empty())
 		.map(|parent| parent.join("data.db"))
 		.unwrap_or_else(|| PathBuf::from("data.db"));
-	format!("sqlite://{}", database_path.display())
+	let database_path = database_path
+		.to_string_lossy()
+		.replace(std::path::MAIN_SEPARATOR, "/");
+	format!("sqlite://{database_path}")
 }
 
 fn read_input(path: &Path) -> anyhow::Result<String> {

--- a/crates/agentgateway-app/src/commands/import.rs
+++ b/crates/agentgateway-app/src/commands/import.rs
@@ -1,0 +1,40 @@
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use crate::ImportArgs;
+
+pub(crate) fn execute(args: ImportArgs) -> anyhow::Result<()> {
+	let ImportArgs { from, file, output } = args;
+	import_file(file, output, &from)
+}
+
+fn import_file(path: PathBuf, output: Option<PathBuf>, source: &str) -> anyhow::Result<()> {
+	let contents = read_input(&path)?;
+	let result = agentgateway::import::import_config(source, &contents)?;
+	let imported = agentgateway::yamlviajson::to_string(&result.config)?;
+	for finding in result.findings {
+		eprintln!(
+			"{}: {}: {}",
+			finding.status.as_str(),
+			finding.source_path,
+			finding.message
+		);
+	}
+	match output {
+		Some(path) if path != std::path::Path::new("-") => {
+			fs_err::write(&path, imported)?;
+			println!("Imported {source} config: {}", path.display());
+		},
+		_ => print!("{imported}"),
+	}
+	Ok(())
+}
+
+fn read_input(path: &Path) -> anyhow::Result<String> {
+	if path != Path::new("-") {
+		return Ok(fs_err::read_to_string(path)?);
+	}
+	let mut contents = String::new();
+	std::io::stdin().read_to_string(&mut contents)?;
+	Ok(contents)
+}

--- a/crates/agentgateway-app/src/commands/mod.rs
+++ b/crates/agentgateway-app/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub(super) mod import;
 // TODO: fix for unix not just linux
 pub(super) mod migrate;
 #[cfg(target_os = "linux")]

--- a/crates/agentgateway-app/src/lib.rs
+++ b/crates/agentgateway-app/src/lib.rs
@@ -237,25 +237,18 @@ fn ensure_default_config_file(path: &std::path::Path) -> anyhow::Result<()> {
 	let parent = path
 		.parent()
 		.ok_or_else(|| anyhow::anyhow!("config path has no parent: {}", path.display()))?;
-	fs_err::write(path, default_config_contents(parent))?;
+	fs_err::write(path, default_config_contents(parent)?)?;
 	Ok(())
 }
 
-fn default_config_contents(dir: &std::path::Path) -> String {
+fn default_config_contents(dir: &std::path::Path) -> anyhow::Result<String> {
 	let db = dir.join("data.db");
-	format!(
-		r#"# yaml-language-server: $schema=https://agentgateway.dev/schema/config
-config:
-  database:
-    url: sqlite://{}
-gateways:
-  default:
-    port: 4000
-ui:
-  gateways: default
-"#,
-		db.display()
-	)
+	let config =
+		agentgateway::types::local::default_standalone_config(&format!("sqlite://{}", db.display()));
+	let yaml = agentgateway::yamlviajson::to_string(&config)?;
+	Ok(format!(
+		"# yaml-language-server: $schema=https://agentgateway.dev/schema/config\n{yaml}"
+	))
 }
 
 fn existing_writable_dir(path: &std::path::Path) -> bool {

--- a/crates/agentgateway-app/src/lib.rs
+++ b/crates/agentgateway-app/src/lib.rs
@@ -94,12 +94,29 @@ pub(crate) struct MigrateArgs {
 	pub(crate) file: PathBuf,
 }
 
+#[derive(ClapArgs, Debug)]
+pub(crate) struct ImportArgs {
+	/// Source gateway configuration format.
+	#[arg(long, value_name = "source")]
+	pub(crate) from: String,
+
+	/// Read source configuration from a file.
+	#[arg(short, long, value_name = "file")]
+	pub(crate) file: PathBuf,
+
+	/// Write generated agentgateway configuration to a file instead of stdout.
+	#[arg(short, long, value_name = "file")]
+	pub(crate) output: Option<PathBuf>,
+}
+
 #[derive(Subcommand, Debug)]
 enum Commands {
 	/// Run agentgateway as a subprocess and exec a command when ready.
 	#[cfg(target_os = "linux")]
 	Oneshot(OneshotArgs),
-	/// Migrate deprecated local config fields to frontendPolicies.
+	/// Import standalone configuration from another gateway.
+	Import(ImportArgs),
+	/// Migrate deprecated fields in a local agentgateway configuration.
 	Migrate(MigrateArgs),
 }
 
@@ -130,6 +147,7 @@ pub fn run() -> anyhow::Result<()> {
 	match args.command {
 		#[cfg(target_os = "linux")]
 		Some(Commands::Oneshot(oneshot)) => commands::oneshot::execute(oneshot),
+		Some(Commands::Import(import)) => commands::import::execute(import),
 		Some(Commands::Migrate(migrate)) => commands::migrate::execute(migrate),
 		None => commands::run::execute(args.run),
 	}

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -1,0 +1,622 @@
+//! Import external gateway configuration into standalone agentgateway configuration.
+//!
+//! Importers normalize source-specific configuration into [`ImportPlan`]. The shared
+//! emitter then produces and validates agentgateway configuration, keeping source
+//! adapters independent from the target configuration format.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, bail};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+/// A source-specific configuration adapter.
+pub trait ConfigImporter: Send + Sync {
+	fn source(&self) -> &'static str;
+	fn import(&self, input: &str) -> anyhow::Result<ImportPlan>;
+}
+
+/// Source-neutral representation consumed by the agentgateway configuration emitter.
+#[derive(Debug, Default)]
+pub struct ImportPlan {
+	pub models: Vec<ImportedModel>,
+	pub routes: IndexMap<String, ImportedRoute>,
+	pub findings: Vec<ImportFinding>,
+}
+
+#[derive(Debug)]
+pub struct ImportedModel {
+	pub name: String,
+	pub provider: String,
+	pub params: Map<String, Value>,
+	pub defaults: Map<String, Value>,
+	pub weight: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct ImportedRoute {
+	pub targets: Vec<String>,
+	pub fallback_groups: Vec<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ImportStatus {
+	Exact,
+	Approximate,
+	Manual,
+	Unsupported,
+}
+
+impl ImportStatus {
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Self::Exact => "exact",
+			Self::Approximate => "approximate",
+			Self::Manual => "manual",
+			Self::Unsupported => "unsupported",
+		}
+	}
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportFinding {
+	pub source_path: String,
+	pub status: ImportStatus,
+	pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportResult {
+	pub source: String,
+	pub config: Value,
+	pub findings: Vec<ImportFinding>,
+}
+
+pub fn available_sources() -> Vec<&'static str> {
+	importers()
+		.iter()
+		.map(|importer| importer.source())
+		.collect()
+}
+
+pub fn import_config(source: &str, input: &str) -> anyhow::Result<ImportResult> {
+	let importer = importers()
+		.into_iter()
+		.find(|importer| importer.source().eq_ignore_ascii_case(source))
+		.ok_or_else(|| {
+			anyhow::anyhow!(
+				"unsupported import source {source:?}; supported sources: {}",
+				available_sources().join(", ")
+			)
+		})?;
+	let plan = importer.import(input)?;
+	emit(importer.source(), plan)
+}
+
+fn importers() -> Vec<Box<dyn ConfigImporter>> {
+	vec![Box::new(LiteLlmImporter)]
+}
+
+fn emit(source: &str, plan: ImportPlan) -> anyhow::Result<ImportResult> {
+	let ImportPlan {
+		models,
+		routes,
+		findings,
+	} = plan;
+	let model_by_name: HashMap<_, _> = models
+		.iter()
+		.map(|model| (model.name.as_str(), model))
+		.collect();
+	let emitted_models = models
+		.iter()
+		.map(|model| {
+			let mut value = Map::from_iter([
+				("name".to_string(), json!(model.name)),
+				("visibility".to_string(), json!("internal")),
+				("provider".to_string(), json!(model.provider)),
+				("params".to_string(), Value::Object(model.params.clone())),
+			]);
+			if !model.defaults.is_empty() {
+				value.insert(
+					"defaults".to_string(),
+					Value::Object(model.defaults.clone()),
+				);
+			}
+			Value::Object(value)
+		})
+		.collect::<Vec<_>>();
+
+	let mut virtual_models = Vec::new();
+	for (name, route) in routes {
+		if route.targets.is_empty() {
+			continue;
+		}
+		let routing = if route.fallback_groups.is_empty() {
+			let targets = route
+				.targets
+				.iter()
+				.map(|target| {
+					let weight = model_by_name.get(target.as_str()).map_or(1, |m| m.weight);
+					json!({"model": target, "weight": weight})
+				})
+				.collect::<Vec<_>>();
+			json!({"weighted": {"targets": targets}})
+		} else {
+			let mut targets = route
+				.targets
+				.iter()
+				.map(|target| json!({"model": target, "priority": 0}))
+				.collect::<Vec<_>>();
+			for (priority, fallback_group) in route.fallback_groups.iter().enumerate() {
+				for fallback in fallback_group {
+					targets.push(json!({"model": fallback, "priority": priority + 1}));
+				}
+			}
+			json!({"failover": {"targets": targets}})
+		};
+		virtual_models.push(json!({"name": name, "routing": routing}));
+	}
+
+	let config = json!({
+		"llm": {
+			"port": 4000,
+			"models": emitted_models,
+			"virtualModels": virtual_models,
+		}
+	});
+	let yaml = crate::yamlviajson::to_string(&config)?;
+	let _: crate::types::local::LocalConfig = crate::yamlviajson::from_str(&yaml)
+		.context("generated agentgateway configuration is invalid")?;
+	Ok(ImportResult {
+		source: source.to_string(),
+		config,
+		findings,
+	})
+}
+
+struct LiteLlmImporter;
+
+#[derive(Debug, Deserialize)]
+struct LiteLlmConfig {
+	#[serde(default)]
+	model_list: Vec<LiteLlmModel>,
+	#[serde(default)]
+	router_settings: Map<String, Value>,
+	#[serde(default)]
+	litellm_settings: Map<String, Value>,
+	#[serde(default)]
+	general_settings: Map<String, Value>,
+	#[serde(default)]
+	environment_variables: Map<String, Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LiteLlmModel {
+	model_name: String,
+	#[serde(default)]
+	litellm_params: Map<String, Value>,
+}
+
+impl ConfigImporter for LiteLlmImporter {
+	fn source(&self) -> &'static str {
+		"litellm"
+	}
+
+	fn import(&self, input: &str) -> anyhow::Result<ImportPlan> {
+		let config: LiteLlmConfig =
+			crate::yamlviajson::from_str(input).context("invalid LiteLLM configuration")?;
+		if config.model_list.is_empty() {
+			bail!("LiteLLM configuration does not contain any model_list entries");
+		}
+
+		let mut plan = ImportPlan::default();
+		let mut counts = HashMap::<String, usize>::new();
+		for (index, model) in config.model_list.into_iter().enumerate() {
+			let source_path = format!("model_list[{index}]");
+			let deployment = counts.entry(model.model_name.clone()).or_default();
+			*deployment += 1;
+			let internal_name = imported_model_name(self.source(), &model.model_name, *deployment);
+			let Some(imported) = import_litellm_model(
+				internal_name.clone(),
+				model,
+				&source_path,
+				&mut plan.findings,
+			) else {
+				continue;
+			};
+			plan
+				.routes
+				.entry(imported.0)
+				.or_default()
+				.targets
+				.push(internal_name);
+			plan.models.push(imported.1);
+		}
+
+		let fallbacks = config
+			.router_settings
+			.get("fallbacks")
+			.or_else(|| config.litellm_settings.get("fallbacks"));
+		if let Some(fallbacks) = fallbacks {
+			apply_fallbacks(fallbacks, &mut plan);
+		}
+
+		if let Some(strategy) = config.router_settings.get("routing_strategy") {
+			plan.findings.push(ImportFinding {
+				source_path: "router_settings.routing_strategy".to_string(),
+				status: ImportStatus::Approximate,
+				message: format!(
+					"LiteLLM routing strategy {strategy} is represented with agentgateway weighted or health-aware routing"
+				),
+			});
+		}
+		for setting in config.router_settings.keys() {
+			if matches!(setting.as_str(), "fallbacks" | "routing_strategy") {
+				continue;
+			}
+			plan.findings.push(ImportFinding {
+				source_path: format!("router_settings.{setting}"),
+				status: ImportStatus::Manual,
+				message: "No automatic mapping is available; review this router setting".to_string(),
+			});
+		}
+		for (section, values) in [
+			("general_settings", &config.general_settings),
+			("environment_variables", &config.environment_variables),
+		] {
+			if !values.is_empty() {
+				plan.findings.push(ImportFinding {
+					source_path: section.to_string(),
+					status: ImportStatus::Manual,
+					message: format!("{section} requires manual review and was not emitted"),
+				});
+			}
+		}
+		for setting in config.litellm_settings.keys() {
+			if setting == "fallbacks" {
+				continue;
+			}
+			plan.findings.push(ImportFinding {
+				source_path: format!("litellm_settings.{setting}"),
+				status: ImportStatus::Unsupported,
+				message: "No automatic mapping is available".to_string(),
+			});
+		}
+		Ok(plan)
+	}
+}
+
+fn import_litellm_model(
+	name: String,
+	model: LiteLlmModel,
+	source_path: &str,
+	findings: &mut Vec<ImportFinding>,
+) -> Option<(String, ImportedModel)> {
+	let public_name = model.model_name;
+	let mut params = model.litellm_params;
+	let model_id = params
+		.remove("model")
+		.and_then(|value| value.as_str().map(str::to_string))
+		.unwrap_or_else(|| public_name.clone());
+	let (provider_prefix, upstream_model) = split_provider(&model_id);
+	let Some(provider) = map_provider(provider_prefix) else {
+		findings.push(ImportFinding {
+			source_path: format!("{source_path}.litellm_params.model"),
+			status: ImportStatus::Unsupported,
+			message: format!("LiteLLM provider {provider_prefix:?} is not supported by this importer"),
+		});
+		return None;
+	};
+
+	let mut output_params = Map::new();
+	output_params.insert("model".to_string(), json!(upstream_model));
+	move_string(&mut params, "api_base", &mut output_params, "baseUrl");
+	move_string(&mut params, "base_url", &mut output_params, "baseUrl");
+	move_string(
+		&mut params,
+		"api_version",
+		&mut output_params,
+		"azureApiVersion",
+	);
+	move_string(
+		&mut params,
+		"aws_region_name",
+		&mut output_params,
+		"awsRegion",
+	);
+	move_string(
+		&mut params,
+		"vertex_project",
+		&mut output_params,
+		"vertexProject",
+	);
+	move_string(
+		&mut params,
+		"vertex_location",
+		&mut output_params,
+		"vertexRegion",
+	);
+	if let Some(api_key) = params.remove("api_key") {
+		output_params.insert("apiKey".to_string(), normalize_secret(api_key));
+	}
+
+	let rpm = params.remove("rpm");
+	let weight = rpm
+		.as_ref()
+		.and_then(|value| value.as_u64())
+		.and_then(|value| usize::try_from(value).ok())
+		.filter(|value| *value > 0)
+		.unwrap_or(1);
+	if rpm.is_some() {
+		findings.push(ImportFinding {
+			source_path: format!("{source_path}.litellm_params.rpm"),
+			status: ImportStatus::Approximate,
+			message: "Used RPM as the deployment's relative routing weight".to_string(),
+		});
+	}
+	let mut defaults = Map::new();
+	for key in [
+		"temperature",
+		"max_tokens",
+		"max_completion_tokens",
+		"top_p",
+		"frequency_penalty",
+		"presence_penalty",
+		"seed",
+		"stop",
+	] {
+		if let Some(value) = params.remove(key) {
+			defaults.insert(key.to_string(), value);
+		}
+	}
+	if !params.is_empty() {
+		let keys = params.keys().cloned().collect::<Vec<_>>().join(", ");
+		findings.push(ImportFinding {
+			source_path: format!("{source_path}.litellm_params"),
+			status: ImportStatus::Manual,
+			message: format!("Review unmapped LiteLLM parameters: {keys}"),
+		});
+	}
+	findings.push(ImportFinding {
+		source_path: source_path.to_string(),
+		status: ImportStatus::Exact,
+		message: format!("Imported model deployment for {public_name}"),
+	});
+	Some((
+		public_name,
+		ImportedModel {
+			name,
+			provider: provider.to_string(),
+			params: output_params,
+			defaults,
+			weight,
+		},
+	))
+}
+
+fn split_provider(model: &str) -> (&str, &str) {
+	match model.split_once('/') {
+		Some((provider, model)) => (provider, model),
+		None => ("openai", model),
+	}
+}
+
+fn map_provider(provider: &str) -> Option<&'static str> {
+	match provider.to_ascii_lowercase().as_str() {
+		"openai" | "text-completion-openai" => Some("openAI"),
+		"azure" | "azure_ai" => Some("azure"),
+		"anthropic" => Some("anthropic"),
+		"bedrock" => Some("bedrock"),
+		"gemini" => Some("gemini"),
+		"vertex_ai" | "vertex_ai_beta" | "vertex" => Some("vertex"),
+		"ollama" => Some("ollama"),
+		"cohere" => Some("cohere"),
+		"huggingface" => Some("huggingface"),
+		"groq" => Some("groq"),
+		"mistral" => Some("mistral"),
+		"openrouter" => Some("openrouter"),
+		"together_ai" | "togetherai" => Some("togetherai"),
+		"xai" => Some("xai"),
+		"deepinfra" => Some("deepinfra"),
+		"deepseek" => Some("deepseek"),
+		"fireworks_ai" | "fireworks" => Some("fireworks"),
+		_ => None,
+	}
+}
+
+fn move_string(
+	source: &mut Map<String, Value>,
+	from: &str,
+	target: &mut Map<String, Value>,
+	to: &str,
+) {
+	if let Some(value) = source.remove(from) {
+		target.insert(to.to_string(), value);
+	}
+}
+
+fn normalize_secret(value: Value) -> Value {
+	let Some(value) = value.as_str() else {
+		return value;
+	};
+	match value.strip_prefix("os.environ/") {
+		Some(environment) => json!(format!("${environment}")),
+		None => json!(value),
+	}
+}
+
+fn apply_fallbacks(value: &Value, plan: &mut ImportPlan) {
+	let Some(entries) = value.as_array() else {
+		plan.findings.push(ImportFinding {
+			source_path: "router_settings.fallbacks".to_string(),
+			status: ImportStatus::Unsupported,
+			message: "Fallbacks must be a list of model mappings".to_string(),
+		});
+		return;
+	};
+	for entry in entries {
+		let Some(entry) = entry.as_object() else {
+			continue;
+		};
+		for (source, fallback_names) in entry {
+			if !plan.routes.contains_key(source) {
+				plan.findings.push(ImportFinding {
+					source_path: "router_settings.fallbacks".to_string(),
+					status: ImportStatus::Manual,
+					message: format!("Fallback source model {source:?} was not imported"),
+				});
+				continue;
+			}
+			let mut seen = HashSet::new();
+			let mut resolved_groups = Vec::new();
+			for fallback_name in fallback_names
+				.as_array()
+				.into_iter()
+				.flatten()
+				.filter_map(Value::as_str)
+			{
+				if !seen.insert(fallback_name) {
+					continue;
+				}
+				if let Some(fallback) = plan.routes.get(fallback_name) {
+					resolved_groups.push(fallback.targets.clone());
+				} else {
+					plan.findings.push(ImportFinding {
+						source_path: "router_settings.fallbacks".to_string(),
+						status: ImportStatus::Manual,
+						message: format!("Fallback target model {fallback_name:?} was not imported"),
+					});
+				}
+			}
+			plan
+				.routes
+				.get_mut(source)
+				.expect("source route checked above")
+				.fallback_groups
+				.extend(resolved_groups);
+		}
+	}
+	plan.findings.push(ImportFinding {
+		source_path: "router_settings.fallbacks".to_string(),
+		status: ImportStatus::Approximate,
+		message: "Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover"
+			.to_string(),
+	});
+}
+
+fn sanitize_name(name: &str) -> String {
+	let sanitized = name
+		.chars()
+		.map(|character| {
+			if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+				character
+			} else {
+				'-'
+			}
+		})
+		.collect::<String>();
+	if sanitized.is_empty() {
+		"model".to_string()
+	} else {
+		sanitized
+	}
+}
+
+fn imported_model_name(source: &str, public_name: &str, deployment: usize) -> String {
+	format!(
+		"imported/{}/{}/{}",
+		sanitize_name(source),
+		sanitize_name(public_name),
+		deployment
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn imports_litellm_models_load_balancing_and_fallbacks() {
+		let input = r#"
+model_list:
+- model_name: fast
+  litellm_params:
+    model: azure/gpt-4o-east
+    api_base: https://east.openai.azure.com
+    api_key: os.environ/AZURE_EAST_KEY
+    api_version: 2025-01-01
+    rpm: 60
+    temperature: 0.2
+- model_name: fast
+  litellm_params:
+    model: openai/gpt-4o
+    api_key: os.environ/OPENAI_API_KEY
+    rpm: 40
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-sonnet-4
+    api_key: os.environ/ANTHROPIC_API_KEY
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+    api_key: os.environ/ANTHROPIC_API_KEY
+router_settings:
+  routing_strategy: simple-shuffle
+  fallbacks:
+  - fast: [backup]
+"#;
+		let result = import_config("litellm", input).unwrap();
+		let llm = &result.config["llm"];
+		assert_eq!(llm["models"].as_array().unwrap().len(), 4);
+		assert_eq!(llm["models"][0]["name"], "imported/litellm/fast/1");
+		assert_eq!(llm["models"][0]["provider"], "azure");
+		assert_eq!(llm["models"][0]["params"]["apiKey"], "$AZURE_EAST_KEY");
+		assert_eq!(llm["models"][0]["defaults"]["temperature"], 0.2);
+		assert_eq!(llm["virtualModels"][0]["name"], "fast");
+		let targets = llm["virtualModels"][0]["routing"]["failover"]["targets"]
+			.as_array()
+			.unwrap();
+		assert_eq!(targets.len(), 4);
+		assert_eq!(targets[0]["priority"], 0);
+		assert_eq!(targets[2]["priority"], 1);
+		assert_eq!(targets[3]["priority"], 1);
+		assert!(
+			result
+				.findings
+				.iter()
+				.any(|finding| finding.status == ImportStatus::Approximate)
+		);
+	}
+
+	#[test]
+	fn reports_unsupported_provider_without_emitting_invalid_route() {
+		let input = r#"
+model_list:
+- model_name: unsupported
+  litellm_params:
+    model: unknown/model
+"#;
+		let result = import_config("litellm", input).unwrap();
+		assert!(
+			result.config["llm"]["models"]
+				.as_array()
+				.unwrap()
+				.is_empty()
+		);
+		assert!(
+			result
+				.findings
+				.iter()
+				.any(|finding| finding.status == ImportStatus::Unsupported)
+		);
+	}
+
+	#[test]
+	fn lists_registered_sources_in_stable_order() {
+		assert_eq!(available_sources(), vec!["litellm"]);
+	}
+}

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -76,6 +76,19 @@ pub struct ImportResult {
 	pub findings: Vec<ImportFinding>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ImportOptions {
+	pub database_url: String,
+}
+
+impl Default for ImportOptions {
+	fn default() -> Self {
+		Self {
+			database_url: "sqlite://data.db".to_string(),
+		}
+	}
+}
+
 pub fn available_sources() -> Vec<&'static str> {
 	importers()
 		.iter()
@@ -84,6 +97,14 @@ pub fn available_sources() -> Vec<&'static str> {
 }
 
 pub fn import_config(source: &str, input: &str) -> anyhow::Result<ImportResult> {
+	import_config_with_options(source, input, &ImportOptions::default())
+}
+
+pub fn import_config_with_options(
+	source: &str,
+	input: &str,
+	options: &ImportOptions,
+) -> anyhow::Result<ImportResult> {
 	let importer = importers()
 		.into_iter()
 		.find(|importer| importer.source().eq_ignore_ascii_case(source))
@@ -94,14 +115,14 @@ pub fn import_config(source: &str, input: &str) -> anyhow::Result<ImportResult> 
 			)
 		})?;
 	let plan = importer.import(input)?;
-	emit(importer.source(), plan)
+	emit(importer.source(), plan, options)
 }
 
 fn importers() -> Vec<Box<dyn ConfigImporter>> {
 	vec![Box::new(LiteLlmImporter)]
 }
 
-fn emit(source: &str, plan: ImportPlan) -> anyhow::Result<ImportResult> {
+fn emit(source: &str, plan: ImportPlan, options: &ImportOptions) -> anyhow::Result<ImportResult> {
 	let ImportPlan {
 		models,
 		routes,
@@ -111,15 +132,38 @@ fn emit(source: &str, plan: ImportPlan) -> anyhow::Result<ImportResult> {
 		.iter()
 		.map(|model| (model.name.as_str(), model))
 		.collect();
+	let internal_names = models
+		.iter()
+		.map(|model| model.name.as_str())
+		.collect::<HashSet<_>>();
+	let direct_model_names = routes
+		.iter()
+		.filter_map(|(public_name, route)| {
+			let [target] = route.targets.as_slice() else {
+				return None;
+			};
+			if !route.fallback_groups.is_empty()
+				|| (internal_names.contains(public_name.as_str()) && public_name != target)
+			{
+				return None;
+			}
+			Some((target.clone(), public_name.clone()))
+		})
+		.collect::<HashMap<_, _>>();
 	let emitted_models = models
 		.iter()
 		.map(|model| {
-			let mut value = Map::from_iter([
-				("name".to_string(), json!(model.name)),
-				("visibility".to_string(), json!("internal")),
-				("provider".to_string(), json!(model.provider)),
-				("params".to_string(), Value::Object(model.params.clone())),
-			]);
+			let direct_name = direct_model_names.get(&model.name);
+			let mut value = Map::new();
+			value.insert(
+				"name".to_string(),
+				json!(direct_name.unwrap_or(&model.name)),
+			);
+			if direct_name.is_none() {
+				value.insert("visibility".to_string(), json!("internal"));
+			}
+			value.insert("provider".to_string(), json!(model.provider));
+			value.insert("params".to_string(), Value::Object(model.params.clone()));
 			if !model.defaults.is_empty() {
 				value.insert(
 					"defaults".to_string(),
@@ -135,12 +179,18 @@ fn emit(source: &str, plan: ImportPlan) -> anyhow::Result<ImportResult> {
 		if route.targets.is_empty() {
 			continue;
 		}
+		if let [target] = route.targets.as_slice()
+			&& direct_model_names.get(target) == Some(&name)
+		{
+			continue;
+		}
 		let routing = if route.fallback_groups.is_empty() {
 			let targets = route
 				.targets
 				.iter()
 				.map(|target| {
 					let weight = model_by_name.get(target.as_str()).map_or(1, |m| m.weight);
+					let target = direct_model_names.get(target).unwrap_or(target);
 					json!({"model": target, "weight": weight})
 				})
 				.collect::<Vec<_>>();
@@ -149,10 +199,14 @@ fn emit(source: &str, plan: ImportPlan) -> anyhow::Result<ImportResult> {
 			let mut targets = route
 				.targets
 				.iter()
-				.map(|target| json!({"model": target, "priority": 0}))
+				.map(|target| {
+					let target = direct_model_names.get(target).unwrap_or(target);
+					json!({"model": target, "priority": 0})
+				})
 				.collect::<Vec<_>>();
 			for (priority, fallback_group) in route.fallback_groups.iter().enumerate() {
 				for fallback in fallback_group {
+					let fallback = direct_model_names.get(fallback).unwrap_or(fallback);
 					targets.push(json!({"model": fallback, "priority": priority + 1}));
 				}
 			}
@@ -161,13 +215,18 @@ fn emit(source: &str, plan: ImportPlan) -> anyhow::Result<ImportResult> {
 		virtual_models.push(json!({"name": name, "routing": routing}));
 	}
 
-	let config = json!({
-		"llm": {
-			"port": 4000,
-			"models": emitted_models,
-			"virtualModels": virtual_models,
-		}
-	});
+	let mut config = crate::types::local::default_standalone_config(&options.database_url);
+	let mut llm = Map::from_iter([
+		("gateways".to_string(), json!("default")),
+		("models".to_string(), Value::Array(emitted_models)),
+	]);
+	if !virtual_models.is_empty() {
+		llm.insert("virtualModels".to_string(), Value::Array(virtual_models));
+	}
+	config
+		.as_object_mut()
+		.expect("default standalone config must be an object")
+		.insert("llm".to_string(), Value::Object(llm));
 	let yaml = crate::yamlviajson::to_string(&config)?;
 	let _: crate::types::local::LocalConfig = crate::yamlviajson::from_str(&yaml)
 		.context("generated agentgateway configuration is invalid")?;
@@ -301,16 +360,26 @@ impl ConfigImporter for LiteLlmImporter {
 			("general_settings", &config.general_settings),
 			("environment_variables", &config.environment_variables),
 		] {
-			report_unmapped_fields(
-				&mut plan.findings,
-				section,
-				values,
-				ImportStatus::Manual,
-				"Requires manual review and was not emitted",
-			);
+			for setting in values.keys() {
+				if setting == "database_url"
+					|| (section == "environment_variables" && setting == "DATABASE_URL")
+				{
+					report_litellm_database(&mut plan.findings, &format!("{section}.{setting}"));
+					continue;
+				}
+				plan.findings.push(ImportFinding {
+					source_path: format!("{section}.{setting}"),
+					status: ImportStatus::Manual,
+					message: "Requires manual review and was not emitted".to_string(),
+				});
+			}
 		}
 		for setting in config.litellm_settings.keys() {
 			if setting == "fallbacks" {
+				continue;
+			}
+			if setting == "database_url" {
+				report_litellm_database(&mut plan.findings, &format!("litellm_settings.{setting}"));
 				continue;
 			}
 			plan.findings.push(ImportFinding {
@@ -328,6 +397,15 @@ impl ConfigImporter for LiteLlmImporter {
 		);
 		Ok(plan)
 	}
+}
+
+fn report_litellm_database(findings: &mut Vec<ImportFinding>, source_path: &str) {
+	findings.push(ImportFinding {
+		source_path: source_path.to_string(),
+		status: ImportStatus::Manual,
+		message: "LiteLLM database configuration was not reused; generated config uses a new agentgateway SQLite database. Configure PostgreSQL manually if desired"
+			.to_string(),
+	});
 }
 
 fn import_litellm_model(
@@ -745,6 +823,16 @@ mod tests {
 	#[test]
 	fn reports_wildcard_models_without_emitting_malformed_names() {
 		assert_litellm_golden("wildcard-model");
+	}
+
+	#[test]
+	fn reports_litellm_database_settings_without_reusing_them() {
+		assert_litellm_golden("database-settings");
+	}
+
+	#[test]
+	fn keeps_routing_for_a_single_model_with_fallbacks() {
+		assert_litellm_golden("single-model-fallback");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -192,6 +192,8 @@ struct LiteLlmConfig {
 	general_settings: Map<String, Value>,
 	#[serde(default)]
 	environment_variables: Map<String, Value>,
+	#[serde(flatten)]
+	other: Map<String, Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -199,6 +201,10 @@ struct LiteLlmModel {
 	model_name: String,
 	#[serde(default)]
 	litellm_params: Map<String, Value>,
+	#[serde(default)]
+	model_info: Map<String, Value>,
+	#[serde(flatten)]
+	other: Map<String, Value>,
 }
 
 impl ConfigImporter for LiteLlmImporter {
@@ -214,6 +220,11 @@ impl ConfigImporter for LiteLlmImporter {
 		}
 
 		let mut plan = ImportPlan::default();
+		let use_rpm_weights = match config.router_settings.get("routing_strategy") {
+			None => true,
+			Some(Value::String(strategy)) => strategy == "simple-shuffle",
+			Some(_) => false,
+		};
 		let mut counts = HashMap::<String, usize>::new();
 		for (index, model) in config.model_list.into_iter().enumerate() {
 			let source_path = format!("model_list[{index}]");
@@ -224,6 +235,7 @@ impl ConfigImporter for LiteLlmImporter {
 				internal_name.clone(),
 				model,
 				&source_path,
+				use_rpm_weights,
 				&mut plan.findings,
 			) else {
 				continue;
@@ -240,18 +252,39 @@ impl ConfigImporter for LiteLlmImporter {
 		let fallbacks = config
 			.router_settings
 			.get("fallbacks")
-			.or_else(|| config.litellm_settings.get("fallbacks"));
-		if let Some(fallbacks) = fallbacks {
-			apply_fallbacks(fallbacks, &mut plan);
+			.map(|fallbacks| ("router_settings.fallbacks", fallbacks))
+			.or_else(|| {
+				config
+					.litellm_settings
+					.get("fallbacks")
+					.map(|fallbacks| ("litellm_settings.fallbacks", fallbacks))
+			});
+		if let Some((source_path, fallbacks)) = fallbacks {
+			apply_fallbacks(fallbacks, source_path, &mut plan);
 		}
 
 		if let Some(strategy) = config.router_settings.get("routing_strategy") {
+			let (status, message) = match strategy.as_str() {
+				Some("simple-shuffle") => (
+					ImportStatus::Approximate,
+					"Approximated LiteLLM simple-shuffle with generated agentgateway routing; RPM is used only by weighted routes"
+						.to_string(),
+				),
+				Some(strategy) => (
+					ImportStatus::Unsupported,
+					format!(
+						"LiteLLM routing strategy {strategy:?} is not preserved; generated routes use equal weights or priority failover"
+					),
+				),
+				None => (
+					ImportStatus::Manual,
+					"Routing strategy must be a string and was not preserved".to_string(),
+				),
+			};
 			plan.findings.push(ImportFinding {
 				source_path: "router_settings.routing_strategy".to_string(),
-				status: ImportStatus::Approximate,
-				message: format!(
-					"LiteLLM routing strategy {strategy} is represented with agentgateway weighted or health-aware routing"
-				),
+				status,
+				message,
 			});
 		}
 		for setting in config.router_settings.keys() {
@@ -268,13 +301,13 @@ impl ConfigImporter for LiteLlmImporter {
 			("general_settings", &config.general_settings),
 			("environment_variables", &config.environment_variables),
 		] {
-			if !values.is_empty() {
-				plan.findings.push(ImportFinding {
-					source_path: section.to_string(),
-					status: ImportStatus::Manual,
-					message: format!("{section} requires manual review and was not emitted"),
-				});
-			}
+			report_unmapped_fields(
+				&mut plan.findings,
+				section,
+				values,
+				ImportStatus::Manual,
+				"Requires manual review and was not emitted",
+			);
 		}
 		for setting in config.litellm_settings.keys() {
 			if setting == "fallbacks" {
@@ -286,6 +319,13 @@ impl ConfigImporter for LiteLlmImporter {
 				message: "No automatic mapping is available".to_string(),
 			});
 		}
+		report_unmapped_fields(
+			&mut plan.findings,
+			"",
+			&config.other,
+			ImportStatus::Unsupported,
+			"Unrecognized LiteLLM top-level field was not emitted",
+		);
 		Ok(plan)
 	}
 }
@@ -294,14 +334,54 @@ fn import_litellm_model(
 	name: String,
 	model: LiteLlmModel,
 	source_path: &str,
+	use_rpm_weights: bool,
 	findings: &mut Vec<ImportFinding>,
 ) -> Option<(String, ImportedModel)> {
-	let public_name = model.model_name;
-	let mut params = model.litellm_params;
-	let model_id = params
-		.remove("model")
-		.and_then(|value| value.as_str().map(str::to_string))
-		.unwrap_or_else(|| public_name.clone());
+	let LiteLlmModel {
+		model_name: public_name,
+		litellm_params: mut params,
+		model_info,
+		other,
+	} = model;
+	report_unmapped_fields(
+		findings,
+		&format!("{source_path}.model_info"),
+		&model_info,
+		ImportStatus::Manual,
+		"LiteLLM model metadata requires manual review and was not emitted",
+	);
+	report_unmapped_fields(
+		findings,
+		source_path,
+		&other,
+		ImportStatus::Unsupported,
+		"Unrecognized LiteLLM model field was not emitted",
+	);
+	let model_id = match params.remove("model") {
+		Some(Value::String(model)) => model,
+		Some(_) => {
+			findings.push(ImportFinding {
+				source_path: format!("{source_path}.litellm_params.model"),
+				status: ImportStatus::Unsupported,
+				message: "LiteLLM model must be a string and was not emitted".to_string(),
+			});
+			return None;
+		},
+		None => public_name.clone(),
+	};
+	if public_name.contains('*') || model_id.contains('*') {
+		let wildcard_path = if public_name.contains('*') {
+			format!("{source_path}.model_name")
+		} else {
+			format!("{source_path}.litellm_params.model")
+		};
+		findings.push(ImportFinding {
+			source_path: wildcard_path,
+			status: ImportStatus::Unsupported,
+			message: "LiteLLM wildcard models are not yet supported and were not emitted".to_string(),
+		});
+		return None;
+	}
 	let (provider_prefix, upstream_model) = split_provider(&model_id);
 	let Some(provider) = map_provider(provider_prefix) else {
 		findings.push(ImportFinding {
@@ -341,21 +421,59 @@ fn import_litellm_model(
 		"vertexRegion",
 	);
 	if let Some(api_key) = params.remove("api_key") {
-		output_params.insert("apiKey".to_string(), normalize_secret(api_key));
+		output_params.insert(
+			"apiKey".to_string(),
+			normalize_environment_references(api_key),
+		);
 	}
 
 	let rpm = params.remove("rpm");
-	let weight = rpm
+	let tpm = params.remove("tpm");
+	if tpm.is_some() {
+		findings.push(ImportFinding {
+			source_path: format!("{source_path}.litellm_params.tpm"),
+			status: ImportStatus::Manual,
+			message: "TPM capacity is not mapped automatically".to_string(),
+		});
+	}
+	let parsed_rpm = rpm
 		.as_ref()
-		.and_then(|value| value.as_u64())
+		.and_then(Value::as_u64)
 		.and_then(|value| usize::try_from(value).ok())
-		.filter(|value| *value > 0)
-		.unwrap_or(1);
+		.filter(|value| *value > 0);
+	let weight = if use_rpm_weights && tpm.is_none() {
+		parsed_rpm.unwrap_or(1)
+	} else {
+		1
+	};
 	if rpm.is_some() {
+		let (status, message) = if parsed_rpm.is_none() {
+			(
+				ImportStatus::Manual,
+				"RPM must be a positive integer and was not mapped".to_string(),
+			)
+		} else if !use_rpm_weights {
+			(
+				ImportStatus::Manual,
+				"RPM capacity was not converted because the routing strategy is not simple-shuffle"
+					.to_string(),
+			)
+		} else if tpm.is_some() {
+			(
+				ImportStatus::Manual,
+				"RPM was not converted because the deployment also specifies unmapped TPM capacity"
+					.to_string(),
+			)
+		} else {
+			(
+				ImportStatus::Approximate,
+				"Used RPM as the relative weight for generated weighted routes".to_string(),
+			)
+		};
 		findings.push(ImportFinding {
 			source_path: format!("{source_path}.litellm_params.rpm"),
-			status: ImportStatus::Approximate,
-			message: "Used RPM as the deployment's relative routing weight".to_string(),
+			status,
+			message,
 		});
 	}
 	let mut defaults = Map::new();
@@ -370,17 +488,16 @@ fn import_litellm_model(
 		"stop",
 	] {
 		if let Some(value) = params.remove(key) {
-			defaults.insert(key.to_string(), value);
+			defaults.insert(key.to_string(), normalize_environment_references(value));
 		}
 	}
-	if !params.is_empty() {
-		let keys = params.keys().cloned().collect::<Vec<_>>().join(", ");
-		findings.push(ImportFinding {
-			source_path: format!("{source_path}.litellm_params"),
-			status: ImportStatus::Manual,
-			message: format!("Review unmapped LiteLLM parameters: {keys}"),
-		});
-	}
+	report_unmapped_fields(
+		findings,
+		&format!("{source_path}.litellm_params"),
+		&params,
+		ImportStatus::Manual,
+		"LiteLLM parameter requires manual review and was not emitted",
+	);
 	findings.push(ImportFinding {
 		source_path: source_path.to_string(),
 		status: ImportStatus::Exact,
@@ -435,50 +552,87 @@ fn move_string(
 	to: &str,
 ) {
 	if let Some(value) = source.remove(from) {
-		target.insert(to.to_string(), value);
+		target.insert(to.to_string(), normalize_environment_references(value));
 	}
 }
 
-fn normalize_secret(value: Value) -> Value {
-	let Some(value) = value.as_str() else {
-		return value;
-	};
-	match value.strip_prefix("os.environ/") {
-		Some(environment) => json!(format!("${environment}")),
-		None => json!(value),
+fn normalize_environment_references(value: Value) -> Value {
+	match value {
+		Value::String(value) => match value.strip_prefix("os.environ/") {
+			Some(environment) => json!(format!("${environment}")),
+			None => json!(value),
+		},
+		Value::Array(values) => Value::Array(
+			values
+				.into_iter()
+				.map(normalize_environment_references)
+				.collect(),
+		),
+		Value::Object(values) => Value::Object(
+			values
+				.into_iter()
+				.map(|(key, value)| (key, normalize_environment_references(value)))
+				.collect(),
+		),
+		value => value,
 	}
 }
 
-fn apply_fallbacks(value: &Value, plan: &mut ImportPlan) {
+fn report_unmapped_fields(
+	findings: &mut Vec<ImportFinding>,
+	prefix: &str,
+	values: &Map<String, Value>,
+	status: ImportStatus,
+	message: &str,
+) {
+	for key in values.keys() {
+		let separator = if prefix.is_empty() { "" } else { "." };
+		findings.push(ImportFinding {
+			source_path: format!("{prefix}{separator}{key}"),
+			status,
+			message: message.to_string(),
+		});
+	}
+}
+
+fn apply_fallbacks(value: &Value, source_path: &str, plan: &mut ImportPlan) {
 	let Some(entries) = value.as_array() else {
 		plan.findings.push(ImportFinding {
-			source_path: "router_settings.fallbacks".to_string(),
+			source_path: source_path.to_string(),
 			status: ImportStatus::Unsupported,
 			message: "Fallbacks must be a list of model mappings".to_string(),
 		});
 		return;
 	};
-	for entry in entries {
+	for (index, entry) in entries.iter().enumerate() {
 		let Some(entry) = entry.as_object() else {
+			plan.findings.push(ImportFinding {
+				source_path: format!("{source_path}[{index}]"),
+				status: ImportStatus::Unsupported,
+				message: "Fallback entry must be a model mapping and was not emitted".to_string(),
+			});
 			continue;
 		};
 		for (source, fallback_names) in entry {
 			if !plan.routes.contains_key(source) {
 				plan.findings.push(ImportFinding {
-					source_path: "router_settings.fallbacks".to_string(),
+					source_path: source_path.to_string(),
 					status: ImportStatus::Manual,
 					message: format!("Fallback source model {source:?} was not imported"),
 				});
 				continue;
 			}
+			let Some(fallback_names) = fallback_names.as_array() else {
+				plan.findings.push(ImportFinding {
+					source_path: format!("{source_path}[{index}].{source}"),
+					status: ImportStatus::Unsupported,
+					message: "Fallback targets must be a list and were not emitted".to_string(),
+				});
+				continue;
+			};
 			let mut seen = HashSet::new();
 			let mut resolved_groups = Vec::new();
-			for fallback_name in fallback_names
-				.as_array()
-				.into_iter()
-				.flatten()
-				.filter_map(Value::as_str)
-			{
+			for fallback_name in fallback_names.iter().filter_map(Value::as_str) {
 				if !seen.insert(fallback_name) {
 					continue;
 				}
@@ -486,7 +640,7 @@ fn apply_fallbacks(value: &Value, plan: &mut ImportPlan) {
 					resolved_groups.push(fallback.targets.clone());
 				} else {
 					plan.findings.push(ImportFinding {
-						source_path: "router_settings.fallbacks".to_string(),
+						source_path: source_path.to_string(),
 						status: ImportStatus::Manual,
 						message: format!("Fallback target model {fallback_name:?} was not imported"),
 					});
@@ -501,7 +655,7 @@ fn apply_fallbacks(value: &Value, plan: &mut ImportPlan) {
 		}
 	}
 	plan.findings.push(ImportFinding {
-		source_path: "router_settings.fallbacks".to_string(),
+		source_path: source_path.to_string(),
 		status: ImportStatus::Approximate,
 		message: "Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover"
 			.to_string(),
@@ -613,6 +767,127 @@ model_list:
 				.iter()
 				.any(|finding| finding.status == ImportStatus::Unsupported)
 		);
+	}
+
+	#[test]
+	fn reports_unmapped_top_level_and_model_fields() {
+		let input = r#"
+model_list:
+- model_name: chat
+  litellm_params:
+    model: openai/gpt-4o
+  model_info:
+    id: deployment-1
+  custom_model_field: true
+credential_list:
+- credential_name: shared
+  credential_values:
+    api_key: os.environ/OPENAI_API_KEY
+  credential_info: {}
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+environment_variables:
+  LOG_LEVEL: info
+custom_section:
+  enabled: true
+"#;
+		let result = import_config("litellm", input).unwrap();
+		for expected in [
+			"model_list[0].model_info.id",
+			"model_list[0].custom_model_field",
+			"credential_list",
+			"general_settings.master_key",
+			"environment_variables.LOG_LEVEL",
+			"custom_section",
+		] {
+			assert!(
+				result
+					.findings
+					.iter()
+					.any(|finding| finding.source_path == expected),
+				"missing finding for {expected}"
+			);
+		}
+	}
+
+	#[test]
+	fn normalizes_environment_references_in_all_mapped_values() {
+		let input = r#"
+model_list:
+- model_name: chat
+  litellm_params:
+    model: azure/gpt-4o
+    api_base: os.environ/AZURE_API_BASE
+    api_key: os.environ/AZURE_API_KEY
+    api_version: os.environ/AZURE_API_VERSION
+    temperature: os.environ/DEFAULT_TEMPERATURE
+    stop: [os.environ/STOP_SEQUENCE]
+"#;
+		let result = import_config("litellm", input).unwrap();
+		let model = &result.config["llm"]["models"][0];
+		assert_eq!(model["params"]["baseUrl"], "$AZURE_API_BASE");
+		assert_eq!(model["params"]["apiKey"], "$AZURE_API_KEY");
+		assert_eq!(model["params"]["azureApiVersion"], "$AZURE_API_VERSION");
+		assert_eq!(model["defaults"]["temperature"], "$DEFAULT_TEMPERATURE");
+		assert_eq!(model["defaults"]["stop"][0], "$STOP_SEQUENCE");
+	}
+
+	#[test]
+	fn does_not_apply_capacity_weights_to_incompatible_routing() {
+		let input = r#"
+model_list:
+- model_name: chat
+  litellm_params:
+    model: openai/gpt-4o
+    rpm: 100
+- model_name: chat
+  litellm_params:
+    model: openai/gpt-4o-mini
+    rpm: 50
+    tpm: 10000
+router_settings:
+  routing_strategy: least-busy
+"#;
+		let result = import_config("litellm", input).unwrap();
+		let targets = result.config["llm"]["virtualModels"][0]["routing"]["weighted"]["targets"]
+			.as_array()
+			.unwrap();
+		assert!(targets.iter().all(|target| target["weight"] == 1));
+		assert!(result.findings.iter().any(|finding| {
+			finding.source_path == "router_settings.routing_strategy"
+				&& finding.status == ImportStatus::Unsupported
+		}));
+		assert!(result.findings.iter().any(|finding| {
+			finding.source_path == "model_list[1].litellm_params.tpm"
+				&& finding.status == ImportStatus::Manual
+		}));
+	}
+
+	#[test]
+	fn reports_wildcard_models_without_emitting_malformed_names() {
+		let input = r#"
+model_list:
+- model_name: "*"
+  litellm_params:
+    model: "openai/*"
+"#;
+		let result = import_config("litellm", input).unwrap();
+		assert!(
+			result.config["llm"]["models"]
+				.as_array()
+				.unwrap()
+				.is_empty()
+		);
+		assert!(
+			result.config["llm"]["virtualModels"]
+				.as_array()
+				.unwrap()
+				.is_empty()
+		);
+		assert!(result.findings.iter().any(|finding| {
+			finding.source_path == "model_list[0].model_name"
+				&& finding.status == ImportStatus::Unsupported
+		}));
 	}
 
 	#[test]

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -691,203 +691,60 @@ fn imported_model_name(source: &str, public_name: &str, deployment: usize) -> St
 
 #[cfg(test)]
 mod tests {
+	use std::fs;
+	use std::path::{Path, PathBuf};
+
 	use super::*;
+
+	fn fixture_path(name: &str) -> PathBuf {
+		Path::new("src/tests/import/litellm").join(format!("{name}.yaml"))
+	}
+
+	fn assert_litellm_golden(name: &str) {
+		let input_path = fixture_path(name);
+		let input = fs::read_to_string(&input_path)
+			.unwrap_or_else(|error| panic!("{}: {error}", input_path.display()));
+		let result = import_config("litellm", &input)
+			.unwrap_or_else(|error| panic!("{}: {error}", input_path.display()));
+
+		insta::with_settings!({
+			description => input_path.to_string_lossy().to_string(),
+			omit_expression => true,
+			prepend_module_to_snapshot => false,
+			snapshot_path => "tests/import/litellm",
+		}, {
+			insta::assert_yaml_snapshot!(name, result);
+		});
+	}
 
 	#[test]
 	fn imports_litellm_models_load_balancing_and_fallbacks() {
-		let input = r#"
-model_list:
-- model_name: fast
-  litellm_params:
-    model: azure/gpt-4o-east
-    api_base: https://east.openai.azure.com
-    api_key: os.environ/AZURE_EAST_KEY
-    api_version: 2025-01-01
-    rpm: 60
-    temperature: 0.2
-- model_name: fast
-  litellm_params:
-    model: openai/gpt-4o
-    api_key: os.environ/OPENAI_API_KEY
-    rpm: 40
-- model_name: backup
-  litellm_params:
-    model: anthropic/claude-sonnet-4
-    api_key: os.environ/ANTHROPIC_API_KEY
-- model_name: backup
-  litellm_params:
-    model: anthropic/claude-haiku-4
-    api_key: os.environ/ANTHROPIC_API_KEY
-router_settings:
-  routing_strategy: simple-shuffle
-  fallbacks:
-  - fast: [backup]
-"#;
-		let result = import_config("litellm", input).unwrap();
-		let llm = &result.config["llm"];
-		assert_eq!(llm["models"].as_array().unwrap().len(), 4);
-		assert_eq!(llm["models"][0]["name"], "imported/litellm/fast/1");
-		assert_eq!(llm["models"][0]["provider"], "azure");
-		assert_eq!(llm["models"][0]["params"]["apiKey"], "$AZURE_EAST_KEY");
-		assert_eq!(llm["models"][0]["defaults"]["temperature"], 0.2);
-		assert_eq!(llm["virtualModels"][0]["name"], "fast");
-		let targets = llm["virtualModels"][0]["routing"]["failover"]["targets"]
-			.as_array()
-			.unwrap();
-		assert_eq!(targets.len(), 4);
-		assert_eq!(targets[0]["priority"], 0);
-		assert_eq!(targets[2]["priority"], 1);
-		assert_eq!(targets[3]["priority"], 1);
-		assert!(
-			result
-				.findings
-				.iter()
-				.any(|finding| finding.status == ImportStatus::Approximate)
-		);
+		assert_litellm_golden("load-balancing-fallbacks");
 	}
 
 	#[test]
 	fn reports_unsupported_provider_without_emitting_invalid_route() {
-		let input = r#"
-model_list:
-- model_name: unsupported
-  litellm_params:
-    model: unknown/model
-"#;
-		let result = import_config("litellm", input).unwrap();
-		assert!(
-			result.config["llm"]["models"]
-				.as_array()
-				.unwrap()
-				.is_empty()
-		);
-		assert!(
-			result
-				.findings
-				.iter()
-				.any(|finding| finding.status == ImportStatus::Unsupported)
-		);
+		assert_litellm_golden("unsupported-provider");
 	}
 
 	#[test]
 	fn reports_unmapped_top_level_and_model_fields() {
-		let input = r#"
-model_list:
-- model_name: chat
-  litellm_params:
-    model: openai/gpt-4o
-  model_info:
-    id: deployment-1
-  custom_model_field: true
-credential_list:
-- credential_name: shared
-  credential_values:
-    api_key: os.environ/OPENAI_API_KEY
-  credential_info: {}
-general_settings:
-  master_key: os.environ/LITELLM_MASTER_KEY
-environment_variables:
-  LOG_LEVEL: info
-custom_section:
-  enabled: true
-"#;
-		let result = import_config("litellm", input).unwrap();
-		for expected in [
-			"model_list[0].model_info.id",
-			"model_list[0].custom_model_field",
-			"credential_list",
-			"general_settings.master_key",
-			"environment_variables.LOG_LEVEL",
-			"custom_section",
-		] {
-			assert!(
-				result
-					.findings
-					.iter()
-					.any(|finding| finding.source_path == expected),
-				"missing finding for {expected}"
-			);
-		}
+		assert_litellm_golden("unmapped-fields");
 	}
 
 	#[test]
 	fn normalizes_environment_references_in_all_mapped_values() {
-		let input = r#"
-model_list:
-- model_name: chat
-  litellm_params:
-    model: azure/gpt-4o
-    api_base: os.environ/AZURE_API_BASE
-    api_key: os.environ/AZURE_API_KEY
-    api_version: os.environ/AZURE_API_VERSION
-    temperature: os.environ/DEFAULT_TEMPERATURE
-    stop: [os.environ/STOP_SEQUENCE]
-"#;
-		let result = import_config("litellm", input).unwrap();
-		let model = &result.config["llm"]["models"][0];
-		assert_eq!(model["params"]["baseUrl"], "$AZURE_API_BASE");
-		assert_eq!(model["params"]["apiKey"], "$AZURE_API_KEY");
-		assert_eq!(model["params"]["azureApiVersion"], "$AZURE_API_VERSION");
-		assert_eq!(model["defaults"]["temperature"], "$DEFAULT_TEMPERATURE");
-		assert_eq!(model["defaults"]["stop"][0], "$STOP_SEQUENCE");
+		assert_litellm_golden("environment-references");
 	}
 
 	#[test]
 	fn does_not_apply_capacity_weights_to_incompatible_routing() {
-		let input = r#"
-model_list:
-- model_name: chat
-  litellm_params:
-    model: openai/gpt-4o
-    rpm: 100
-- model_name: chat
-  litellm_params:
-    model: openai/gpt-4o-mini
-    rpm: 50
-    tpm: 10000
-router_settings:
-  routing_strategy: least-busy
-"#;
-		let result = import_config("litellm", input).unwrap();
-		let targets = result.config["llm"]["virtualModels"][0]["routing"]["weighted"]["targets"]
-			.as_array()
-			.unwrap();
-		assert!(targets.iter().all(|target| target["weight"] == 1));
-		assert!(result.findings.iter().any(|finding| {
-			finding.source_path == "router_settings.routing_strategy"
-				&& finding.status == ImportStatus::Unsupported
-		}));
-		assert!(result.findings.iter().any(|finding| {
-			finding.source_path == "model_list[1].litellm_params.tpm"
-				&& finding.status == ImportStatus::Manual
-		}));
+		assert_litellm_golden("incompatible-routing");
 	}
 
 	#[test]
 	fn reports_wildcard_models_without_emitting_malformed_names() {
-		let input = r#"
-model_list:
-- model_name: "*"
-  litellm_params:
-    model: "openai/*"
-"#;
-		let result = import_config("litellm", input).unwrap();
-		assert!(
-			result.config["llm"]["models"]
-				.as_array()
-				.unwrap()
-				.is_empty()
-		);
-		assert!(
-			result.config["llm"]["virtualModels"]
-				.as_array()
-				.unwrap()
-				.is_empty()
-		);
-		assert!(result.findings.iter().any(|finding| {
-			finding.source_path == "model_list[0].model_name"
-				&& finding.status == ImportStatus::Unsupported
-		}));
+		assert_litellm_golden("wildcard-model");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -31,6 +31,7 @@ pub mod config_store;
 pub mod control;
 pub mod database;
 pub mod http;
+pub mod import;
 pub mod json;
 pub mod llm;
 pub mod management;

--- a/crates/agentgateway/src/tests/import/litellm/database-settings.snap
+++ b/crates/agentgateway/src/tests/import/litellm/database-settings.snap
@@ -1,0 +1,34 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/database-settings.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: chat
+        provider: openAI
+        params:
+          model: gpt-4o
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for chat
+  - sourcePath: general_settings.database_url
+    status: manual
+    message: LiteLLM database configuration was not reused; generated config uses a new agentgateway SQLite database. Configure PostgreSQL manually if desired
+  - sourcePath: environment_variables.DATABASE_URL
+    status: manual
+    message: LiteLLM database configuration was not reused; generated config uses a new agentgateway SQLite database. Configure PostgreSQL manually if desired
+  - sourcePath: litellm_settings.database_url
+    status: manual
+    message: LiteLLM database configuration was not reused; generated config uses a new agentgateway SQLite database. Configure PostgreSQL manually if desired

--- a/crates/agentgateway/src/tests/import/litellm/database-settings.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/database-settings.yaml
@@ -1,0 +1,10 @@
+model_list:
+- model_name: chat
+  litellm_params:
+    model: openai/gpt-4o
+general_settings:
+  database_url: os.environ/GENERAL_DATABASE_URL
+litellm_settings:
+  database_url: os.environ/LITELLM_DATABASE_URL
+environment_variables:
+  DATABASE_URL: os.environ/ENVIRONMENT_DATABASE_URL

--- a/crates/agentgateway/src/tests/import/litellm/environment-references.snap
+++ b/crates/agentgateway/src/tests/import/litellm/environment-references.snap
@@ -4,11 +4,18 @@ description: src/tests/import/litellm/environment-references.yaml
 ---
 source: litellm
 config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
   llm:
-    port: 4000
+    gateways: default
     models:
-      - name: imported/litellm/chat/1
-        visibility: internal
+      - name: chat
         provider: azure
         params:
           model: gpt-4o
@@ -19,13 +26,6 @@ config:
           temperature: $DEFAULT_TEMPERATURE
           stop:
             - $STOP_SEQUENCE
-    virtualModels:
-      - name: chat
-        routing:
-          weighted:
-            targets:
-              - model: imported/litellm/chat/1
-                weight: 1
 findings:
   - sourcePath: "model_list[0]"
     status: exact

--- a/crates/agentgateway/src/tests/import/litellm/environment-references.snap
+++ b/crates/agentgateway/src/tests/import/litellm/environment-references.snap
@@ -1,0 +1,32 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/environment-references.yaml
+---
+source: litellm
+config:
+  llm:
+    port: 4000
+    models:
+      - name: imported/litellm/chat/1
+        visibility: internal
+        provider: azure
+        params:
+          model: gpt-4o
+          baseUrl: $AZURE_API_BASE
+          azureApiVersion: $AZURE_API_VERSION
+          apiKey: $AZURE_API_KEY
+        defaults:
+          temperature: $DEFAULT_TEMPERATURE
+          stop:
+            - $STOP_SEQUENCE
+    virtualModels:
+      - name: chat
+        routing:
+          weighted:
+            targets:
+              - model: imported/litellm/chat/1
+                weight: 1
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for chat

--- a/crates/agentgateway/src/tests/import/litellm/environment-references.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/environment-references.yaml
@@ -1,0 +1,9 @@
+model_list:
+- model_name: chat
+  litellm_params:
+    model: azure/gpt-4o
+    api_base: os.environ/AZURE_API_BASE
+    api_key: os.environ/AZURE_API_KEY
+    api_version: os.environ/AZURE_API_VERSION
+    temperature: os.environ/DEFAULT_TEMPERATURE
+    stop: [os.environ/STOP_SEQUENCE]

--- a/crates/agentgateway/src/tests/import/litellm/incompatible-routing.snap
+++ b/crates/agentgateway/src/tests/import/litellm/incompatible-routing.snap
@@ -1,0 +1,47 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/incompatible-routing.yaml
+---
+source: litellm
+config:
+  llm:
+    port: 4000
+    models:
+      - name: imported/litellm/chat/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: imported/litellm/chat/2
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o-mini
+    virtualModels:
+      - name: chat
+        routing:
+          weighted:
+            targets:
+              - model: imported/litellm/chat/1
+                weight: 1
+              - model: imported/litellm/chat/2
+                weight: 1
+findings:
+  - sourcePath: "model_list[0].litellm_params.rpm"
+    status: manual
+    message: RPM capacity was not converted because the routing strategy is not simple-shuffle
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for chat
+  - sourcePath: "model_list[1].litellm_params.tpm"
+    status: manual
+    message: TPM capacity is not mapped automatically
+  - sourcePath: "model_list[1].litellm_params.rpm"
+    status: manual
+    message: RPM capacity was not converted because the routing strategy is not simple-shuffle
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for chat
+  - sourcePath: router_settings.routing_strategy
+    status: unsupported
+    message: "LiteLLM routing strategy \"least-busy\" is not preserved; generated routes use equal weights or priority failover"

--- a/crates/agentgateway/src/tests/import/litellm/incompatible-routing.snap
+++ b/crates/agentgateway/src/tests/import/litellm/incompatible-routing.snap
@@ -4,8 +4,16 @@ description: src/tests/import/litellm/incompatible-routing.yaml
 ---
 source: litellm
 config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
   llm:
-    port: 4000
+    gateways: default
     models:
       - name: imported/litellm/chat/1
         visibility: internal

--- a/crates/agentgateway/src/tests/import/litellm/incompatible-routing.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/incompatible-routing.yaml
@@ -1,0 +1,12 @@
+model_list:
+- model_name: chat
+  litellm_params:
+    model: openai/gpt-4o
+    rpm: 100
+- model_name: chat
+  litellm_params:
+    model: openai/gpt-4o-mini
+    rpm: 50
+    tpm: 10000
+router_settings:
+  routing_strategy: least-busy

--- a/crates/agentgateway/src/tests/import/litellm/load-balancing-fallbacks.snap
+++ b/crates/agentgateway/src/tests/import/litellm/load-balancing-fallbacks.snap
@@ -1,0 +1,83 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/load-balancing-fallbacks.yaml
+---
+source: litellm
+config:
+  llm:
+    port: 4000
+    models:
+      - name: imported/litellm/fast/1
+        visibility: internal
+        provider: azure
+        params:
+          model: gpt-4o-east
+          baseUrl: "https://east.openai.azure.com"
+          azureApiVersion: 2025-01-01
+          apiKey: $AZURE_EAST_KEY
+        defaults:
+          temperature: 0.2
+      - name: imported/litellm/fast/2
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o
+          apiKey: $OPENAI_API_KEY
+      - name: imported/litellm/backup/1
+        visibility: internal
+        provider: anthropic
+        params:
+          model: claude-sonnet-4
+          apiKey: $ANTHROPIC_API_KEY
+      - name: imported/litellm/backup/2
+        visibility: internal
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+          apiKey: $ANTHROPIC_API_KEY
+    virtualModels:
+      - name: fast
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/fast/1
+                priority: 0
+              - model: imported/litellm/fast/2
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+              - model: imported/litellm/backup/2
+                priority: 1
+      - name: backup
+        routing:
+          weighted:
+            targets:
+              - model: imported/litellm/backup/1
+                weight: 1
+              - model: imported/litellm/backup/2
+                weight: 1
+findings:
+  - sourcePath: "model_list[0].litellm_params.rpm"
+    status: approximate
+    message: Used RPM as the relative weight for generated weighted routes
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for fast
+  - sourcePath: "model_list[1].litellm_params.rpm"
+    status: approximate
+    message: Used RPM as the relative weight for generated weighted routes
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for fast
+  - sourcePath: "model_list[2]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: "model_list[3]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: router_settings.fallbacks
+    status: approximate
+    message: Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover
+  - sourcePath: router_settings.routing_strategy
+    status: approximate
+    message: Approximated LiteLLM simple-shuffle with generated agentgateway routing; RPM is used only by weighted routes

--- a/crates/agentgateway/src/tests/import/litellm/load-balancing-fallbacks.snap
+++ b/crates/agentgateway/src/tests/import/litellm/load-balancing-fallbacks.snap
@@ -4,8 +4,16 @@ description: src/tests/import/litellm/load-balancing-fallbacks.yaml
 ---
 source: litellm
 config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
   llm:
-    port: 4000
+    gateways: default
     models:
       - name: imported/litellm/fast/1
         visibility: internal

--- a/crates/agentgateway/src/tests/import/litellm/load-balancing-fallbacks.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/load-balancing-fallbacks.yaml
@@ -1,0 +1,26 @@
+model_list:
+- model_name: fast
+  litellm_params:
+    model: azure/gpt-4o-east
+    api_base: https://east.openai.azure.com
+    api_key: os.environ/AZURE_EAST_KEY
+    api_version: 2025-01-01
+    rpm: 60
+    temperature: 0.2
+- model_name: fast
+  litellm_params:
+    model: openai/gpt-4o
+    api_key: os.environ/OPENAI_API_KEY
+    rpm: 40
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-sonnet-4
+    api_key: os.environ/ANTHROPIC_API_KEY
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+    api_key: os.environ/ANTHROPIC_API_KEY
+router_settings:
+  routing_strategy: simple-shuffle
+  fallbacks:
+  - fast: [backup]

--- a/crates/agentgateway/src/tests/import/litellm/single-model-fallback.snap
+++ b/crates/agentgateway/src/tests/import/litellm/single-model-fallback.snap
@@ -1,0 +1,45 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/single-model-fallback.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: imported/litellm/primary/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: backup
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+    virtualModels:
+      - name: primary
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/primary/1
+                priority: 0
+              - model: backup
+                priority: 1
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for primary
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: router_settings.fallbacks
+    status: approximate
+    message: Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover

--- a/crates/agentgateway/src/tests/import/litellm/single-model-fallback.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/single-model-fallback.yaml
@@ -1,0 +1,10 @@
+model_list:
+- model_name: primary
+  litellm_params:
+    model: openai/gpt-4o
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+router_settings:
+  fallbacks:
+  - primary: [backup]

--- a/crates/agentgateway/src/tests/import/litellm/unmapped-fields.snap
+++ b/crates/agentgateway/src/tests/import/litellm/unmapped-fields.snap
@@ -1,0 +1,43 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/unmapped-fields.yaml
+---
+source: litellm
+config:
+  llm:
+    port: 4000
+    models:
+      - name: imported/litellm/chat/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o
+    virtualModels:
+      - name: chat
+        routing:
+          weighted:
+            targets:
+              - model: imported/litellm/chat/1
+                weight: 1
+findings:
+  - sourcePath: "model_list[0].model_info.id"
+    status: manual
+    message: LiteLLM model metadata requires manual review and was not emitted
+  - sourcePath: "model_list[0].custom_model_field"
+    status: unsupported
+    message: Unrecognized LiteLLM model field was not emitted
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for chat
+  - sourcePath: general_settings.master_key
+    status: manual
+    message: Requires manual review and was not emitted
+  - sourcePath: environment_variables.LOG_LEVEL
+    status: manual
+    message: Requires manual review and was not emitted
+  - sourcePath: credential_list
+    status: unsupported
+    message: Unrecognized LiteLLM top-level field was not emitted
+  - sourcePath: custom_section
+    status: unsupported
+    message: Unrecognized LiteLLM top-level field was not emitted

--- a/crates/agentgateway/src/tests/import/litellm/unmapped-fields.snap
+++ b/crates/agentgateway/src/tests/import/litellm/unmapped-fields.snap
@@ -4,21 +4,21 @@ description: src/tests/import/litellm/unmapped-fields.yaml
 ---
 source: litellm
 config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
   llm:
-    port: 4000
+    gateways: default
     models:
-      - name: imported/litellm/chat/1
-        visibility: internal
+      - name: chat
         provider: openAI
         params:
           model: gpt-4o
-    virtualModels:
-      - name: chat
-        routing:
-          weighted:
-            targets:
-              - model: imported/litellm/chat/1
-                weight: 1
 findings:
   - sourcePath: "model_list[0].model_info.id"
     status: manual

--- a/crates/agentgateway/src/tests/import/litellm/unmapped-fields.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/unmapped-fields.yaml
@@ -1,0 +1,18 @@
+model_list:
+- model_name: chat
+  litellm_params:
+    model: openai/gpt-4o
+  model_info:
+    id: deployment-1
+  custom_model_field: true
+credential_list:
+- credential_name: shared
+  credential_values:
+    api_key: os.environ/OPENAI_API_KEY
+  credential_info: {}
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+environment_variables:
+  LOG_LEVEL: info
+custom_section:
+  enabled: true

--- a/crates/agentgateway/src/tests/import/litellm/unsupported-provider.snap
+++ b/crates/agentgateway/src/tests/import/litellm/unsupported-provider.snap
@@ -1,0 +1,14 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/unsupported-provider.yaml
+---
+source: litellm
+config:
+  llm:
+    port: 4000
+    models: []
+    virtualModels: []
+findings:
+  - sourcePath: "model_list[0].litellm_params.model"
+    status: unsupported
+    message: "LiteLLM provider \"unknown\" is not supported by this importer"

--- a/crates/agentgateway/src/tests/import/litellm/unsupported-provider.snap
+++ b/crates/agentgateway/src/tests/import/litellm/unsupported-provider.snap
@@ -4,10 +4,17 @@ description: src/tests/import/litellm/unsupported-provider.yaml
 ---
 source: litellm
 config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
   llm:
-    port: 4000
+    gateways: default
     models: []
-    virtualModels: []
 findings:
   - sourcePath: "model_list[0].litellm_params.model"
     status: unsupported

--- a/crates/agentgateway/src/tests/import/litellm/unsupported-provider.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/unsupported-provider.yaml
@@ -1,0 +1,4 @@
+model_list:
+- model_name: unsupported
+  litellm_params:
+    model: unknown/model

--- a/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
+++ b/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
@@ -1,0 +1,14 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/wildcard-model.yaml
+---
+source: litellm
+config:
+  llm:
+    port: 4000
+    models: []
+    virtualModels: []
+findings:
+  - sourcePath: "model_list[0].model_name"
+    status: unsupported
+    message: LiteLLM wildcard models are not yet supported and were not emitted

--- a/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
+++ b/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
@@ -4,10 +4,17 @@ description: src/tests/import/litellm/wildcard-model.yaml
 ---
 source: litellm
 config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
   llm:
-    port: 4000
+    gateways: default
     models: []
-    virtualModels: []
 findings:
   - sourcePath: "model_list[0].model_name"
     status: unsupported

--- a/crates/agentgateway/src/tests/import/litellm/wildcard-model.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/wildcard-model.yaml
@@ -1,0 +1,4 @@
+model_list:
+- model_name: "*"
+  litellm_params:
+    model: "openai/*"

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -49,6 +49,25 @@ type LocalMcpGuardrails = crate::mcp::guardrails::McpGuardrails;
 const DEFAULT_LLM_PORT: u16 = 4000;
 const DEFAULT_MCP_PORT: u16 = 3000;
 
+/// Build the base configuration used by a standalone agentgateway instance.
+pub fn default_standalone_config(database_url: &str) -> serde_json::Value {
+	serde_json::json!({
+		"config": {
+			"database": {
+				"url": database_url,
+			},
+		},
+		"gateways": {
+			"default": {
+				"port": DEFAULT_LLM_PORT,
+			},
+		},
+		"ui": {
+			"gateways": "default",
+		},
+	})
+}
+
 // Windows has different output, for now easier to just not deal with it
 #[cfg(all(test, target_family = "unix"))]
 #[path = "local_tests.rs"]


### PR DESCRIPTION
## Summary

- add a standalone `agentgateway import --from <source>` command with file and stdin/stdout support
- add a source-adapter interface, shared emitter, native config validation, and compatibility findings
- add LiteLLM proxy configuration support for common providers, aliases, deployments, weighted routing, and fallbacks
- report unhandled source fields and unsupported wildcards instead of silently dropping them
- preserve environment references across mapped fields and avoid applying RPM weights to incompatible routing strategies

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p agentgateway import::tests --lib`
- `cargo check -p agentgateway-app`
- `cargo clippy -p agentgateway --lib -- -D warnings`
- end-to-end LiteLLM and generated agentgateway request testing

Fixes: #2533