### PR TITLE
Add InferencePool model discovery

### DIFF
--- a/controller/pkg/agentgateway/modeldiscovery/discovery.go
+++ b/controller/pkg/agentgateway/modeldiscovery/discovery.go
@@ -1,0 +1,474 @@
+package modeldiscovery
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
+	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/logging"
+)
+
+const (
+	EnabledAnnotation    = "agentgateway.dev/model-discovery"
+	PathAnnotation       = "agentgateway.dev/model-discovery-path"
+	IntervalAnnotation   = "agentgateway.dev/model-discovery-interval"
+	StaleAfterAnnotation = "agentgateway.dev/model-discovery-stale-after"
+
+	defaultPath           = "/v1/models"
+	defaultInterval       = 30 * time.Second
+	defaultStaleAfter     = 5 * time.Minute
+	defaultScanInterval   = time.Second
+	defaultRequestTimeout = 5 * time.Second
+	maxResponseBytes      = 1 << 20
+	maxModelsPerResponse  = 10_000
+	maxModelIDLength      = 1_024
+	maxConcurrentPolls    = 16
+	minPollInterval       = 5 * time.Second
+)
+
+var logger = logging.New("agentgateway/model-discovery")
+
+// Model is a normalized model discovered for one AgentgatewayModel anchor.
+type Model struct {
+	Owner   types.NamespacedName
+	ID      string
+	Created uint64
+}
+
+func (m Model) ResourceName() string {
+	digest := sha256.Sum256([]byte(m.ID))
+	return m.Owner.String() + "/" + hex.EncodeToString(digest[:8])
+}
+
+func (m Model) Equals(other Model) bool {
+	return m.Owner == other.Owner &&
+		m.ID == other.ID &&
+		m.Created == other.Created
+}
+
+// AnchorConfig is the validated discovery configuration for an
+// AgentgatewayModel.
+type AnchorConfig struct {
+	Owner      types.NamespacedName
+	Pool       types.NamespacedName
+	Path       string
+	Interval   time.Duration
+	StaleAfter time.Duration
+}
+
+// ParseAnchor validates the provisional annotation-based discovery contract.
+func ParseAnchor(model *agentgateway.AgentgatewayModel) (AnchorConfig, bool, error) {
+	if model.Annotations[EnabledAnnotation] != "enabled" {
+		return AnchorConfig{}, false, nil
+	}
+	cfg := AnchorConfig{
+		Owner: types.NamespacedName{
+			Namespace: model.Namespace,
+			Name:      model.Name,
+		},
+		Path:       defaultPath,
+		Interval:   defaultInterval,
+		StaleAfter: defaultStaleAfter,
+	}
+	if model.Spec.Match != nil {
+		return AnchorConfig{}, true, errors.New("model discovery requires spec.match to be omitted")
+	}
+	if model.Spec.Provider == nil || *model.Spec.Provider != agentgateway.ModelProviderCustom {
+		return AnchorConfig{}, true, errors.New("model discovery requires provider Custom")
+	}
+	if model.Spec.Custom == nil || model.Spec.Custom.BackendRef == nil {
+		return AnchorConfig{}, true, errors.New("model discovery requires custom.backendRef")
+	}
+	ref := model.Spec.Custom.BackendRef
+	if ref.Group == nil || *ref.Group != "inference.networking.k8s.io" ||
+		ref.Kind == nil || *ref.Kind != "InferencePool" {
+		return AnchorConfig{}, true, errors.New("model discovery custom.backendRef must target an InferencePool")
+	}
+	if ref.Port != nil {
+		return AnchorConfig{}, true, errors.New("model discovery does not support a backendRef port")
+	}
+	cfg.Pool = types.NamespacedName{Namespace: model.Namespace, Name: ref.Name}
+
+	if raw := model.Annotations[PathAnnotation]; raw != "" {
+		parsed, err := url.ParseRequestURI(raw)
+		if err != nil || !strings.HasPrefix(raw, "/") || parsed.IsAbs() || parsed.Host != "" ||
+			parsed.RawQuery != "" || parsed.Fragment != "" {
+			return AnchorConfig{}, true, fmt.Errorf("%s must be an absolute path", PathAnnotation)
+		}
+		cfg.Path = raw
+	}
+	if raw := model.Annotations[IntervalAnnotation]; raw != "" {
+		interval, err := time.ParseDuration(raw)
+		if err != nil || interval < minPollInterval {
+			return AnchorConfig{}, true, fmt.Errorf("%s must be at least %s", IntervalAnnotation, minPollInterval)
+		}
+		cfg.Interval = interval
+	}
+	if raw := model.Annotations[StaleAfterAnnotation]; raw != "" {
+		staleAfter, err := time.ParseDuration(raw)
+		if err != nil || staleAfter < cfg.Interval {
+			return AnchorConfig{}, true, fmt.Errorf("%s must be at least the polling interval", StaleAfterAnnotation)
+		}
+		cfg.StaleAfter = staleAfter
+	}
+	return cfg, true, nil
+}
+
+type Options struct {
+	HTTPClient   *http.Client
+	ScanInterval time.Duration
+	Now          func() time.Time
+}
+
+type anchorState struct {
+	config      AnchorConfig
+	nextPoll    time.Time
+	lastSuccess time.Time
+}
+
+// Controller polls model inventories and publishes normalized entries into a
+// reactive collection consumed by model translation.
+type Controller struct {
+	models krt.Collection[*agentgateway.AgentgatewayModel]
+	pools  krt.Collection[*inf.InferencePool]
+	pods   krt.Collection[*corev1.Pod]
+
+	discovered krt.StaticCollection[Model]
+	client     *http.Client
+	now        func() time.Time
+	scanEvery  time.Duration
+
+	mu     sync.Mutex
+	states map[types.NamespacedName]anchorState
+}
+
+func NewController(
+	stop <-chan struct{},
+	models krt.Collection[*agentgateway.AgentgatewayModel],
+	pools krt.Collection[*inf.InferencePool],
+	pods krt.Collection[*corev1.Pod],
+	opts Options,
+	collectionOpts ...krt.CollectionOption,
+) *Controller {
+	client := opts.HTTPClient
+	if client == nil {
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.Proxy = nil
+		client = &http.Client{
+			Transport: transport,
+			Timeout:   defaultRequestTimeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+	if opts.ScanInterval <= 0 {
+		opts.ScanInterval = defaultScanInterval
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	c := &Controller{
+		models:     models,
+		pools:      pools,
+		pods:       pods,
+		discovered: krt.NewStaticCollection[Model](nil, nil, collectionOpts...),
+		client:     client,
+		now:        opts.Now,
+		scanEvery:  opts.ScanInterval,
+		states:     map[types.NamespacedName]anchorState{},
+	}
+	go c.run(stop)
+	return c
+}
+
+func (c *Controller) Collection() krt.Collection[Model] {
+	return c.discovered
+}
+
+func (c *Controller) run(stop <-chan struct{}) {
+	select {
+	case <-stop:
+		return
+	default:
+	}
+	c.reconcile(context.Background())
+	ticker := time.NewTicker(c.scanEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			c.reconcile(context.Background())
+		}
+	}
+}
+
+func (c *Controller) reconcile(ctx context.Context) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	active := map[types.NamespacedName]struct{}{}
+	for _, anchor := range c.models.List() {
+		cfg, enabled, err := ParseAnchor(anchor)
+		if !enabled {
+			continue
+		}
+		active[cfg.Owner] = struct{}{}
+		if err != nil {
+			logger.Warn("invalid model discovery anchor", "anchor", cfg.Owner.String(), "error", err)
+			c.removeOwner(cfg.Owner)
+			continue
+		}
+		state, found := c.states[cfg.Owner]
+		if found && state.config != cfg {
+			c.removeOwner(cfg.Owner)
+			state = anchorState{}
+			found = false
+		}
+		if found && now.Before(state.nextPoll) {
+			continue
+		}
+		state.config = cfg
+		state.nextPoll = now.Add(cfg.Interval)
+
+		pool := findPool(c.pools.List(), cfg.Pool)
+		endpoints := readyEndpoints(c.pods.List(), pool)
+		models, successful := c.pollEndpoints(ctx, cfg, endpoints, anchor.CreationTimestamp.Unix())
+		if successful {
+			state.lastSuccess = now
+			c.replaceOwner(cfg.Owner, models)
+		} else if state.lastSuccess.IsZero() || now.Sub(state.lastSuccess) >= cfg.StaleAfter {
+			c.discovered.DeleteObjects(func(model Model) bool {
+				return model.Owner == cfg.Owner
+			})
+		}
+		c.states[cfg.Owner] = state
+	}
+	for owner := range c.states {
+		if _, found := active[owner]; !found {
+			c.removeOwner(owner)
+		}
+	}
+}
+
+func (c *Controller) removeOwner(owner types.NamespacedName) {
+	delete(c.states, owner)
+	c.discovered.DeleteObjects(func(model Model) bool {
+		return model.Owner == owner
+	})
+}
+
+func (c *Controller) replaceOwner(owner types.NamespacedName, models []Model) {
+	incoming := make(map[string]Model, len(models))
+	for _, model := range models {
+		incoming[model.ResourceName()] = model
+		c.discovered.ConditionalUpdateObject(model)
+	}
+	c.discovered.DeleteObjects(func(model Model) bool {
+		if model.Owner != owner {
+			return false
+		}
+		_, found := incoming[model.ResourceName()]
+		return !found
+	})
+}
+
+func findPool(pools []*inf.InferencePool, key types.NamespacedName) *inf.InferencePool {
+	for _, pool := range pools {
+		if pool.Namespace == key.Namespace && pool.Name == key.Name {
+			return pool
+		}
+	}
+	return nil
+}
+
+type endpoint struct {
+	address string
+	port    int32
+}
+
+func readyEndpoints(pods []*corev1.Pod, pool *inf.InferencePool) []endpoint {
+	if pool == nil || len(pool.Spec.TargetPorts) == 0 {
+		return nil
+	}
+	matchLabels := make(labels.Set, len(pool.Spec.Selector.MatchLabels))
+	for key, value := range pool.Spec.Selector.MatchLabels {
+		matchLabels[string(key)] = string(value)
+	}
+	selector := labels.SelectorFromSet(matchLabels)
+	port := int32(pool.Spec.TargetPorts[0].Number)
+	var out []endpoint
+	for _, pod := range pods {
+		if pod.Namespace != pool.Namespace || pod.Status.Phase != corev1.PodRunning ||
+			pod.Status.PodIP == "" || !selector.Matches(labels.Set(pod.Labels)) || !podReady(pod) {
+			continue
+		}
+		out = append(out, endpoint{address: pod.Status.PodIP, port: port})
+	}
+	slices.SortFunc(out, func(a, b endpoint) int {
+		if cmp := strings.Compare(a.address, b.address); cmp != 0 {
+			return cmp
+		}
+		return int(a.port - b.port)
+	})
+	return out
+}
+
+func podReady(pod *corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+type pollResult struct {
+	models []responseModel
+	err    error
+}
+
+func (c *Controller) pollEndpoints(
+	ctx context.Context,
+	cfg AnchorConfig,
+	endpoints []endpoint,
+	anchorCreated int64,
+) ([]Model, bool) {
+	if len(endpoints) == 0 {
+		return nil, false
+	}
+	results := make(chan pollResult, len(endpoints))
+	jobs := make(chan endpoint)
+	workers := min(len(endpoints), maxConcurrentPolls)
+	for range workers {
+		go func() {
+			for target := range jobs {
+				models, err := c.pollEndpoint(ctx, target, cfg.Path)
+				results <- pollResult{models: models, err: err}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, target := range endpoints {
+			jobs <- target
+		}
+	}()
+
+	union := map[string]Model{}
+	successful := false
+	for range endpoints {
+		result := <-results
+		if result.err != nil {
+			continue
+		}
+		successful = true
+		for _, discovered := range result.models {
+			created := discovered.Created
+			if created == 0 && anchorCreated > 0 {
+				created = uint64(anchorCreated)
+			}
+			current, found := union[discovered.ID]
+			if !found || current.Created == 0 || created != 0 && created < current.Created {
+				union[discovered.ID] = Model{Owner: cfg.Owner, ID: discovered.ID, Created: created}
+			}
+		}
+	}
+	models := make([]Model, 0, len(union))
+	for _, model := range union {
+		models = append(models, model)
+	}
+	slices.SortFunc(models, func(a, b Model) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	return models, successful
+}
+
+type modelListResponse struct {
+	Data []responseModel `json:"data"`
+}
+
+type responseModel struct {
+	ID      string `json:"id"`
+	Created uint64 `json:"created"`
+}
+
+func (c *Controller) pollEndpoint(ctx context.Context, target endpoint, path string) ([]responseModel, error) {
+	requestURL := (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(target.address, fmt.Sprint(target.port)),
+		Path:   path,
+	}).String()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("discovery endpoint returned status %d", resp.StatusCode)
+	}
+	return parseResponse(io.LimitReader(resp.Body, maxResponseBytes+1))
+}
+
+func parseResponse(reader io.Reader) ([]responseModel, error) {
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxResponseBytes {
+		return nil, fmt.Errorf("model discovery response exceeds %d bytes", maxResponseBytes)
+	}
+	var response modelListResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("parse model discovery response: %w", err)
+	}
+	if len(response.Data) > maxModelsPerResponse {
+		return nil, fmt.Errorf("model discovery response exceeds %d entries", maxModelsPerResponse)
+	}
+	deduplicated := map[string]responseModel{}
+	for _, model := range response.Data {
+		if model.ID == "" {
+			return nil, errors.New("model discovery response contains an empty model ID")
+		}
+		if len(model.ID) > maxModelIDLength {
+			return nil, fmt.Errorf("model discovery response contains a model ID longer than %d bytes", maxModelIDLength)
+		}
+		current, found := deduplicated[model.ID]
+		if !found || current.Created == 0 || model.Created != 0 && model.Created < current.Created {
+			deduplicated[model.ID] = model
+		}
+	}
+	out := make([]responseModel, 0, len(deduplicated))
+	for _, model := range deduplicated {
+		out = append(out, model)
+	}
+	slices.SortFunc(out, func(a, b responseModel) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	return out, nil
+}

--- a/controller/pkg/agentgateway/modeldiscovery/discovery_test.go
+++ b/controller/pkg/agentgateway/modeldiscovery/discovery_test.go
@@ -1,0 +1,192 @@
+package modeldiscovery
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
+	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+)
+
+func TestParseAnchor(t *testing.T) {
+	model := discoveryAnchor()
+	cfg, enabled, err := ParseAnchor(model)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !enabled {
+		t.Fatal("discovery should be enabled")
+	}
+	if cfg.Pool.Namespace != "default" || cfg.Pool.Name != "llama-pool" {
+		t.Fatalf("pool = %v, want default/llama-pool", cfg.Pool)
+	}
+	if cfg.Path != defaultPath || cfg.Interval != defaultInterval || cfg.StaleAfter != defaultStaleAfter {
+		t.Fatalf("unexpected defaults: %#v", cfg)
+	}
+
+	model.Spec.Match = &agentgateway.ModelMatch{}
+	if _, _, err := ParseAnchor(model); err == nil || !strings.Contains(err.Error(), "spec.match") {
+		t.Fatalf("error = %v, want match validation", err)
+	}
+
+	model = discoveryAnchor()
+	model.Annotations[PathAnnotation] = "http://metadata.invalid/models"
+	if _, _, err := ParseAnchor(model); err == nil || !strings.Contains(err.Error(), "absolute path") {
+		t.Fatalf("error = %v, want path validation", err)
+	}
+}
+
+func TestParseResponse(t *testing.T) {
+	models, err := parseResponse(strings.NewReader(`{
+		"object": "list",
+		"data": [
+			{"id": "z-model", "created": 20, "owned_by": "runtime"},
+			{"id": "a-model", "created": 10},
+			{"id": "a-model", "created": 15}
+		]
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("models = %d, want 2", len(models))
+	}
+	if models[0].ID != "a-model" || models[0].Created != 10 || models[1].ID != "z-model" {
+		t.Fatalf("unexpected models: %#v", models)
+	}
+
+	if _, err := parseResponse(strings.NewReader(`{"data":[{"id":""}]}`)); err == nil {
+		t.Fatal("empty model ID should fail")
+	}
+}
+
+func TestControllerRetainsAndExpiresLastKnownGood(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	transport := &mutableTransport{
+		body: `{"object":"list","data":[{"id":"tweet-summary","created":42}]}`,
+	}
+	models := krt.NewStaticCollection[*agentgateway.AgentgatewayModel](nil, []*agentgateway.AgentgatewayModel{discoveryAnchor()})
+	pools := krt.NewStaticCollection[*inf.InferencePool](nil, []*inf.InferencePool{testPool()})
+	pods := krt.NewStaticCollection[*corev1.Pod](nil, []*corev1.Pod{readyPod()})
+	c := &Controller{
+		models:     models,
+		pools:      pools,
+		pods:       pods,
+		discovered: krt.NewStaticCollection[Model](nil, nil),
+		client:     &http.Client{Transport: transport},
+		now:        func() time.Time { return now },
+		states:     map[types.NamespacedName]anchorState{},
+	}
+
+	c.reconcile(t.Context())
+	if got := c.discovered.List(); len(got) != 1 || got[0].ID != "tweet-summary" {
+		t.Fatalf("discovered models = %#v", got)
+	}
+
+	transport.setError(errors.New("runtime unavailable"))
+	now = now.Add(defaultInterval + time.Second)
+	c.reconcile(t.Context())
+	if got := c.discovered.List(); len(got) != 1 {
+		t.Fatalf("transient failure removed last-known-good models: %#v", got)
+	}
+
+	now = now.Add(defaultStaleAfter)
+	c.reconcile(t.Context())
+	if got := c.discovered.List(); len(got) != 0 {
+		t.Fatalf("expired models = %#v, want empty", got)
+	}
+}
+
+func discoveryAnchor() *agentgateway.AgentgatewayModel {
+	provider := agentgateway.ModelProviderCustom
+	group := "inference.networking.k8s.io"
+	kind := "InferencePool"
+	return &agentgateway.AgentgatewayModel{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "llama-models",
+			Annotations: map[string]string{
+				EnabledAnnotation: "enabled",
+			},
+			CreationTimestamp: metav1.NewTime(time.Unix(100, 0)),
+		},
+		Spec: agentgateway.AgentgatewayModelSpec{
+			Provider: &provider,
+			Custom: &agentgateway.CustomProviderSettings{
+				BackendRef: &agentgateway.LocalBackendObjectReference{
+					Group: &group,
+					Kind:  &kind,
+					Name:  "llama-pool",
+				},
+				Formats: []agentgateway.ProviderFormatConfig{{
+					Type: agentgateway.ProviderFormatCompletions,
+				}},
+			},
+		},
+	}
+}
+
+func testPool() *inf.InferencePool {
+	return &inf.InferencePool{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "llama-pool"},
+		Spec: inf.InferencePoolSpec{
+			Selector: inf.LabelSelector{MatchLabels: map[inf.LabelKey]inf.LabelValue{
+				"app": "llama",
+			}},
+			TargetPorts: []inf.Port{{Number: 8000}},
+		},
+	}
+}
+
+func readyPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "llama-0",
+			Labels:    map[string]string{"app": "llama"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.1",
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+type mutableTransport struct {
+	mu   sync.Mutex
+	body string
+	err  error
+}
+
+func (m *mutableTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(m.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func (m *mutableTransport) setError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}

--- a/controller/pkg/agentgateway/plugins/collection.go
+++ b/controller/pkg/agentgateway/plugins/collection.go
@@ -11,12 +11,14 @@ import (
 	"istio.io/istio/pkg/ptr"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/apimachinery/pkg/types"
 	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1b1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	apisettings "github.com/agentgateway/agentgateway/controller/api/settings"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/modeldiscovery"
 	"github.com/agentgateway/agentgateway/controller/pkg/apiclient"
 	kgwversioned "github.com/agentgateway/agentgateway/controller/pkg/client/clientset/versioned"
 	"github.com/agentgateway/agentgateway/controller/pkg/meshconfig"
@@ -71,11 +73,13 @@ type AgwCollections struct {
 	InferencePoolsByNamespace krt.Index[string, *inf.InferencePool]
 
 	// agentgateway resources
-	Backends             krt.Collection[*agentgateway.AgentgatewayBackend]
-	BackendsByNamespace  krt.Index[string, *agentgateway.AgentgatewayBackend]
-	Models               krt.Collection[*agentgateway.AgentgatewayModel]
-	ModelsByNamespace    krt.Index[string, *agentgateway.AgentgatewayModel]
-	AgentgatewayPolicies krt.Collection[*agentgateway.AgentgatewayPolicy]
+	Backends                krt.Collection[*agentgateway.AgentgatewayBackend]
+	BackendsByNamespace     krt.Index[string, *agentgateway.AgentgatewayBackend]
+	Models                  krt.Collection[*agentgateway.AgentgatewayModel]
+	ModelsByNamespace       krt.Index[string, *agentgateway.AgentgatewayModel]
+	DiscoveredModels        krt.Collection[modeldiscovery.Model]
+	DiscoveredModelsByOwner krt.Index[types.NamespacedName, modeldiscovery.Model]
+	AgentgatewayPolicies    krt.Collection[*agentgateway.AgentgatewayPolicy]
 
 	// ControllerName is the name of the Gateway controller.
 	ControllerName string
@@ -212,6 +216,7 @@ func NewAgwCollections(
 		AgentgatewayPolicies: krt.NewFilteredInformer[*agentgateway.AgentgatewayPolicy](client, filter, krtOptions.ToOptions("informer/AgentgatewayPolicies")...),
 		Backends:             krt.NewFilteredInformer[*agentgateway.AgentgatewayBackend](client, filter, krtOptions.ToOptions("informer/AgentgatewayBackends")...),
 		Models:               krt.NewStaticCollection[*agentgateway.AgentgatewayModel](nil, nil, krtOptions.ToOptions("disable/AgentgatewayModels")...),
+		DiscoveredModels:     krt.NewStaticCollection[modeldiscovery.Model](nil, nil, krtOptions.ToOptions("disable/DiscoveredModels")...),
 	}
 
 	if settings.EnableInferExt {
@@ -221,6 +226,17 @@ func NewAgwCollections(
 	}
 	if settings.EnableAgentgatewayModels {
 		agwCollections.Models = krt.NewFilteredInformer[*agentgateway.AgentgatewayModel](client, filter, krtOptions.ToOptions("informer/AgentgatewayModels")...)
+	}
+	if settings.EnableAgentgatewayModels && settings.EnableInferExt {
+		discoveryController := modeldiscovery.NewController(
+			krtOptions.Stop,
+			agwCollections.Models,
+			agwCollections.InferencePools,
+			agwCollections.Pods,
+			modeldiscovery.Options{},
+			krtOptions.ToOptions("discovery/AgentgatewayModels")...,
+		)
+		agwCollections.DiscoveredModels = discoveryController.Collection()
 	}
 	agwCollections.SetupIndexes()
 
@@ -237,6 +253,9 @@ func (c *AgwCollections) SetupIndexes() {
 	c.ListenerSetsByNamespace = krt.NewNamespaceIndex(c.ListenerSets)
 	c.BackendsByNamespace = krt.NewNamespaceIndex(c.Backends)
 	c.ModelsByNamespace = krt.NewNamespaceIndex(c.Models)
+	c.DiscoveredModelsByOwner = krt.NewIndex(c.DiscoveredModels, "owner", func(model modeldiscovery.Model) []types.NamespacedName {
+		return []types.NamespacedName{model.Owner}
+	})
 	c.InferencePoolsByNamespace = krt.NewNamespaceIndex(c.InferencePools)
 }
 

--- a/controller/pkg/agentgateway/testutils/util.go
+++ b/controller/pkg/agentgateway/testutils/util.go
@@ -27,6 +27,7 @@ import (
 	apitests "github.com/agentgateway/agentgateway/controller/api/tests"
 	agwv1alpha1 "github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/jwks"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/modeldiscovery"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/policyselection"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/remotehttp"
@@ -248,6 +249,7 @@ func BuildMockCollection(t test.Failer, inputs []any) *plugins.AgwCollections {
 		InferencePools:       krttest.GetMockCollection[*inf.InferencePool](mock),
 		Backends:             krttest.GetMockCollection[*agwv1alpha1.AgentgatewayBackend](mock),
 		Models:               krttest.GetMockCollection[*agwv1alpha1.AgentgatewayModel](mock),
+		DiscoveredModels:     krttest.GetMockCollection[modeldiscovery.Model](mock),
 		AgentgatewayPolicies: krttest.GetMockCollection[*agwv1alpha1.AgentgatewayPolicy](mock),
 		ControllerName:       wellknown.DefaultAgwControllerName,
 		SystemNamespace:      "agentgateway-system",

--- a/controller/pkg/agentgateway/translator/model_collections.go
+++ b/controller/pkg/agentgateway/translator/model_collections.go
@@ -17,6 +17,7 @@ import (
 	"github.com/agentgateway/agentgateway/api"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 	agwir "github.com/agentgateway/agentgateway/controller/pkg/agentgateway/ir"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/modeldiscovery"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
@@ -52,6 +53,116 @@ func AgwModelCollection(
 
 	attachments := gatewayRouteAttachmentCollection(inputs, models, wellknown.AgentgatewayModelGVK, krtopts)
 	return modelResources, attachments
+}
+
+func convertModelForParent(
+	ctx RouteContext,
+	model *agentgateway.AgentgatewayModel,
+	parent RouteParentReference,
+) ([]*api.Resource, error) {
+	_, discoveryEnabled, discoveryErr := modeldiscovery.ParseAnchor(model)
+	if discoveryEnabled {
+		if discoveryErr != nil {
+			return nil, discoveryErr
+		}
+		discovered := krt.Fetch(
+			ctx.Krt,
+			ctx.DiscoveredModels,
+			krt.FilterIndex(ctx.DiscoveredModelsByOwner, config.NamespacedName(model)),
+		)
+		slices.SortFunc(discovered, func(a, b modeldiscovery.Model) int {
+			return strings.Compare(a.ID, b.ID)
+		})
+		return convertDiscoveredAgentgatewayModel(ctx, model, parent, discovered)
+	}
+	return convertAgentgatewayModel(ctx, model, parent)
+}
+
+func convertDiscoveredAgentgatewayModel(
+	ctx RouteContext,
+	model *agentgateway.AgentgatewayModel,
+	parent RouteParentReference,
+	discovered []modeldiscovery.Model,
+) ([]*api.Resource, error) {
+	backend, err := modelConcreteBackend(ctx, model, parent, nil)
+	if err != nil {
+		return nil, err
+	}
+	resources := []*api.Resource{backendResource(backend)}
+
+	// Keep the per-listener model router installed while discovery is empty.
+	// This route is internal and its synthetic name is not advertised or
+	// selected directly.
+	anchor, err := discoveredModelRoute(
+		ctx,
+		model,
+		parent,
+		modelRouteKey(model, parent),
+		"__discovery_anchor/"+config.NamespacedName(model).String(),
+		uint64(max(model.CreationTimestamp.Unix(), 0)),
+		api.ModelRoute_ConcreteModel_INTERNAL,
+		backend.Key,
+	)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, &api.Resource{Kind: &api.Resource_ModelRoute{ModelRoute: anchor}})
+
+	for _, discoveredModel := range discovered {
+		route, err := discoveredModelRoute(
+			ctx,
+			model,
+			parent,
+			"~discovered/"+discoveredModel.ResourceName()+routeKeySuffix(parent),
+			discoveredModel.ID,
+			discoveredModel.Created,
+			translateModelVisibility(model.Spec.Visibility),
+			backend.Key,
+		)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, &api.Resource{Kind: &api.Resource_ModelRoute{ModelRoute: route}})
+	}
+	return resources, nil
+}
+
+func discoveredModelRoute(
+	ctx RouteContext,
+	model *agentgateway.AgentgatewayModel,
+	parent RouteParentReference,
+	key string,
+	match string,
+	created uint64,
+	visibility api.ModelRoute_ConcreteModel_ModelVisibility,
+	backendKey string,
+) (*api.ModelRoute, error) {
+	route := &api.ModelRoute{
+		Key:         key,
+		ListenerKey: parent.ListenerKey,
+		Match:       &api.ModelRoute_Match{Model: match},
+		Created:     created,
+		Kind: &api.ModelRoute_ConcreteModel_{
+			ConcreteModel: &api.ModelRoute_ConcreteModel{
+				ModelVisibility: visibility,
+				Backend:         backendRef(backendKey),
+			},
+		},
+	}
+	aiPolicy, err := translateModelRouteAIPolicy(ctx, model.Namespace, model.Spec.Policies)
+	if err != nil {
+		return nil, err
+	}
+	route.AiPolicy = aiPolicy
+	if model.Spec.Policies == nil || model.Spec.Policies.Authorization == nil {
+		return route, nil
+	}
+	authorization, err := plugins.TranslateAuthorization(model.Spec.Policies.Authorization)
+	if err != nil {
+		return nil, err
+	}
+	route.Authorization = authorization
+	return route, nil
 }
 
 func translateModelForParents(
@@ -91,7 +202,7 @@ func translateModelForParents(
 		if a := agg[parentStatusKey(parent)]; a != nil {
 			a.anyAllowed = true
 		}
-		parentResources, err := convertAgentgatewayModel(ctx, model, parent)
+		parentResources, err := convertModelForParent(ctx, model, parent)
 		if err != nil {
 			conversionErr = &reporter.RouteCondition{
 				Type:    gwv1.RouteConditionResolvedRefs,

--- a/controller/pkg/agentgateway/translator/model_collections_test.go
+++ b/controller/pkg/agentgateway/translator/model_collections_test.go
@@ -4,10 +4,16 @@ import (
 	"strings"
 	"testing"
 
+	"istio.io/istio/pkg/kube/krt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/api"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/modeldiscovery"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
 
@@ -181,6 +187,76 @@ func TestModelAuthorization(t *testing.T) {
 	}
 	if got := route.GetAuthorization().GetAllow(); len(got) != 1 || got[0] != "request.headers['x-model-access'] == 'allowed'" {
 		t.Errorf("authorization allow = %#v, want model access rule", got)
+	}
+}
+
+func TestDiscoveredModelRoutes(t *testing.T) {
+	providerType := agentgateway.ModelProviderCustom
+	group := wellknown.InferencePoolGVK.Group
+	kind := wellknown.InferencePoolGVK.Kind
+	model := &agentgateway.AgentgatewayModel{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "llama-models"},
+		Spec: agentgateway.AgentgatewayModelSpec{
+			Provider: &providerType,
+			Custom: &agentgateway.CustomProviderSettings{
+				BackendRef: &agentgateway.LocalBackendObjectReference{
+					Group: &group,
+					Kind:  &kind,
+					Name:  "llama-pool",
+				},
+				Formats: []agentgateway.ProviderFormatConfig{{Type: agentgateway.ProviderFormatCompletions}},
+			},
+			Policies: &agentgateway.ModelPolicies{
+				Authorization: &agentgateway.Authorization{
+					Policy: agentgateway.AuthorizationPolicy{
+						MatchExpressions: []agentgateway.CELExpression{"request.headers['x-tenant'] == 'allowed'"},
+					},
+				},
+			},
+		},
+	}
+	ctx := RouteContext{RouteContextInputs: RouteContextInputs{
+		References: plugins.ReferenceTypes{
+			RouteBackend: func(
+				_ krt.HandlerContext,
+				_ string,
+				_ schema.GroupKind,
+				_ gwv1.ObjectName,
+				_ *gwv1.Namespace,
+				_ *gwv1.PortNumber,
+			) (*api.BackendReference, error) {
+				return &api.BackendReference{}, nil
+			},
+		},
+	}}
+	parent := RouteParentReference{ListenerKey: "default/gateway.llm"}
+	discovered := []modeldiscovery.Model{
+		{Owner: types.NamespacedName{Namespace: "default", Name: "llama-models"}, ID: "base-model", Created: 10},
+		{Owner: types.NamespacedName{Namespace: "default", Name: "llama-models"}, ID: "tweet-summary", Created: 20},
+	}
+
+	resources, err := convertDiscoveredAgentgatewayModel(ctx, model, parent, discovered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resources) != 4 {
+		t.Fatalf("resources = %d, want backend, anchor, and two models", len(resources))
+	}
+	anchor := resources[1].GetModelRoute()
+	if anchor.GetConcreteModel().GetModelVisibility() != api.ModelRoute_ConcreteModel_INTERNAL {
+		t.Fatalf("anchor visibility = %v, want internal", anchor.GetConcreteModel().GetModelVisibility())
+	}
+	for i, want := range []string{"base-model", "tweet-summary"} {
+		route := resources[i+2].GetModelRoute()
+		if got := route.GetMatch().GetModel(); got != want {
+			t.Errorf("route %d model = %q, want %q", i, got, want)
+		}
+		if route.GetConcreteModel().GetBackend().GetBackend() != resources[0].GetBackend().GetKey() {
+			t.Errorf("route %d does not share the discovery anchor backend", i)
+		}
+		if route.GetAuthorization() == nil {
+			t.Errorf("route %d did not inherit authorization", i)
+		}
 	}
 }
 

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -27,6 +27,7 @@ import (
 	apisettings "github.com/agentgateway/agentgateway/controller/api/settings"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 	agwir "github.com/agentgateway/agentgateway/controller/pkg/agentgateway/ir"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/modeldiscovery"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
@@ -959,20 +960,22 @@ type RouteContext struct {
 
 // RouteContextInputs defines the collections needed to translate a route.
 type RouteContextInputs struct {
-	Collections         *plugins.AgwCollections
-	Grants              ReferenceGrants
-	RouteParents        ParentResolver
-	Services            krt.Collection[*corev1.Service]
-	Secrets             krt.Collection[*corev1.Secret]
-	InferencePools      krt.Collection[*inf.InferencePool]
-	Namespaces          krt.Collection[*corev1.Namespace]
-	ServiceEntries      krt.Collection[*networkingclient.ServiceEntry]
-	Backends            krt.Collection[*agentgateway.AgentgatewayBackend]
-	Models              krt.Collection[*agentgateway.AgentgatewayModel]
-	ModelsByNamespace   krt.Index[string, *agentgateway.AgentgatewayModel]
-	References          plugins.ReferenceTypes
-	ControllerName      string
-	BackendRefGrantMode apisettings.BackendRefGrantMode
+	Collections             *plugins.AgwCollections
+	Grants                  ReferenceGrants
+	RouteParents            ParentResolver
+	Services                krt.Collection[*corev1.Service]
+	Secrets                 krt.Collection[*corev1.Secret]
+	InferencePools          krt.Collection[*inf.InferencePool]
+	Namespaces              krt.Collection[*corev1.Namespace]
+	ServiceEntries          krt.Collection[*networkingclient.ServiceEntry]
+	Backends                krt.Collection[*agentgateway.AgentgatewayBackend]
+	Models                  krt.Collection[*agentgateway.AgentgatewayModel]
+	ModelsByNamespace       krt.Index[string, *agentgateway.AgentgatewayModel]
+	DiscoveredModels        krt.Collection[modeldiscovery.Model]
+	DiscoveredModelsByOwner krt.Index[types.NamespacedName, modeldiscovery.Model]
+	References              plugins.ReferenceTypes
+	ControllerName          string
+	BackendRefGrantMode     apisettings.BackendRefGrantMode
 }
 
 func (i RouteContextInputs) WithCtx(krtctx krt.HandlerContext) RouteContext {

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -463,20 +463,22 @@ func (s *Syncer) buildAgwResources(
 	}
 
 	routeInputs := translator.RouteContextInputs{
-		Collections:         s.agwCollections,
-		Grants:              refGrants,
-		RouteParents:        routeParents,
-		ControllerName:      s.controllerName,
-		Services:            s.agwCollections.Services,
-		Secrets:             s.agwCollections.Secrets,
-		Namespaces:          s.agwCollections.Namespaces,
-		ServiceEntries:      s.agwCollections.ServiceEntries,
-		InferencePools:      s.agwCollections.InferencePools,
-		Backends:            s.agwCollections.Backends,
-		Models:              s.agwCollections.Models,
-		ModelsByNamespace:   s.agwCollections.ModelsByNamespace,
-		References:          referenceTypes,
-		BackendRefGrantMode: s.agwCollections.Settings.BackendRefGrantMode,
+		Collections:             s.agwCollections,
+		Grants:                  refGrants,
+		RouteParents:            routeParents,
+		ControllerName:          s.controllerName,
+		Services:                s.agwCollections.Services,
+		Secrets:                 s.agwCollections.Secrets,
+		Namespaces:              s.agwCollections.Namespaces,
+		ServiceEntries:          s.agwCollections.ServiceEntries,
+		InferencePools:          s.agwCollections.InferencePools,
+		Backends:                s.agwCollections.Backends,
+		Models:                  s.agwCollections.Models,
+		ModelsByNamespace:       s.agwCollections.ModelsByNamespace,
+		DiscoveredModels:        s.agwCollections.DiscoveredModels,
+		DiscoveredModelsByOwner: s.agwCollections.DiscoveredModelsByOwner,
+		References:              referenceTypes,
+		BackendRefGrantMode:     s.agwCollections.Settings.BackendRefGrantMode,
 	}
 
 	baseAgwRoutes, routeAttachments, ancestorBackends := translator.AgwRouteCollection(s.statusCollections, s.agwCollections.HTTPRoutes, s.agwCollections.GRPCRoutes, s.agwCollections.TCPRoutes, s.agwCollections.TLSRoutes, routeInputs, krtopts)

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use agent_core::strng;
@@ -187,19 +188,21 @@ impl ModelRouter {
 	}
 
 	fn model_list_response(&self, req: &Request) -> Response {
-		let data = self
-			.models
-			.iter()
-			.filter(|model| model.visibility == ModelVisibility::Public)
-			.filter(|model| model_authorized(model, req))
-			.map(|model| model_list_entry(&model.name, model.created))
-			.chain(
-				self
-					.virtual_models
-					.iter()
-					.map(|model| model_list_entry(&model.name, model.created)),
-			)
-			.collect::<Vec<_>>();
+		let mut seen = HashSet::new();
+		let mut data = Vec::new();
+		for model in &self.models {
+			if model.visibility == ModelVisibility::Public
+				&& model_authorized(model, req)
+				&& seen.insert(model.name.clone())
+			{
+				data.push(model_list_entry(&model.name, model.created));
+			}
+		}
+		for model in &self.virtual_models {
+			if seen.insert(model.name.clone()) {
+				data.push(model_list_entry(&model.name, model.created));
+			}
+		}
 		let body = serde_json::json!({
 			"data": data,
 			"object": "list",
@@ -722,6 +725,41 @@ mod tests {
 
 		assert!(model_authorized(&model, &allowed));
 		assert!(!model_authorized(&model, &denied));
+	}
+
+	#[tokio::test]
+	async fn model_list_deduplicates_model_names() {
+		let model = |created| ModelRoute {
+			id: None,
+			name: "shared-model".to_string(),
+			created,
+			visibility: ModelVisibility::Public,
+			header_matches: vec![],
+			backend: RouteBackendReference {
+				weight: 1,
+				target: RouteBackendTarget::Invalid,
+				inline_policies: vec![],
+			},
+			policies: ModelRoutePolicies {
+				llm: default_route_types(),
+				authorization: None,
+			},
+			backend_policies: vec![],
+		};
+		let router = ModelRouter::new(vec![model(10), model(20)], vec![]);
+		let request = ::http::Request::builder()
+			.uri("http://example.com/v1/models")
+			.body(http::Body::empty())
+			.expect("valid request");
+
+		let response = router.model_list_response(&request);
+		let body = http::read_body_with_limit(response.into_body(), 1024)
+			.await
+			.expect("model list body");
+		let body: Value = serde_json::from_slice(&body).expect("model list JSON");
+		assert_eq!(body["data"].as_array().map(Vec::len), Some(1));
+		assert_eq!(body["data"][0]["id"], "shared-model");
+		assert_eq!(body["data"][0]["created"], 10);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

-Diiscover OpenAI-compatible model inventories from opted-in InferencePool-backed AgentgatewayModel anchors.
- Publish exact per-listener ModelRoute resources with inherited visibility and policies.
- Preserve last-known-good inventories and deduplicate `/v1/models` entries.

## Details

Discovery is configured with provisional annotations while the API remains experimental. This draft implements the initial discovery path from #1708 and requires both the AgentgatewayModel and inference extension feature gates.

## Testing

- `go test ./controller/...`
- `make -C controller analyze`
- `cargo test -p agentgateway model_list_deduplicates_model_names`
- `cargo test -p agentgateway concrete_model_authorization_filters_requests`
- `cargo clippy -p agentgateway --lib --tests -- -D warnings`

Related: #1462

Design: #1708
