### PR TITLE
feat: allow tunnel for remote JWKS and FileInlineOrRemote fetches

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -505,6 +505,16 @@ impl Client {
 	}
 
 	pub async fn simple_call(&self, req: http::Request) -> Result<http::Response, ProxyError> {
+		self.simple_call_with_tunnel(req, None).await
+	}
+
+	/// Like [`Self::simple_call`], optionally tunneling through an HTTP CONNECT /
+	/// absolute-form proxy (same transport as backend `backendTunnel`).
+	pub async fn simple_call_with_tunnel(
+		&self,
+		req: http::Request,
+		tunnel: Option<Target>,
+	) -> Result<http::Response, ProxyError> {
 		let host = req
 			.uri()
 			.host()
@@ -518,10 +528,21 @@ impl Client {
 			.port()
 			.map(|p| p.as_u16())
 			.unwrap_or_else(|| if scheme == &Scheme::HTTPS { 443 } else { 80 });
-		let transport = if scheme == &Scheme::HTTPS {
-			ApplicationTransport::Tls(http::backendtls::SYSTEM_TRUST.base_config()).into()
+		let application = if scheme == &Scheme::HTTPS {
+			ApplicationTransport::Tls(http::backendtls::SYSTEM_TRUST.base_config())
 		} else {
-			ApplicationTransport::Plaintext.into()
+			ApplicationTransport::Plaintext
+		};
+		let transport = match tunnel {
+			Some(proxy) => Transport::Tunnel(
+				application,
+				TunnelConfig {
+					target: proxy,
+					transport: Box::new(Transport::Plain(ApplicationTransport::Plaintext)),
+					token: None,
+				},
+			),
+			None => application.into(),
 		};
 		let target = Target::from((host, port));
 		self

--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -35,6 +35,33 @@ fn test_deserialize_missing_jwt_validation_options_defaults_to_exp() {
 	}
 }
 
+#[test]
+fn test_deserialize_remote_jwks_with_tunnel() {
+	let json = r#"{
+		"issuer": "https://example.com",
+		"jwks": {
+			"url": "https://example.com/.well-known/jwks.json",
+			"tunnel": {
+				"proxy": {
+					"host": "corporate-proxy.example.com:8080"
+				}
+			}
+		}
+	}"#;
+	let config: LocalJwtConfig = serde_json::from_str(json).unwrap();
+	match config {
+		LocalJwtConfig::Single { jwks, .. } => match jwks {
+			crate::serdes::FileInlineOrRemote::Remote { url, tunnel } => {
+				assert_eq!(url.to_string(), "https://example.com/.well-known/jwks.json");
+				let tunnel = tunnel.expect("tunnel should be present");
+				assert_eq!(tunnel.proxy.host, "corporate-proxy.example.com:8080");
+			},
+			other => panic!("expected remote JWKS, got {other:?}"),
+		},
+		_ => panic!("expected Single variant"),
+	}
+}
+
 // Deserialization: jwtValidationOptions present but requiredClaims omitted defaults to ["exp"]
 #[test]
 fn test_deserialize_jwt_validation_options_without_required_claims_defaults_to_exp() {

--- a/crates/agentgateway/src/http/oidc/local.rs
+++ b/crates/agentgateway/src/http/oidc/local.rs
@@ -145,6 +145,7 @@ impl LocalOidcConfig {
 					Some(discovery) => discovery,
 					None => FileInlineOrRemote::Remote {
 						url: default_discovery_url(&issuer)?,
+						tunnel: None,
 					},
 				};
 				let discovered = discover_provider_metadata(resources, &issuer, discovery).await?;
@@ -224,6 +225,12 @@ async fn discover_provider_metadata(
 			.jwks_uri
 			.parse()
 			.map_err(|e| Error::Config(format!("invalid jwks uri: {e}")))?,
+		// Discovery-derived JWKS inherits no tunnel; operators who need a proxy
+		// should set an explicit jwks remote with tunnel, or set tunnel on discovery.
+		tunnel: match &discovery {
+			FileInlineOrRemote::Remote { tunnel, .. } => tunnel.clone(),
+			_ => None,
+		},
 	};
 	Ok(DiscoveredProviderMetadata {
 		authorization_endpoint: document
@@ -354,6 +361,6 @@ fn describe_file_inline_or_remote(source: &FileInlineOrRemote) -> String {
 	match source {
 		FileInlineOrRemote::File { file } => format!("file '{}'", file.display()),
 		FileInlineOrRemote::Inline(_) => "inline configuration".into(),
-		FileInlineOrRemote::Remote { url } => format!("uri '{url}'"),
+		FileInlineOrRemote::Remote { url, .. } => format!("uri '{url}'"),
 	}
 }

--- a/crates/agentgateway/src/http/oidc/tests.rs
+++ b/crates/agentgateway/src/http/oidc/tests.rs
@@ -1029,6 +1029,7 @@ async fn local_oidc_config_rejects_ambiguous_provider_source_configuration() {
 					url: "https://example.invalid/should-not-be-called"
 						.parse()
 						.expect("discovery override url"),
+					tunnel: None,
 				}),
 				..explicit_local_oidc_config()
 			},

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -1543,6 +1543,7 @@ async fn test_openapi_from_url() {
 		backend,
 		schema: FileInlineOrRemote::Remote {
 			url: schema_url.parse().unwrap(),
+			tunnel: None,
 		},
 	};
 

--- a/crates/agentgateway/src/resource_manager.rs
+++ b/crates/agentgateway/src/resource_manager.rs
@@ -45,7 +45,12 @@ impl ResourceKind {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum ResourceRef {
 	File(PathBuf),
-	Http { url: http::Uri, kind: ResourceKind },
+	Http {
+		url: http::Uri,
+		kind: ResourceKind,
+		/// Optional CONNECT / absolute-form proxy as `host:port`.
+		tunnel: Option<String>,
+	},
 }
 
 #[derive(Clone, Debug, Default)]
@@ -709,13 +714,21 @@ async fn fetch_direct(client: &Client, resource: &ResourceRef) -> anyhow::Result
 				next: None,
 			})
 		},
