### PR TITLE
fix(mcp): emit explicit SSE message events

### DIFF
--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1439,6 +1439,64 @@ fn mcp_json_post<'a>(
 		.json(body)
 }
 
+#[tokio::test]
+async fn streamable_http_downstream_sse_frames_include_message_event() {
+	use wiremock::{Mock, ResponseTemplate};
+
+	let upstream = wiremock::MockServer::start().await;
+	let upstream_frame = concat!(
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{",
+		"\"protocolVersion\":\"2025-06-18\",",
+		"\"capabilities\":{\"tools\":{}},",
+		"\"serverInfo\":{\"name\":\"mock\",\"version\":\"0.0.1\"}",
+		"}}\n\n",
+	);
+	Mock::given(wiremock::matchers::method("POST"))
+		.respond_with(ResponseTemplate::new(200).set_body_raw(upstream_frame, "text/event-stream"))
+		.mount(&upstream)
+		.await;
+
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend(*upstream.address(), true, false)
+		.with_bind(simple_bind())
+		.with_route(basic_route(*upstream.address()));
+	let io = t.serve_real_listener(BIND_KEY).await;
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+	let initialize = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "initialize",
+		"params": {
+			"protocolVersion": "2025-06-18",
+			"capabilities": {},
+			"clientInfo": {
+				"name": "test-client",
+				"version": "0.0.1"
+			}
+		}
+	});
+
+	let response = mcp_json_post(&client, &url, &initialize)
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(response.status(), reqwest::StatusCode::OK);
+	assert!(
+		response
+			.headers()
+			.get(reqwest::header::CONTENT_TYPE)
+			.and_then(|v| v.to_str().ok())
+			.is_some_and(|ct| ct.starts_with("text/event-stream"))
+	);
+	let text = response.text().await.unwrap();
+	assert!(
+		text.contains("event: message\ndata:"),
+		"expected explicit SSE message event, got: {text}"
+	);
+}
+
 // Forwarded modern responses may come back as a single JSON object or as an SSE stream.
 // Validation-layer errors are always plain JSON.
 async fn read_response_message(response: reqwest::Response) -> serde_json::Value {

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -971,7 +971,7 @@ pub(crate) fn sse_stream_response(
 	use futures::StreamExt;
 	let stream = SseBody::new(stream.map(|message| {
 		let data = serde_json::to_string(&message.message).expect("valid message");
-		let mut sse = Sse::default().data(data);
+		let mut sse = Sse::default().event("message").data(data);
 		sse.id = message.event_id;
 		Result::<Sse, Infallible>::Ok(sse)
 	}));


### PR DESCRIPTION
Fixes #2167.

## Summary

- Emit explicit `event: message` SSE fields for downstream MCP streamable-HTTP JSON-RPC frames.
- Preserve existing SSE `id` behavior.
- Keep upstream SSE parsing unchanged, so data-only upstream MCP servers remain compatible.

## Validation

- `cargo fmt -p agentgateway`
- `cargo fmt --check -p agentgateway`
- `cargo test -p agentgateway streamable_http_downstream_sse_frames_include_message_event`
- Remote E2E on `root@134.199.199.149` using a live agentgateway binary, a mock upstream streamable-HTTP MCP server that returns data-only SSE frames, and the affected `@ai-sdk/mcp@1.0.47` HTTP client:
  - Parent commit `31b17832abdf27d012b65811047e2961330fa1ea`: raw gateway SSE had only `data:` and the SDK client timed out during `createMCPClient`.
  - This branch `95eddeff63a164dcb8e92874ac82c4d4ded063b2` has the same code changes as the validated branch commit: raw gateway SSE included `event: message`, and the SDK completed `initialize` and `tools/list`, returning tool `echo`.

## Notes

- I also ran `cargo test -p agentgateway mcp::tests`; it had 4 access-log telemetry failures locally. A representative failure reproduced on clean `main` with the same `crates/core/src/telemetry.rs:751` timeout, so I do not believe those failures are introduced by this change.
