### PR TITLE
controller: properly handle conflicts on internal GW/ListenerSet

### DIFF
--- a/controller/api/annotations/agentgateway.go
+++ b/controller/api/annotations/agentgateway.go
@@ -20,7 +20,7 @@ const MCPServiceTargetName = "agentgateway.dev/mcp-target-name"
 
 // InternalPorts is a comma-separated list of ports whose bind should be internal
 // (routing-only: no OS listener socket, no Service port, no container port). It may
-// be set on a Gateway or a ListenerSet, and may only reference ports defined by that
+// be set on a Gateway or a ListenerSet and may only reference ports defined by that
 // same object's listeners.
 const InternalPorts = "agentgateway.dev/internal-ports"
 

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -385,14 +385,6 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 			})
 		}
 		validateListenerConflicts(result)
-		if ports := internalPortDisagreements(result); len(ports) > 0 {
-			gwReporter.SetCondition(reporter.GatewayCondition{
-				Type:    gwv1.GatewayConditionAccepted,
-				Status:  metav1.ConditionFalse,
-				Reason:  gwv1.GatewayReasonInvalid,
-				Message: fmt.Sprintf("conflicting %s annotation: port(s) %v are marked internal by some listeners but standard by others", annotations.InternalPorts, ports),
-			})
-		}
 		uniqueListenerSets := sets.New[utils.TypedNamespacedName]()
 		for _, ls := range result {
 			if !(ls.Valid && ls.Conflict == "" && ls.ParentObject.Kind == wellknown.ListenerSetGVK.Kind) {
@@ -410,6 +402,7 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 type portProtocol struct {
 	hostnames sets.String
 	protocol  gwv1.ProtocolType
+	internal  bool
 }
 
 type ListenerConflict string
@@ -417,40 +410,18 @@ type ListenerConflict string
 const (
 	ListenerConflictHostname = "hostname"
 	ListenerConflictProtocol = "protocol"
+	ListenerConflictBindMode = "bind-mode"
 )
-
-// internalPortDisagreements returns the sorted set of ports for which non-conflicting
-// listeners disagree on internal vs standard bind mode. A bind is per-port and shared,
-// so such a port cannot be resolved to a single mode and must be reported as invalid.
-func internalPortDisagreements(listeners []*GatewayListener) []int32 {
-	var sawInternal, sawStandard sets.Set[gwv1.PortNumber]
-	sawInternal = sets.New[gwv1.PortNumber]()
-	sawStandard = sets.New[gwv1.PortNumber]()
-	for _, l := range listeners {
-		if l.Conflict != "" {
-			continue
-		}
-		if l.ParentInfo.Internal {
-			sawInternal.Insert(l.ParentInfo.Port)
-		} else {
-			sawStandard.Insert(l.ParentInfo.Port)
-		}
-	}
-	var conflicting []int32
-	for port := range sawInternal {
-		if sawStandard.Contains(port) {
-			conflicting = append(conflicting, int32(port))
-		}
-	}
-	slices.Sort(conflicting)
-	return conflicting
-}
 
 func validateListenerConflicts(listeners []*GatewayListener) {
 	portMap := make(map[gwv1.PortNumber]*portProtocol)
 	for _, listener := range listeners {
 		if p, ok := portMap[listener.ParentInfo.Port]; ok {
-			if p.protocol == listener.ParentInfo.Protocol {
+			if p.internal != listener.ParentInfo.Internal {
+				// Listeners are ordered by Gateway API precedence before validation.
+				// Preserve the winning bind mode and reject only the later listener.
+				listener.Conflict = ListenerConflictBindMode
+			} else if p.protocol == listener.ParentInfo.Protocol {
 				if slices.ContainsFunc(listener.ParentInfo.Hostnames, p.hostnames.Contains) {
 					listener.Conflict = ListenerConflictHostname
 				} else {
@@ -463,6 +434,7 @@ func validateListenerConflicts(listeners []*GatewayListener) {
 			portMap[listener.ParentInfo.Port] = &portProtocol{
 				hostnames: sets.New(listener.ParentInfo.Hostnames...),
 				protocol:  listener.ParentInfo.Protocol,
+				internal:  listener.ParentInfo.Internal,
 			}
 		}
 	}

--- a/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind-listenerset-conflict.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/gateways/internal-bind-listenerset-conflict.yaml
@@ -3,8 +3,6 @@ kind: Gateway
 metadata:
   name: example
   namespace: default
-  annotations:
-    agentgateway.dev/internal-ports: "8080"
 spec:
   gatewayClassName: agentgateway
   listeners:
@@ -21,6 +19,8 @@ kind: ListenerSet
 metadata:
   name: foo
   namespace: default
+  annotations:
+    agentgateway.dev/internal-ports: "8080"
 spec:
   parentRef:
     name: example
@@ -44,7 +44,6 @@ output:
   resource:
     bind:
       key: 8080/default/example
-      mode: INTERNAL
       port: 8080
 - gateway:
     Name: example

--- a/controller/pkg/pluginsdk/collections/deployer.go
+++ b/controller/pkg/pluginsdk/collections/deployer.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"cmp"
 	"fmt"
 
 	"istio.io/istio/pilot/pkg/serviceregistry/ambient"
@@ -86,14 +87,13 @@ func GatewaysForDeployerTransformationFunc(
 	}
 }
 
-// ComputeInternalPorts returns the ports whose bind is internal, mirroring the bind-mode
-// decision in the syncer: a port is internal only if every contributing listener (across
-// the Gateway and its ListenerSets) agrees. Disagreement leaves the port standard (and is
-// surfaced as Accepted=False during translation). Invalid annotations are ignored here;
-// translation reports them.
+// ComputeInternalPorts returns the ports whose winning listener selects an internal
+// bind. Gateway listeners have precedence over ListenerSets. ListenerSets are ordered
+// oldest first, then by namespace/name, matching listener conflict validation.
+// A lower-precedence listener with a different mode is rejected by translation and
+// cannot change Service/container exposure here.
 func ComputeInternalPorts(gw *gwv1.Gateway, lsets []*gwv1.ListenerSet) smallset.Set[int32] {
-	sawInternal := sets.New[int32]()
-	sawStandard := sets.New[int32]()
+	portModes := map[int32]bool{}
 
 	gwInternal, _ := annotations.ParseInternalPorts(
 		gw.GetAnnotations()[annotations.InternalPorts],
@@ -107,19 +107,24 @@ func ComputeInternalPorts(gw *gwv1.Gateway, lsets []*gwv1.ListenerSet) smallset.
 		},
 	)
 	for _, l := range gw.Spec.Listeners {
-		if gwInternal.Has(l.Port) {
-			sawInternal.Insert(l.Port)
-		} else {
-			sawStandard.Insert(l.Port)
-		}
+		portModes[int32(l.Port)] = gwInternal.Has(l.Port)
 	}
 
+	slices.SortFunc(lsets, func(a, b *gwv1.ListenerSet) int {
+		if r := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); r != 0 {
+			return r
+		}
+		if r := cmp.Compare(a.Namespace, b.Namespace); r != 0 {
+			return r
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
 	for _, ls := range lsets {
 		lsInternal, _ := annotations.ParseInternalPorts(
 			ls.GetAnnotations()[annotations.InternalPorts],
 			func(p int32) bool {
 				for _, l := range ls.Spec.Listeners {
-					if port, err := kubeutils.DetectListenerPortNumber(l.Protocol, l.Port); err == nil && int32(port) == p {
+					if port, err := kubeutils.DetectListenerPortNumber(l.Protocol, l.Port); err == nil && port == p {
 						return true
 					}
 				}
@@ -131,21 +136,19 @@ func ComputeInternalPorts(gw *gwv1.Gateway, lsets []*gwv1.ListenerSet) smallset.
 			if err != nil {
 				continue
 			}
-			if lsInternal.Has(port) {
-				sawInternal.Insert(port)
-			} else {
-				sawStandard.Insert(port)
+			if _, winnerSelected := portModes[port]; !winnerSelected {
+				portModes[port] = lsInternal.Has(port)
 			}
 		}
 	}
 
-	internal := []int32{}
-	for p := range sawInternal {
-		if !sawStandard.Contains(p) {
-			internal = append(internal, p)
+	internal := sets.New[int32]()
+	for port, mode := range portModes {
+		if mode {
+			internal.Insert(port)
 		}
 	}
-	return smallset.New(internal...)
+	return smallset.New(internal.UnsortedList()...)
 }
 
 type GatewayForDeployer struct {
@@ -155,8 +158,8 @@ type GatewayForDeployer struct {
 	// All ports from all listeners
 	Ports smallset.Set[int32]
 	// InternalPorts are ports whose bind is internal (routing-only). They are excluded
-	// from the generated Service and container ports. Derived from the
-	// agentgateway.dev/internal-ports annotation on the Gateway and its ListenerSets.
+	// from the generated Service and container ports. Derived from the winning listener's
+	// agentgateway.dev/internal-ports annotation.
 	InternalPorts smallset.Set[int32]
 	// MeshTrustDomain changes should trigger reconciliation
 	// this field isn't read outside of Equals for a trigger

--- a/controller/pkg/pluginsdk/collections/deployer_internalports_test.go
+++ b/controller/pkg/pluginsdk/collections/deployer_internalports_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"testing"
+	"time"
 
 	"istio.io/istio/pkg/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,8 +26,11 @@ func gw(annotation string, ports ...gwv1.PortNumber) *gwv1.Gateway {
 	return g
 }
 
-func ls(annotation string, ports ...gwv1.PortNumber) *gwv1.ListenerSet {
-	l := &gwv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{Name: "ls"}}
+func ls(name, annotation string, created time.Time, ports ...gwv1.PortNumber) *gwv1.ListenerSet {
+	l := &gwv1.ListenerSet{ObjectMeta: metav1.ObjectMeta{
+		Name:              name,
+		CreationTimestamp: metav1.NewTime(created),
+	}}
 	if annotation != "" {
 		l.Annotations = map[string]string{annotations.InternalPorts: annotation}
 	}
@@ -41,6 +45,7 @@ func ls(annotation string, ports ...gwv1.PortNumber) *gwv1.ListenerSet {
 }
 
 func TestComputeInternalPorts(t *testing.T) {
+	now := time.Now()
 	tests := []struct {
 		name  string
 		gw    *gwv1.Gateway
@@ -53,22 +58,31 @@ func TestComputeInternalPorts(t *testing.T) {
 			want: []int32{8080},
 		},
 		{
-			name:  "listenerset annotation marks its port internal",
+			name:  "listenerset can add an internal port",
 			gw:    gw("", 80),
-			lsets: []*gwv1.ListenerSet{ls("9090", 9090)},
+			lsets: []*gwv1.ListenerSet{ls("internal", "9090", now, 9090)},
 			want:  []int32{9090},
 		},
 		{
-			name:  "disagreement on shared port stays standard",
+			name:  "gateway internal mode wins over standard listenerset",
 			gw:    gw("8080", 8080),
-			lsets: []*gwv1.ListenerSet{ls("", 8080)},
+			lsets: []*gwv1.ListenerSet{ls("standard", "", now, 8080)},
+			want:  []int32{8080},
+		},
+		{
+			name:  "gateway standard mode wins over internal listenerset",
+			gw:    gw("", 8080),
+			lsets: []*gwv1.ListenerSet{ls("internal", "8080", now, 8080)},
 			want:  nil,
 		},
 		{
-			name:  "agreement on shared port is internal",
-			gw:    gw("8080", 8080),
-			lsets: []*gwv1.ListenerSet{ls("8080", 8080)},
-			want:  []int32{8080},
+			name: "older listenerset mode wins",
+			gw:   gw("", 80),
+			lsets: []*gwv1.ListenerSet{
+				ls("newer-standard", "", now.Add(time.Minute), 9090),
+				ls("older-internal", "9090", now, 9090),
+			},
+			want: []int32{9090},
 		},
 		{
 			name: "invalid annotation is ignored",

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -298,6 +298,10 @@ func (s *Syncer) buildFinalListenerSetStatus(
 						invalidListenerCount++
 						ListenerMessageProtocolConflict := "Found conflicting protocols on listeners, a single port can only contain listeners with compatible protocols"
 						ReportListenerSetListenerConflicts(&lsStatus.Listeners[idx], i.Obj, string(gwv1.ListenerReasonProtocolConflict), ListenerMessageProtocolConflict)
+					} else if obj.Conflict == translator.ListenerConflictBindMode {
+						invalidListenerCount++
+						listenerMessageBindModeConflict := "Found conflicting bind modes on listeners; the higher-precedence listener determines whether the shared port is internal"
+						ReportListenerSetListenerConflicts(&lsStatus.Listeners[idx], i.Obj, "BindModeConflict", listenerMessageBindModeConflict)
 					}
 				}
 				lsStatus.Listeners[idx].AttachedRoutes = counts[string(l.Name)]
@@ -419,6 +423,11 @@ func (s *Syncer) buildAgwResources(
 	// (resources for additional gateway classes should be created by the downstream providing them)
 	filteredGateways := krt.NewCollection(gateways, func(ctx krt.HandlerContext, gw *translator.GatewayListener) **translator.GatewayListener {
 		if _, isAdditionalClass := s.additionalGatewayClasses[gw.ParentInfo.ParentGatewayClassName]; isAdditionalClass {
+			return nil
+		}
+		if gw.Conflict == translator.ListenerConflictBindMode {
+			// Bind mode is selected by listener precedence. Keep the losing listener
+			// available to status reporting, but do not program it or attach routes.
 			return nil
 		}
 		return &gw
@@ -573,7 +582,6 @@ func (s *Syncer) buildBindsFromGateway(listeners []*translator.GatewayListener) 
 		protocol       api.Bind_Protocol
 		tunnelProtocol api.Bind_TunnelProtocol
 		sawInternal    bool
-		sawStandard    bool
 	}
 	byPort := map[uint32]*bindInfo{}
 	for _, listener := range listeners {
@@ -593,13 +601,12 @@ func (s *Syncer) buildBindsFromGateway(listeners []*translator.GatewayListener) 
 			if tp := s.getTunnelProtocol(listener); tp != api.Bind_DIRECT {
 				bi.tunnelProtocol = tp
 			}
-			// A bind is internal only if every contributing listener agrees. Disagreement
-			// (sawInternal && sawStandard) is reported as Accepted=False in translation and
-			// leaves the bind standard here.
+			// A bind is internal if any contributing listener marks it internal. Translation
+			// reports disagreement as Accepted=False, but the bind must fail closed: a
+			// standard listener (including one from a delegated ListenerSet) must not make
+			// another listener's internal route externally reachable.
 			if listener.ParentInfo.Internal {
 				bi.sawInternal = true
-			} else {
-				bi.sawStandard = true
 			}
 		}
 	}
@@ -608,7 +615,7 @@ func (s *Syncer) buildBindsFromGateway(listeners []*translator.GatewayListener) 
 	for _, port := range slices.Sort(maps.Keys(byPort)) { // sorted for deterministic output
 		bi := byPort[port]
 		mode := api.Bind_STANDARD
-		if bi.sawInternal && !bi.sawStandard {
+		if bi.sawInternal {
 			mode = api.Bind_INTERNAL
 		}
 		bind := translator.AgwBind{


### PR DESCRIPTION
This avoids conflicts where a GW sets a port, and a listenerset declares it as internal. This is a boundary violation.

or the opposite and we accidentally make an internal port external

 - Gateway listeners take precedence over ListenerSets.
  - ListenerSets are ordered by creation time, then namespace/name.
  - If a lower-precedence listener disagrees about whether the port is internal, it is rejected with BindModeConflict.
  - The rejected listener is marked Conflicted=True, Accepted=False, and Programmed=False.
  - It is excluded from listener programming and route attachment.