### PR TITLE
krt: fix Equals signatures

### DIFF
--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -350,7 +350,7 @@ func (r RouteAttachment) ResourceName() string {
 	return r.From.Kind + "/" + r.From.NamespacedName.String() + "->" + to + "/" + r.ListenerName
 }
 
-func (r RouteAttachment) Equals(other RouteAttachment) bool {
+func (r *RouteAttachment) Equals(other *RouteAttachment) bool {
 	return r.From == other.From && r.To == other.To && r.ListenerName == other.ListenerName && r.Gateway == other.Gateway
 }
 
@@ -374,7 +374,7 @@ type PolicyAttachment struct {
 	Source  utils.TypedNamespacedName
 }
 
-func (a PolicyAttachment) Equals(other PolicyAttachment) bool {
+func (a *PolicyAttachment) Equals(other *PolicyAttachment) bool {
 	return a.Target == other.Target && a.Backend == other.Backend && a.Source == other.Source
 }
 

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -160,7 +160,7 @@ func (g PortBindings) ResourceName() string {
 }
 
 func (g PortBindings) Equals(other PortBindings) bool {
-	return g.GatewayListener.Equals(other.GatewayListener) &&
+	return g.GatewayListener.Equals(&other.GatewayListener) &&
 		g.Port == other.Port
 }
 
@@ -182,7 +182,7 @@ func (g GatewayListener) ResourceName() string {
 	return g.Name
 }
 
-func (g GatewayListener) Equals(other GatewayListener) bool {
+func (g *GatewayListener) Equals(other *GatewayListener) bool {
 	if (g.TLSInfo != nil) != (other.TLSInfo != nil) {
 		return false
 	}

--- a/controller/pkg/agentgateway/utils/utils.go
+++ b/controller/pkg/agentgateway/utils/utils.go
@@ -241,7 +241,7 @@ type AncestorBackend struct {
 	Source  TypedNamespacedName
 }
 
-func (a AncestorBackend) Equals(other AncestorBackend) bool {
+func (a *AncestorBackend) Equals(other *AncestorBackend) bool {
 	return a.Gateway == other.Gateway && a.Backend == other.Backend && a.Source == other.Source
 }
 


### PR DESCRIPTION
https://pkg.go.dev/golang.org/x/tools/go/analysis allows writing custom static analysis.

Over the weekend (with AI) I experimented with adding a [linter](https://github.com/stevenctl/istio/tree/stevenctl/krtlint ) for krt usage which has a handful of footguns (Lookup vs Fetch, improper Equals impls) that can lead to missed updates.

It found that our signatures for Equals here don't actually get called by krt, falling back to a deep equals. 