### PR TITLE
openapi: set title based on summary

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -450,7 +450,7 @@ pub(crate) fn parse_openapi_schema(
 									"final schema is not an object".to_string(),
 								))?
 								.clone();
-							let tool = Tool::new_with_raw(
+							let mut tool = Tool::new_with_raw(
 								Cow::Owned(name.clone()),
 								Some(Cow::Owned(
 									op.description
@@ -460,6 +460,10 @@ pub(crate) fn parse_openapi_schema(
 								)),
 								Arc::new(final_json),
 							);
+							if let Some(summary) = op.summary.as_ref().filter(|s| !s.is_empty()) {
+								let end = std::cmp::min(64, summary.len());
+								tool = tool.with_title(summary[..summary.floor_char_boundary(end)].to_string());
+							}
 							let upstream = UpstreamOpenAPICall {
 								// method: Method::from_bytes(method.as_ref()).expect("todo"),
 								method: method.to_string(),

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -804,6 +804,52 @@ fn nested_schema<'a>(
 }
 
 #[test]
+fn test_parse_openapi_schema_maps_summary_to_tool_title() {
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "Titles", "version": "1.0.0"},
+		"paths": {
+			"/tags": {
+				"get": {
+					"operationId": "getTagsForWorkspace",
+					"summary": "Get tags in a workspace",
+					"description": "Returns the tags in a workspace",
+					"responses": {"200": {"description": "ok"}}
+				}
+			},
+			"/users": {
+				"get": {
+					"operationId": "getUsers",
+					"description": "Returns the users",
+					"responses": {"200": {"description": "ok"}}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let (with_summary, _) = tools
+		.iter()
+		.find(|(tool, _)| tool.name == "getTagsForWorkspace")
+		.expect("tool should exist");
+	assert_eq!(
+		with_summary.title.as_deref(),
+		Some("Get tags in a workspace")
+	);
+	assert_eq!(
+		with_summary.description.as_deref(),
+		Some("Returns the tags in a workspace")
+	);
+
+	let (without_summary, _) = tools
+		.iter()
+		.find(|(tool, _)| tool.name == "getUsers")
+		.expect("tool should exist");
+	assert_eq!(without_summary.title, None);
+}
+
+#[test]
 fn test_parse_openapi_schema_includes_path_level_parameters_in_tool_schema() {
 	let raw = r#"{
 		"openapi": "3.0.0",


### PR DESCRIPTION
 The MCP spec revision 2025-06-18 added title as the human-readable display name so that name can serve as a stable programmatic identifier.

This re-uses `summary` as that human readable title. Should this be configurable somehow? 