### PR TITLE
ui: align status on logs

### DIFF
--- a/ui/src/pages/Logs.tsx
+++ b/ui/src/pages/Logs.tsx
@@ -1159,25 +1159,20 @@ function LogCallRow(props: {
         <span className="log-type-chip">
           {(props.entry.genAi.operationName ?? "chat").toUpperCase()}
         </span>
+        <span className="log-call-status">
+          <span className={statusBad ? "badge bad" : "badge ok"}>
+            {props.entry.httpStatus ?? "n/a"}
+          </span>
+        </span>
         <span
           className={hasPreview ? "log-call-main" : "log-call-main no-preview"}
         >
           {hasPreview ? (
             <span className="log-call-title-row">
               <span className="log-message-preview">{preview}</span>
-              <span className={statusBad ? "badge bad" : "badge ok"}>
-                {props.entry.httpStatus ?? "n/a"}
-              </span>
             </span>
           ) : null}
           <span className="log-call-subtitle">
-            {!hasPreview ? (
-              <span className="log-call-inline-status">
-                <span className={statusBad ? "badge bad" : "badge ok"}>
-                  {props.entry.httpStatus ?? "n/a"}
-                </span>
-              </span>
-            ) : null}
             <span className="log-model-flow">
               {originalModel &&
               originalModel !== props.entry.genAi.requestModel ? (

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3004,8 +3004,8 @@ tbody tr:hover {
   display: grid;
   width: 100%;
   grid-template-columns:
-    4px minmax(126px, 0.55fr) auto minmax(0, 2fr) minmax(230px, 0.9fr)
-    auto;
+    4px minmax(126px, 0.55fr) auto 48px minmax(0, 2fr)
+    minmax(230px, 0.9fr) auto;
   gap: 14px;
   align-items: center;
   border: 0;
@@ -3082,10 +3082,7 @@ tbody tr:hover {
 }
 
 .log-call-title-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
-  align-items: center;
+  min-width: 0;
 }
 
 .log-message-preview {
@@ -3107,9 +3104,9 @@ tbody tr:hover {
   font-size: 12px;
 }
 
-.log-call-inline-status {
+.log-call-status {
   display: inline-flex;
-  flex: 0 0 auto;
+  justify-content: center;
 }
 
 .log-call-subtitle > span {
@@ -5829,6 +5826,12 @@ details summary {
   .log-call-main {
     grid-column: 2 / 4;
     grid-row: 1;
+  }
+
+  .log-call-status {
+    grid-column: 3;
+    grid-row: 2;
+    justify-self: end;
   }
 
   .log-call-title-row {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3082,6 +3082,8 @@ tbody tr:hover {
 }
 
 .log-call-title-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
   min-width: 0;
 }
 
@@ -5800,12 +5802,13 @@ details summary {
   }
 
   .log-call-summary {
-    grid-template-columns: 4px minmax(0, 1fr) auto;
+    grid-template-columns: 4px minmax(0, 1fr) 48px;
     gap: 10px;
     padding: 12px;
   }
 
   .log-status-rail {
+    grid-column: 1;
     grid-row: 1 / span 5;
   }
 
@@ -5831,7 +5834,7 @@ details summary {
   .log-call-status {
     grid-column: 3;
     grid-row: 2;
-    justify-self: end;
+    justify-self: stretch;
   }
 
   .log-call-title-row {


### PR DESCRIPTION
Before it would moved based on prompt vs no prompt

Signed-off-by: John Howard <john.howard@solo.io>

<img width="2042" height="393" alt="2026-07-22_13-06-50" src="https://github.com/user-attachments/assets/44ef53a4-280c-4f3f-a5be-f010c3b9f9b8" />
<img width="3349" height="392" alt="2026-07-22_13-01-54" src="https://github.com/user-attachments/assets/5e42f639-6d84-41e4-bc09-9be9abe90f3b" />
