### PR TITLE
cel: if the body exceeds the buffer size, expose it as a separate attribute

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -360,13 +360,13 @@ fn attributes_for(expression: &cel::IdedExpr) -> FlagSet<Attributes> {
 	let mut attributes: FlagSet<Attributes> = FlagSet::default();
 	for tokens in props {
 		match tokens.as_slice() {
-			["request", "body", ..] => {
+			["request", "body" | "bodyPrefix", ..] => {
 				attributes |= Attributes::Request | Attributes::RequestBody;
 			},
 			["request", ..] => {
 				attributes |= Attributes::Request;
 			},
-			["response", "body", ..] => {
+			["response", "body" | "bodyPrefix", ..] => {
 				attributes |= Attributes::Response | Attributes::ResponseBody;
 			},
 			["response", ..] => {

--- a/crates/agentgateway/src/cel/tests.rs
+++ b/crates/agentgateway/src/cel/tests.rs
@@ -220,6 +220,30 @@ async fn request_body_expression_fails_when_body_exceeds_buffer_limit() {
 }
 
 #[tokio::test]
+async fn request_body_prefix_is_available_when_body_exceeds_buffer_limit() {
+	let exp = Expression::new_strict("request.bodyPrefix").unwrap();
+	let mut cb = ContextBuilder::new();
+	cb.register_expression(&exp);
+	let mut req = ::http::Request::builder()
+		.method(Method::POST)
+		.uri("http://example.com")
+		.body(Body::from("hello"))
+		.unwrap();
+	req
+		.extensions_mut()
+		.insert(crate::http::BufferLimit::new(4));
+
+	cb.maybe_buffer_request_body(&mut req).await;
+
+	assert_eq!(
+		helpers::value_as_byte_or_json(Executor::new_request(&req).eval(&exp).unwrap()).unwrap(),
+		bytes::Bytes::from_static(b"hell")
+	);
+	let sent = req.into_body().collect().await.unwrap().to_bytes();
+	assert_eq!(sent, bytes::Bytes::from_static(b"hello"));
+}
+
+#[tokio::test]
 async fn log_only_response_body_records_without_buffering() {
 	let exp = Expression::new_strict("response.body").unwrap();
 	let mut cb = ContextBuilder::new();
@@ -248,6 +272,39 @@ async fn log_only_response_body_records_without_buffering() {
 	assert_eq!(
 		helpers::value_as_byte_or_json(exec.eval(&exp).unwrap()).unwrap(),
 		bytes::Bytes::from_static(b"world")
+	);
+}
+
+#[tokio::test]
+async fn log_only_response_body_prefix_records_up_to_buffer_limit() {
+	let exp = Expression::new_strict("response.bodyPrefix").unwrap();
+	let mut cb = ContextBuilder::new();
+	cb.register_log_expression(&exp);
+	let mut resp = ::http::Response::builder()
+		.status(200)
+		.body(Body::from("world"))
+		.unwrap();
+	resp
+		.extensions_mut()
+		.insert(crate::http::BufferLimit::new(4));
+
+	cb.maybe_buffer_response_body(&mut resp).await;
+
+	assert!(resp.extensions().get::<BufferedBody>().is_none());
+	let snapshot = cb.maybe_snapshot_response(&mut resp).unwrap();
+	let body = std::mem::replace(resp.body_mut(), Body::empty());
+	let sent = body.collect().await.unwrap().to_bytes();
+	assert_eq!(sent, bytes::Bytes::from_static(b"world"));
+
+	let exec = Executor::new_logger(None, Some(&snapshot), None, None, None, None);
+	assert_eq!(
+		helpers::value_as_byte_or_json(exec.eval(&exp).unwrap()).unwrap(),
+		bytes::Bytes::from_static(b"worl")
+	);
+	assert!(
+		exec
+			.eval(&Expression::new_strict("response.body").unwrap())
+			.is_err()
 	);
 }
 

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -2199,7 +2199,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			version: Version::HTTP_11,
 			headers: req_headers,
 			body: Some(BufferedBody::complete(Bytes::from(r#"{"model": "fast"}"#))),
-			body_prefix: None,
+			body_prefix: Some(BufferedBody::complete(Bytes::from(r#"{"model": "fast"}"#))),
 			start_time: Some(RequestTime(
 				chrono::DateTime::parse_from_rfc3339("2000-01-01T12:00:00Z").unwrap(),
 			)),
@@ -2212,7 +2212,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			grpc_status: None,
 			headers: resp_headers,
 			body: Some(BufferedBody::complete(Bytes::from(r#"{"ok": true}"#))),
-			body_prefix: None,
+			body_prefix: Some(BufferedBody::complete(Bytes::from(r#"{"ok": true}"#))),
 		}),
 		proxy: Some(ProxyContext {
 			bind: Some("bind".into()),

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -907,6 +907,11 @@ pub struct RequestRef<'a> {
 	#[serde(skip_serializing_if = "is_body_extension_or_direct_none")]
 	pub body: BodyExtensionOrDirect<'a>,
 
+	/// The request body buffered up to `maxBufferSize`. Unlike `body`, this remains available when
+	/// the complete body exceeds the limit and contains the first `maxBufferSize` bytes.
+	#[serde(skip_serializing_if = "BodyPrefixExtensionOrDirect::is_none")]
+	pub body_prefix: BodyPrefixExtensionOrDirect<'a>,
+
 	#[serde(skip_serializing_if = "is_extension_or_direct_none")]
 	pub start_time: ExtensionOrDirect<'a, RequestTime>,
 
@@ -940,6 +945,15 @@ pub struct ResponseRef<'a> {
 
 	#[serde(skip_serializing_if = "is_body_extension_or_direct_none")]
 	pub body: BodyExtensionOrDirect<'a>,
+
+	/// The response body buffered up to `maxBufferSize`. Unlike `body`, this remains available when
+	/// the complete body exceeds the limit and contains the first `maxBufferSize` bytes.
+	#[serde(
+		rename = "bodyPrefix",
+		skip_serializing_if = "BodyPrefixExtensionOrDirect::is_none"
+	)]
+	#[dynamic(rename = "bodyPrefix")]
+	pub body_prefix: BodyPrefixExtensionOrDirect<'a>,
 }
 
 impl<'a> From<&'a ResponseSnapshot> for ResponseRef<'a> {
@@ -952,6 +966,10 @@ impl<'a> From<&'a ResponseSnapshot> for ResponseRef<'a> {
 				buffered: value.body.as_ref(),
 				recorded: value.recorded_body.as_ref(),
 			},
+			body_prefix: BodyPrefixExtensionOrDirect(BodyExtensionOrDirect::Direct {
+				buffered: value.body.as_ref(),
+				recorded: value.recorded_body.as_ref(),
+			}),
 		}
 	}
 }
@@ -1007,6 +1025,11 @@ pub struct RequestRefSerde {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub body: Option<BufferedBody>,
 
+	/// The request body buffered up to `maxBufferSize`. If the complete body exceeds the limit,
+	/// this contains the first `maxBufferSize` bytes.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub body_prefix: Option<BufferedBody>,
+
 	/// The time the request started
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub start_time: Option<RequestTime>,
@@ -1042,6 +1065,15 @@ pub struct ResponseRefSerde {
 	/// Including this attribute in an expression will trigger the body to be buffered.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub body: Option<BufferedBody>,
+
+	/// The response body buffered up to `maxBufferSize`. If the complete body exceeds the limit,
+	/// this contains the first `maxBufferSize` bytes.
+	#[serde(
+		default,
+		rename = "bodyPrefix",
+		skip_serializing_if = "Option::is_none"
+	)]
+	pub body_prefix: Option<BufferedBody>,
 }
 
 impl<'a> From<&'a RequestSnapshot> for RequestRef<'a> {
@@ -1059,6 +1091,10 @@ impl<'a> From<&'a RequestSnapshot> for RequestRef<'a> {
 				buffered: value.body.as_ref(),
 				recorded: value.recorded_body.as_ref(),
 			},
+			body_prefix: BodyPrefixExtensionOrDirect(BodyExtensionOrDirect::Direct {
+				buffered: value.body.as_ref(),
+				recorded: value.recorded_body.as_ref(),
+			}),
 			start_time: value.start_time.as_ref().into(),
 			end_time: None,
 		}
@@ -1076,6 +1112,7 @@ impl<'a, B> From<&'a ::http::Request<B>> for RequestRef<'a> {
 			version: req.version(),
 			headers: Headers::new(req.headers()),
 			body: BodyExtensionOrDirect::Extension(req.extensions()),
+			body_prefix: BodyPrefixExtensionOrDirect(BodyExtensionOrDirect::Extension(req.extensions())),
 			start_time: req.extensions().into(),
 			// Only known in snapshot phase...
 			end_time: None,
@@ -1090,6 +1127,7 @@ impl<'a> From<&'a crate::http::Response> for ResponseRef<'a> {
 			grpc_status: crate::proxy::httpproxy::parse_grpc_status(resp.headers()),
 			headers: Headers::new(resp.headers()),
 			body: BodyExtensionOrDirect::Extension(resp.extensions()),
+			body_prefix: BodyPrefixExtensionOrDirect(BodyExtensionOrDirect::Extension(resp.extensions())),
 		}
 	}
 }
@@ -1103,7 +1141,7 @@ pub struct BufferedBody(
 #[derive(Debug, Clone)]
 enum BufferedBodyState {
 	Complete(Bytes),
-	ExceededLimit,
+	ExceededLimit(Bytes),
 }
 
 impl BufferedBody {
@@ -1111,19 +1149,25 @@ impl BufferedBody {
 		Self(BufferedBodyState::Complete(bytes))
 	}
 
-	pub fn exceeded_limit() -> Self {
-		Self(BufferedBodyState::ExceededLimit)
+	pub fn exceeded_limit(bytes: Bytes) -> Self {
+		Self(BufferedBodyState::ExceededLimit(bytes))
 	}
 
 	pub fn bytes(&self) -> Option<&Bytes> {
 		match &self.0 {
 			BufferedBodyState::Complete(bytes) => Some(bytes),
-			BufferedBodyState::ExceededLimit => None,
+			BufferedBodyState::ExceededLimit(_) => None,
+		}
+	}
+
+	fn prefix_bytes(&self) -> &Bytes {
+		match &self.0 {
+			BufferedBodyState::Complete(bytes) | BufferedBodyState::ExceededLimit(bytes) => bytes,
 		}
 	}
 
 	fn is_too_large(&self) -> bool {
-		matches!(&self.0, BufferedBodyState::ExceededLimit)
+		matches!(&self.0, BufferedBodyState::ExceededLimit(_))
 	}
 }
 
@@ -1131,7 +1175,7 @@ impl From<crate::http::BodyInspection> for BufferedBody {
 	fn from(inspection: crate::http::BodyInspection) -> Self {
 		match inspection {
 			crate::http::BodyInspection::Complete(bytes) => Self::complete(bytes),
-			crate::http::BodyInspection::Partial(_) => Self::exceeded_limit(),
+			crate::http::BodyInspection::Partial(bytes) => Self::exceeded_limit(bytes),
 		}
 	}
 }
@@ -1147,7 +1191,7 @@ impl Serialize for BufferedBody {
 				let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
 				serializer.serialize_str(&encoded)
 			},
-			BufferedBodyState::ExceededLimit => serializer.serialize_none(),
+			BufferedBodyState::ExceededLimit(_) => serializer.serialize_none(),
 		}
 	}
 }
@@ -1174,7 +1218,7 @@ impl DynamicType for BufferedBody {
 	fn materialize(&self) -> Value<'_> {
 		match &self.0 {
 			BufferedBodyState::Complete(bytes) => Value::Bytes(BytesValue::Bytes(bytes.clone())),
-			BufferedBodyState::ExceededLimit => Value::Null,
+			BufferedBodyState::ExceededLimit(_) => Value::Null,
 		}
 	}
 }
@@ -1209,6 +1253,14 @@ impl BodyExtensionOrDirect<'_> {
 		}
 		if let Some(buffered) = self.buffered() {
 			buffered.bytes().cloned()
+		} else {
+			self.recorded().map(RecordedBodyHandle::bytes)
+		}
+	}
+
+	fn prefix_bytes(&self) -> Option<Bytes> {
+		if let Some(buffered) = self.buffered() {
+			Some(buffered.prefix_bytes().clone())
 		} else {
 			self.recorded().map(RecordedBodyHandle::bytes)
 		}
@@ -1254,6 +1306,40 @@ impl DynamicType for BodyExtensionOrDirect<'_> {
 
 	fn materialize(&self) -> Value<'_> {
 		match self.bytes() {
+			Some(bytes) => Value::Bytes(BytesValue::Bytes(bytes)),
+			None => Value::Null,
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct BodyPrefixExtensionOrDirect<'a>(BodyExtensionOrDirect<'a>);
+
+impl BodyPrefixExtensionOrDirect<'_> {
+	fn is_none(&self) -> bool {
+		self.0.buffered().is_none() && self.0.recorded().is_none()
+	}
+}
+
+impl Serialize for BodyPrefixExtensionOrDirect<'_> {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		match self.0.prefix_bytes() {
+			Some(bytes) => BufferedBody::complete(bytes).serialize(serializer),
+			None => serializer.serialize_none(),
+		}
+	}
+}
+
+impl DynamicType for BodyPrefixExtensionOrDirect<'_> {
+	fn auto_materialize(&self) -> bool {
+		true
+	}
+
+	fn materialize(&self) -> Value<'_> {
+		match self.0.prefix_bytes() {
 			Some(bytes) => Value::Bytes(BytesValue::Bytes(bytes)),
 			None => Value::Null,
 		}
