### PR TITLE
waypoint: accept traffic when serving as a weighted waypoint

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -35,7 +35,6 @@ use crate::types::agent::{
 	BindKey, BindProtocol, Listener, ListenerProtocol, TransportProtocol, TunnelProtocol,
 };
 use crate::types::discovery::Service;
-use crate::types::discovery::gatewayaddress::Destination;
 use crate::types::frontend;
 use crate::{ProxyInputs, Stores, client};
 
@@ -1443,32 +1442,29 @@ impl Gateway {
 		};
 
 		// Make sure the service is actually bound to us
-		let Some(wp) = svc.waypoint.as_ref() else {
+		if !svc.has_fronting_waypoint() {
 			anyhow::bail!(
 				"service {}.{} is not bound to a waypoint",
 				svc.hostname,
 				svc.namespace
 			);
-		};
+		}
 		let Some(self_id) = pi.cfg.self_addr.as_ref() else {
 			anyhow::bail!("self_id required for waypoint");
 		};
-		let is_ours = match &wp.destination {
-			Destination::Address(addr) => self_id.matches_address(addr, |a| {
-				discovery
-					.services
-					.get_by_vip(a)
-					.map(|s| (s.name.clone(), s.namespace.clone()))
-			}),
-			Destination::Hostname(n) => self_id.matches_hostname(n),
-		};
+		let is_ours = self_id.fronts_service(&svc, |a| {
+			discovery
+				.services
+				.get_by_vip(a)
+				.map(|s| (s.name.clone(), s.namespace.clone()))
+		});
 		if !is_ours {
 			anyhow::bail!(
-				"service {} is meant for waypoint {:?}, but we are {}.{}",
+				"service {} is not fronted by waypoint {}.{}; its waypoints are {:?}",
 				svc.hostname,
-				wp.destination,
 				self_id.gateway,
-				self_id.namespace
+				self_id.namespace,
+				svc.fronting_waypoint_destinations(),
 			);
 		}
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -3336,6 +3336,7 @@ mod tests {
 			endpoints: Default::default(),
 			subject_alt_names: Vec::new(),
 			waypoint: None,
+			weighted_waypoints: Vec::new(),
 			load_balancer: None,
 			ip_families: None,
 			ingress_use_waypoint: false,

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -17,7 +17,6 @@ use crate::types::agent::{
 	SimpleBackendWithPolicies, TCPRoute, TCPRouteBackend, TCPRouteBackendReference, Target,
 	TransportProtocol,
 };
-use crate::types::discovery::gatewayaddress::Destination;
 use crate::types::discovery::{NetworkAddress, WaypointIdentity};
 use crate::types::{agent, frontend};
 use crate::{ProxyInputs, Stores, *};
@@ -386,24 +385,23 @@ fn resolve_waypoint_service(
 			address: dst.ip(),
 		})?;
 
-	let wp = svc.waypoint.as_ref()?;
-	let is_ours = match &wp.destination {
-		Destination::Address(addr) => {
-			let stores_ref = stores.clone();
-			self_id.matches_address(addr, |a| {
-				let discovery = stores_ref.read_discovery();
-				discovery
-					.services
-					.get_by_vip(a)
-					.map(|s| (s.name.clone(), s.namespace.clone()))
-			})
-		},
-		Destination::Hostname(n) => self_id.matches_hostname(n),
-	};
+	if !svc.has_fronting_waypoint() {
+		return None;
+	}
+	let is_ours = self_id.fronts_service(&svc, |a| {
+		stores
+			.read_discovery()
+			.services
+			.get_by_vip(a)
+			.map(|s| (s.name.clone(), s.namespace.clone()))
+	});
 	if !is_ours {
 		warn!(
-			"service {} is meant for waypoint {:?}, but we are {}.{}",
-			svc.hostname, wp.destination, self_id.gateway, self_id.namespace
+			"service {} is not fronted by waypoint {}.{}; its waypoints are {:?}",
+			svc.hostname,
+			self_id.gateway,
+			self_id.namespace,
+			svc.fronting_waypoint_destinations(),
 		);
 		return None;
 	}

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -146,7 +146,16 @@ impl WaypointIdentity {
 		addr: &NetworkAddress,
 		get_service_at: impl FnOnce(&NetworkAddress) -> Option<(Strng, Strng)>,
 	) -> bool {
-		get_service_at(addr).is_some_and(|(name, ns)| name == self.gateway && ns == self.namespace)
+		match get_service_at(addr) {
+			Some((name, ns)) => name == self.gateway && ns == self.namespace,
+			None => {
+				warn!(
+					"waypoint {}.{} cannot resolve service at {} for address verification",
+					self.gateway, self.namespace, addr
+				);
+				false
+			},
+		}
 	}
 
 	/// Checks whether this waypoint fronts `svc`, and may therefore serve traffic for it. That is

