### PR TITLE
fix: send x-ratelimit headers on all rate limited responses

### DIFF
--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -69,15 +69,45 @@ impl TryFrom<RateLimitSpec> for RateLimit {
 	}
 }
 
-impl RateLimit {
-	pub fn check_request(&self) -> Result<(), ProxyError> {
-		if self.spec.limit_type != RateLimitType::Requests {
-			return Ok(());
+/// Snapshot of a local rate limit bucket, used to emit `x-ratelimit-*` headers on allowed responses.
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimitStatus {
+	pub limit: u64,
+	pub remaining: u64,
+	pub reset_seconds: u64,
+}
+
+impl RateLimitStatus {
+	/// Returns the tighter of two limits (fewest tokens remaining), used to report the limit a
+	/// client is most likely to hit next when several rate limits apply.
+	pub fn most_constrained(a: Option<Self>, b: Option<Self>) -> Option<Self> {
+		match (a, b) {
+			(Some(a), Some(b)) => Some(if b.remaining < a.remaining { b } else { a }),
+			(a, b) => a.or(b),
 		}
-		// TODO: return headers on success, not just failure
+	}
+}
+
+impl RateLimit {
+	fn status(&self) -> RateLimitStatus {
+		let now = clocksource::precise::Instant::now();
+		let next = self.ratelimit.next_refill();
+		let reset_seconds = if next > now { (next - now).as_secs() } else { 0 };
+		RateLimitStatus {
+			limit: self.ratelimit.max_tokens(),
+			remaining: self.ratelimit.available(),
+			reset_seconds,
+		}
+	}
+
+	pub fn check_request(&self) -> Result<Option<RateLimitStatus>, ProxyError> {
+		if self.spec.limit_type != RateLimitType::Requests {
+			return Ok(None);
+		}
 		self
 			.ratelimit
 			.try_wait()
+			.map(|()| Some(self.status()))
 			.map_err(|(limit, remaining, reset)| ProxyError::RateLimitExceeded {
 				limit,
 				remaining,
@@ -85,9 +115,9 @@ impl RateLimit {
 			})
 	}
 
-	pub fn check_llm_request(&self, req: &LLMRequest) -> Result<(), ProxyError> {
+	pub fn check_llm_request(&self, req: &LLMRequest) -> Result<Option<RateLimitStatus>, ProxyError> {
 		if self.spec.limit_type != RateLimitType::Tokens {
-			return Ok(());
+			return Ok(None);
 		}
 		if let Some(it) = req.input_tokens {
 			// If we tokenized the request, check to make sure we permit that many tokens
@@ -95,6 +125,7 @@ impl RateLimit {
 			self
 				.ratelimit
 				.try_wait_n(it)
+				.map(|()| Some(self.status()))
 				.map_err(|(limit, remaining, reset)| ProxyError::RateLimitExceeded {
 					limit,
 					remaining,
@@ -105,7 +136,7 @@ impl RateLimit {
 			// Note this may lead to large over-allowance, especially with fast fill_intervals.
 			let avail = self.ratelimit.available_refill();
 			if avail > 0 {
-				Ok(())
+				Ok(Some(self.status()))
 			} else {
 				Err(ProxyError::RateLimitExceeded {
 					limit: self.ratelimit.max_tokens(),
@@ -134,10 +165,78 @@ impl crate::store::RequestPolicyTrait for Vec<RateLimit> {
 		_log: &mut crate::telemetry::log::RequestLog,
 		_req: &mut http::Request,
 	) -> Result<http::PolicyResponse, crate::proxy::ProxyResponse> {
+		let mut status: Option<RateLimitStatus> = None;
 		for rate_limit in self {
-			rate_limit.check_request()?;
+			status = RateLimitStatus::most_constrained(status, rate_limit.check_request()?);
 		}
-		Ok(http::PolicyResponse::default())
+		let mut res = http::PolicyResponse::default();
+		if let Some(status) = status {
+			let mut hm = http::HeaderMap::new();
+			http::x_headers::set_ratelimit_headers(
+				&mut hm,
+				status.limit,
+				status.remaining,
+				status.reset_seconds,
+			);
+			res.response_headers = Some(hm);
+		}
+		Ok(res)
+	}
+}
+
+#[cfg(test)]
+mod policy_tests {
+	use super::*;
+
+	fn requests_limit(max: u64) -> RateLimit {
+		RateLimit::try_from(RateLimitSpec {
+			max_tokens: max,
+			tokens_per_fill: max,
+			fill_interval: std::time::Duration::from_secs(60),
+			limit_type: RateLimitType::Requests,
+		})
+		.unwrap()
+	}
+
+	#[test]
+	fn check_request_returns_status_on_success() {
+		let rl = requests_limit(10);
+		let status = rl
+			.check_request()
+			.expect("request is allowed")
+			.expect("status is reported on success");
+		assert_eq!(status.limit, 10);
+		// One token was consumed by this request.
+		assert_eq!(status.remaining, 9);
+	}
+
+	#[test]
+	fn check_request_is_noop_for_token_limit() {
+		let mut rl = requests_limit(10);
+		rl.spec.limit_type = RateLimitType::Tokens;
+		assert!(rl.check_request().unwrap().is_none());
+	}
+
+	#[test]
+	fn most_constrained_prefers_fewest_remaining() {
+		let a = RateLimitStatus {
+			limit: 100,
+			remaining: 9,
+			reset_seconds: 10,
+		};
+		let b = RateLimitStatus {
+			limit: 5,
+			remaining: 2,
+			reset_seconds: 30,
+		};
+		let best = RateLimitStatus::most_constrained(Some(a), Some(b)).unwrap();
+		assert_eq!(best.remaining, 2);
+		assert_eq!(best.limit, 5);
+		assert_eq!(
+			RateLimitStatus::most_constrained(None, Some(a)).unwrap().remaining,
+			9
+		);
+		assert!(RateLimitStatus::most_constrained(None, None).is_none());
 	}
 }
 

--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -92,7 +92,11 @@ impl RateLimit {
 	fn status(&self) -> RateLimitStatus {
 		let now = clocksource::precise::Instant::now();
 		let next = self.ratelimit.next_refill();
-		let reset_seconds = if next > now { (next - now).as_secs() } else { 0 };
+		let reset_seconds = if next > now {
+			(next - now).as_secs()
+		} else {
+			0
+		};
 		RateLimitStatus {
 			limit: self.ratelimit.max_tokens(),
 			remaining: self.ratelimit.available(),
@@ -233,7 +237,9 @@ mod policy_tests {
 		assert_eq!(best.remaining, 2);
 		assert_eq!(best.limit, 5);
 		assert_eq!(
-			RateLimitStatus::most_constrained(None, Some(a)).unwrap().remaining,
+			RateLimitStatus::most_constrained(None, Some(a))
+				.unwrap()
+				.remaining,
 			9
 		);
 		assert!(RateLimitStatus::most_constrained(None, None).is_none());

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -1,4 +1,4 @@
-use ::http::{HeaderMap, StatusCode};
+use ::http::{HeaderMap, HeaderValue, StatusCode};
 use itertools::Itertools;
 
 use crate::cel::{Executor, Expression};
@@ -435,24 +435,41 @@ impl RemoteRateLimit {
 	}
 
 	fn apply(req: &mut Request, cr: proto::RateLimitResponse) -> Result<PolicyResponse, ProxyError> {
+		let proto::RateLimitResponse {
+			overall_code,
+			statuses,
+			response_headers_to_add,
+			request_headers_to_add,
+			raw_body,
+			..
+		} = cr;
 		let mut res = PolicyResponse::default();
 		// if not OK, we directly respond
-		if cr.overall_code != (proto::rate_limit_response::Code::Ok as i32) {
+		if overall_code != (proto::rate_limit_response::Code::Ok as i32) {
 			let mut rb = ::http::response::Builder::new().status(StatusCode::TOO_MANY_REQUESTS);
 			if let Some(hm) = rb.headers_mut() {
-				process_headers(hm, cr.response_headers_to_add)
+				process_headers(hm, response_headers_to_add);
+				process_ratelimit_status_headers(hm, &statuses);
+				if !hm.contains_key(http::x_headers::X_ENVOY_RATELIMITED) {
+					hm.insert(
+						http::x_headers::X_ENVOY_RATELIMITED,
+						HeaderValue::from_static("true"),
+					);
+				}
 			}
 			let resp = rb
-				.body(http::Body::from(cr.raw_body))
+				.body(http::Body::from(raw_body))
 				.map_err(|e| ProxyError::Processing(e.into()))?;
 			res.direct_response = Some(resp);
 			return Ok(res);
 		}
 
-		process_headers(req.headers_mut(), cr.request_headers_to_add);
-		if !cr.response_headers_to_add.is_empty() {
-			let mut hm = HeaderMap::new();
-			process_headers(&mut hm, cr.response_headers_to_add);
+		process_headers(req.headers_mut(), request_headers_to_add);
+		// Surface the standard x-ratelimit-* headers on allowed responses so clients can self-throttle.
+		let mut hm = HeaderMap::new();
+		process_headers(&mut hm, response_headers_to_add);
+		process_ratelimit_status_headers(&mut hm, &statuses);
+		if !hm.is_empty() {
 			res.response_headers = Some(hm);
 		}
 		Ok(res)
@@ -547,6 +564,36 @@ fn process_headers(hm: &mut HeaderMap, headers: Vec<proto::HeaderValue>) {
 	for h in headers {
 		let _ = envoy_proto_common::apply_header_value(hm, &h);
 	}
+}
+
+/// Derives the standard `x-ratelimit-*` headers from the rate limit service's per-descriptor
+/// statuses. When multiple descriptors apply, the most-constrained one (fewest requests
+/// remaining) is reported, matching the limit a client is most likely to hit next.
+fn process_ratelimit_status_headers(
+	hm: &mut HeaderMap,
+	statuses: &[proto::rate_limit_response::DescriptorStatus],
+) {
+	let Some(best) = statuses
+		.iter()
+		.filter(|status| status.current_limit.is_some())
+		.min_by_key(|status| status.limit_remaining)
+	else {
+		return;
+	};
+	let Some(limit) = best.current_limit.as_ref() else {
+		return;
+	};
+	let reset_seconds = best
+		.duration_until_reset
+		.as_ref()
+		.map(|d| d.seconds.max(0) as u64)
+		.unwrap_or(0);
+	http::x_headers::set_ratelimit_headers(
+		hm,
+		limit.requests_per_unit as u64,
+		best.limit_remaining as u64,
+		reset_seconds,
+	);
 }
 
 fn eval_cost(

--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -1,4 +1,4 @@
-use ::http::{HeaderMap, HeaderValue, StatusCode};
+use ::http::{HeaderMap, StatusCode};
 use itertools::Itertools;
 
 use crate::cel::{Executor, Expression};
@@ -450,12 +450,6 @@ impl RemoteRateLimit {
 			if let Some(hm) = rb.headers_mut() {
 				process_headers(hm, response_headers_to_add);
 				process_ratelimit_status_headers(hm, &statuses);
-				if !hm.contains_key(http::x_headers::X_ENVOY_RATELIMITED) {
-					hm.insert(
-						http::x_headers::X_ENVOY_RATELIMITED,
-						HeaderValue::from_static("true"),
-					);
-				}
 			}
 			let resp = rb
 				.body(http::Body::from(raw_body))

--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -669,6 +669,176 @@ fn apply_over_limit_response_returns_429() {
 	assert_eq!(direct.headers().get("retry-after").unwrap(), "60");
 }
 
+#[test]
+fn apply_over_limit_response_sets_x_ratelimit_headers_from_most_constrained_status() {
+	use ::http::StatusCode;
+
+	use crate::http::tests_common::request_for_uri;
+
+	let mut req = request_for_uri("http://example.com/test");
+	let response = proto::RateLimitResponse {
+		overall_code: proto::rate_limit_response::Code::OverLimit as i32,
+		statuses: vec![
+			proto::rate_limit_response::DescriptorStatus {
+				code: proto::rate_limit_response::Code::Ok as i32,
+				current_limit: Some(proto::rate_limit_response::RateLimit {
+					name: "less constrained".to_string(),
+					requests_per_unit: 100,
+					unit: proto::rate_limit_response::rate_limit::Unit::Minute as i32,
+				}),
+				limit_remaining: 9,
+				duration_until_reset: Some(prost_types::Duration {
+					seconds: 10,
+					nanos: 0,
+				}),
+				quota: None,
+			},
+			proto::rate_limit_response::DescriptorStatus {
+				code: proto::rate_limit_response::Code::OverLimit as i32,
+				current_limit: Some(proto::rate_limit_response::RateLimit {
+					name: "most constrained".to_string(),
+					requests_per_unit: 1,
+					unit: proto::rate_limit_response::rate_limit::Unit::Minute as i32,
+				}),
+				limit_remaining: 0,
+				duration_until_reset: Some(prost_types::Duration {
+					seconds: 38,
+					nanos: 0,
+				}),
+				quota: None,
+			},
+		],
+		response_headers_to_add: vec![proto::HeaderValue {
+			key: "retry-after".to_string(),
+			value: "38".to_string(),
+			raw_value: vec![],
+		}],
+		request_headers_to_add: vec![],
+		raw_body: b"rate limit exceeded".to_vec(),
+		dynamic_metadata: None,
+		quota: None,
+	};
+
+	let result = RemoteRateLimit::apply(&mut req, response).unwrap();
+	let direct = result.direct_response.unwrap();
+
+	assert_eq!(direct.status(), StatusCode::TOO_MANY_REQUESTS);
+	assert_eq!(direct.headers().get("retry-after").unwrap(), "38");
+	// Headers come from the most-constrained descriptor (fewest remaining), not the first one.
+	assert_eq!(direct.headers().get("x-ratelimit-limit").unwrap(), "1");
+	assert_eq!(direct.headers().get("x-ratelimit-remaining").unwrap(), "0");
+	assert_eq!(direct.headers().get("x-ratelimit-reset").unwrap(), "38");
+	assert_eq!(direct.headers().get("x-envoy-ratelimited").unwrap(), "true");
+}
+
+#[test]
+fn apply_over_limit_preserves_service_provided_x_envoy_ratelimited() {
+	use ::http::StatusCode;
+
+	use crate::http::tests_common::request_for_uri;
+
+	let mut req = request_for_uri("http://example.com/test");
+	let response = proto::RateLimitResponse {
+		overall_code: proto::rate_limit_response::Code::OverLimit as i32,
+		statuses: vec![],
+		// The rate limit service explicitly set x-envoy-ratelimited; we must pass it through as-is
+		// rather than overwriting it with our synthesized default.
+		response_headers_to_add: vec![proto::HeaderValue {
+			key: "x-envoy-ratelimited".to_string(),
+			value: "custom".to_string(),
+			raw_value: vec![],
+		}],
+		request_headers_to_add: vec![],
+		raw_body: b"rate limit exceeded".to_vec(),
+		dynamic_metadata: None,
+		quota: None,
+	};
+
+	let result = RemoteRateLimit::apply(&mut req, response).unwrap();
+	let direct = result.direct_response.unwrap();
+	assert_eq!(direct.status(), StatusCode::TOO_MANY_REQUESTS);
+	assert_eq!(direct.headers().get("x-envoy-ratelimited").unwrap(), "custom");
+}
+
+#[test]
+fn apply_ok_response_sets_x_ratelimit_headers() {
+	use crate::http::tests_common::request_for_uri;
+
+	let mut req = request_for_uri("http://example.com/test");
+	let response = proto::RateLimitResponse {
+		overall_code: proto::rate_limit_response::Code::Ok as i32,
+		statuses: vec![proto::rate_limit_response::DescriptorStatus {
+			code: proto::rate_limit_response::Code::Ok as i32,
+			current_limit: Some(proto::rate_limit_response::RateLimit {
+				name: "limit".to_string(),
+				requests_per_unit: 100,
+				unit: proto::rate_limit_response::rate_limit::Unit::Minute as i32,
+			}),
+			limit_remaining: 42,
+			duration_until_reset: Some(prost_types::Duration {
+				seconds: 30,
+				nanos: 0,
+			}),
+			quota: None,
+		}],
+		response_headers_to_add: vec![],
+		request_headers_to_add: vec![],
+		raw_body: vec![],
+		dynamic_metadata: None,
+		quota: None,
+	};
+
+	let result = RemoteRateLimit::apply(&mut req, response).unwrap();
+	// Request is allowed, so no direct response...
+	assert!(result.direct_response.is_none());
+	// ...but the advisory x-ratelimit-* headers are surfaced on the 2xx response.
+	let headers = result
+		.response_headers
+		.expect("x-ratelimit headers on allowed response");
+	assert_eq!(headers.get("x-ratelimit-limit").unwrap(), "100");
+	assert_eq!(headers.get("x-ratelimit-remaining").unwrap(), "42");
+	assert_eq!(headers.get("x-ratelimit-reset").unwrap(), "30");
+}
+
+#[test]
+fn apply_ok_response_preserves_explicit_ratelimit_header() {
+	use crate::http::tests_common::request_for_uri;
+
+	let mut req = request_for_uri("http://example.com/test");
+	let response = proto::RateLimitResponse {
+		overall_code: proto::rate_limit_response::Code::Ok as i32,
+		statuses: vec![proto::rate_limit_response::DescriptorStatus {
+			code: proto::rate_limit_response::Code::Ok as i32,
+			current_limit: Some(proto::rate_limit_response::RateLimit {
+				name: "limit".to_string(),
+				requests_per_unit: 100,
+				unit: proto::rate_limit_response::rate_limit::Unit::Minute as i32,
+			}),
+			limit_remaining: 42,
+			duration_until_reset: None,
+			quota: None,
+		}],
+		// The rate limit service explicitly set its own remaining value; it must win over the
+		// value we would otherwise derive from the descriptor status.
+		response_headers_to_add: vec![proto::HeaderValue {
+			key: "x-ratelimit-remaining".to_string(),
+			value: "7".to_string(),
+			raw_value: vec![],
+		}],
+		request_headers_to_add: vec![],
+		raw_body: vec![],
+		dynamic_metadata: None,
+		quota: None,
+	};
+
+	let result = RemoteRateLimit::apply(&mut req, response).unwrap();
+	let headers = result
+		.response_headers
+		.expect("x-ratelimit headers on allowed response");
+	assert_eq!(headers.get("x-ratelimit-remaining").unwrap(), "7");
+	assert_eq!(headers.get("x-ratelimit-limit").unwrap(), "100");
+}
+
 // --- ProxyError mapping tests ---
 
 #[test]

--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -757,7 +757,10 @@ fn apply_over_limit_preserves_service_provided_x_envoy_ratelimited() {
 	let result = RemoteRateLimit::apply(&mut req, response).unwrap();
 	let direct = result.direct_response.unwrap();
 	assert_eq!(direct.status(), StatusCode::TOO_MANY_REQUESTS);
-	assert_eq!(direct.headers().get("x-envoy-ratelimited").unwrap(), "custom");
+	assert_eq!(
+		direct.headers().get("x-envoy-ratelimited").unwrap(),
+		"custom"
+	);
 }
 
 #[test]

--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -728,39 +728,6 @@ fn apply_over_limit_response_sets_x_ratelimit_headers_from_most_constrained_stat
 	assert_eq!(direct.headers().get("x-ratelimit-limit").unwrap(), "1");
 	assert_eq!(direct.headers().get("x-ratelimit-remaining").unwrap(), "0");
 	assert_eq!(direct.headers().get("x-ratelimit-reset").unwrap(), "38");
-	assert_eq!(direct.headers().get("x-envoy-ratelimited").unwrap(), "true");
-}
-
-#[test]
-fn apply_over_limit_preserves_service_provided_x_envoy_ratelimited() {
-	use ::http::StatusCode;
-
-	use crate::http::tests_common::request_for_uri;
-
-	let mut req = request_for_uri("http://example.com/test");
-	let response = proto::RateLimitResponse {
-		overall_code: proto::rate_limit_response::Code::OverLimit as i32,
-		statuses: vec![],
-		// The rate limit service explicitly set x-envoy-ratelimited; we must pass it through as-is
-		// rather than overwriting it with our synthesized default.
-		response_headers_to_add: vec![proto::HeaderValue {
-			key: "x-envoy-ratelimited".to_string(),
-			value: "custom".to_string(),
-			raw_value: vec![],
-		}],
-		request_headers_to_add: vec![],
-		raw_body: b"rate limit exceeded".to_vec(),
-		dynamic_metadata: None,
-		quota: None,
-	};
-
-	let result = RemoteRateLimit::apply(&mut req, response).unwrap();
-	let direct = result.direct_response.unwrap();
-	assert_eq!(direct.status(), StatusCode::TOO_MANY_REQUESTS);
-	assert_eq!(
-		direct.headers().get("x-envoy-ratelimited").unwrap(),
-		"custom"
-	);
 }
 
 #[test]
@@ -821,8 +788,8 @@ fn apply_ok_response_preserves_explicit_ratelimit_header() {
 			duration_until_reset: None,
 			quota: None,
 		}],
-		// The rate limit service explicitly set its own remaining value; it must win over the
-		// value we would otherwise derive from the descriptor status.
+		// The rate limit service set an x-ratelimit-* header; we defer the whole set to it rather
+		// than mixing in our derived values.
 		response_headers_to_add: vec![proto::HeaderValue {
 			key: "x-ratelimit-remaining".to_string(),
 			value: "7".to_string(),
@@ -839,7 +806,8 @@ fn apply_ok_response_preserves_explicit_ratelimit_header() {
 		.response_headers
 		.expect("x-ratelimit headers on allowed response");
 	assert_eq!(headers.get("x-ratelimit-remaining").unwrap(), "7");
-	assert_eq!(headers.get("x-ratelimit-limit").unwrap(), "100");
+	// Atomic: because the service supplied an x-ratelimit-* header, we do not add our derived ones.
+	assert!(headers.get("x-ratelimit-limit").is_none());
 }
 
 // --- ProxyError mapping tests ---

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -482,8 +482,20 @@ async fn apply_llm_request_policies(
 		.filter(|rate_limit| rate_limit.spec.limit_type == http::localratelimit::RateLimitType::Tokens)
 		.cloned()
 		.collect::<Vec<_>>();
+	let mut local_status: Option<http::localratelimit::RateLimitStatus> = None;
 	for lrl in &local_rate_limit {
-		lrl.check_llm_request(llm_req)?;
+		local_status = http::localratelimit::RateLimitStatus::most_constrained(
+			local_status,
+			lrl.check_llm_request(llm_req)?,
+		);
+	}
+	if let Some(status) = local_status {
+		http::x_headers::set_ratelimit_headers(
+			response_headers,
+			status.limit,
+			status.remaining,
+			status.reset_seconds,
+		);
 	}
 	let (rl_resp, response) = if let Some(rrl) = &policies.remote_rate_limit {
 		// For the LLM request side, request either the count of the input tokens (if tokenization was done)

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -344,14 +344,14 @@ impl ProxyError {
 			reset_seconds,
 		} = self
 		{
-			if let Ok(hv) = HeaderValue::try_from(limit.to_string()) {
-				rb = rb.header(http::x_headers::X_RATELIMIT_LIMIT, hv)
-			}
-			if let Ok(hv) = HeaderValue::try_from(remaining.to_string()) {
-				rb = rb.header(http::x_headers::X_RATELIMIT_REMAINING, hv)
-			}
-			if let Ok(hv) = HeaderValue::try_from(reset_seconds.to_string()) {
-				rb = rb.header(http::x_headers::X_RATELIMIT_RESET, hv)
+			// Mirror Envoy's rate limit filters, which set x-envoy-ratelimited on the enforced 429 for
+			// both local and global rate limiting.
+			if let Some(hm) = rb.headers_mut() {
+				http::x_headers::set_ratelimit_headers(hm, limit, remaining, reset_seconds);
+				hm.insert(
+					http::x_headers::X_ENVOY_RATELIMITED,
+					HeaderValue::from_static("true"),
+				);
 			}
 		}
 

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -344,14 +344,8 @@ impl ProxyError {
 			reset_seconds,
 		} = self
 		{
-			// Mirror Envoy's rate limit filters, which set x-envoy-ratelimited on the enforced 429 for
-			// both local and global rate limiting.
 			if let Some(hm) = rb.headers_mut() {
 				http::x_headers::set_ratelimit_headers(hm, limit, remaining, reset_seconds);
-				hm.insert(
-					http::x_headers::X_ENVOY_RATELIMITED,
-					HeaderValue::from_static("true"),
-				);
 			}
 		}
 

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -343,10 +343,9 @@ impl ProxyError {
 			remaining,
 			reset_seconds,
 		} = self
+			&& let Some(hm) = rb.headers_mut()
 		{
-			if let Some(hm) = rb.headers_mut() {
-				http::x_headers::set_ratelimit_headers(hm, limit, remaining, reset_seconds);
-			}
+			http::x_headers::set_ratelimit_headers(hm, limit, remaining, reset_seconds);
 		}
 
 		// Add WWW-Authenticate header for basic auth failures

--- a/crates/agentgateway/tests/tests/auth.rs
+++ b/crates/agentgateway/tests/tests/auth.rs
@@ -344,8 +344,18 @@ async fn local_ratelimit() {
 
 	let res = send_request(io.clone(), Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 200);
+	// Allowed responses advertise the current limit so clients can self-throttle.
+	assert_eq!(res.hdr("x-ratelimit-limit"), "1");
+	assert_eq!(res.hdr("x-ratelimit-remaining"), "0");
+	assert!(!res.hdr("x-ratelimit-reset").is_empty());
+
 	let res = send_request(io.clone(), Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 429);
+	// The 429 carries the limit info plus x-envoy-ratelimited, matching Envoy's local rate limit
+	// filter (which sets it on the enforced 429, the same as the global filter).
+	assert_eq!(res.hdr("x-ratelimit-limit"), "1");
+	assert_eq!(res.hdr("x-ratelimit-remaining"), "0");
+	assert_eq!(res.hdr("x-envoy-ratelimited"), "true");
 }
 
 #[tokio::test]

--- a/crates/agentgateway/tests/tests/auth.rs
+++ b/crates/agentgateway/tests/tests/auth.rs
@@ -351,11 +351,9 @@ async fn local_ratelimit() {
 
 	let res = send_request(io.clone(), Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 429);
-	// The 429 carries the limit info plus x-envoy-ratelimited, matching Envoy's local rate limit
-	// filter (which sets it on the enforced 429, the same as the global filter).
+	// The 429 still carries the limit info.
 	assert_eq!(res.hdr("x-ratelimit-limit"), "1");
 	assert_eq!(res.hdr("x-ratelimit-remaining"), "0");
-	assert_eq!(res.hdr("x-envoy-ratelimited"), "true");
 }
 
 #[tokio::test]

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -43,6 +43,7 @@ pub mod x_headers {
 	pub const X_RATELIMIT_LIMIT: HeaderName = HeaderName::from_static("x-ratelimit-limit");
 	pub const X_RATELIMIT_REMAINING: HeaderName = HeaderName::from_static("x-ratelimit-remaining");
 	pub const X_RATELIMIT_RESET: HeaderName = HeaderName::from_static("x-ratelimit-reset");
+	pub const X_ENVOY_RATELIMITED: HeaderName = HeaderName::from_static("x-envoy-ratelimited");
 	pub const X_AMZN_REQUESTID: HeaderName = HeaderName::from_static("x-amzn-requestid");
 	pub const X_FORWARDED_PROTO: HeaderName = HeaderName::from_static("x-forwarded-proto");
 
@@ -84,5 +85,30 @@ pub mod x_headers {
 		let mut parts = uri.into_parts();
 		parts.scheme = Some(scheme);
 		Uri::from_parts(parts).unwrap_or(original)
+	}
+
+	/// Sets the standard `x-ratelimit-limit`, `x-ratelimit-remaining` and `x-ratelimit-reset`
+	/// response headers describing the most-constrained applicable limit.
+	///
+	/// Headers are only inserted if not already present, so an explicit value provided by an
+	/// upstream rate limit service (via `response_headers_to_add`) is preserved.
+	pub fn set_ratelimit_headers(
+		hm: &mut HeaderMap<HeaderValue>,
+		limit: u64,
+		remaining: u64,
+		reset_seconds: u64,
+	) {
+		insert_header_if_absent(hm, X_RATELIMIT_LIMIT, limit);
+		insert_header_if_absent(hm, X_RATELIMIT_REMAINING, remaining);
+		insert_header_if_absent(hm, X_RATELIMIT_RESET, reset_seconds);
+	}
+
+	fn insert_header_if_absent(hm: &mut HeaderMap<HeaderValue>, name: HeaderName, value: u64) {
+		if hm.contains_key(&name) {
+			return;
+		}
+		if let Ok(hv) = HeaderValue::try_from(value.to_string()) {
+			hm.insert(name, hv);
+		}
 	}
 }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -43,7 +43,6 @@ pub mod x_headers {
 	pub const X_RATELIMIT_LIMIT: HeaderName = HeaderName::from_static("x-ratelimit-limit");
 	pub const X_RATELIMIT_REMAINING: HeaderName = HeaderName::from_static("x-ratelimit-remaining");
 	pub const X_RATELIMIT_RESET: HeaderName = HeaderName::from_static("x-ratelimit-reset");
-	pub const X_ENVOY_RATELIMITED: HeaderName = HeaderName::from_static("x-envoy-ratelimited");
 	pub const X_AMZN_REQUESTID: HeaderName = HeaderName::from_static("x-amzn-requestid");
 	pub const X_FORWARDED_PROTO: HeaderName = HeaderName::from_static("x-forwarded-proto");
 
@@ -87,26 +86,26 @@ pub mod x_headers {
 		Uri::from_parts(parts).unwrap_or(original)
 	}
 
-	/// Sets the standard `x-ratelimit-limit`, `x-ratelimit-remaining` and `x-ratelimit-reset`
-	/// response headers describing the most-constrained applicable limit.
-	///
-	/// Headers are only inserted if not already present, so an explicit value provided by an
-	/// upstream rate limit service (via `response_headers_to_add`) is preserved.
+	/// Sets `x-ratelimit-limit`/`-remaining`/`-reset` for the most-constrained limit. No-op if any
+	/// is already present (e.g. from an upstream rate limit service) to avoid mixing header sets.
 	pub fn set_ratelimit_headers(
 		hm: &mut HeaderMap<HeaderValue>,
 		limit: u64,
 		remaining: u64,
 		reset_seconds: u64,
 	) {
-		insert_header_if_absent(hm, X_RATELIMIT_LIMIT, limit);
-		insert_header_if_absent(hm, X_RATELIMIT_REMAINING, remaining);
-		insert_header_if_absent(hm, X_RATELIMIT_RESET, reset_seconds);
-	}
-
-	fn insert_header_if_absent(hm: &mut HeaderMap<HeaderValue>, name: HeaderName, value: u64) {
-		if hm.contains_key(&name) {
+		if hm.contains_key(&X_RATELIMIT_LIMIT)
+			|| hm.contains_key(&X_RATELIMIT_REMAINING)
+			|| hm.contains_key(&X_RATELIMIT_RESET)
+		{
 			return;
 		}
+		insert_header(hm, X_RATELIMIT_LIMIT, limit);
+		insert_header(hm, X_RATELIMIT_REMAINING, remaining);
+		insert_header(hm, X_RATELIMIT_RESET, reset_seconds);
+	}
+
+	fn insert_header(hm: &mut HeaderMap<HeaderValue>, name: HeaderName, value: u64) {
 		if let Ok(hv) = HeaderValue::try_from(value.to_string()) {
 			hm.insert(name, hv);
 		}


### PR DESCRIPTION
Previously, we only added the x-ratelimit headers (`x-ratelimit-limit`,`x-ratelimit-remaining`, and `x-ratelimit-reset`) to failing local responses. We now add these headers to both failing + passing rate limit responses from **local** and **global** config.

Fixes #1313 
Fixes #2351