### PR TITLE
chore: add max length to certain policy fields

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -308,6 +308,8 @@ type BackendEviction struct {
 	// If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
 	// rather than failing entirely.
 	// If unset, defaults to `3s`.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1s')",message="evictionDuration must be at least 1 second"
 	// +kubebuilder:default="3s"
@@ -667,6 +669,8 @@ type FrontendHTTP struct {
 	// Timeout before an unused connection is
 	// closed.
 	// If unset, this defaults to 10 minutes.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1s')",message="http1IdleTimeout must be at least 1 second"
 	// +optional
@@ -699,10 +703,14 @@ type FrontendHTTP struct {
 	// If unset, this defaults to `16Ki`.
 	// +optional
 	HTTP2MaxHeaderSize *ByteSize `json:"http2MaxHeaderSize,omitempty"`
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1s')",message="http2KeepaliveInterval must be at least 1 second"
 	// +optional
 	HTTP2KeepaliveInterval *metav1.Duration `json:"http2KeepaliveInterval,omitempty"`
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1s')",message="http2KeepaliveTimeout must be at least 1 second"
 	// +optional
@@ -710,6 +718,8 @@ type FrontendHTTP struct {
 	// Maximum time a connection is allowed to remain open.
 	// After this duration, the connection is gracefully closed after the current in-flight request completes.
 	// Useful for ensuring even traffic distribution behind load balancers during scaling events.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1s')",message="maxConnectionDuration must be at least 1 second"
 	// +optional
@@ -720,6 +730,8 @@ type FrontendHTTP struct {
 type FrontendTLS struct {
 	// Deadline for a TLS handshake to
 	// complete. If unset, this defaults to `15s`.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('100ms')",message="handshakeTimeout must be at least 100ms"
 	// +optional
@@ -814,6 +826,8 @@ type Keepalive struct {
 
 	// Time a connection needs to be idle before keepalive probes start being sent.
 	// If unset, this defaults to 180s.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1s')",message="time must be at least 1 second"
 	// +optional
@@ -821,6 +835,8 @@ type Keepalive struct {
 
 	// Time between keepalive probes.
 	// If unset, this defaults to 180s.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1s')",message="interval must be at least 1 second"
 	// +optional
@@ -1171,6 +1187,8 @@ type RemoteJWKS struct {
 	// +kubebuilder:validation:MaxLength=2000
 	JwksPath string `json:"jwksPath"`
 	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('5m')",message="cacheDuration must be at least 5m."
 	// +kubebuilder:default="5m"
@@ -2313,6 +2331,8 @@ type BackendHTTP struct {
 	Version *HTTPVersion `json:"version,omitempty"`
 
 	// Deadline for receiving a response from the backend.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('1ms')",message="requestTimeout must be at least 1ms"
 	// +optional
@@ -2334,6 +2354,8 @@ type BackendTCP struct {
 	Keepalive *Keepalive `json:"keepalive,omitempty"`
 	// Deadline for establishing a connection to
 	// the destination.
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('100ms')",message="connectTimeout must be at least 100ms"
 	// +optional
@@ -3077,6 +3099,8 @@ type Timeouts struct {
 	// Timeout for an individual request from the gateway to a backend. This covers the time from when
 	// the request first starts being sent from the gateway to when the full response has been received from the backend.
 	//
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:MaxLength=32
 	// +kubebuilder:validation:XValidation:rule="matches(self, '^([0-9]{1,5}(h|m|s|ms)){1,4}$')",message="invalid duration value"
 	// +kubebuilder:validation:XValidation:rule="duration(self) >= duration('100ms')",message="request must be at least 1ms"
 	// +optional

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -939,6 +939,7 @@ spec:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -970,6 +971,7 @@ spec:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -990,6 +992,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1013,6 +1016,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1417,6 +1421,7 @@ spec:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -1448,6 +1453,7 @@ spec:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -1468,6 +1474,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1491,6 +1498,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1914,6 +1922,7 @@ spec:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -1945,6 +1954,7 @@ spec:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -1965,6 +1975,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -1988,6 +1999,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -2778,6 +2790,7 @@ spec:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -2809,6 +2822,7 @@ spec:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -2829,6 +2843,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -2852,6 +2867,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -3256,6 +3272,7 @@ spec:
                                                               description: Deadline
                                                                 for receiving a response
                                                                 from the backend.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -3287,6 +3304,7 @@ spec:
                                                               description: |-
                                                                 Deadline for establishing a connection to
                                                                 the destination.
+                                                              maxLength: 32
                                                               type: string
                                                               x-kubernetes-validations:
                                                               - message: invalid duration
@@ -3307,6 +3325,7 @@ spec:
                                                                   description: |-
                                                                     Time between keepalive probes.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -3330,6 +3349,7 @@ spec:
                                                                   description: |-
                                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                                     If unset, this defaults to 180s.
+                                                                  maxLength: 32
                                                                   type: string
                                                                   x-kubernetes-validations:
                                                                   - message: invalid
@@ -5447,6 +5467,7 @@ spec:
                                               If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
                                               rather than failing entirely.
                                               If unset, defaults to `3s`.
+                                            maxLength: 32
                                             type: string
                                             x-kubernetes-validations:
                                             - message: invalid duration value
@@ -5496,6 +5517,7 @@ spec:
                                       requestTimeout:
                                         description: Deadline for receiving a response
                                           from the backend.
+                                        maxLength: 32
                                         type: string
                                         x-kubernetes-validations:
                                         - message: invalid duration value
@@ -5522,6 +5544,7 @@ spec:
                                         description: |-
                                           Deadline for establishing a connection to
                                           the destination.
+                                        maxLength: 32
                                         type: string
                                         x-kubernetes-validations:
                                         - message: invalid duration value
@@ -5538,6 +5561,7 @@ spec:
                                             description: |-
                                               Time between keepalive probes.
                                               If unset, this defaults to 180s.
+                                            maxLength: 32
                                             type: string
                                             x-kubernetes-validations:
                                             - message: invalid duration value
@@ -5557,6 +5581,7 @@ spec:
                                             description: |-
                                               Time a connection needs to be idle before keepalive probes start being sent.
                                               If unset, this defaults to 180s.
+                                            maxLength: 32
                                             type: string
                                             x-kubernetes-validations:
                                             - message: invalid duration value
@@ -8202,6 +8227,7 @@ spec:
                                     requestTimeout:
                                       description: Deadline for receiving a response
                                         from the backend.
+                                      maxLength: 32
                                       type: string
                                       x-kubernetes-validations:
                                       - message: invalid duration value
@@ -8227,6 +8253,7 @@ spec:
                                       description: |-
                                         Deadline for establishing a connection to
                                         the destination.
+                                      maxLength: 32
                                       type: string
                                       x-kubernetes-validations:
                                       - message: invalid duration value
@@ -8242,6 +8269,7 @@ spec:
                                           description: |-
                                             Time between keepalive probes.
                                             If unset, this defaults to 180s.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -8260,6 +8288,7 @@ spec:
                                           description: |-
                                             Time a connection needs to be idle before keepalive probes start being sent.
                                             If unset, this defaults to 180s.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -8979,6 +9008,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9005,6 +9035,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9021,6 +9052,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9040,6 +9072,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9382,6 +9415,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9408,6 +9442,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9424,6 +9459,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9443,6 +9479,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9807,6 +9844,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9833,6 +9871,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -9849,6 +9888,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -9868,6 +9908,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -10552,6 +10593,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -10578,6 +10620,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -10594,6 +10637,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -10613,6 +10657,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -10955,6 +11000,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -10981,6 +11027,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -10997,6 +11044,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -11016,6 +11064,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -13159,6 +13208,7 @@ spec:
                               If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
                               rather than failing entirely.
                               If unset, defaults to `3s`.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -13205,6 +13255,7 @@ spec:
                     properties:
                       requestTimeout:
                         description: Deadline for receiving a response from the backend.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -13353,6 +13404,7 @@ spec:
                                     ? has(self.port) : true'
                               cacheDuration:
                                 default: 5m
+                                maxLength: 32
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid duration value
@@ -13636,6 +13688,7 @@ spec:
                         description: |-
                           Deadline for establishing a connection to
                           the destination.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -13651,6 +13704,7 @@ spec:
                             description: |-
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -13669,6 +13723,7 @@ spec:
                             description: |-
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -1542,6 +1542,7 @@ spec:
                               If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
                               rather than failing entirely.
                               If unset, defaults to `3s`.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -1859,6 +1860,7 @@ spec:
                                         requestTimeout:
                                           description: Deadline for receiving a response
                                             from the backend.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -1885,6 +1887,7 @@ spec:
                                           description: |-
                                             Deadline for establishing a connection to
                                             the destination.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -1901,6 +1904,7 @@ spec:
                                               description: |-
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -1920,6 +1924,7 @@ spec:
                                               description: |-
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2255,6 +2260,7 @@ spec:
                                         requestTimeout:
                                           description: Deadline for receiving a response
                                             from the backend.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -2281,6 +2287,7 @@ spec:
                                           description: |-
                                             Deadline for establishing a connection to
                                             the destination.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -2297,6 +2304,7 @@ spec:
                                               description: |-
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2316,6 +2324,7 @@ spec:
                                               description: |-
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2670,6 +2679,7 @@ spec:
                                         requestTimeout:
                                           description: Deadline for receiving a response
                                             from the backend.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -2696,6 +2706,7 @@ spec:
                                           description: |-
                                             Deadline for establishing a connection to
                                             the destination.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -2712,6 +2723,7 @@ spec:
                                               description: |-
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2731,6 +2743,7 @@ spec:
                                               description: |-
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -3401,6 +3414,7 @@ spec:
                                         requestTimeout:
                                           description: Deadline for receiving a response
                                             from the backend.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -3427,6 +3441,7 @@ spec:
                                           description: |-
                                             Deadline for establishing a connection to
                                             the destination.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -3443,6 +3458,7 @@ spec:
                                               description: |-
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -3462,6 +3478,7 @@ spec:
                                               description: |-
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -3797,6 +3814,7 @@ spec:
                                         requestTimeout:
                                           description: Deadline for receiving a response
                                             from the backend.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -3823,6 +3841,7 @@ spec:
                                           description: |-
                                             Deadline for establishing a connection to
                                             the destination.
+                                          maxLength: 32
                                           type: string
                                           x-kubernetes-validations:
                                           - message: invalid duration value
@@ -3839,6 +3858,7 @@ spec:
                                               description: |-
                                                 Time between keepalive probes.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -3858,6 +3878,7 @@ spec:
                                               description: |-
                                                 Time a connection needs to be idle before keepalive probes start being sent.
                                                 If unset, this defaults to 180s.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -542,6 +542,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -568,6 +569,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -584,6 +586,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -603,6 +606,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -945,6 +949,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -971,6 +976,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -987,6 +993,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -1006,6 +1013,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -1370,6 +1378,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -1396,6 +1405,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -1412,6 +1422,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -1431,6 +1442,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -2115,6 +2127,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2141,6 +2154,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2157,6 +2171,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -2176,6 +2191,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -2518,6 +2534,7 @@ spec:
                                             requestTimeout:
                                               description: Deadline for receiving
                                                 a response from the backend.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2544,6 +2561,7 @@ spec:
                                               description: |-
                                                 Deadline for establishing a connection to
                                                 the destination.
+                                              maxLength: 32
                                               type: string
                                               x-kubernetes-validations:
                                               - message: invalid duration value
@@ -2560,6 +2578,7 @@ spec:
                                                   description: |-
                                                     Time between keepalive probes.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -2579,6 +2598,7 @@ spec:
                                                   description: |-
                                                     Time a connection needs to be idle before keepalive probes start being sent.
                                                     If unset, this defaults to 180s.
+                                                  maxLength: 32
                                                   type: string
                                                   x-kubernetes-validations:
                                                   - message: invalid duration value
@@ -4722,6 +4742,7 @@ spec:
                               If all endpoints are evicted, the load balancer falls back to returning evicted endpoints
                               rather than failing entirely.
                               If unset, defaults to `3s`.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -4768,6 +4789,7 @@ spec:
                     properties:
                       requestTimeout:
                         description: Deadline for receiving a response from the backend.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -4916,6 +4938,7 @@ spec:
                                     ? has(self.port) : true'
                               cacheDuration:
                                 default: 5m
+                                maxLength: 32
                                 type: string
                                 x-kubernetes-validations:
                                 - message: invalid duration value
@@ -5199,6 +5222,7 @@ spec:
                         description: |-
                           Deadline for establishing a connection to
                           the destination.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -5214,6 +5238,7 @@ spec:
                             description: |-
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -5232,6 +5257,7 @@ spec:
                             description: |-
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -5904,6 +5930,7 @@ spec:
                           Timeout before an unused connection is
                           closed.
                           If unset, this defaults to 10 minutes.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -5954,6 +5981,7 @@ spec:
                           rule: (self >= 1 && self <= 4294967295) || self.size() >
                             0
                       http2KeepaliveInterval:
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -5961,6 +5989,7 @@ spec:
                         - message: http2KeepaliveInterval must be at least 1 second
                           rule: duration(self) >= duration('1s')
                       http2KeepaliveTimeout:
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -6020,6 +6049,7 @@ spec:
                           Maximum time a connection is allowed to remain open.
                           After this duration, the connection is gracefully closed after the current in-flight request completes.
                           Useful for ensuring even traffic distribution behind load balancers during scaling events.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -6173,6 +6203,7 @@ spec:
                             description: |-
                               Time between keepalive probes.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -6191,6 +6222,7 @@ spec:
                             description: |-
                               Time a connection needs to be idle before keepalive probes start being sent.
                               If unset, this defaults to 180s.
+                            maxLength: 32
                             type: string
                             x-kubernetes-validations:
                             - message: invalid duration value
@@ -6241,6 +6273,7 @@ spec:
                         description: |-
                           Deadline for a TLS handshake to
                           complete. If unset, this defaults to `15s`.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value
@@ -8739,6 +8772,7 @@ spec:
                                           == ''Service'') ? has(self.port) : true'
                                     cacheDuration:
                                       default: 5m
+                                      maxLength: 32
                                       type: string
                                       x-kubernetes-validations:
                                       - message: invalid duration value
@@ -9304,6 +9338,7 @@ spec:
                         description: |-
                           Timeout for an individual request from the gateway to a backend. This covers the time from when
                           the request first starts being sent from the gateway to when the full response has been received from the backend.
+                        maxLength: 32
                         type: string
                         x-kubernetes-validations:
                         - message: invalid duration value


### PR DESCRIPTION
These fields will never be >32 characters long (for some, it's enforced via regex validation), so allow the k8s complexity evaluator to evaluate the more common case.