--- a/crates/agentgateway/src/types/discovery.rs
+++ b/crates/agentgateway/src/types/discovery.rs
@@ -146,16 +146,22 @@ impl WaypointIdentity {
 		addr: &NetworkAddress,
 		get_service_at: impl FnOnce(&NetworkAddress) -> Option<(Strng, Strng)>,
 	) -> bool {
-		match get_service_at(addr) {
-			Some((name, ns)) => name == self.gateway && ns == self.namespace,
-			None => {
-				warn!(
-					"waypoint {}.{} cannot resolve service at {} for address verification",
-					self.gateway, self.namespace, addr
-				);
-				false
-			},
-		}
+		get_service_at(addr).is_some_and(|(name, ns)| name == self.gateway && ns == self.namespace)
+	}
+
+	/// Checks whether this waypoint fronts `svc`, and may therefore serve traffic for it. That is
+	/// either as the service's primary waypoint, or as one of the weighted waypoints the service
+	/// is being migrated across: the client picks one of those per connection, while `waypoint`
+	/// keeps naming the primary.
+	pub fn fronts_service(
+		&self,
+		svc: &Service,
+		get_service_at: impl Fn(&NetworkAddress) -> Option<(Strng, Strng)>,
+	) -> bool {
+		svc.fronting_waypoints().any(|wp| match &wp.destination {
+			gatewayaddress::Destination::Address(addr) => self.matches_address(addr, &get_service_at),
+			gatewayaddress::Destination::Hostname(nh) => self.matches_hostname(nh),
+		})
 	}
 }
 
