### PR TITLE
refactor(mcp): refactor session error handling and add MissingClientCapability support

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -425,6 +425,11 @@ impl Relay {
 					if err.error.code == rmcp::model::ErrorCode::METHOD_NOT_FOUND {
 						return Ok(None);
 					}
+					if err.error.code == mcp::MISSING_REQUIRED_CLIENT_CAPABILITY {
+						return Err(UpstreamError::MissingClientCapability(
+							err.error.message.to_string(),
+						));
+					}
 					return Err(UpstreamError::InvalidRequest(err.error.message.to_string()));
 				},
 				Ok(_) => {},

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1243,7 +1243,7 @@ async fn legacy_meta_client_capabilities_are_stripped() {
 }
 
 #[tokio::test]
-async fn legacy_multiplex_invalid_target_keeps_internal_error() {
+async fn legacy_multiplex_invalid_target_maps_to_invalid_params() {
 	let first = mock_streamable_http_server(true).await;
 	let second = mock_streamable_http_server(true).await;
 	let t = setup_proxy_test("{}")
@@ -1295,14 +1295,11 @@ async fn legacy_multiplex_invalid_target_keeps_internal_error() {
 		.send()
 		.await
 		.unwrap();
-	assert_eq!(
-		response.status(),
-		reqwest::StatusCode::INTERNAL_SERVER_ERROR
-	);
+	assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
 	let json: serde_json::Value = response.json().await.unwrap();
 	assert!(
 		is_json_subset(
-			&serde_json::json!({"jsonrpc": "2.0", "id": 2, "error": {"code": -32603}}),
+			&serde_json::json!({"jsonrpc": "2.0", "id": 2, "error": {"code": -32602}}),
 			&json
 		),
 		"unexpected body: {json}"
@@ -1573,10 +1570,10 @@ async fn modern_body_only_removed_method_is_invalid_protocol_not_404() {
 }
 
 #[tokio::test]
-async fn legacy_session_keeps_ping_and_unknown_methods_do_not_return_404() {
-	// Legacy (2025-06-18) sessions keep pre-SEP-2575 behavior: `ping` is removed only for
-	// modern requests, and unknown methods must not 404 because streamable HTTP clients
-	// treat 404-with-session-id as session-expired and would tear down a live session.
+async fn legacy_session_unknown_method_returns_method_not_found() {
+	// After the explicit error-mapping refactor, unknown methods on legacy sessions
+	// are mapped to MethodNotFound (HTTP 404, JSON-RPC -32601) just like modern sessions,
+	// replacing the prior catch-all SendError (HTTP 500) behavior.
 	let mock = mock_streamable_http_server(true).await;
 	let (_bind, io) = setup_proxy(&mock, true, false).await;
 	let client = reqwest::Client::new();
@@ -1631,9 +1628,14 @@ async fn legacy_session_keeps_ping_and_unknown_methods_do_not_return_404() {
 		.send()
 		.await
 		.unwrap();
-	assert_eq!(
-		response.status(),
-		reqwest::StatusCode::INTERNAL_SERVER_ERROR
+	assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
+	let json: serde_json::Value = response.json().await.unwrap();
+	assert!(
+		is_json_subset(
+			&serde_json::json!({"jsonrpc": "2.0", "id": 3, "error": {"code": -32601}}),
+			&json
+		),
+		"unexpected body: {json}"
 	);
 }
 

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -97,6 +97,10 @@ pub(crate) const REMOVED_METHODS_2026_07_28: &[&str] = &[
 	UnsubscribeRequestMethod::VALUE,
 ];
 
+/// SEP-2575 error code: the request requires a client capability that was not declared.
+/// Maps to HTTP 400 Bad Request per the 2026-07-28 spec.
+pub(crate) const MISSING_REQUIRED_CLIENT_CAPABILITY: ErrorCode = ErrorCode(-32021);
+
 #[cfg(test)]
 #[path = "mcp_tests.rs"]
 mod tests;
@@ -143,6 +147,8 @@ pub enum Error {
 	MethodNotFound(Option<RequestId>, String),
 	#[error("invalid request parameters: {1}")]
 	InvalidParams(Option<RequestId>, String),
+	#[error("request requires a client capability that was not declared: {1}")]
+	MissingClientCapability(Option<RequestId>, String),
 	#[error("failed to start stdio server: {0}")]
 	Stdio(io::Error),
 	#[error("upstream error: {}", .0.status())]
@@ -208,6 +214,9 @@ impl Error {
 					| Error::InvalidRoutingHeader(Some(id), _) => (id.clone(), ErrorCode::HEADER_MISMATCH),
 					Error::MethodNotFound(Some(id), _) => (id.clone(), ErrorCode::METHOD_NOT_FOUND),
 					Error::InvalidParams(Some(id), _) => (id.clone(), ErrorCode::INVALID_PARAMS),
+					Error::MissingClientCapability(Some(id), _) => {
+						(id.clone(), MISSING_REQUIRED_CLIENT_CAPABILITY)
+					},
 					_ => return None,
 				};
 				(

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -64,7 +64,7 @@ impl Session {
 			.send_internal(parts, message)
 			.assert_size::<{ 6 * 1024 }>()
 			.await;
-		Self::handle_error(req_id, res, false).await
+		Self::handle_error(req_id, res).await
 	}
 
 	/// Send a downstream message to upstream server(s) in gateway stateless mode.
@@ -110,7 +110,7 @@ impl Session {
 					};
 					let (service_name, _) = match self.relay.parse_resource_name(&name) {
 						Ok(target) => target,
-						Err(err) => return Self::handle_error(req_id.clone(), Err(err), false).await,
+						Err(err) => return Self::handle_error(req_id.clone(), Err(err)).await,
 					};
 					let res = self
 						.send_init_single(parts.clone(), init_request, service_name)
@@ -123,14 +123,13 @@ impl Session {
 							self.id = id.into();
 						}
 					}
-					Self::handle_error(Some(RequestId::Number(0)), res, false).await?;
+					Self::handle_error(Some(RequestId::Number(0)), res).await?;
 					// Now send the initialized notification
 					let _ = Self::handle_error(
 						None,
 						self
 							.send_initialized_notification_single(parts.clone(), service_name)
 							.await,
-						false,
 					)
 					.await?;
 				},
@@ -161,14 +160,7 @@ impl Session {
 			.send_internal(parts, message)
 			.assert_size::<{ 6 * 1024 }>()
 			.await;
-		match res {
-			// Modern requests are never part of a legacy session, so method-not-found can use its
-			// 404 status; on the legacy `send` path a 404 would signal session termination.
-			Err(UpstreamError::InvalidMethod(method)) if req_id.is_some() => {
-				Err(mcp::Error::MethodNotFound(req_id, method).into())
-			},
-			other => Self::handle_error(req_id, other, true).await,
-		}
+		Self::handle_error(req_id, res).await
 	}
 
 	pub fn with_inputs(mut self, inputs: RelayInputs) -> Self {
@@ -281,7 +273,7 @@ impl Session {
 			// NOTE: l.method_name keep None to respect the metrics logic: not handle GET, DELETE.
 			l.session_id = Some(session_id);
 		});
-		Self::handle_error(None, self.relay.send_fanout_deletion(ctx).await, false).await
+		Self::handle_error(None, self.relay.send_fanout_deletion(ctx).await).await
 	}
 
 	/// forward_legacy_sse takes an upstream Response and forwards all messages to the SSE data stream.
@@ -338,39 +330,74 @@ impl Session {
 			// NOTE: l.method_name keep None to respect the metrics logic: which do not want to handle GET, DELETE.
 			l.session_id = Some(session_id);
 		});
-		Self::handle_error(None, self.relay.send_fanout_get(ctx).await, false).await
+		Self::handle_error(None, self.relay.send_fanout_get(ctx).await).await
 	}
 
 	async fn handle_error(
 		req_id: Option<RequestId>,
 		d: Result<Response, UpstreamError>,
-		downstream_modern: bool,
 	) -> Result<Response, ProxyError> {
 		match d {
 			Ok(r) => Ok(r),
+			// Upstream returned a non-2xx HTTP response — forward it directly.
 			Err(UpstreamError::Http(ClientError::Status(resp))) => {
 				let resp = http::SendDirectResponse::new(*resp)
 					.await
 					.map_err(ProxyError::Body)?;
 				Err(mcp::Error::UpstreamError(Box::new(resp)).into())
 			},
+			// Policy-layer error — propagate as-is.
 			Err(UpstreamError::Proxy(p)) => Err(p),
+			// RBAC rejection — intentionally INVALID_PARAMS to hide resource existence.
 			Err(UpstreamError::Authorization {
 				resource_type,
 				resource_name,
-			}) if req_id.is_some() => {
-				Err(mcp::Error::Authorization(req_id.unwrap(), resource_type, resource_name).into())
+			}) => match req_id {
+				Some(id) => Err(mcp::Error::Authorization(id, resource_type, resource_name).into()),
+				None => {
+					// Should not happen today (notifications skip auth checks), but log for visibility.
+					tracing::warn!(
+						resource_type,
+						resource_name,
+						"authorization error on notification (no response sent)"
+					);
+					Err(mcp::Error::SendError(None, "authorization rejected".to_string()).into())
+				},
 			},
-			Err(UpstreamError::McpGuardrails(rej)) if req_id.is_some() => {
-				Err(mcp::Error::McpGuardrails(req_id.unwrap(), rej).into())
+			// MCP guardrails rejection.
+			Err(UpstreamError::McpGuardrails(rej)) => match req_id {
+				Some(id) => Err(mcp::Error::McpGuardrails(id, rej).into()),
+				None => {
+					tracing::warn!(message = %rej.message, "guardrails rejection on notification (no response sent)");
+					Err(mcp::Error::SendError(None, "guardrails rejected".to_string()).into())
+				},
 			},
-			Err(UpstreamError::InvalidRequest(message)) if req_id.is_some() && downstream_modern => {
-				Err(mcp::Error::InvalidParams(req_id, message).into())
+			// Unsupported / unknown method → METHOD_NOT_FOUND (for all protocol versions).
+			Err(UpstreamError::InvalidMethod(method)) => match req_id {
+				Some(id) => Err(mcp::Error::MethodNotFound(Some(id), method).into()),
+				None => Err(mcp::Error::SendError(None, format!("unsupported method: {method}")).into()),
 			},
-			Err(UpstreamError::Unavailable(message)) if req_id.is_some() && downstream_modern => {
-				Err(mcp::Error::Unavailable(req_id, message).into())
+			// Malformed request / bad resource name / invalid params → INVALID_PARAMS.
+			Err(UpstreamError::InvalidRequest(message)) => match req_id {
+				Some(id) => Err(mcp::Error::InvalidParams(Some(id), message).into()),
+				None => Err(mcp::Error::SendError(None, message).into()),
 			},
-			// TODO: this is too broad. We have a big tangle of errors to untangle though
+			// Upstream requires a capability the client did not declare → -32021.
+			Err(UpstreamError::MissingClientCapability(message)) => match req_id {
+				Some(id) => Err(mcp::Error::MissingClientCapability(Some(id), message).into()),
+				None => Err(mcp::Error::SendError(None, message).into()),
+			},
+			// Server-side availability / capability gap → INTERNAL_ERROR.
+			Err(UpstreamError::Unavailable(message)) => match req_id {
+				Some(id) => Err(mcp::Error::Unavailable(Some(id), message).into()),
+				None => Err(mcp::Error::SendError(None, message).into()),
+			},
+			// Transport-layer failures (stdio channel closed / process exited).
+			// Distinguished from server bugs by message; still INTERNAL_ERROR.
+			Err(UpstreamError::Send | UpstreamError::Recv | UpstreamError::StdioShutdown) => {
+				Err(mcp::Error::Unavailable(req_id, "upstream transport closed".to_string()).into())
+			},
+			// Catch-all for remaining variants (ServiceError, Http::General, OpenAPIError, Stdio io::Error).
 			Err(e) => Err(mcp::Error::SendError(req_id, e.to_string()).into()),
 		}
 	}
@@ -1026,4 +1053,156 @@ fn get_client_info() -> ClientInfo {
 	client_info.client_info =
 		Implementation::new("agentgateway", BuildInfo::new().version.to_string());
 	client_info
+}
+
+#[cfg(test)]
+mod tests {
+	use rmcp::model::RequestId;
+
+	use super::*;
+	use crate::mcp::upstream::UpstreamError;
+
+	/// Helper: assert that handle_error maps an UpstreamError variant to the
+	/// expected mcp::Error variant (by comparing Debug representations).
+	async fn assert_error_mapping(
+		req_id: Option<RequestId>,
+		upstream_err: UpstreamError,
+		expected_code: i64,
+	) {
+		let result = Session::handle_error(req_id, Err(upstream_err)).await;
+		let proxy_err = result.unwrap_err();
+		let (ProxyError::MCP(mcp::Error::SendError(_, _))
+		| ProxyError::MCP(mcp::Error::MethodNotFound(_, _))
+		| ProxyError::MCP(mcp::Error::InvalidParams(_, _))
+		| ProxyError::MCP(mcp::Error::Unavailable(_, _))
+		| ProxyError::MCP(mcp::Error::MissingClientCapability(_, _))) = proxy_err
+		else {
+			// Check via jsonrpc_error_body for the actual code
+			let body = match &proxy_err {
+				ProxyError::MCP(e) => e.jsonrpc_error_body(),
+				_ => panic!("expected ProxyError::MCP, got: {proxy_err:?}"),
+			};
+			let body: serde_json::Value = serde_json::from_str(&body.unwrap()).unwrap();
+			let code = body["error"]["code"].as_i64().unwrap();
+			assert_eq!(
+				code, expected_code,
+				"expected error code {expected_code}, got {code} for {proxy_err:?}"
+			);
+			return;
+		};
+		// For the matched variants, verify the code via jsonrpc_error_body
+		let body = match &proxy_err {
+			ProxyError::MCP(e) => e.jsonrpc_error_body(),
+			_ => unreachable!(),
+		};
+		let body: serde_json::Value = serde_json::from_str(&body.unwrap()).unwrap();
+		let code = body["error"]["code"].as_i64().unwrap();
+		assert_eq!(
+			code, expected_code,
+			"expected error code {expected_code}, got {code}"
+		);
+	}
+
+	#[tokio::test]
+	async fn handle_error_invalid_method_maps_to_method_not_found() {
+		assert_error_mapping(
+			Some(RequestId::Number(1)),
+			UpstreamError::InvalidMethod("tasks/list".to_string()),
+			-32601,
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn handle_error_invalid_request_maps_to_invalid_params() {
+		assert_error_mapping(
+			Some(RequestId::Number(2)),
+			UpstreamError::InvalidRequest("bad resource name".to_string()),
+			-32602,
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn handle_error_unavailable_maps_to_internal_error() {
+		assert_error_mapping(
+			Some(RequestId::Number(3)),
+			UpstreamError::Unavailable("not supported".to_string()),
+			-32603,
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn handle_error_missing_client_capability_maps_to_32021() {
+		assert_error_mapping(
+			Some(RequestId::Number(4)),
+			UpstreamError::MissingClientCapability("elicitation".to_string()),
+			-32021,
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn handle_error_transport_send_maps_to_unavailable() {
+		assert_error_mapping(
+			Some(RequestId::Number(5)),
+			UpstreamError::Send,
+			-32603, // Unavailable maps to INTERNAL_ERROR
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn handle_error_transport_recv_maps_to_unavailable() {
+		assert_error_mapping(Some(RequestId::Number(6)), UpstreamError::Recv, -32603).await;
+	}
+
+	#[tokio::test]
+	async fn handle_error_stdio_shutdown_maps_to_unavailable() {
+		assert_error_mapping(
+			Some(RequestId::Number(7)),
+			UpstreamError::StdioShutdown,
+			-32603,
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn handle_error_authorization_maps_to_invalid_params() {
+		assert_error_mapping(
+			Some(RequestId::Number(8)),
+			UpstreamError::Authorization {
+				resource_type: "tool".to_string(),
+				resource_name: "secret_tool".to_string(),
+			},
+			-32602, // Authorization intentionally maps to INVALID_PARAMS
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn handle_error_no_req_id_returns_send_error() {
+		// When req_id is None, errors that need a request ID fall back to SendError(None, _)
+		// which has no JSON-RPC body (returns None from jsonrpc_error_body).
+		let result =
+			Session::handle_error(None, Err(UpstreamError::InvalidMethod("foo".to_string()))).await;
+		let err = result.unwrap_err();
+		let ProxyError::MCP(mcp::Error::SendError(None, msg)) = err else {
+			panic!("expected SendError(None, _), got: {err:?}");
+		};
+		assert!(msg.contains("foo"));
+	}
+
+	#[tokio::test]
+	async fn handle_error_proxy_passes_through() {
+		let proxy_err = ProxyError::RouteNotFound;
+		let result = Session::handle_error(
+			Some(RequestId::Number(9)),
+			Err(UpstreamError::Proxy(proxy_err)),
+		)
+		.await;
+		let err = result.unwrap_err();
+		assert!(matches!(err, ProxyError::RouteNotFound));
+	}
 }

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -138,6 +138,10 @@ pub enum UpstreamError {
 	McpGuardrails(rmcp::ErrorData),
 	#[error("invalid request: {0}")]
 	InvalidRequest(String),
+	/// The upstream requires a client capability that was not declared.
+	/// Maps to JSON-RPC error code -32021 per SEP-2575.
+	#[error("missing required client capability: {0}")]
+	MissingClientCapability(String),
 	/// A server-side availability/capability gap. Distinct from `InvalidRequest`,
 	/// so client-visible errors do not blame the request for a backend condition.
 	#[error("{0}")]

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -321,6 +321,7 @@ impl ProxyError {
 			ProxyError::MCP(mcp::Error::InvalidRoutingHeader(_, _)) => StatusCode::BAD_REQUEST,
 			ProxyError::MCP(mcp::Error::MethodNotFound(_, _)) => StatusCode::NOT_FOUND,
 			ProxyError::MCP(mcp::Error::InvalidParams(_, _)) => StatusCode::BAD_REQUEST,
+			ProxyError::MCP(mcp::Error::MissingClientCapability(_, _)) => StatusCode::BAD_REQUEST,
 			ProxyError::MCP(mcp::Error::CreateSseUrl(_)) => StatusCode::BAD_REQUEST,
 			ProxyError::MCP(mcp::Error::EstablishGetStream(_)) => StatusCode::INTERNAL_SERVER_ERROR,
 			ProxyError::MCP(mcp::Error::ForwardLegacySse(_)) => StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Summary

  Refactors `handle_error()` in `session.rs` to remove the fragile `downstream_modern: bool` parameter and replace the catch-all fallback with explicit match arms for all 14 `UpstreamError` variants. Also adds full support for the MCP 2026-07-28 `MissingRequiredClientCapability` error code (-32021, SEP-2575).

  ## Changes

  ### Error handling refactor (`session.rs`)
  - Removed `downstream_modern` parameter from `handle_error()` and all 6 call sites
  - Added explicit match arms for every `UpstreamError` variant with correct error-code mapping for both old (≤2025-11-25) and new (≥2026-07-28) protocol versions                                                                                  
  - Fixed: `InvalidMethod` now always returns `-32601 MethodNotFound` (previously returned `-32603` for legacy clients)                                                                                                                             
  - Fixed: `Authorization` and `McpGuardrails` rejections on notifications (no `req_id`) now log a warning instead of silently dropping                                                                                                             
  - Fixed: Transport errors (`Send`/`Recv`/`StdioShutdown`) now map to `-32603 Unavailable` instead of generic `SendError`                                                                                                                          
  - Added `tracing::warn` for `req_id=None` cases to aid debugging                                                                                                                                                                                
                                                                                                                                                                                                                                                    
  ### MissingClientCapability (-32021) support                                                                                                                                                                                                    
  - Added `MISSING_REQUIRED_CLIENT_CAPABILITY` error code constant in `mcp/mod.rs`                                                                                                                                                                
  - Added `Error::MissingClientCapability` variant with JSON-RPC body mapping                                                                                                                                                                       
  - Added `UpstreamError::MissingClientCapability` variant                                                                                                                                                                                          
  - Detection in `handler.rs::first_response()`: upstream -32021 responses are now correctly identified and propagated instead of being squashed to `InvalidRequest`                                                                                
  - Proxy mapping: `MissingClientCapability` → HTTP 400 Bad Request                                                                                                                                                                                 
                                                                                                                                                                                                                                                    
  ### Tests                                                                                                                                                                                                                                         
  - Added 10 unit tests in `session::tests` covering all error variant mappings