-		ResourceRef::Http { url, kind } => {
+		ResourceRef::Http { url, kind, tunnel } => {
+			let tunnel_target = match tunnel.as_deref() {
+				Some(host) => Some(
+					crate::types::agent::Target::try_from(host)
+						.with_context(|| format!("invalid remote resource tunnel proxy '{host}'"))?,
+				),
+				None => None,
+			};
 			let resp = client
-				.simple_call(
+				.simple_call_with_tunnel(
 					::http::Request::builder()
 						.uri(url)
 						.body(Body::empty())
 						.expect("builder should succeed"),
+					tunnel_target,
 				)
 				.await
 				.with_context(|| format!("fetch {url}"))?;
@@ -753,14 +766,17 @@ fn cache_control_max_age(headers: &http::HeaderMap) -> Option<Duration> {
 fn resource_key(resource: &ResourceRef) -> String {
 	match resource {
 		ResourceRef::File(path) => format!("file:{}", path.display()),
-		ResourceRef::Http { url, kind } => format!("http:{kind:?}:{url}"),
+		ResourceRef::Http { url, kind, tunnel } => match tunnel {
+			Some(proxy) => format!("http:{kind:?}:{url}:tunnel:{proxy}"),
+			None => format!("http:{kind:?}:{url}"),
+		},
 	}
 }
 
 fn normalize_resource(resource: ResourceRef) -> anyhow::Result<ResourceRef> {
 	Ok(match resource {
 		ResourceRef::File(path) => ResourceRef::File(absolute(path)?),
-		ResourceRef::Http { url, kind } => ResourceRef::Http { url, kind },
+		ResourceRef::Http { url, kind, tunnel } => ResourceRef::Http { url, kind, tunnel },
 	})
 }
 
@@ -961,5 +977,68 @@ mod tests {
 			.await
 			.expect("resource deletion should notify")
 			.expect("change channel should remain open");
+	}
+
+	#[tokio::test]
+	async fn remote_jwks_fetch_via_http_tunnel() {
+		use jsonwebtoken::jwk::JwkSet;
+		use wiremock::matchers::method;
+		use wiremock::{Mock, MockServer, ResponseTemplate};
+
+		use crate::serdes::{FileInlineOrRemote, RemoteHttpTunnel, RemoteHttpTunnelProxy};
+
+		let jwks_body = serde_json::json!({
+			"keys": [{
+				"use": "sig",
+				"kty": "EC",
+				"kid": "test-kid",
+				"crv": "P-256",
+				"alg": "ES256",
+				"x": "WM7udBHga09KxC5kxq6GhrZ9M3Y8S9ZThq_XxsOcDhk",
+				"y": "xc7T4afkXmwjEbJMzQXCdQcU3PZKiLFlHl23GE1z4ug"
+			}]
+		});
+
+		// Absolute-form HTTP proxy that serves JWKS for tunneled fetches.
+		let proxy = MockServer::start().await;
+		Mock::given(method("GET"))
+			.respond_with(ResponseTemplate::new(200).set_body_json(&jwks_body))
+			.mount(&proxy)
+			.await;
+
+		// Unreachable JWKS origin — without a tunnel this fetch must fail.
+		let jwks_url: http::Uri = "http://127.0.0.1:1/.well-known/jwks.json"
+			.parse()
+			.expect("jwks url");
+
+		let resources = ResourceFetcher::direct(test_client());
+
+		let with_tunnel = FileInlineOrRemote::Remote {
+			url: jwks_url.clone(),
+			tunnel: Some(RemoteHttpTunnel {
+				proxy: RemoteHttpTunnelProxy {
+					host: proxy.address().to_string(),
+				},
+			}),
+		};
+		let jwks: JwkSet = with_tunnel
+			.load(&resources, ResourceKind::Jwks)
+			.await
+			.expect("JWKS fetch via tunnel should succeed");
+		assert_eq!(jwks.keys.len(), 1);
+		assert_eq!(jwks.keys[0].common.key_id.as_deref(), Some("test-kid"));
+
+		let without_tunnel = FileInlineOrRemote::Remote {
+			url: jwks_url,
+			tunnel: None,
+		};
+		let err = without_tunnel
+			.load::<JwkSet>(&resources, ResourceKind::Jwks)
+			.await
+			.expect_err("direct fetch to unreachable JWKS host should fail");
+		assert!(
+			err.to_string().contains("fetch") || err.to_string().contains("Connection"),
+			"unexpected error: {err}"
+		);
 	}
 }

--- a/crates/agentgateway/src/serdes.rs
+++ b/crates/agentgateway/src/serdes.rs
@@ -8,6 +8,28 @@ use crate::resource_manager::{ResourceFetcher, ResourceKind, ResourceRef};
 
 define_schema_aliases!();
 
+/// Optional HTTP CONNECT / absolute-form proxy for a remote resource URL.
+///
+/// Mirrors backend `backendTunnel` semantics for control-plane style fetches
+/// (JWKS, OIDC discovery, remote OpenAPI schemas). Only inline `host:port`
+/// proxies are supported; named backends are out of scope for resource fetches.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteHttpTunnel {
+	/// Proxy used to reach the remote URL.
+	pub proxy: RemoteHttpTunnelProxy,
+}
+
+/// Inline proxy address for [`RemoteHttpTunnel`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteHttpTunnelProxy {
+	/// Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).
+	pub host: String,
+}
+
 #[derive(Debug, Clone, serde::Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(untagged)]
@@ -21,6 +43,12 @@ pub enum FileInlineOrRemote {
 		#[serde(deserialize_with = "de_parse")]
 		#[cfg_attr(feature = "schema", schemars(with = "String"))]
 		url: http::Uri,
+		/// Optional HTTP CONNECT / absolute-form proxy for this remote URL.
+		/// When set, the fetch is tunneled through the proxy (same transport as
+		/// backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.
+		#[serde(default)]
+		#[cfg_attr(feature = "schema", schemars(default))]
+		tunnel: Option<RemoteHttpTunnel>,
 	},
 }
 
