### PR TITLE
database: make connection pool size configurable

### DIFF
--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -142,12 +142,12 @@ pub struct ConfigResourceUpsert {
 }
 
 pub async fn setup(cfg: &log_store::Config) -> anyhow::Result<ConfigResourceStore> {
-	ConfigResourceStore::connect(&cfg.url).await
+	ConfigResourceStore::connect(&cfg.url, cfg.max_connections).await
 }
 
 impl ConfigResourceStore {
-	async fn connect(url: &str) -> anyhow::Result<Self> {
-		Self::from_pool(DatabasePool::connect(url).await?).await
+	async fn connect(url: &str, max_connections: Option<u32>) -> anyhow::Result<Self> {
+		Self::from_pool(DatabasePool::connect_with_max_connections(url, max_connections).await?).await
 	}
 
 	async fn from_pool(pool: DatabasePool) -> anyhow::Result<Self> {
@@ -1849,7 +1849,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn renames_resources_atomically() {
-		let store = ConfigResourceStore::connect("sqlite::memory:")
+		let store = ConfigResourceStore::connect("sqlite::memory:", None)
 			.await
 			.expect("connect config resource store");
 		store

--- a/crates/agentgateway/src/database.rs
+++ b/crates/agentgateway/src/database.rs
@@ -11,11 +11,25 @@ pub enum DatabasePool {
 	Postgres(PgPool),
 }
 
+/// Default pool size when `maxConnections` is not set in config. Kept small
+/// since agentgateway opens a separate pool per store (request log + config
+/// store) per process; each replica's total connection usage is roughly
+/// `2 * max_connections`.
+const DEFAULT_MAX_CONNECTIONS: u32 = 5;
+
 impl DatabasePool {
 	pub async fn connect(url: &str) -> anyhow::Result<Self> {
+		Self::connect_with_max_connections(url, None).await
+	}
+
+	pub async fn connect_with_max_connections(
+		url: &str,
+		max_connections: Option<u32>,
+	) -> anyhow::Result<Self> {
+		let max_connections = max_connections.unwrap_or(DEFAULT_MAX_CONNECTIONS);
 		if url.starts_with("postgres://") || url.starts_with("postgresql://") {
 			let pool = PgPoolOptions::new()
-				.max_connections(5)
+				.max_connections(max_connections)
 				.connect(url)
 				.await
 				.context("failed to connect postgres database")?;
@@ -30,7 +44,7 @@ impl DatabasePool {
 			.synchronous(SqliteSynchronous::Normal)
 			.busy_timeout(Duration::from_secs(5));
 		let pool = SqlitePoolOptions::new()
-			.max_connections(5)
+			.max_connections(max_connections)
 			.connect_with(options)
 			.await
 			.context("failed to connect sqlite database")?;

--- a/crates/agentgateway/src/telemetry/log_store.rs
+++ b/crates/agentgateway/src/telemetry/log_store.rs
@@ -23,6 +23,11 @@ static REQUEST_LOG_STORE_BACKLOG: AtomicUsize = AtomicUsize::new(0);
 pub struct Config {
 	/// Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.
 	pub url: String,
+	/// Maximum number of connections to open in this database's connection pool. Defaults to 5.
+	/// Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which
+	/// is sized independently from the same field when both share the same `url`.
+	#[serde(default)]
+	pub max_connections: Option<u32>,
 }
 
 #[derive(Clone)]
@@ -686,7 +691,13 @@ impl Backend {
 	) -> anyhow::Result<Self> {
 		let pool = match pool {
 			Some(pool) => pool,
-			None => crate::database::DatabasePool::connect(&cfg.url).await?,
+			None => {
+				crate::database::DatabasePool::connect_with_max_connections(
+					&cfg.url,
+					cfg.max_connections,
+				)
+				.await?
+			},
 		};
 		match pool {
 			crate::database::DatabasePool::Sqlite(pool) => {

--- a/crates/agentgateway/src/telemetry/log_store.rs
+++ b/crates/agentgateway/src/telemetry/log_store.rs
@@ -692,11 +692,8 @@ impl Backend {
 		let pool = match pool {
 			Some(pool) => pool,
 			None => {
-				crate::database::DatabasePool::connect_with_max_connections(
-					&cfg.url,
-					cfg.max_connections,
-				)
-				.await?
+				crate::database::DatabasePool::connect_with_max_connections(&cfg.url, cfg.max_connections)
+					.await?
 			},
 		};
 		match pool {

--- a/schema/config.json
+++ b/schema/config.json
@@ -668,13 +668,14 @@
           "type": "string"
         },
         "maxConnections": {
-          "description": "Maximum number of connections to open in this database's connection pool. Defaults to 5. Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which is sized independently from the same field when both share the same `url`.",
+          "description": "Maximum number of connections to open in this database's connection pool. Defaults to 5.\nNote this pool is separate from the config store's pool (config.storage.mode=hybrid), which\nis sized independently from the same field when both share the same `url`.",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
-          "minimum": 0
+          "minimum": 0,
+          "default": null
         }
       },
       "additionalProperties": false,

--- a/schema/config.json
+++ b/schema/config.json
@@ -666,6 +666,15 @@
         "url": {
           "description": "Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.",
           "type": "string"
+        },
+        "maxConnections": {
+          "description": "Maximum number of connections to open in this database's connection pool. Defaults to 5. Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which is sized independently from the same field when both share the same `url`.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
         }
       },
       "additionalProperties": false,

--- a/schema/config.md
+++ b/schema/config.md
@@ -34,7 +34,7 @@
 |`config.modelCatalog[].inline.providers.*.models.*.tiers[].rates.outputAudio`|string|Cost per 1M output audio tokens. Falls back to the output rate if unset.|
 |`config.database`|object|Primary database used by local runtime features.|
 |`config.database.url`|string|Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.|
-|`config.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5. Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which is sized independently from the same field when both share the same `url`.|
+|`config.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5.<br>Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which<br>is sized independently from the same field when both share the same `url`.|
 |`config.storage`|object|Controls whether UI-managed configuration is written to the config file or a DB overlay.|
 |`config.storage.mode`|enum|Possible values: `file`, `hybrid`.|
 |`config.caAddress`|string|Address of the Certificate Authority used to issue SPIFFE certificates.|
@@ -82,7 +82,7 @@
 |`config.logging.format`|enum|Log output format: `text` or `json`.<br>Possible values: `text`, `json`, `null`.|
 |`config.logging.database`|object|Log-store database configuration; enables request logging to a database backend.|
 |`config.logging.database.url`|string|Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.|
-|`config.logging.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5. Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which is sized independently from the same field when both share the same `url`.|
+|`config.logging.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5.<br>Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which<br>is sized independently from the same field when both share the same `url`.|
 |`config.metrics`|object|Metrics configuration, including metric removal and custom fields.|
 |`config.metrics.remove`|[]string|Metric names to exclude from collection.|
 |`config.metrics.fields`|object|Custom fields to add to all metrics.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -34,6 +34,7 @@
 |`config.modelCatalog[].inline.providers.*.models.*.tiers[].rates.outputAudio`|string|Cost per 1M output audio tokens. Falls back to the output rate if unset.|
 |`config.database`|object|Primary database used by local runtime features.|
 |`config.database.url`|string|Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.|
+|`config.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5. Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which is sized independently from the same field when both share the same `url`.|
 |`config.storage`|object|Controls whether UI-managed configuration is written to the config file or a DB overlay.|
 |`config.storage.mode`|enum|Possible values: `file`, `hybrid`.|
 |`config.caAddress`|string|Address of the Certificate Authority used to issue SPIFFE certificates.|
@@ -81,6 +82,7 @@
 |`config.logging.format`|enum|Log output format: `text` or `json`.<br>Possible values: `text`, `json`, `null`.|
 |`config.logging.database`|object|Log-store database configuration; enables request logging to a database backend.|
 |`config.logging.database.url`|string|Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.|
+|`config.logging.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5. Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which is sized independently from the same field when both share the same `url`.|
 |`config.metrics`|object|Metrics configuration, including metric removal and custom fields.|
 |`config.metrics.remove`|[]string|Metric names to exclude from collection.|
 |`config.metrics.fields`|object|Custom fields to add to all metrics.|


### PR DESCRIPTION
Both the request-log store and config store hardcode `max_connections(5)` for their Postgres/SQLite pools, with no way to override it. Each store opens its own separate pool from the same `config.database.url`, so a single replica can open up to 2x the hardcoded limit in practice.

Under load - e.g. several concurrent Admin UI page loads, each firing a handful of parallel /api/* calls - 5 connections is exhausted quickly, surfacing as "pool timed out while waiting for an open connection" in the UI even though the underlying Postgres instance has ample headroom.

Add an optional maxConnections field alongside url, defaulting to 5 to preserve current behavior. Threaded through both pool construction call sites (`config_store::ConfigResourceStore::connect` and `telemetry::log_store::Backend::connect`) since they build independent pools from the same config today.