### PR TITLE
llm: allow logging user AND prompt

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -134,7 +134,17 @@ pub fn apply_logging_policy_to_log(log: &mut RequestLog, lp: &frontend::LoggingP
 	if let Some(database) = &lp.database
 		&& !database.add.is_empty()
 	{
-		log.cel.database_fields.add = database.add.clone();
+		log.cel.database_fields.add = Arc::new(
+			log
+				.cel
+				.database_fields
+				.add
+				.iter()
+				.filter(|(key, _)| !database.add.contains_key(key))
+				.chain(database.add.iter())
+				.map(|(key, value)| (key.clone(), value.clone()))
+				.collect(),
+		);
 	}
 }
 


### PR DESCRIPTION
Before, if we added the prompt field it would replace the entire
existing log fields. The existing fields are what make user set.

Fixes https://github.com/agentgateway/agentgateway/issues/2293

Signed-off-by: John Howard <john.howard@solo.io>