@@ -61,10 +89,58 @@ impl FileInlineOrRemote {
 		match self {
 			FileInlineOrRemote::File { file } => Some(ResourceRef::File(file.clone())),
 			FileInlineOrRemote::Inline(_) => None,
-			FileInlineOrRemote::Remote { url } => Some(ResourceRef::Http {
+			FileInlineOrRemote::Remote { url, tunnel } => Some(ResourceRef::Http {
 				url: url.clone(),
 				kind,
+				tunnel: tunnel.as_ref().map(|t| t.proxy.host.clone()),
 			}),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn remote_without_tunnel_deserializes() {
+		let v: FileInlineOrRemote = serde_json::from_value(serde_json::json!({
+			"url": "https://idp.example.com/.well-known/jwks.json"
+		}))
+		.unwrap();
+		match v {
+			FileInlineOrRemote::Remote { url, tunnel } => {
+				assert_eq!(
+					url.to_string(),
+					"https://idp.example.com/.well-known/jwks.json"
+				);
+				assert!(tunnel.is_none());
+			},
+			other => panic!("expected Remote, got {other:?}"),
+		}
+	}
+
+	#[test]
+	fn remote_with_tunnel_deserializes() {
+		let v: FileInlineOrRemote = serde_json::from_value(serde_json::json!({
+			"url": "https://idp.example.com/.well-known/jwks.json",
+			"tunnel": {
+				"proxy": {
+					"host": "corporate-proxy.example.com:8080"
+				}
+			}
+		}))
+		.unwrap();
+		match v {
+			FileInlineOrRemote::Remote { url, tunnel } => {
+				assert_eq!(
+					url.to_string(),
+					"https://idp.example.com/.well-known/jwks.json"
+				);
+				let tunnel = tunnel.expect("tunnel");
+				assert_eq!(tunnel.proxy.host, "corporate-proxy.example.com:8080");
+			},
+			other => panic!("expected Remote, got {other:?}"),
 		}
 	}
 }

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2947,13 +2947,15 @@ impl LocalMcpAuthentication {
 		let jwks = match &self.jwks {
 			None => FileInlineOrRemote::Remote {
 				url: self.derived_jwks_url()?,
+				tunnel: None,
 			},
-			Some(FileInlineOrRemote::Remote { url }) => FileInlineOrRemote::Remote {
+			Some(FileInlineOrRemote::Remote { url, tunnel }) => FileInlineOrRemote::Remote {
 				url: if !url.to_string().is_empty() {
 					url.clone()
 				} else {
 					self.derived_jwks_url()?
 				},
+				tunnel: tunnel.clone(),
 			},
 			Some(jwks @ (FileInlineOrRemote::Inline(_) | FileInlineOrRemote::File { .. })) => {
 				jwks.clone()
@@ -3647,7 +3649,7 @@ jwtValidationOptions:
 
 		match jwt_config {
 			http::jwt::LocalJwtConfig::Single { jwks, .. } => match jwks {
-				FileInlineOrRemote::Remote { url } => {
+				FileInlineOrRemote::Remote { url, tunnel: _ } => {
 					assert_eq!(
 						url.to_string(),
 						"https://authentik.example.com/application/o/mcp/jwks/"

--- a/schema/config.json
+++ b/schema/config.json
@@ -4527,12 +4527,49 @@
           "properties": {
             "url": {
               "type": "string"
+            },
+            "tunnel": {
+              "description": "Optional HTTP CONNECT / absolute-form proxy for this remote URL.\nWhen set, the fetch is tunneled through the proxy (same transport as\nbackend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/RemoteHttpTunnel"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [
             "url"
           ]
         }
+      ]
+    },
+    "RemoteHttpTunnel": {
+      "description": "Optional HTTP CONNECT / absolute-form proxy for a remote resource URL.\n\nMirrors backend `backendTunnel` semantics for control-plane style fetches\n(JWKS, OIDC discovery, remote OpenAPI schemas). Only inline `host:port`\nproxies are supported; named backends are out of scope for resource fetches.",
+      "type": "object",
+      "properties": {
+        "proxy": {
+          "description": "Proxy used to reach the remote URL.",
+          "$ref": "#/$defs/RemoteHttpTunnelProxy"
+        }
+      },
+      "required": [
+        "proxy"
+      ]
+    },
+    "RemoteHttpTunnelProxy": {
+      "description": "Inline proxy address for [`RemoteHttpTunnel`].",
+      "type": "object",
+      "properties": {
+        "host": {
+          "description": "Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "host"
       ]
     },
     "McpAuthenticationMode": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -479,6 +479,9 @@
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.url`|string||
+|`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.mode`|enum|Controls whether MCP requests must include a valid JWT.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.authorizationLocation`|object|Where to read the JWT from in incoming MCP requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.authorizationLocation.header`|object|Read the credential from an HTTP header.|
@@ -3265,6 +3268,9 @@
 |`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwks.url`|string||
+|`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`binds[].listeners[].routes[].policies.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -3272,6 +3278,9 @@
 |`binds[].listeners[].routes[].policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`binds[].listeners[].routes[].policies.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.jwtAuth.jwks.url`|string||
+|`binds[].listeners[].routes[].policies.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].routes[].policies.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].routes[].policies.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].routes[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].routes[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`binds[].listeners[].routes[].policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
@@ -3279,12 +3288,18 @@
 |`binds[].listeners[].routes[].policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`binds[].listeners[].routes[].policies.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.oidc.discovery.url`|string||
+|`binds[].listeners[].routes[].policies.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].routes[].policies.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].routes[].policies.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].routes[].policies.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`binds[].listeners[].routes[].policies.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`binds[].listeners[].routes[].policies.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`binds[].listeners[].routes[].policies.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`binds[].listeners[].routes[].policies.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.oidc.jwks.url`|string||
+|`binds[].listeners[].routes[].policies.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].routes[].policies.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].routes[].policies.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].routes[].policies.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`binds[].listeners[].routes[].policies.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`binds[].listeners[].routes[].policies.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -4498,6 +4513,9 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema.url`|string||
+|`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].openapi.schema.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].name`|string|Name identifying this MCP target, used to prefix tool and resource names when multiplexing.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies`|object|Transport policies for connecting to this target's backend. Not supported<br>on stdio targets. MCP policies (mcpAuthorization, mcpGuardrails) apply to<br>the full target set and belong on the route or `mcp.policies`.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
@@ -13350,12 +13368,18 @@
 |`binds[].listeners[].policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`binds[].listeners[].policies.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].policies.oidc.discovery.url`|string||
+|`binds[].listeners[].policies.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].policies.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].policies.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].policies.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`binds[].listeners[].policies.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`binds[].listeners[].policies.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`binds[].listeners[].policies.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`binds[].listeners[].policies.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].policies.oidc.jwks.url`|string||
+|`binds[].listeners[].policies.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].policies.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].policies.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].policies.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`binds[].listeners[].policies.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`binds[].listeners[].policies.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -13377,6 +13401,9 @@
 |`binds[].listeners[].policies.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`binds[].listeners[].policies.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].policies.jwtAuth.providers[].jwks.url`|string||
+|`binds[].listeners[].policies.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].policies.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].policies.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`binds[].listeners[].policies.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -13384,6 +13411,9 @@
 |`binds[].listeners[].policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`binds[].listeners[].policies.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].policies.jwtAuth.jwks.url`|string||
