### PR TITLE
refactor(controller): use apiequality.Semantic.DeepEqual for K8s API comparisons

### DIFF
--- a/controller/pkg/agentgateway/jwks/owner.go
+++ b/controller/pkg/agentgateway/jwks/owner.go
@@ -2,8 +2,9 @@ package jwks
 
 import (
 	"fmt"
-	"reflect"
 	"time"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 )
@@ -43,7 +44,7 @@ func (o RemoteJwksOwner) Equals(other RemoteJwksOwner) bool {
 	return o.ID == other.ID &&
 		o.DefaultNamespace == other.DefaultNamespace &&
 		o.TTL == other.TTL &&
-		reflect.DeepEqual(o.Remote, other.Remote)
+		apiequality.Semantic.DeepEqual(o.Remote, other.Remote)
 }
 
 func OwnersFromPolicy(policy *agentgateway.AgentgatewayPolicy) []RemoteJwksOwner {

--- a/controller/pkg/agentgateway/jwks/types.go
+++ b/controller/pkg/agentgateway/jwks/types.go
@@ -3,8 +3,9 @@ package jwks
 import (
 	"crypto/tls"
 	"encoding/json"
-	"reflect"
 	"time"
+
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
 )
@@ -36,7 +37,7 @@ func (s JwksSource) ResourceName() string {
 func (s JwksSource) Equals(other JwksSource) bool {
 	return s.OwnerKey == other.OwnerKey &&
 		s.RequestKey == other.RequestKey &&
-		reflect.DeepEqual(s.Target, other.Target) &&
+		apiequality.Semantic.DeepEqual(s.Target, other.Target) &&
 		s.TTL == other.TTL
 }
 
@@ -78,7 +79,7 @@ func (r SharedJwksRequest) ResourceName() string {
 
 func (r SharedJwksRequest) Equals(other SharedJwksRequest) bool {
 	return r.RequestKey == other.RequestKey &&
-		reflect.DeepEqual(r.Target, other.Target) &&
+		apiequality.Semantic.DeepEqual(r.Target, other.Target) &&
 		r.TTL == other.TTL
 }
 

--- a/controller/pkg/agentgateway/translator/model.go
+++ b/controller/pkg/agentgateway/translator/model.go
@@ -3,7 +3,6 @@ package translator
 import (
 	"fmt"
 	"maps"
-	"reflect"
 	"slices"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"istio.io/istio/pkg/config/schema/kind"
 	"istio.io/istio/pkg/util/hash"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -186,7 +186,7 @@ func equals(a any, b any) bool {
 	}
 	// We do NOT do gogo here. The reason is Kubernetes has hacked up almost-gogo types that do not allow Equals() calls
 
-	return reflect.DeepEqual(a, b)
+	return apiequality.Semantic.DeepEqual(a, b)
 }
 
 type Status any

--- a/controller/pkg/reports/status.go
+++ b/controller/pkg/reports/status.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"reflect"
 	"strings"
 
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -313,7 +313,7 @@ func (r *ReportMap) BuildRouteStatusWithParentRefDefaulting(
 		// Get the status of the current parentRef conditions if they exist
 		var currentParentRefConditions []metav1.Condition
 		currentParentRefIdx := slices.IndexFunc(existingStatus.Parents, func(s gwv1.RouteParentStatus) bool {
-			return reflect.DeepEqual(s.ParentRef, parentRef)
+			return apiequality.Semantic.DeepEqual(s.ParentRef, parentRef)
 		})
 		if currentParentRefIdx != -1 {
 			currentParentRefConditions = existingStatus.Parents[currentParentRefIdx].Conditions


### PR DESCRIPTION
## Summary

- Replace `reflect.DeepEqual` with `apiequality.Semantic.DeepEqual` across the controller to avoid spurious diffs caused by `metav1.Time` timezone pointer inequality and nil-vs-empty slice/map distinctions.

`apiequality.Semantic.DeepEqual` uses registered equality functions for known Kubernetes API types (e.g. `metav1.Time`, `resource.Quantity`), and falls back to `reflect.DeepEqual` for other types — so it is a safe drop-in replacement everywhere.

## Changed call sites

| File | What is compared |
|------|------------------|
| `controller/pkg/reports/status.go` | `gwv1.ParentReference` equality when looking up existing route parent status |
| `controller/pkg/agentgateway/translator/model.go` | `Config` Spec/Status fallback comparison (Status may contain `metav1.Time`) |
| `controller/pkg/agentgateway/jwks/types.go` | `FetchTarget` equality in `JwksSource.Equals` and `SharedJwksRequest.Equals` |
| `controller/pkg/agentgateway/jwks/owner.go` | `RemoteJWKS` equality in `RemoteJwksOwner.Equals` |

In each file the now-unused `"reflect"` import is removed and `apiequality "k8s.io/apimachinery/pkg/api/equality"` is added.

## Test

- [x] `go build ./controller/...` — compiles cleanly
- [x] `go vet ./controller/...` — no new warnings
- [x] `make lint` — 0 issues across all 25 active linters (including `kubeapilinter`, `krtequals`, `unused`, `unparam`)
- [x] `go test ./controller/pkg/...` — all unit tests pass