@@ -575,6 +581,12 @@ pub struct Service {
 	#[serde(default, skip_serializing_if = "is_default")]
 	pub waypoint: Option<GatewayAddress>,
 
+	/// The full set of waypoints fronting this service while it is being migrated from one
+	/// waypoint to another. `waypoint` stays populated with the primary.
+	/// Empty when no migration is in progress.
+	#[serde(default, skip_serializing_if = "is_default")]
+	pub weighted_waypoints: Vec<WeightedWaypoint>,
+
 	#[serde(default, skip_serializing_if = "is_default")]
 	pub load_balancer: Option<LoadBalancer>,
 
@@ -588,6 +600,26 @@ pub struct Service {
 }
 
 impl Service {
+	/// The waypoints that may serve traffic for this service. A non-empty weighted set is
+	/// authoritative and includes the primary; otherwise the single primary waypoint is used.
+	pub fn fronting_waypoints(&self) -> impl Iterator<Item = &GatewayAddress> {
+		self
+			.waypoint
+			.iter()
+			.filter(|_| self.weighted_waypoints.is_empty())
+			.chain(self.weighted_waypoints.iter().map(|w| &w.destination))
+	}
+
+	/// Whether any waypoint fronts this service.
+	pub fn has_fronting_waypoint(&self) -> bool {
+		self.fronting_waypoints().next().is_some()
+	}
+
+	/// The destinations of every waypoint fronting this service, for diagnostics.
+	pub fn fronting_waypoint_destinations(&self) -> Vec<&gatewayaddress::Destination> {
+		self.fronting_waypoints().map(|w| &w.destination).collect()
+	}
+
 	pub fn port_is_http2(&self, port: u16) -> bool {
 		matches!(
 			self.app_protocols.get(&port),
@@ -620,6 +652,13 @@ impl Service {
 				.map(|lb| lb.health_policy == LoadBalancerHealthPolicy::AllowAll)
 				.unwrap_or(false)
 	}
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct WeightedWaypoint {
+	pub destination: GatewayAddress,
+	pub weight: u32,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, serde::Serialize, serde::Deserialize)]
@@ -929,6 +968,20 @@ impl TryFrom<&XdsService> for Service {
 			Some(w) => Some(GatewayAddress::try_from(w)?),
 			None => None,
 		};
+		let weighted_waypoints = s
+			.weighted_waypoints
+			.iter()
+			.map(|w| -> Result<WeightedWaypoint, ProtoError> {
+				let destination = w
+					.destination
+					.as_ref()
+					.ok_or(ProtoError::MissingRequiredField)?;
+				Ok(WeightedWaypoint {
+					destination: GatewayAddress::try_from(destination)?,
+					weight: w.weight,
+				})
+			})
+			.collect::<Result<Vec<_>, _>>()?;
 		let lb = if let Some(lb) = &s.load_balancing {
 			Some(LoadBalancer {
 				routing_preferences: lb
@@ -986,6 +1039,7 @@ impl TryFrom<&XdsService> for Service {
 				})
 				.collect(),
 			waypoint,
+			weighted_waypoints,
 			load_balancer: lb,
 			ip_families,
 			ingress_use_waypoint: s.ingress_use_waypoint,
@@ -1046,5 +1100,160 @@ impl TryFrom<XdsScope> for LoadBalancerScopes {
 			XdsScope::Network => Ok(LoadBalancerScopes::Network),
 			_ => Err(ProtoError::EnumParse("invalid target".to_string())),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::net::Ipv4Addr;
+
+	use super::*;
+
+	fn waypoint_id(gateway: &str, namespace: &str) -> WaypointIdentity {
+		WaypointIdentity {
+			gateway: gateway.into(),
+			namespace: namespace.into(),
+		}
+	}
+
+	fn hostname_waypoint(gateway: &str, namespace: &str) -> GatewayAddress {
+		GatewayAddress {
+			destination: gatewayaddress::Destination::Hostname(NamespacedHostname {
+				namespace: namespace.into(),
+				hostname: strng::format!("{gateway}.{namespace}.svc.cluster.local"),
+			}),
+			hbone_mtls_port: 15008,
+		}
+	}
+
+	fn address_waypoint(last_octet: u8) -> GatewayAddress {
+		GatewayAddress {
+			destination: gatewayaddress::Destination::Address(NetworkAddress {
+				network: "".into(),
+				address: IpAddr::V4(Ipv4Addr::new(10, 0, 0, last_octet)),
+			}),
+			hbone_mtls_port: 15008,
+		}
+	}
+
+	fn weighted_waypoint(destination: GatewayAddress, weight: u32) -> WeightedWaypoint {
+		WeightedWaypoint {
+			destination,
+			weight,
+		}
+	}
+
+	/// Resolves 10.0.0.1 to primary-wp.ns1 and 10.0.0.2 to canary-wp.ns1; anything else is unknown.
+	fn resolve_vip(addr: &NetworkAddress) -> Option<(Strng, Strng)> {
+		match addr.address {
+			IpAddr::V4(v4) if v4 == Ipv4Addr::new(10, 0, 0, 1) => {
+				Some(("primary-wp".into(), "ns1".into()))
+			},
+			IpAddr::V4(v4) if v4 == Ipv4Addr::new(10, 0, 0, 2) => {
+				Some(("canary-wp".into(), "ns1".into()))
+			},
+			_ => None,
+		}
+	}
+
+	#[test]
+	fn fronting_waypoints_uses_weighted_set_when_present() {
+		let svc = Service {
+			waypoint: Some(hostname_waypoint("primary-wp", "ns1")),
+			weighted_waypoints: vec![
+				weighted_waypoint(hostname_waypoint("primary-wp", "ns1"), 95),
+				weighted_waypoint(hostname_waypoint("canary-wp", "ns1"), 5),
+			],
+			..Default::default()
+		};
+		assert_eq!(svc.fronting_waypoints().count(), 2);
+	}
+
+	#[test]
+	fn fronts_service_matches_primary_waypoint() {
+		let svc = Service {
+			waypoint: Some(hostname_waypoint("primary-wp", "ns1")),
+			..Default::default()
+		};
+		assert!(waypoint_id("primary-wp", "ns1").fronts_service(&svc, resolve_vip));
+	}
+
+	#[test]
+	fn fronts_service_matches_weighted_waypoint() {
+		// The mixed canary pairing: some other waypoint is primary, we are only the canary. istiod
+		// publishes both as weighted waypoints while `waypoint` keeps naming the primary.
+		let svc = Service {
+			waypoint: Some(hostname_waypoint("primary-wp", "ns1")),
+			weighted_waypoints: vec![
+				weighted_waypoint(hostname_waypoint("primary-wp", "ns1"), 95),
+				weighted_waypoint(hostname_waypoint("canary-wp", "ns1"), 5),
+			],
+			..Default::default()
+		};
+		assert!(waypoint_id("canary-wp", "ns1").fronts_service(&svc, resolve_vip));
+		// The primary still fronts it too, so traffic left on the primary is served.
+		assert!(waypoint_id("primary-wp", "ns1").fronts_service(&svc, resolve_vip));
+	}
+
+	#[test]
+	fn fronts_service_matches_neither() {
+		let svc = Service {
+			waypoint: Some(hostname_waypoint("primary-wp", "ns1")),
+			weighted_waypoints: vec![
+				weighted_waypoint(hostname_waypoint("primary-wp", "ns1"), 95),
+				weighted_waypoint(hostname_waypoint("canary-wp", "ns1"), 5),
+			],
+			..Default::default()
+		};
+		// Right name, wrong namespace, and an unrelated waypoint entirely.
+		assert!(!waypoint_id("canary-wp", "ns2").fronts_service(&svc, resolve_vip));
+		assert!(!waypoint_id("other-wp", "ns1").fronts_service(&svc, resolve_vip));
+	}
+
+	#[test]
+	fn fronts_service_with_no_waypoints() {
+		let svc = Service::default();
+		assert!(!waypoint_id("primary-wp", "ns1").fronts_service(&svc, resolve_vip));
+	}
+
+	#[test]
+	fn fronts_service_matches_weighted_waypoint_by_address() {
+		// Address destinations resolve through the VIP lookup rather than the hostname.
+		let svc = Service {
+			waypoint: Some(address_waypoint(1)),
+			weighted_waypoints: vec![
+				weighted_waypoint(address_waypoint(1), 95),
+				weighted_waypoint(address_waypoint(2), 5),
+			],
+			..Default::default()
+		};
+		assert!(waypoint_id("canary-wp", "ns1").fronts_service(&svc, resolve_vip));
+		assert!(waypoint_id("primary-wp", "ns1").fronts_service(&svc, resolve_vip));
+		assert!(!waypoint_id("other-wp", "ns1").fronts_service(&svc, resolve_vip));
+	}
+
+	#[test]
+	fn fronts_service_unresolvable_address_does_not_match() {
+		// An address we cannot resolve must not be treated as ours.
+		let svc = Service {
+			waypoint: Some(address_waypoint(99)),
+			..Default::default()
+		};
+		assert!(!waypoint_id("primary-wp", "ns1").fronts_service(&svc, resolve_vip));
+	}
+
+	#[test]
+	fn service_rejects_weighted_waypoint_without_destination() {
+		let svc = XdsService {
+			weighted_waypoints: vec![workload::WeightedWaypoint {
+				destination: None,
+				weight: 5,
+			}],
+			..Default::default()
+		};
+		assert!(matches!(
+			Service::try_from(&svc),
+			Err(ProtoError::MissingRequiredField)
+		));
 	}
 }

--- a/crates/protos/proto/workload.proto
+++ b/crates/protos/proto/workload.proto
@@ -98,6 +98,30 @@ message Service {
   // for this service through the service's waypoint proxy.
   // This is controlled by the istio.io/ingress-use-waypoint label on the Service or its namespace.
   bool ingress_use_waypoint = 12;
+
+  // weighted_waypoints, when non-empty, describes a weighted set of waypoints for this
+  // service, and the client dataplane selects one waypoint per connection proportional to
+  // each entry's weight. This is used to shift a configurable share of a service's
+  // in-mesh connections from one waypoint to another (for example, a canary migration between
+  // two waypoint revisions or implementations).
+  //
+  // When this is empty, the single `waypoint` field is used exactly as before. When it is
+  // set, `waypoint` remains populated with the primary waypoint so that dataplanes which do
+  // not understand this field continue to send all traffic to the primary.
+  repeated WeightedWaypoint weighted_waypoints = 13;
+  // Visibility controls which clients can resolve and send traffic to a service.
+  enum Visibility {
+    // Visible to every client the control plane serves. This is the default,
+    // and matches the behavior before this field was introduced.
+    PUBLIC = 0;
+    // Visible only to clients in the same namespace as the service.
+    NAMESPACE = 1;
+  }
+
+  // visibility controls which clients this service is resolvable by. When
+  // unset it defaults to PUBLIC. Services that a mesh administrator has scoped
+  // to no visibility at all are simply not sent, so they do not appear here.
+  Visibility visibility = 14;
 }
 
 enum IPFamilies {
@@ -381,12 +405,29 @@ message GatewayAddress {
   reserved 4;
 }
 
+// WeightedWaypoint is a single waypoint together with the relative weight for
+// selecting it out of a weighted set (see Service.weighted_waypoints).
+message WeightedWaypoint {
+  // The waypoint address, in the same form as Service.waypoint. The destination
+  // identity is resolved from the waypoint's own workload record at connect time,
+  // exactly as for the single-waypoint field; this message adds no identity.
+  GatewayAddress destination = 1;
+  // Relative weight for selecting this waypoint. The realized share of connections
+  // sent to this waypoint is weight / (sum of weights in the set). A weight of 0
+  // means the waypoint is described (and may be validated/reported) but receives no
+  // traffic.
+  uint32 weight = 2;
+}
+
 // NetworkAddress represents an address bound to a specific network.
 message NetworkAddress {
   // Network represents the network this address is on.
   string network = 1;
   // Address presents the IP (v4 or v6).
   bytes address = 2;
+  // CIDR prefix length. If absent, this is a host address (/32 or /128).
+  // If present, this represents a CIDR range (e.g., 24 for /24).
+  optional uint32 length = 3;
 }
 
 // NamespacedHostname represents a service bound to a specific namespace.


### PR DESCRIPTION
Ambient supports shifting a configurable share of a service's connections from one waypoint to another (istio/istio#60805), which is how a service is migrated between waypoint revisions or implementations - including onto agentgateway.
During a migration the client dataplane picks a waypoint per connection by weight, so an agentgateway acting as the canary starts receiving connections for services whose primary waypoint is something else.
Today it rejects them: the inbound checks compare our own identity against `Service.waypoint` only, which names the primary, so every canary connection is refused as "meant for waypoint X, but we are Y".

This teaches the agentgateway dataplane to accept traffic for any service it fronts, whether as the primary waypoint or as one of the weighted waypoints.

## Changes

**Proto.** Resyncs `crates/protos/proto/workload.proto` with upstream `pkg/workloadapi/workload.proto`, which brings in `Service.weighted_waypoints` and the `WeightedWaypoint` message. Two unrelated upstream fields come along with the resync, `Service.visibility` and `NetworkAddress.length`; neither is consumed by the dataplane yet.

**Dataplane.** Adds `Service::fronting_waypoints()`, which treats a non-empty weighted set as authoritative and otherwise falls back to the single primary. istiod builds the set as `[{primary, 100-weight}, {canary, weight}]`, so the primary is always included and traffic left on it keeps being served. `WaypointIdentity::fronts_service()` replaces the open-coded primary-only comparison at both inbound checks, HBONE CONNECT in `gateway.rs` and TCP in `tcpproxy.rs`, and the rejection message now lists every waypoint fronting the service instead of just the primary.

## Control plane

The workload API fields consumed here are already upstream and reach agentgateway today: istiod's agentgateway WDS path builds its address collections from the same ambient `ServicesCollection` that populates `weighted_waypoints`. A follow-up Istio PR wires up the remaining agentgateway-specific half, so that a canary agentgateway waypoint also receives the routing config for the services it now accepts traffic for - a waypoint service binding for the canary, and route attachment resolving a service to both its primary and canary waypoints.

## Not in this PR

Client-side weighted selection, planned as follow-up work. When agentgateway is the client rather than the waypoint (a gateway sending to a service labeled `istio.io/ingress-use-waypoint`), it still sends everything to `Service.waypoint` and ignores the weights, so a configured split is not honored for that traffic. Behavior there is unchanged.