+|`binds[].listeners[].policies.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`binds[].listeners[].policies.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`binds[].listeners[].policies.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`binds[].listeners[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`binds[].listeners[].policies.authorization`|object|Authorization rules for incoming HTTP requests.|
@@ -15755,6 +15785,9 @@
 |`policies[].policy.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`policies[].policy.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.mcpAuthentication.jwks.url`|string||
+|`policies[].policy.mcpAuthentication.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`policies[].policy.mcpAuthentication.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`policies[].policy.mcpAuthentication.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`policies[].policy.mcpAuthentication.mode`|enum|Controls whether MCP requests must include a valid JWT.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`policies[].policy.mcpAuthentication.authorizationLocation`|object|Where to read the JWT from in incoming MCP requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
 |`policies[].policy.mcpAuthentication.authorizationLocation.header`|object|Read the credential from an HTTP header.|
@@ -18541,6 +18574,9 @@
 |`policies[].policy.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`policies[].policy.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.jwtAuth.providers[].jwks.url`|string||
+|`policies[].policy.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`policies[].policy.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`policies[].policy.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`policies[].policy.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`policies[].policy.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`policies[].policy.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -18548,6 +18584,9 @@
 |`policies[].policy.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`policies[].policy.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.jwtAuth.jwks.url`|string||
+|`policies[].policy.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`policies[].policy.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`policies[].policy.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`policies[].policy.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`policies[].policy.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`policies[].policy.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
@@ -18555,12 +18594,18 @@
 |`policies[].policy.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`policies[].policy.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.oidc.discovery.url`|string||
+|`policies[].policy.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`policies[].policy.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`policies[].policy.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`policies[].policy.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`policies[].policy.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`policies[].policy.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`policies[].policy.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`policies[].policy.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.oidc.jwks.url`|string||
+|`policies[].policy.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`policies[].policy.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`policies[].policy.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`policies[].policy.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`policies[].policy.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`policies[].policy.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -19771,6 +19816,9 @@
 |`backends[].mcp.targets[].openapi.schema`|object||
 |`backends[].mcp.targets[].openapi.schema.file`|string|Path to a file on disk to load the value from.|
 |`backends[].mcp.targets[].openapi.schema.url`|string||
+|`backends[].mcp.targets[].openapi.schema.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`backends[].mcp.targets[].openapi.schema.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`backends[].mcp.targets[].openapi.schema.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`backends[].mcp.targets[].name`|string|Name identifying this MCP target, used to prefix tool and resource names when multiplexing.|
 |`backends[].mcp.targets[].policies`|object|Transport policies for connecting to this target's backend. Not supported<br>on stdio targets. MCP policies (mcpAuthorization, mcpGuardrails) apply to<br>the full target set and belong on the route or `mcp.policies`.|
 |`backends[].mcp.targets[].policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
@@ -28937,6 +28985,9 @@
 |`routeGroups[].routes[].policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`routeGroups[].routes[].policies.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.mcpAuthentication.jwks.url`|string||
+|`routeGroups[].routes[].policies.mcpAuthentication.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routeGroups[].routes[].policies.mcpAuthentication.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routeGroups[].routes[].policies.mcpAuthentication.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routeGroups[].routes[].policies.mcpAuthentication.mode`|enum|Controls whether MCP requests must include a valid JWT.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`routeGroups[].routes[].policies.mcpAuthentication.authorizationLocation`|object|Where to read the JWT from in incoming MCP requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
 |`routeGroups[].routes[].policies.mcpAuthentication.authorizationLocation.header`|object|Read the credential from an HTTP header.|
@@ -31723,6 +31774,9 @@
 |`routeGroups[].routes[].policies.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`routeGroups[].routes[].policies.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.jwtAuth.providers[].jwks.url`|string||
+|`routeGroups[].routes[].policies.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routeGroups[].routes[].policies.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routeGroups[].routes[].policies.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routeGroups[].routes[].policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`routeGroups[].routes[].policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`routeGroups[].routes[].policies.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -31730,6 +31784,9 @@
 |`routeGroups[].routes[].policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`routeGroups[].routes[].policies.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.jwtAuth.jwks.url`|string||
+|`routeGroups[].routes[].policies.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routeGroups[].routes[].policies.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routeGroups[].routes[].policies.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routeGroups[].routes[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`routeGroups[].routes[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`routeGroups[].routes[].policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
@@ -31737,12 +31794,18 @@
 |`routeGroups[].routes[].policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`routeGroups[].routes[].policies.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.oidc.discovery.url`|string||
+|`routeGroups[].routes[].policies.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routeGroups[].routes[].policies.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routeGroups[].routes[].policies.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routeGroups[].routes[].policies.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`routeGroups[].routes[].policies.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`routeGroups[].routes[].policies.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`routeGroups[].routes[].policies.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`routeGroups[].routes[].policies.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.oidc.jwks.url`|string||
+|`routeGroups[].routes[].policies.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routeGroups[].routes[].policies.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routeGroups[].routes[].policies.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routeGroups[].routes[].policies.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`routeGroups[].routes[].policies.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`routeGroups[].routes[].policies.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -32956,6 +33019,9 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema`|object||
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema.url`|string||
+|`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routeGroups[].routes[].backends[].mcp.targets[].openapi.schema.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routeGroups[].routes[].backends[].mcp.targets[].name`|string|Name identifying this MCP target, used to prefix tool and resource names when multiplexing.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies`|object|Transport policies for connecting to this target's backend. Not supported<br>on stdio targets. MCP policies (mcpAuthorization, mcpGuardrails) apply to<br>the full target set and belong on the route or `mcp.policies`.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
@@ -41784,12 +41850,18 @@
 |`gateways.*.listeners[].oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`gateways.*.listeners[].oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.listeners[].oidc.discovery.url`|string||
+|`gateways.*.listeners[].oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`gateways.*.listeners[].oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`gateways.*.listeners[].oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`gateways.*.listeners[].oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`gateways.*.listeners[].oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`gateways.*.listeners[].oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`gateways.*.listeners[].oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`gateways.*.listeners[].oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.listeners[].oidc.jwks.url`|string||
+|`gateways.*.listeners[].oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`gateways.*.listeners[].oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`gateways.*.listeners[].oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`gateways.*.listeners[].oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`gateways.*.listeners[].oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`gateways.*.listeners[].oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -41811,6 +41883,9 @@
 |`gateways.*.listeners[].jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`gateways.*.listeners[].jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.listeners[].jwtAuth.providers[].jwks.url`|string||
+|`gateways.*.listeners[].jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`gateways.*.listeners[].jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`gateways.*.listeners[].jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`gateways.*.listeners[].jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`gateways.*.listeners[].jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`gateways.*.listeners[].jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -41818,6 +41893,9 @@
 |`gateways.*.listeners[].jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`gateways.*.listeners[].jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.listeners[].jwtAuth.jwks.url`|string||
+|`gateways.*.listeners[].jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`gateways.*.listeners[].jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`gateways.*.listeners[].jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`gateways.*.listeners[].jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`gateways.*.listeners[].jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`gateways.*.listeners[].authorization`|object|Authorization rules for incoming HTTP requests.|
@@ -42998,12 +43076,18 @@
 |`gateways.*.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`gateways.*.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.oidc.discovery.url`|string||
+|`gateways.*.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`gateways.*.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`gateways.*.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`gateways.*.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`gateways.*.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`gateways.*.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`gateways.*.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`gateways.*.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.oidc.jwks.url`|string||
+|`gateways.*.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`gateways.*.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`gateways.*.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`gateways.*.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`gateways.*.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`gateways.*.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -43025,6 +43109,9 @@
 |`gateways.*.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`gateways.*.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.jwtAuth.providers[].jwks.url`|string||
+|`gateways.*.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`gateways.*.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`gateways.*.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`gateways.*.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`gateways.*.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`gateways.*.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -43032,6 +43119,9 @@
 |`gateways.*.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`gateways.*.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.jwtAuth.jwks.url`|string||
+|`gateways.*.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`gateways.*.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`gateways.*.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`gateways.*.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`gateways.*.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`gateways.*.authorization`|object|Authorization rules for incoming HTTP requests.|
@@ -44558,6 +44648,9 @@
 |`routes[].policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`routes[].policies.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.mcpAuthentication.jwks.url`|string||
+|`routes[].policies.mcpAuthentication.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routes[].policies.mcpAuthentication.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routes[].policies.mcpAuthentication.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routes[].policies.mcpAuthentication.mode`|enum|Controls whether MCP requests must include a valid JWT.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`routes[].policies.mcpAuthentication.authorizationLocation`|object|Where to read the JWT from in incoming MCP requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
 |`routes[].policies.mcpAuthentication.authorizationLocation.header`|object|Read the credential from an HTTP header.|
@@ -47344,6 +47437,9 @@
 |`routes[].policies.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`routes[].policies.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.jwtAuth.providers[].jwks.url`|string||
+|`routes[].policies.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routes[].policies.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routes[].policies.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routes[].policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`routes[].policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`routes[].policies.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -47351,6 +47447,9 @@
 |`routes[].policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`routes[].policies.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.jwtAuth.jwks.url`|string||
+|`routes[].policies.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routes[].policies.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routes[].policies.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routes[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`routes[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`routes[].policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
@@ -47358,12 +47457,18 @@
 |`routes[].policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`routes[].policies.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.oidc.discovery.url`|string||
+|`routes[].policies.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routes[].policies.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routes[].policies.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routes[].policies.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`routes[].policies.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`routes[].policies.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`routes[].policies.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`routes[].policies.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.oidc.jwks.url`|string||
+|`routes[].policies.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routes[].policies.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routes[].policies.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routes[].policies.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`routes[].policies.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`routes[].policies.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -48577,6 +48682,9 @@
 |`routes[].backends[].mcp.targets[].openapi.schema`|object||
 |`routes[].backends[].mcp.targets[].openapi.schema.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].mcp.targets[].openapi.schema.url`|string||
+|`routes[].backends[].mcp.targets[].openapi.schema.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`routes[].backends[].mcp.targets[].openapi.schema.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`routes[].backends[].mcp.targets[].openapi.schema.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`routes[].backends[].mcp.targets[].name`|string|Name identifying this MCP target, used to prefix tool and resource names when multiplexing.|
 |`routes[].backends[].mcp.targets[].policies`|object|Transport policies for connecting to this target's backend. Not supported<br>on stdio targets. MCP policies (mcpAuthorization, mcpGuardrails) apply to<br>the full target set and belong on the route or `mcp.policies`.|
 |`routes[].backends[].mcp.targets[].policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
@@ -60149,12 +60257,18 @@
 |`llm.policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`llm.policies.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.oidc.discovery.url`|string||
+|`llm.policies.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`llm.policies.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`llm.policies.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`llm.policies.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`llm.policies.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`llm.policies.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`llm.policies.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`llm.policies.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.oidc.jwks.url`|string||
+|`llm.policies.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`llm.policies.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`llm.policies.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`llm.policies.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`llm.policies.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`llm.policies.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -60176,6 +60290,9 @@
 |`llm.policies.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`llm.policies.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.jwtAuth.providers[].jwks.url`|string||
+|`llm.policies.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`llm.policies.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`llm.policies.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`llm.policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`llm.policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`llm.policies.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -60183,6 +60300,9 @@
 |`llm.policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`llm.policies.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.jwtAuth.jwks.url`|string||
+|`llm.policies.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`llm.policies.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`llm.policies.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`llm.policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`llm.policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`llm.policies.authorization`|object|Authorization rules for incoming HTTP requests.|
@@ -63484,6 +63604,9 @@
 |`mcp.targets[].openapi.schema`|object||
 |`mcp.targets[].openapi.schema.file`|string|Path to a file on disk to load the value from.|
 |`mcp.targets[].openapi.schema.url`|string||
+|`mcp.targets[].openapi.schema.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`mcp.targets[].openapi.schema.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`mcp.targets[].openapi.schema.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`mcp.targets[].name`|string|Name identifying this MCP target, used to prefix tool and resource names when multiplexing.|
 |`mcp.targets[].policies`|object|Transport policies for connecting to this target's backend. Not supported<br>on stdio targets. MCP policies (mcpAuthorization, mcpGuardrails) apply to<br>the full target set and belong on the route or `mcp.policies`.|
 |`mcp.targets[].policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
@@ -64077,6 +64200,9 @@
 |`mcp.policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`mcp.policies.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.mcpAuthentication.jwks.url`|string||
+|`mcp.policies.mcpAuthentication.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`mcp.policies.mcpAuthentication.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`mcp.policies.mcpAuthentication.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`mcp.policies.mcpAuthentication.mode`|enum|Controls whether MCP requests must include a valid JWT.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`mcp.policies.mcpAuthentication.authorizationLocation`|object|Where to read the JWT from in incoming MCP requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
 |`mcp.policies.mcpAuthentication.authorizationLocation.header`|object|Read the credential from an HTTP header.|
@@ -66863,6 +66989,9 @@
 |`mcp.policies.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`mcp.policies.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.jwtAuth.providers[].jwks.url`|string||
+|`mcp.policies.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`mcp.policies.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`mcp.policies.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`mcp.policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`mcp.policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`mcp.policies.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -66870,6 +66999,9 @@
 |`mcp.policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`mcp.policies.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.jwtAuth.jwks.url`|string||
+|`mcp.policies.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`mcp.policies.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`mcp.policies.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`mcp.policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`mcp.policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`mcp.policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
@@ -66877,12 +67009,18 @@
 |`mcp.policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`mcp.policies.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.oidc.discovery.url`|string||
+|`mcp.policies.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`mcp.policies.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`mcp.policies.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`mcp.policies.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`mcp.policies.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`mcp.policies.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`mcp.policies.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`mcp.policies.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.oidc.jwks.url`|string||
+|`mcp.policies.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`mcp.policies.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`mcp.policies.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`mcp.policies.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`mcp.policies.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`mcp.policies.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -68072,12 +68210,18 @@
 |`ui.policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
 |`ui.policies.oidc.discovery.file`|string|Path to a file on disk to load the value from.|
 |`ui.policies.oidc.discovery.url`|string||
+|`ui.policies.oidc.discovery.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`ui.policies.oidc.discovery.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`ui.policies.oidc.discovery.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`ui.policies.oidc.authorizationEndpoint`|string|Authorization endpoint used to start the browser login flow.|
 |`ui.policies.oidc.tokenEndpoint`|string|Token endpoint used to exchange the authorization code.|
 |`ui.policies.oidc.tokenEndpointAuth`|enum|Token endpoint client authentication method for explicit provider configuration.<br><br>Discovery mode derives this from provider metadata. Explicit mode defaults to<br>`clientSecretBasic` when omitted.<br>Possible values: `clientSecretBasic`, `clientSecretPost`, `null`.|
 |`ui.policies.oidc.jwks`|object|JWKS source used to validate returned ID tokens.|
 |`ui.policies.oidc.jwks.file`|string|Path to a file on disk to load the value from.|
 |`ui.policies.oidc.jwks.url`|string||
+|`ui.policies.oidc.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`ui.policies.oidc.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`ui.policies.oidc.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`ui.policies.oidc.clientId`|string|OAuth2 client identifier used for authorization and token exchange.|
 |`ui.policies.oidc.clientSecret`|string|OAuth2 client secret used for token exchange.|
 |`ui.policies.oidc.redirectURI`|string|Absolute callback URI handled by the gateway.<br>This policy always redirects unauthenticated non-callback requests back through this login<br>flow.|
@@ -68099,6 +68243,9 @@
 |`ui.policies.jwtAuth.providers[].jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`ui.policies.jwtAuth.providers[].jwks.file`|string|Path to a file on disk to load the value from.|
 |`ui.policies.jwtAuth.providers[].jwks.url`|string||
+|`ui.policies.jwtAuth.providers[].jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`ui.policies.jwtAuth.providers[].jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`ui.policies.jwtAuth.providers[].jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`ui.policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`ui.policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`ui.policies.jwtAuth.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
@@ -68106,6 +68253,9 @@
 |`ui.policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
 |`ui.policies.jwtAuth.jwks.file`|string|Path to a file on disk to load the value from.|
 |`ui.policies.jwtAuth.jwks.url`|string||
+|`ui.policies.jwtAuth.jwks.tunnel`|object|Optional HTTP CONNECT / absolute-form proxy for this remote URL.<br>When set, the fetch is tunneled through the proxy (same transport as<br>backend `backendTunnel`). Does not honor `HTTP_PROXY` / `HTTPS_PROXY`.|
+|`ui.policies.jwtAuth.jwks.tunnel.proxy`|object|Proxy used to reach the remote URL.|
+|`ui.policies.jwtAuth.jwks.tunnel.proxy.host`|string|Proxy address as `host:port` (for example `corporate-proxy.example.com:8080`).|
 |`ui.policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`ui.policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to require no claims.|
 |`ui.policies.authorization`|object|Authorization rules for incoming HTTP requests.|


### PR DESCRIPTION
## Summary

- Fixes #2721 by adding an **opt-in per-URL `tunnel`** on `FileInlineOrRemote::Remote` so JWKS / OIDC discovery / other remote resource fetches can reach IdPs through an HTTP CONNECT / absolute-form proxy.
- Reuses the existing backend tunnel transport (`Transport::Tunnel`) — does **not** honor global `HTTP_PROXY` / `HTTPS_PROXY`.
- Inline `host:port` proxies only (v1); named backends / proxy auth are out of scope.

Example:

```yaml
mcpAuthentication:
  issuer: https://idp.example.com
  audiences: [dfactory-api]
  jwks:
    url: https://idp.example.com/.well-known/jwks.json
    tunnel:
      proxy:
        host: corporate-proxy.example.com:8080
```

## Test plan

- [x] Unit: deserialize remote JWKS with/without `tunnel`
- [x] Integration: `remote_jwks_fetch_via_http_tunnel` — unreachable JWKS origin fails without tunnel, succeeds via absolute-form HTTP proxy
- [x] `make lint` (fmt + clippy)
- [x] `make generate-schema` (config schema includes `RemoteHttpTunnel`)
- [ ] CI green on this PR