@@ -2048,6 +2134,10 @@ impl ExecutorSerde {
 					buffered: req.body.as_ref(),
 					recorded: None,
 				},
+				body_prefix: BodyPrefixExtensionOrDirect(BodyExtensionOrDirect::Direct {
+					buffered: req.body_prefix.as_ref().or(req.body.as_ref()),
+					recorded: None,
+				}),
 				start_time: ExtensionOrDirect::Direct(req.start_time.as_ref()),
 				end_time: req.end_time.as_ref(),
 			});
@@ -2063,6 +2153,10 @@ impl ExecutorSerde {
 					buffered: resp.body.as_ref(),
 					recorded: None,
 				},
+				body_prefix: BodyPrefixExtensionOrDirect(BodyExtensionOrDirect::Direct {
+					buffered: resp.body_prefix.as_ref().or(resp.body.as_ref()),
+					recorded: None,
+				}),
 			});
 		}
 		exec.proxy = ExtensionOrDirect::Direct(self.proxy.as_ref());
@@ -2105,6 +2199,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			version: Version::HTTP_11,
 			headers: req_headers,
 			body: Some(BufferedBody::complete(Bytes::from(r#"{"model": "fast"}"#))),
+			body_prefix: None,
 			start_time: Some(RequestTime(
 				chrono::DateTime::parse_from_rfc3339("2000-01-01T12:00:00Z").unwrap(),
 			)),
@@ -2117,6 +2212,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			grpc_status: None,
 			headers: resp_headers,
 			body: Some(BufferedBody::complete(Bytes::from(r#"{"ok": true}"#))),
+			body_prefix: None,
 		}),
 		proxy: Some(ProxyContext {
 			bind: Some("bind".into()),

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -67,6 +67,13 @@
             "null"
           ]
         },
+        "bodyPrefix": {
+          "description": "The request body buffered up to `maxBufferSize`. If the complete body exceeds the limit,\nthis contains the first `maxBufferSize` bytes.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "startTime": {
           "description": "The time the request started",
           "type": [
@@ -119,6 +126,13 @@
         },
         "body": {
           "description": "The response's body, buffered up to `maxBufferSize`. If the body exceeds the max buffer size,\nthis field is not available and will fail to evaluate.\nIncluding this attribute in an expression will trigger the body to be buffered.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "bodyPrefix": {
+          "description": "The response body buffered up to `maxBufferSize`. If the complete body exceeds the limit,\nthis contains the first `maxBufferSize` bytes.",
           "type": [
             "string",
             "null"

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -12,6 +12,7 @@
 |`request.version`|string|The version of the request. For example, `HTTP/1.1`.|
 |`request.headers`|object|The headers of the request.|
 |`request.body`|string|The request's body, buffered up to `maxBufferSize`. If the body exceeds the max buffer size,<br>this field is not available and will fail to evaluate.<br>Including this attribute in an expression will trigger the body to be buffered.|
+|`request.bodyPrefix`|string|The request body buffered up to `maxBufferSize`. If the complete body exceeds the limit,<br>this contains the first `maxBufferSize` bytes.|
 |`request.startTime`|string|The time the request started|
 |`request.endTime`|string|The time the request completed|
 |`response`|object|`response` contains attributes about the HTTP response|
@@ -19,6 +20,7 @@
 |`response.grpcStatus`|integer|The gRPC status code of the response, when present.|
 |`response.headers`|object|The headers of the response.|
 |`response.body`|string|The response's body, buffered up to `maxBufferSize`. If the body exceeds the max buffer size,<br>this field is not available and will fail to evaluate.<br>Including this attribute in an expression will trigger the body to be buffered.|
+|`response.bodyPrefix`|string|The response body buffered up to `maxBufferSize`. If the complete body exceeds the limit,<br>this contains the first `maxBufferSize` bytes.|
 |`proxy`|object|`proxy` contains proxy timing information for the request.|
 |`proxy.bind`|string|The bind that accepted the request.|
 |`proxy.gateway`|object|The selected Gateway.|


### PR DESCRIPTION
In v1.4 we changed body to not be available if truncated. this gives a
way to get the old behavior back.

Signed-off-by: John Howard <john.howard@solo.io>
