### PR TITLE
oauth: fail closed when the configured subject token is missing

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -15951,8 +15951,9 @@ func (x *OAuthClientAuth_PrivateKeyJwt) GetCertificateHeader() OAuthClientAuth_P
 type OAuthTokenExchange_TokenSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Where to extract the token from the incoming request. The `expression`
-	// (CEL) variant is permitted here. Only the default Authorization Bearer
-	// source falls back to validated Claims when its credential is absent.
+	// (CEL) variant is permitted here. An upstream JWT credential is reused only
+	// for a matching header, query parameter, or cookie source. Expressions are
+	// reevaluated and do not reuse credentials removed from another source.
 	Source *AuthorizationLocation `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
 	// RFC 8693 token type URI sent as subject_token_type / actor_token_type.
 	// Built-ins such as "urn:ietf:params:oauth:token-type:access_token" and

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -15951,9 +15951,8 @@ func (x *OAuthClientAuth_PrivateKeyJwt) GetCertificateHeader() OAuthClientAuth_P
 type OAuthTokenExchange_TokenSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Where to extract the token from the incoming request. The `expression`
-	// (CEL) variant is permitted here. A Header/Authorization source also reads
-	// from the Claims extension when an upstream JWT policy has stripped the
-	// header, so the default keeps working behind a JWT auth policy.
+	// (CEL) variant is permitted here. Only the default Authorization Bearer
+	// source falls back to validated Claims when its credential is absent.
 	Source *AuthorizationLocation `protobuf:"bytes,1,opt,name=source,proto3" json:"source,omitempty"`
 	// RFC 8693 token type URI sent as subject_token_type / actor_token_type.
 	// Built-ins such as "urn:ietf:params:oauth:token-type:access_token" and

--- a/crates/agentgateway/src/http/auth/mod.rs
+++ b/crates/agentgateway/src/http/auth/mod.rs
@@ -188,8 +188,7 @@ async fn apply_backend_auth_kind(
 		BackendAuthKind::Passthrough { location } => {
 			let explicit = location.is_some();
 			let resolved = location.as_ref().unwrap_or(&DEFAULT_AUTHORIZATION_LOCATION);
-			// They should have a JWT policy defined. That will strip the token. Here we add it back
-			// TODO: should we also support API key, etc?
+			// Unlike token exchange, passthrough forwards JWT or OIDC Claims without source matching
 			if let Some(token) = req
 				.extensions()
 				.get::<Claims>()
@@ -319,16 +318,31 @@ impl AuthorizationLocation {
 		}
 	}
 
-	/// Whether this is the default [`Self::bearer_header`] location. The prefix is compared
-	/// the same case-insensitive way [`Self::extract`] strips it, so configs differing only
-	/// in prefix casing are not treated as distinct locations.
-	pub(crate) fn is_bearer_header(&self) -> bool {
-		matches!(
-			self,
-			Self::Header { name, prefix }
-				if *name == http::header::AUTHORIZATION
-					&& prefix.as_deref().is_some_and(|p| p.eq_ignore_ascii_case("Bearer "))
-		)
+	pub fn matches_source(&self, other: &Self) -> bool {
+		match (self, other) {
+			(
+				Self::Header {
+					name,
+					prefix: source_prefix,
+				},
+				Self::Header {
+					name: other_name,
+					prefix: other_prefix,
+				},
+			) => {
+				let source_prefix = source_prefix.as_deref().filter(|prefix| !prefix.is_empty());
+				let other_prefix = other_prefix.as_deref().filter(|prefix| !prefix.is_empty());
+				let prefix_matches = match (source_prefix, other_prefix) {
+					(Some(source), Some(other)) => source.eq_ignore_ascii_case(other),
+					(None, None) => true,
+					_ => false,
+				};
+				name == other_name && prefix_matches
+			},
+			(Self::QueryParameter { name }, Self::QueryParameter { name: other_name })
+			| (Self::Cookie { name }, Self::Cookie { name: other_name }) => name == other_name,
+			_ => false,
+		}
 	}
 
 	pub fn extract<'a>(&self, req: &'a Request) -> Option<Cow<'a, str>> {

--- a/crates/agentgateway/src/http/auth/mod.rs
+++ b/crates/agentgateway/src/http/auth/mod.rs
@@ -319,6 +319,18 @@ impl AuthorizationLocation {
 		}
 	}
 
+	/// Whether this is the default [`Self::bearer_header`] location. The prefix is compared
+	/// the same case-insensitive way [`Self::extract`] strips it, so configs differing only
+	/// in prefix casing are not treated as distinct locations.
+	pub(crate) fn is_bearer_header(&self) -> bool {
+		matches!(
+			self,
+			Self::Header { name, prefix }
+				if *name == http::header::AUTHORIZATION
+					&& prefix.as_deref().is_some_and(|p| p.eq_ignore_ascii_case("Bearer "))
+		)
+	}
+
 	pub fn extract<'a>(&self, req: &'a Request) -> Option<Cow<'a, str>> {
 		match self {
 			AuthorizationLocation::Header { name, prefix } => {

--- a/crates/agentgateway/src/http/auth/oauth/mod.rs
+++ b/crates/agentgateway/src/http/auth/oauth/mod.rs
@@ -10,7 +10,7 @@ use tracing::{debug, trace, warn};
 
 use super::AuthorizationLocation;
 use crate::http::Request;
-use crate::http::jwt::Claims;
+use crate::http::jwt::{Claims, ValidatedCredential};
 use crate::http::oauth::{TOKEN_TYPE_ACCESS, TOKEN_TYPE_ID, TOKEN_TYPE_ID_JAG, TOKEN_TYPE_JWT};
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
@@ -759,7 +759,7 @@ pub(super) async fn apply_identity_assertion(
 	Ok(explicit)
 }
 
-/// Extract the subject token, falling back to Claims only for the default source.
+/// Extract the subject token, reusing a matching credential stripped by JWT auth.
 pub(super) fn extract_subject_token(
 	source: &AuthorizationLocation,
 	req: &Request,
@@ -768,20 +768,12 @@ pub(super) fn extract_subject_token(
 		return Some(token.into_owned());
 	}
 
-	if !source.is_bearer_header() {
-		return None;
-	}
-
-	// Claims has no source provenance. OIDC also populates it with the ID token
-	// from an encrypted session cookie, even when no Authorization header existed
-	extract_validated_claims_token(req).filter(|token| !token.trim().is_empty())
-}
-
-fn extract_validated_claims_token(req: &Request) -> Option<String> {
 	req
 		.extensions()
-		.get::<Claims>()
-		.map(|claims| claims.jwt.expose_secret().to_string())
+		.get::<ValidatedCredential>()
+		.and_then(|credential| credential.token_for_source(source))
+		.filter(|token| !token.trim().is_empty())
+		.map(str::to_owned)
 }
 
 fn actor_token_from_request(

--- a/crates/agentgateway/src/http/auth/oauth/mod.rs
+++ b/crates/agentgateway/src/http/auth/oauth/mod.rs
@@ -759,18 +759,22 @@ pub(super) async fn apply_identity_assertion(
 	Ok(explicit)
 }
 
-/// Read a subject token for exchange. A JWT auth policy may have already stripped
-/// the configured credential after validation, so fall back to populated Claims.
+/// Extract the subject token, falling back to Claims only for the default source.
 pub(super) fn extract_subject_token(
 	source: &AuthorizationLocation,
 	req: &Request,
 ) -> Option<String> {
-	source
-		.extract(req)
-		.map(|token| token.into_owned())
-		.filter(|token| !token.trim().is_empty())
-		.or_else(|| extract_validated_claims_token(req))
-		.filter(|token| !token.trim().is_empty())
+	if let Some(token) = source.extract(req).filter(|token| !token.trim().is_empty()) {
+		return Some(token.into_owned());
+	}
+
+	if !source.is_bearer_header() {
+		return None;
+	}
+
+	// Claims has no source provenance. OIDC also populates it with the ID token
+	// from an encrypted session cookie, even when no Authorization header existed
+	extract_validated_claims_token(req).filter(|token| !token.trim().is_empty())
 }
 
 fn extract_validated_claims_token(req: &Request) -> Option<String> {

--- a/crates/agentgateway/src/http/auth/tests.rs
+++ b/crates/agentgateway/src/http/auth/tests.rs
@@ -2,7 +2,7 @@ use secrecy::SecretString;
 use serde_json::Map;
 
 use super::*;
-use crate::http::jwt::Claims;
+use crate::http::jwt::{Claims, ValidatedCredential};
 use crate::llm::bedrock::AwsRegion;
 use crate::test_helpers::proxymock::setup_proxy_test;
 
@@ -697,20 +697,33 @@ async fn test_aws_sign_request_implicit_configured_region_wins() {
 }
 
 #[test]
-fn extract_subject_token_falls_back_to_claims_for_authorization_header() {
-	// Default source is the Authorization Bearer header; a JWT policy stripped it,
-	// leaving only the Claims extension.
+fn subject_token_reuses_default_jwt() {
+	let mut req = ::http::Request::builder()
+		.uri("http://example/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	req.extensions_mut().insert(ValidatedCredential {
+		token: SecretString::from("validated-jwt"),
+		source: AuthorizationLocation::default(),
+	});
+
+	let token = oauth::extract_subject_token(&AuthorizationLocation::default(), &req);
+	assert_eq!(token.as_deref(), Some("validated-jwt"));
+}
+
+#[test]
+fn subject_token_ignores_claims() {
 	let mut req = ::http::Request::builder()
 		.uri("http://example/")
 		.body(crate::http::Body::empty())
 		.unwrap();
 	req.extensions_mut().insert(Claims {
 		inner: Map::new(),
-		jwt: SecretString::from("claims-jwt"),
+		jwt: SecretString::from("oidc-id-token"),
 	});
 
 	let token = oauth::extract_subject_token(&AuthorizationLocation::default(), &req);
-	assert_eq!(token.as_deref(), Some("claims-jwt"));
+	assert_eq!(token, None);
 }
 
 #[test]
@@ -726,19 +739,19 @@ fn extract_subject_token_uses_authorization_header_without_claims() {
 }
 
 #[test]
-fn extract_subject_token_empty_authorization_header_falls_back_to_claims() {
+fn subject_token_empty_source_reuses_jwt() {
 	let mut req = ::http::Request::builder()
 		.uri("http://example/")
 		.header(::http::header::AUTHORIZATION, "Bearer ")
 		.body(crate::http::Body::empty())
 		.unwrap();
-	req.extensions_mut().insert(Claims {
-		inner: Map::new(),
-		jwt: SecretString::from("claims-jwt"),
+	req.extensions_mut().insert(ValidatedCredential {
+		token: SecretString::from("validated-jwt"),
+		source: AuthorizationLocation::default(),
 	});
 
 	let token = oauth::extract_subject_token(&AuthorizationLocation::default(), &req);
-	assert_eq!(token.as_deref(), Some("claims-jwt"));
+	assert_eq!(token.as_deref(), Some("validated-jwt"));
 }
 
 #[test]
@@ -754,15 +767,15 @@ fn extract_subject_token_empty_authorization_header_is_missing() {
 }
 
 #[test]
-fn extract_subject_token_prefers_authorization_header_over_claims() {
+fn subject_token_prefers_configured_source() {
 	let mut req = ::http::Request::builder()
 		.uri("http://example/")
 		.header(::http::header::AUTHORIZATION, "Bearer header-tok")
 		.body(crate::http::Body::empty())
 		.unwrap();
-	req.extensions_mut().insert(Claims {
-		inner: Map::new(),
-		jwt: SecretString::from("claims-jwt"),
+	req.extensions_mut().insert(ValidatedCredential {
+		token: SecretString::from("validated-jwt"),
+		source: AuthorizationLocation::default(),
 	});
 
 	let token = oauth::extract_subject_token(&AuthorizationLocation::default(), &req);
@@ -807,20 +820,69 @@ fn extract_subject_token_custom_source_prefers_configured_location_over_claims()
 #[case::expression(AuthorizationLocation::Expression(std::sync::Arc::new(
 	crate::cel::Expression::new_strict(r#"request.headers["x-subject"]"#).unwrap(),
 )))]
-fn extract_subject_token_custom_sources_do_not_fall_back_to_claims(
-	#[case] source: AuthorizationLocation,
-) {
+fn subject_token_rejects_mismatched_jwt(#[case] source: AuthorizationLocation) {
 	let mut req = ::http::Request::builder()
 		.uri("http://example/")
 		.body(crate::http::Body::empty())
 		.unwrap();
 	req.extensions_mut().insert(Claims {
 		inner: Map::new(),
-		jwt: SecretString::from("claims-jwt"),
+		jwt: SecretString::from("oidc-id-token"),
+	});
+	req.extensions_mut().insert(ValidatedCredential {
+		token: SecretString::from("different-validated-jwt"),
+		source: AuthorizationLocation::default(),
 	});
 
 	let token = oauth::extract_subject_token(&source, &req);
 	assert_eq!(token, None);
+}
+
+#[rstest::rstest]
+#[case::header(AuthorizationLocation::Header {
+	name: ::http::HeaderName::from_static("x-subject"),
+	prefix: None,
+})]
+#[case::query_parameter(AuthorizationLocation::QueryParameter {
+	name: "subject".into(),
+})]
+#[case::cookie(AuthorizationLocation::Cookie {
+	name: "subject".into(),
+})]
+fn subject_token_reuses_matching_jwt(#[case] source: AuthorizationLocation) {
+	let mut req = ::http::Request::builder()
+		.uri("http://example/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	req.extensions_mut().insert(ValidatedCredential {
+		token: SecretString::from("validated-jwt"),
+		source: source.clone(),
+	});
+
+	let token = oauth::extract_subject_token(&source, &req);
+	assert_eq!(token.as_deref(), Some("validated-jwt"));
+}
+
+#[test]
+fn subject_token_reuses_jwt_with_empty_prefix() {
+	let mut req = ::http::Request::builder()
+		.uri("http://example/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	req.extensions_mut().insert(ValidatedCredential {
+		token: SecretString::from("validated-jwt"),
+		source: AuthorizationLocation::Header {
+			name: ::http::header::AUTHORIZATION,
+			prefix: Some("".into()),
+		},
+	});
+
+	let source = AuthorizationLocation::Header {
+		name: ::http::header::AUTHORIZATION,
+		prefix: None,
+	};
+	let token = oauth::extract_subject_token(&source, &req);
+	assert_eq!(token.as_deref(), Some("validated-jwt"));
 }
 
 fn credential(name: &'static str, value: &str, prefix: Option<&str>) -> BackendAuthCredential {

--- a/crates/agentgateway/src/http/auth/tests.rs
+++ b/crates/agentgateway/src/http/auth/tests.rs
@@ -789,8 +789,27 @@ fn extract_subject_token_custom_source_prefers_configured_location_over_claims()
 	assert_eq!(token.as_deref(), Some("custom-tok"));
 }
 
-#[test]
-fn extract_subject_token_custom_header_falls_back_to_claims() {
+#[rstest::rstest]
+#[case::header(AuthorizationLocation::Header {
+	name: ::http::HeaderName::from_static("x-subject"),
+	prefix: None,
+})]
+#[case::basic_authorization(AuthorizationLocation::Header {
+	name: ::http::header::AUTHORIZATION,
+	prefix: Some("Basic ".into()),
+})]
+#[case::query_parameter(AuthorizationLocation::QueryParameter {
+	name: "subject".into(),
+})]
+#[case::cookie(AuthorizationLocation::Cookie {
+	name: "subject".into(),
+})]
+#[case::expression(AuthorizationLocation::Expression(std::sync::Arc::new(
+	crate::cel::Expression::new_strict(r#"request.headers["x-subject"]"#).unwrap(),
+)))]
+fn extract_subject_token_custom_sources_do_not_fall_back_to_claims(
+	#[case] source: AuthorizationLocation,
+) {
 	let mut req = ::http::Request::builder()
 		.uri("http://example/")
 		.body(crate::http::Body::empty())
@@ -799,31 +818,9 @@ fn extract_subject_token_custom_header_falls_back_to_claims() {
 		inner: Map::new(),
 		jwt: SecretString::from("claims-jwt"),
 	});
-	let source = AuthorizationLocation::Header {
-		name: ::http::HeaderName::from_static("x-subject"),
-		prefix: None,
-	};
 
 	let token = oauth::extract_subject_token(&source, &req);
-	assert_eq!(token.as_deref(), Some("claims-jwt"));
-}
-
-#[test]
-fn extract_subject_token_expression_falls_back_to_claims() {
-	let mut req = ::http::Request::builder()
-		.uri("http://example/")
-		.body(crate::http::Body::empty())
-		.unwrap();
-	req.extensions_mut().insert(Claims {
-		inner: Map::new(),
-		jwt: SecretString::from("claims-jwt"),
-	});
-	let source = AuthorizationLocation::Expression(std::sync::Arc::new(
-		crate::cel::Expression::new_strict(r#"request.headers["x-subject"]"#).unwrap(),
-	));
-
-	let token = oauth::extract_subject_token(&source, &req);
-	assert_eq!(token.as_deref(), Some("claims-jwt"));
+	assert_eq!(token, None);
 }
 
 fn credential(name: &'static str, value: &str, prefix: Option<&str>) -> BackendAuthCredential {

--- a/crates/agentgateway/src/http/jwt.rs
+++ b/crates/agentgateway/src/http/jwt.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use ::cel::types::dynamic::DynamicType;
 use jsonwebtoken::jwk::{AlgorithmParameters, EllipticCurve, JwkSet, KeyAlgorithm};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use serde_json::{Map, Value};
 
 use crate::http::Request;
@@ -427,6 +427,21 @@ pub struct Claims {
 	pub jwt: SecretString,
 }
 
+#[derive(Clone, Debug)]
+pub struct ValidatedCredential {
+	pub token: SecretString,
+	pub source: AuthorizationLocation,
+}
+
+impl ValidatedCredential {
+	pub fn token_for_source(&self, source: &AuthorizationLocation) -> Option<&str> {
+		self
+			.source
+			.matches_source(source)
+			.then_some(self.token.expose_secret())
+	}
+}
+
 #[cfg(feature = "schema")]
 impl schemars::JsonSchema for Claims {
 	fn schema_name() -> std::borrow::Cow<'static, str> {
@@ -540,13 +555,17 @@ impl Jwt {
 			.location
 			.remove(req)
 			.map_err(|e| TokenError::CredentialRemoval(e.to_string()))?;
-		// Insert the claims into extensions so we can reference it later
 		dtrace::pol_result!(
 			dtrace::Severity::Info,
 			Apply,
 			"authenticated request with JWT claims {}",
 			serde_json::to_string(&claims).unwrap_or_else(|_| "invalid claims".to_string())
 		);
+		// Preserve validated auth state for later policies
+		req.extensions_mut().insert(ValidatedCredential {
+			token: claims.jwt.clone(),
+			source: self.location.clone(),
+		});
 		req.extensions_mut().insert(claims);
 		Ok(())
 	}

--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -535,6 +535,14 @@ pub async fn test_apply_permissive_valid_token_inserts_claims_and_removes_header
 			.is_none()
 	);
 	assert!(req.extensions().get::<super::Claims>().is_some());
+	let credential = req
+		.extensions()
+		.get::<super::ValidatedCredential>()
+		.expect("validated credential");
+	assert_eq!(
+		credential.token_for_source(&bearer_location()),
+		Some(token.as_str())
+	);
 }
 
 // Optional mode: allow requests without a token and do not attach claims
@@ -630,6 +638,14 @@ pub async fn test_apply_query_parameter_token_inserts_claims_and_removes_query_p
 	assert!(res.is_ok());
 	assert_eq!(req.uri().to_string(), "http://example.com/?keep=yes");
 	assert!(req.extensions().get::<super::Claims>().is_some());
+	let source = crate::http::auth::AuthorizationLocation::QueryParameter {
+		name: "token".into(),
+	};
+	let credential = req
+		.extensions()
+		.get::<super::ValidatedCredential>()
+		.expect("validated credential");
+	assert_eq!(credential.token_for_source(&source), Some(token.as_str()));
 }
 
 fn make_min_req_log() -> crate::telemetry::log::RequestLog {

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1891,8 +1891,9 @@ message OAuthClientAuth {
 message OAuthTokenExchange {
   message TokenSpec {
     // Where to extract the token from the incoming request. The `expression`
-    // (CEL) variant is permitted here. Only the default Authorization Bearer
-    // source falls back to validated Claims when its credential is absent.
+    // (CEL) variant is permitted here. An upstream JWT credential is reused only
+    // for a matching header, query parameter, or cookie source. Expressions are
+    // reevaluated and do not reuse credentials removed from another source.
     AuthorizationLocation source = 1;
     // RFC 8693 token type URI sent as subject_token_type / actor_token_type.
     // Built-ins such as "urn:ietf:params:oauth:token-type:access_token" and

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1891,9 +1891,8 @@ message OAuthClientAuth {
 message OAuthTokenExchange {
   message TokenSpec {
     // Where to extract the token from the incoming request. The `expression`
-    // (CEL) variant is permitted here. A Header/Authorization source also reads
-    // from the Claims extension when an upstream JWT policy has stripped the
-    // header, so the default keeps working behind a JWT auth policy.
+    // (CEL) variant is permitted here. Only the default Authorization Bearer
+    // source falls back to validated Claims when its credential is absent.
     AuthorizationLocation source = 1;
     // RFC 8693 token type URI sent as subject_token_type / actor_token_type.
     // Built-ins such as "urn:ietf:params:oauth:token-type:access_token" and


### PR DESCRIPTION
Prevent OAuth token exchange from silently substituting a different validated credential when the configured subject-token source is missing.

JWT authentication removes credentials after validation. To preserve the default token-exchange flow, the validated token can still be reused—but only when the JWT policy validated it from the same source configured by `subjectToken.source`.

Custom subject-token sources now fail closed when their credential is missing, while credentials stripped by a JWT policy can still be reused when the configured and validated sources agree.