### PR TITLE
feat(a2a): add response telemetry

### DIFF
--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -2,9 +2,9 @@ use agent_core::strng::Strng;
 use http::{Request, Uri, header};
 use serde::Deserialize;
 use serde_json::Value;
-use tracing::warn;
+use tracing::{debug, warn};
 
-use crate::http::{Body, Response, filters};
+use crate::http::{Body, BodyInspection, Response, filters};
 use crate::json;
 use crate::types::agent::A2aPolicy;
 
@@ -62,13 +62,70 @@ pub enum RequestType {
 	Call(Strng),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResponseInfo {
+	pub outcome: ResponseOutcome,
+	pub error_code: Option<i64>,
+	pub result_kind: Option<Strng>,
+	pub task_state: Option<Strng>,
+}
+
+impl ResponseInfo {
+	fn from_json(value: &Value) -> Self {
+		let error = value.get("error").filter(|e| !e.is_null());
+		let result = value.get("result").filter(|r| !r.is_null());
+		let outcome = if error.is_some() {
+			ResponseOutcome::Error
+		} else if result.is_some() {
+			ResponseOutcome::Success
+		} else {
+			ResponseOutcome::Unknown
+		};
+		let error_code = error
+			.and_then(|e| e.get("code"))
+			.and_then(serde_json::Value::as_i64);
+		let result_kind = result
+			.and_then(|r| r.get("kind"))
+			.and_then(serde_json::Value::as_str)
+			.map(Strng::from);
+		let task_state = result
+			.and_then(|r| r.get("status"))
+			.and_then(|status| status.get("state"))
+			.and_then(serde_json::Value::as_str)
+			.map(Strng::from);
+		Self {
+			outcome,
+			error_code,
+			result_kind,
+			task_state,
+		}
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseOutcome {
+	Success,
+	Error,
+	Unknown,
+}
+
+impl ResponseOutcome {
+	pub fn as_str(self) -> &'static str {
+		match self {
+			ResponseOutcome::Success => "success",
+			ResponseOutcome::Error => "error",
+			ResponseOutcome::Unknown => "unknown",
+		}
+	}
+}
+
 pub async fn apply_to_response(
 	pol: Option<&A2aPolicy>,
 	a2a_type: RequestType,
 	resp: &mut Response,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Option<ResponseInfo>> {
 	if pol.is_none() {
-		return Ok(());
+		return Ok(None);
 	};
 	match a2a_type {
 		RequestType::AgentCard(uri) => {
@@ -107,13 +164,35 @@ pub async fn apply_to_response(
 
 			resp.headers_mut().remove(header::CONTENT_LENGTH);
 			*resp.body_mut() = json::to_body(agent_card)?;
-			Ok(())
+			Ok(None)
 		},
-		RequestType::Call(_) => {
-			// We don't currently inspect A2A responses.
-			Ok(())
+		RequestType::Call(_) => Ok(inspect_call_response(resp).await),
+		RequestType::Unknown => Ok(None),
+	}
+}
+
+async fn inspect_call_response(resp: &mut Response) -> Option<ResponseInfo> {
+	if !matches!(
+		crate::http::classify_content_type(resp.headers()),
+		crate::http::WellKnownContentTypes::Json
+	) {
+		return None;
+	}
+
+	let body = match crate::http::inspect_response_body(resp).await {
+		Ok(BodyInspection::Complete(body)) => body,
+		Ok(BodyInspection::Partial(_)) => return None,
+		Err(err) => {
+			debug!("failed to inspect a2a response: {err}");
+			return None;
 		},
-		RequestType::Unknown => Ok(()),
+	};
+	match serde_json::from_slice::<Value>(&body) {
+		Ok(value) => Some(ResponseInfo::from_json(&value)),
+		Err(err) => {
+			debug!("failed to parse a2a response JSON: {err}");
+			None
+		},
 	}
 }
 

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -1,8 +1,12 @@
+use bytes::Bytes;
 use http::Uri;
+use http_body::Frame;
+use http_body_util::StreamBody;
 use serde_json::json;
 
 use super::*;
 use crate::http::{self, Method, header};
+use crate::transport::BufferLimit;
 use crate::types::agent::A2aPolicy;
 
 #[test]
@@ -180,7 +184,7 @@ async fn test_apply_to_response_rewrites_agent_card_url() {
 		))
 		.unwrap();
 
-	apply_to_response(
+	let info = apply_to_response(
 		Some(&A2aPolicy {}),
 		RequestType::AgentCard(
 			"https://example.com/api/.well-known/agent-card.json"
@@ -191,6 +195,7 @@ async fn test_apply_to_response_rewrites_agent_card_url() {
 	)
 	.await
 	.unwrap();
+	assert!(info.is_none());
 
 	let body = http::read_resp_body(resp).await.unwrap();
 	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -212,7 +217,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_single_interface() {
 		))
 		.unwrap();
 
-	apply_to_response(
+	let info = apply_to_response(
 		Some(&A2aPolicy {}),
 		RequestType::AgentCard(
 			"https://example.com/api/.well-known/agent-card.json"
@@ -223,6 +228,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_single_interface() {
 	)
 	.await
 	.unwrap();
+	assert!(info.is_none());
 
 	let body = http::read_resp_body(resp).await.unwrap();
 	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -248,7 +254,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_multiple_interfaces() {
 		))
 		.unwrap();
 
-	apply_to_response(
+	let info = apply_to_response(
 		Some(&A2aPolicy {}),
 		RequestType::AgentCard(
 			"https://example.com/api/.well-known/agent-card.json"
@@ -259,6 +265,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_multiple_interfaces() {
 	)
 	.await
 	.unwrap();
+	assert!(info.is_none());
 
 	let body = http::read_resp_body(resp).await.unwrap();
 	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -287,7 +294,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_root_path() {
 		))
 		.unwrap();
 
-	apply_to_response(
+	let info = apply_to_response(
 		Some(&A2aPolicy {}),
 		RequestType::AgentCard(
 			"https://example.com/.well-known/agent-card.json"
@@ -298,6 +305,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_root_path() {
 	)
 	.await
 	.unwrap();
+	assert!(info.is_none());
 
 	let body = http::read_resp_body(resp).await.unwrap();
 	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -323,7 +331,7 @@ async fn test_apply_to_response_skips_interface_without_url() {
 		))
 		.unwrap();
 
-	apply_to_response(
+	let info = apply_to_response(
 		Some(&A2aPolicy {}),
 		RequestType::AgentCard(
 			"https://example.com/api/.well-known/agent-card.json"
@@ -334,6 +342,7 @@ async fn test_apply_to_response_skips_interface_without_url() {
 	)
 	.await
 	.unwrap();
+	assert!(info.is_none());
 
 	let body = http::read_resp_body(resp).await.unwrap();
 	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -370,5 +379,200 @@ async fn test_apply_to_response_errors_when_neither_url_field_present() {
 			.unwrap_err()
 			.to_string()
 			.contains("agent card missing URL")
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_records_success_call_telemetry() {
+	let payload = json!({
+		"jsonrpc": "2.0",
+		"id": "1",
+		"result": {
+			"kind": "task",
+			"status": { "state": "completed" }
+		}
+	});
+	let raw = serde_json::to_vec(&payload).unwrap();
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(raw.clone()))
+		.unwrap();
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("tasks/send")),
+		&mut resp,
+	)
+	.await
+	.unwrap()
+	.expect("success response should produce telemetry");
+
+	assert_eq!(info.outcome, ResponseOutcome::Success);
+	assert_eq!(info.error_code, None);
+	assert_eq!(info.result_kind.as_ref().map(|s| s.as_str()), Some("task"));
+	assert_eq!(
+		info.task_state.as_ref().map(|s| s.as_str()),
+		Some("completed")
+	);
+	assert_eq!(http::read_resp_body(resp).await.unwrap(), raw);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_records_error_call_telemetry() {
+	let payload = json!({
+		"jsonrpc": "2.0",
+		"id": "1",
+		"error": {
+			"code": -32602,
+			"message": "Invalid params"
+		}
+	});
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(serde_json::to_vec(&payload).unwrap()))
+		.unwrap();
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("tasks/send")),
+		&mut resp,
+	)
+	.await
+	.unwrap()
+	.expect("error response should produce telemetry");
+
+	assert_eq!(info.outcome, ResponseOutcome::Error);
+	assert_eq!(info.error_code, Some(-32602));
+	assert_eq!(info.result_kind, None);
+	assert_eq!(info.task_state, None);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_records_unknown_size_json_call_telemetry() {
+	let frames = futures_util::stream::iter([
+		Ok::<_, crate::http::Error>(Frame::data(Bytes::from_static(
+			b"{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{",
+		))),
+		Ok::<_, crate::http::Error>(Frame::data(Bytes::from_static(
+			b"\"kind\":\"task\",\"status\":{\"state\":\"working\"}}}",
+		))),
+	]);
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::new(StreamBody::new(frames)))
+		.unwrap();
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("tasks/send")),
+		&mut resp,
+	)
+	.await
+	.unwrap()
+	.expect("finite JSON without a size hint should produce telemetry");
+
+	assert_eq!(info.outcome, ResponseOutcome::Success);
+	assert_eq!(info.result_kind.as_ref().map(|s| s.as_str()), Some("task"));
+	assert_eq!(
+		info.task_state.as_ref().map(|s| s.as_str()),
+		Some("working")
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_records_unknown_call_telemetry() {
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(r#"{"jsonrpc":"2.0","id":"1"}"#))
+		.unwrap();
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("tasks/send")),
+		&mut resp,
+	)
+	.await
+	.unwrap()
+	.expect("parseable response should produce telemetry");
+
+	assert_eq!(info.outcome, ResponseOutcome::Unknown);
+	assert_eq!(info.error_code, None);
+	assert_eq!(info.result_kind, None);
+	assert_eq!(info.task_state, None);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_skips_invalid_json_call_telemetry() {
+	let raw = Bytes::from_static(b"{\"jsonrpc\":\"2.0\"");
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(raw.clone()))
+		.unwrap();
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("tasks/send")),
+		&mut resp,
+	)
+	.await
+	.unwrap();
+
+	assert!(info.is_none());
+	assert_eq!(
+		http::read_body_with_limit(resp.into_body(), raw.len())
+			.await
+			.unwrap(),
+		raw
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_skips_non_json_call_telemetry() {
+	let raw = Bytes::from_static(b"ok");
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "text/plain")
+		.body(http::Body::from(raw.clone()))
+		.unwrap();
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("tasks/send")),
+		&mut resp,
+	)
+	.await
+	.unwrap();
+
+	assert!(info.is_none());
+	assert_eq!(
+		http::read_body_with_limit(resp.into_body(), raw.len())
+			.await
+			.unwrap(),
+		raw
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_skips_partial_call_telemetry() {
+	let raw = Bytes::from_static(b"{\"jsonrpc\":\"2.0\",\"result\":{\"kind\":\"task\"}}");
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(raw.clone()))
+		.unwrap();
+	resp.extensions_mut().insert(BufferLimit::new(4));
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("tasks/send")),
+		&mut resp,
+	)
+	.await
+	.unwrap();
+
+	assert!(info.is_none());
+	assert_eq!(
+		http::read_body_with_limit(resp.into_body(), raw.len())
+			.await
+			.unwrap(),
+		raw
 	);
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2572,13 +2572,18 @@ async fn make_backend_call(
 			));
 		dtrace::snapshot!(Response, "raw response", log, &resp);
 	}
-	a2a::apply_to_response(
+	if let Some(a2a_response) = a2a::apply_to_response(
 		backend_call.backend_policies.a2a.as_ref(),
 		a2a_type,
 		&mut resp,
 	)
 	.await
-	.map_err(ProxyError::Processing)?;
+	.map_err(ProxyError::Processing)?
+	{
+		log.add(|l| {
+			l.a2a_response = Some(a2a_response);
+		});
+	}
 	let mut resp = if let (Some(llm), Some(llm_request)) = (
 		backend_call.backend_policies.llm_provider.clone(),
 		llm_request,

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -47,7 +47,7 @@ use crate::telemetry::{log_store, trc};
 use crate::transport::stream::{TCPConnectionInfo, TLSConnectionInfo};
 use crate::types::agent::{BackendInfo, BindKey, ListenerName, RouteName, Target};
 use crate::types::loadbalancer::ActiveHandle;
-use crate::{cel, llm, mcp};
+use crate::{a2a, cel, llm, mcp};
 
 fn u64_to_i64(value: Option<u64>) -> Option<i64> {
 	value.map(|value| value.min(i64::MAX as u64) as i64)
@@ -934,6 +934,7 @@ impl RequestLog {
 			llm_request: None,
 			llm_response: Default::default(),
 			a2a_method: None,
+			a2a_response: None,
 			inference_pool: None,
 			request_handle: None,
 			request_snapshot: None,
@@ -1087,6 +1088,7 @@ pub struct RequestLog {
 	pub llm_response: AsyncLog<llm::LLMInfo>,
 
 	pub a2a_method: Option<Strng>,
+	pub a2a_response: Option<a2a::ResponseInfo>,
 
 	pub inference_pool: Option<SocketAddr>,
 
@@ -1395,6 +1397,34 @@ impl Drop for DropOnLog {
 				("jwt.sub", log.jwt_sub.display()),
 				("protocol", log.backend_protocol.as_ref().map(debug)),
 				("a2a.method", log.a2a_method.display()),
+				(
+					"a2a.response.outcome",
+					log.a2a_response.as_ref().map(|r| r.outcome.as_str().into()),
+				),
+				(
+					"a2a.response.error_code",
+					log
+						.a2a_response
+						.as_ref()
+						.and_then(|r| r.error_code)
+						.map(Into::into),
+				),
+				(
+					"a2a.result.kind",
+					log
+						.a2a_response
+						.as_ref()
+						.and_then(|r| r.result_kind.as_ref())
+						.map(display),
+				),
+				(
+					"a2a.task.state",
+					log
+						.a2a_response
+						.as_ref()
+						.and_then(|r| r.task_state.as_ref())
+						.map(display),
+				),
 				(
 					"mcp.method.name",
 					mcp
@@ -2380,5 +2410,41 @@ mod tests {
 				.all(|attr| attr.key.as_str() != "agw.usage.cost"),
 			"cost should use the AGW AI usage namespace"
 		);
+	}
+
+	#[test]
+	fn a2a_response_span_attributes() {
+		let (tracer, exporter) = test_tracer();
+		let mut log = test_request_log();
+		log.tracer = Some(tracer.clone());
+		let mut outgoing = trc::TraceParent::new();
+		outgoing.flags = 1;
+		log.outgoing_span = Some(outgoing);
+		log.backend_protocol = Some(cel::BackendProtocol::a2a);
+		log.a2a_method = Some(strng::literal!("tasks/send"));
+		log.a2a_response = Some(a2a::ResponseInfo {
+			outcome: a2a::ResponseOutcome::Error,
+			error_code: Some(-32602),
+			result_kind: Some(strng::literal!("task")),
+			task_state: Some(strng::literal!("failed")),
+		});
+
+		drop(DropOnLog::from(log));
+		let _ = tracer.provider.force_flush();
+
+		let spans = exporter.finished_spans();
+		let span = spans
+			.iter()
+			.find(|span| span.name.as_ref() == "unknown")
+			.expect("request span should be exported");
+		let has = |key: &str| span.attributes.iter().any(|attr| attr.key.as_str() == key);
+		for expected in [
+			"a2a.response.outcome",
+			"a2a.response.error_code",
+			"a2a.result.kind",
+			"a2a.task.state",
+		] {
+			assert!(has(expected), "expected {expected} span attribute");
+		}
 	}
 }

--- a/examples/traffic-a2a/README.md
+++ b/examples/traffic-a2a/README.md
@@ -56,5 +56,16 @@ Additionally, as we send requests we can see A2A specific information in the log
 2025-07-03T16:56:34.379262Z     info    request gateway=bind/3000 listener=listener0
     route=route0 endpoint=localhost:9999 src.addr=127.0.0.1:57408
     http.method=POST http.host=localhost http.path=/ http.version=HTTP/1.1 http.status=200
-    a2a.method=message/stream duration=2ms
+    a2a.method=message/stream a2a.response.outcome=success a2a.result.kind=task
+    a2a.task.state=completed duration=2ms
+```
+
+If the upstream agent returns a JSON-RPC error with an HTTP 200 status, the log includes the A2A response outcome and error code:
+
+```plain
+2025-07-03T16:56:34.379262Z     info    request gateway=bind/3000 listener=listener0
+    route=route0 endpoint=localhost:9999 src.addr=127.0.0.1:57408
+    http.method=POST http.host=localhost http.path=/ http.version=HTTP/1.1 http.status=200
+    a2a.method=message/stream a2a.response.outcome=error
+    a2a.response.error_code=-32602 duration=2ms
 ```


### PR DESCRIPTION
## Summary

- add response-side semantic telemetry for A2A JSON-RPC calls
- record A2A response outcome, numeric JSON-RPC error code, result kind, and task state in the shared request telemetry fields
- preserve existing Agent Card rewrite behavior and skip telemetry for non-JSON, partial, streaming, or invalid response bodies

## Details

A2A request telemetry already records the request method via `a2a.method`, but JSON-RPC responses can fail at the protocol layer while still returning HTTP 200. This adds low-cardinality response fields so logs, OTLP logs, traces, and request-log attributes can distinguish those outcomes without changing routing or response bodies.

This does not add Prometheus metrics; that can be considered separately if we want dedicated A2A counters.

## Testing

- `cargo test -p agentgateway --lib a2a::`
- `cargo test -p agentgateway --lib telemetry::log`
- `cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true`
- `cargo clippy -p agentgateway --lib -- -D warnings`
- `PATH=/Users/wuhao/.cargo/bin:$PATH make lint`
