### PR TITLE
better cpu profile defaults

### DIFF
--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -41,6 +41,16 @@ const PPROF_DEFAULT_SECONDS: u64 = 10;
 const PPROF_MIN_SECONDS: u64 = 1;
 #[cfg(target_os = "linux")]
 const PPROF_MAX_SECONDS: u64 = 300;
+// Default matches Go's CPU profiler. Higher rates severely under-report on a
+// multi-core-busy process: SIGPROF is non-queuing, so expirations coalesce, and
+// pprof-rs's handler serializes all threads through one lock and drops samples
+// that arrive while it is held.
+#[cfg(target_os = "linux")]
+const PPROF_DEFAULT_FREQUENCY: i32 = 100;
+#[cfg(target_os = "linux")]
+const PPROF_MIN_FREQUENCY: i32 = 1;
+#[cfg(target_os = "linux")]
+const PPROF_MAX_FREQUENCY: i32 = 1000;
 
 struct AdminError(anyhow::Error);
 
@@ -235,7 +245,7 @@ async fn handle_dashboard(_req: Request) -> Response {
 	let apis = &[
 		(
 			"debug/pprof/profile",
-			"build profile using the pprof profiler (if supported). Use ?seconds=N to specify duration (1-300s, default: 10s)",
+			"build profile using the pprof profiler (if supported). Use ?seconds=N to specify duration (1-300s, default: 10s) and ?frequency=N the sampling rate in Hz (1-1000, default: 100)",
 		),
 		(
 			"debug/pprof/heap",
@@ -274,7 +284,7 @@ async fn handle_dashboard(_req: Request) -> Response {
 async fn handle_pprof(req: Request) -> Result<Response, AdminError> {
 	use pprof::protos::Message;
 
-	// Parse query parameters to extract optional "seconds" parameter
+	// Parse query parameters to extract optional "seconds" and "frequency" parameters
 	let qp: HashMap<String, String> = req
 		.uri()
 		.query()
@@ -295,8 +305,18 @@ async fn handle_pprof(req: Request) -> Result<Response, AdminError> {
 		PPROF_DEFAULT_SECONDS // Default if not provided
 	};
 
+	// Extract frequency parameter with validation
+	let frequency = if let Some(frequency_str) = qp.get("frequency") {
+		match frequency_str.parse::<i32>() {
+			Ok(f) if (PPROF_MIN_FREQUENCY..=PPROF_MAX_FREQUENCY).contains(&f) => f,
+			_ => PPROF_DEFAULT_FREQUENCY, // Default if invalid or out of range
+		}
+	} else {
+		PPROF_DEFAULT_FREQUENCY // Default if not provided
+	};
+
 	let guard = pprof::ProfilerGuardBuilder::default()
-		.frequency(1000)
+		.frequency(frequency)
 		// .blocklist(&["libc", "libgcc", "pthread", "vdso"])
 		.build()?;
 


### PR DESCRIPTION
- Change the default frequency for pprof to 100hz.
- Add a query param on the profile endpoint to set frequency.

Started this work after seeing a ztunnel profile which seemed to have a lot of missing data. Turns out the pprof-rs crate has a global write lock which is accessed by try. When a handler fails to grab the mutex, it silently drops that data rather than forming a queue behind the mutex.

100hz is the value used by golang and the value used in the pprof-rs multi-thread example.

Testing results:

## Frequency sweep

10s captures via `/debug/pprof/profile?frequency=N` under sustained fortio load (~4 cores busy); actual CPU from `/proc/<pid>/stat` over the same window.

| freq_hz | captured_s | actual_s | ratio_pct |
| --- | --- | --- | --- |
| 10 | 36.30 | 37.23 | 97.5 |
| 50 | 37.04 | 38.27 | 96.8 |
| 100 | 36.95 | 38.39 | 96.2 |
| 200 | 36.62 | 38.31 | 95.6 |
| 300 | 30.73 | 38.46 | 79.9 |
| 400 | 24.06 | 38.22 | 63.0 |
| 500 | 20.01 | 38.49 | 52.0 |
| 600 | 17.31 | 38.05 | 45.5 |
| 700 | 15.50 | 39.04 | 39.7 |
| 800 | 14.47 | 37.39 | 38.7 |
| 900 | 14.18 | 39.30 | 36.1 |
| 1000 | 13.11 | 38.55 | 34.0 |

## comparison with perf

Comparison of `perf record -F 99 -g -p <node-pid>` vs our endpoint at 100hz; separate runs, so load may levels differ slightly:

| function (cumulative %) | perf | endpoint |
| --- | --- | --- |
| Gateway::proxy | 65.7% | 66.3% |
| HTTPProxy::proxy | 25.5% | 31.4% |
| HTTPProxy::proxy_internal | 21.2% | 24.9% |
| attempt_upstream | 11.0% | 13.8% |
| make_backend_call | 9.6% | 11.1% |
| DropOnLog::drop | 8.6% | 9.2% |