### PR TITLE
standalone: reject shared port for llm and mcp

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2920,17 +2920,9 @@ async fn convert(
 		}
 	}
 
-	match (llm, mcp) {
-		(Some(llm_config), Some(mcp_config))
-			if llm_config.gateways.is_empty()
-				&& mcp_config.gateways.is_empty()
-				&& llm_config.port.unwrap_or(DEFAULT_LLM_PORT)
-					== mcp_config.port.unwrap_or(DEFAULT_MCP_PORT) =>
-		{
-			if llm_config.tls.is_some() {
-				bail!("top-level llm and mcp cannot share a port when llm.tls is configured");
-			}
-			let (llm_bind, mut llm_routes, llm_policies, llm_backends) = Box::pin(convert_llm_config(
+	if let Some(llm_config) = llm {
+		if llm_config.gateways.is_empty() {
+			let (llm_bind, llm_routes, llm_policies, llm_backends) = Box::pin(convert_llm_config(
 				resources,
 				config,
 				gateway.clone(),
@@ -2938,82 +2930,52 @@ async fn convert(
 				false,
 			))
 			.await?;
-			let (_mcp_bind, mcp_routes, mcp_policies, mcp_backends) = Box::pin(convert_mcp_config(
-				resources,
-				config,
-				gateway.clone(),
-				mcp_config,
-				true,
-			))
-			.await?;
-			llm_routes.extend(mcp_routes);
 			all_listener_routes.push((strng::new(llm::LOCAL_LISTENER_NAME), llm_routes));
 			all_listener_tcp_routes.push((strng::new(llm::LOCAL_LISTENER_NAME), Vec::new()));
 			all_binds.push(llm_bind);
 			all_policies.extend_from_slice(&llm_policies);
-			all_policies.extend_from_slice(&mcp_policies);
 			all_backends.extend_from_slice(&llm_backends);
+		} else {
+			Box::pin(convert_attached_llm(
+				resources,
+				config,
+				gateway.clone(),
+				llm_config,
+				&gateway_refs,
+				&mut all_listener_routes,
+				&mut all_policies,
+				&mut all_backends,
+			))
+			.await?;
+		}
+	}
+	if let Some(mcp_config) = mcp {
+		if mcp_config.gateways.is_empty() {
+			let (mcp_bind, mcp_routes, mcp_policies, mcp_backends) = Box::pin(convert_mcp_config(
+				resources,
+				config,
+				gateway.clone(),
+				mcp_config,
+				false,
+			))
+			.await?;
+			all_listener_routes.push((strng::new("mcp"), mcp_routes));
+			all_listener_tcp_routes.push((strng::new("mcp"), Vec::new()));
+			all_binds.push(mcp_bind);
+			all_policies.extend_from_slice(&mcp_policies);
 			all_backends.extend_from_slice(&mcp_backends);
-		},
-		(llm, mcp) => {
-			if let Some(llm_config) = llm {
-				if llm_config.gateways.is_empty() {
-					let (llm_bind, llm_routes, llm_policies, llm_backends) = Box::pin(convert_llm_config(
-						resources,
-						config,
-						gateway.clone(),
-						llm_config,
-						false,
-					))
-					.await?;
-					all_listener_routes.push((strng::new(llm::LOCAL_LISTENER_NAME), llm_routes));
-					all_listener_tcp_routes.push((strng::new(llm::LOCAL_LISTENER_NAME), Vec::new()));
-					all_binds.push(llm_bind);
-					all_policies.extend_from_slice(&llm_policies);
-					all_backends.extend_from_slice(&llm_backends);
-				} else {
-					Box::pin(convert_attached_llm(
-						resources,
-						config,
-						gateway.clone(),
-						llm_config,
-						&gateway_refs,
-						&mut all_listener_routes,
-						&mut all_policies,
-						&mut all_backends,
-					))
-					.await?;
-				}
-			}
-			if let Some(mcp_config) = mcp {
-				if mcp_config.gateways.is_empty() {
-					let (mcp_bind, mcp_routes, mcp_policies, mcp_backends) = Box::pin(convert_mcp_config(
-						resources,
-						config,
-						gateway.clone(),
-						mcp_config,
-						false,
-					))
-					.await?;
-					all_listener_routes.push((strng::new("mcp"), mcp_routes));
-					all_listener_tcp_routes.push((strng::new("mcp"), Vec::new()));
-					all_binds.push(mcp_bind);
-					all_policies.extend_from_slice(&mcp_policies);
-					all_backends.extend_from_slice(&mcp_backends);
-				} else {
-					Box::pin(convert_attached_mcp(
-						resources,
-						config,
-						gateway.clone(),
-						mcp_config,
-						&gateway_refs,
-						&mut all_listener_routes,
-						&mut all_backends,
-					))
-					.await?;
-				}
-			}
-		},
+		} else {
+			Box::pin(convert_attached_mcp(
+				resources,
+				config,
+				gateway.clone(),
+				mcp_config,
+				&gateway_refs,
+				&mut all_listener_routes,
+				&mut all_backends,
+			))
+			.await?;
+		}
 	}
 	if let Some(ui_config) = ui {
 		Box::pin(convert_attached_ui(
@@ -3220,43 +3182,39 @@ fn validate_local_listener_ports(config: &LocalConfig) -> anyhow::Result<()> {
 			wildcard_binds
 		);
 	}
-	match (&config.llm, &config.mcp) {
-		(Some(llm), Some(mcp))
-			if llm.gateways.is_empty()
-				&& mcp.gateways.is_empty()
-				&& llm.port.unwrap_or(DEFAULT_LLM_PORT) == mcp.port.unwrap_or(DEFAULT_MCP_PORT) =>
-		{
-			insert_local_listener_port(
-				llm.port.unwrap_or(DEFAULT_LLM_PORT),
-				"llm and mcp".to_string(),
-			)?;
-		},
-		(llm, mcp) => {
-			if let Some(llm) = llm
-				&& llm.gateways.is_empty()
-			{
-				insert_local_listener_port(
-					llm.port.unwrap_or(DEFAULT_LLM_PORT),
-					if llm.port.is_some() {
-						"llm".to_string()
-					} else {
-						"llm (default)".to_string()
-					},
-				)?;
-			}
-			if let Some(mcp) = mcp
-				&& mcp.gateways.is_empty()
-			{
-				insert_local_listener_port(
-					mcp.port.unwrap_or(DEFAULT_MCP_PORT),
-					if mcp.port.is_some() {
-						"mcp".to_string()
-					} else {
-						"mcp (default)".to_string()
-					},
-				)?;
-			}
-		},
+	if let (Some(llm), Some(mcp)) = (&config.llm, &config.mcp)
+		&& llm.gateways.is_empty()
+		&& mcp.gateways.is_empty()
+		&& llm.port.unwrap_or(DEFAULT_LLM_PORT) == mcp.port.unwrap_or(DEFAULT_MCP_PORT)
+	{
+		let port = llm.port.unwrap_or(DEFAULT_LLM_PORT);
+		bail!(
+			"top-level llm and mcp cannot use the same port {port}; attach both to the same gateway instead"
+		);
+	}
+	if let Some(llm) = &config.llm
+		&& llm.gateways.is_empty()
+	{
+		insert_local_listener_port(
+			llm.port.unwrap_or(DEFAULT_LLM_PORT),
+			if llm.port.is_some() {
+				"llm".to_string()
+			} else {
+				"llm (default)".to_string()
+			},
+		)?;
+	}
+	if let Some(mcp) = &config.mcp
+		&& mcp.gateways.is_empty()
+	{
+		insert_local_listener_port(
+			mcp.port.unwrap_or(DEFAULT_MCP_PORT),
+			if mcp.port.is_some() {
+				"mcp".to_string()
+			} else {
+				"mcp (default)".to_string()
+			},
+		)?;
 	}
 	Ok(())
 }

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -919,72 +919,16 @@ async fn test_mcp_simple_config() {
 }
 
 #[tokio::test]
-async fn test_llm_mcp_same_port_share_listener_routes() {
-	let normalized = normalize_test_yaml(
-		r#"
-llm:
-  port: 3000
-  models:
-  - name: gpt-4
-    provider: openAI
-mcp:
-  targets:
-  - name: time
-    stdio:
-      cmd: uvx
-"#,
-	)
-	.await
-	.expect("same-port LLM and MCP should normalize");
-
-	assert_eq!(normalized.binds.len(), 1);
-	assert_eq!(normalized.binds[0].address.port(), 3000);
-	assert_eq!(
-		normalized.binds[0]
-			.listeners
-			.iter()
-			.map(|listener| listener.key.as_str())
-			.collect::<Vec<_>>(),
-		vec!["llm"],
-	);
-	assert_eq!(normalized.listener_routes.len(), 1);
-	assert_eq!(normalized.listener_routes[0].0.as_str(), "llm");
-	let routes = &normalized.listener_routes[0].1;
-	assert!(
-		routes
-			.iter()
-			.any(|route| route.key.as_str() == "llm:request")
-	);
-	let mcp_route = routes
-		.iter()
-		.find(|route| route.key.as_str() == "mcp:default")
-		.expect("expected MCP route on shared listener");
-	assert_eq!(
-		mcp_route
-			.matches
-			.iter()
-			.map(|route_match| match &route_match.path {
-				PathMatch::PathPrefix(path) => path.as_str(),
-				other => panic!("expected path prefix match, got {other:?}"),
-			})
-			.collect::<Vec<_>>(),
-		vec!["/mcp", "/sse", "/.well-known"],
-	);
-}
-
-#[tokio::test]
-async fn test_llm_mcp_same_port_rejects_llm_tls() {
+async fn test_llm_mcp_same_port_is_rejected() {
 	let err = normalize_test_yaml(
 		r#"
 llm:
   port: 3000
-  tls:
-    cert: inline
-    key: inline
   models:
   - name: gpt-4
     provider: openAI
 mcp:
+  port: 3000
   targets:
   - name: time
     stdio:
@@ -992,11 +936,11 @@ mcp:
 "#,
 	)
 	.await
-	.expect_err("same-port LLM and MCP should reject llm.tls");
+	.expect_err("same-port LLM and MCP should be rejected");
 	assert!(
 		err
 			.to_string()
-			.contains("top-level llm and mcp cannot share a port when llm.tls is configured"),
+			.contains("top-level llm and mcp cannot use the same port 3000"),
 		"{err:?}"
 	);
 }


### PR DESCRIPTION
This is obsolete with the new 'gateways' field and its complex +
slightly buggy.

Signed-off-by: John Howard <john.howard@solo.io>
