### PR TITLE
ext*: do not limit serve response size

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -359,7 +359,8 @@ impl ExtAuthz {
 		let chan = self
 			.target
 			.grpc_channel(client.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::ExtAuthz));
-		let mut grpc_client = AuthorizationClient::new(chan);
+		let mut grpc_client = AuthorizationClient::new(chan)
+			.max_decoding_message_size(defaults::GRPC_MAX_DECODING_MESSAGE_SIZE);
 		// Get connection info with proper error handling
 		// Clone the fields we need to avoid borrow checker issues
 		let (peer_addr, local_addr, connection_start_time) = {

--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -407,7 +407,10 @@ impl ExtProcInstance {
 			failure_mode,
 			protocol_config_sent: false,
 			mode_state: processing_options.into(),
-			client: Some(proto::external_processor_client::ExternalProcessorClient::new(chan)),
+			client: Some(
+				proto::external_processor_client::ExternalProcessorClient::new(chan)
+					.max_decoding_message_size(defaults::GRPC_MAX_DECODING_MESSAGE_SIZE),
+			),
 			tx_req: None,
 			rx_resp_for_request: None,
 			rx_resp_for_response: None,
@@ -444,9 +447,20 @@ impl ExtProcInstance {
 			};
 			trace!("initial stream established");
 			let mut responses = responses.into_inner();
-			while let Ok(Some(item)) = responses.message().await {
-				trace!("received response item {item:?}");
-				let _ = tx_resp.send(item).await;
+			loop {
+				match responses.message().await {
+					Ok(Some(item)) => {
+						trace!("received response item {item:?}");
+						if tx_resp.send(item).await.is_err() {
+							return;
+						}
+					},
+					Ok(None) => return,
+					Err(error) => {
+						warn!(%error, "ext_proc response stream failed");
+						return;
+					},
+				}
 			}
 		});
 

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -324,6 +324,13 @@ mod defaults {
 		2_097_152
 	}
 
+	/// Semi-trusted, controller-configured gRPC services that return body mutations do not impose
+	/// a message-size limit.
+	///
+	/// Tonic otherwise defaults to a 4 MiB receive limit, which is too small for services that may
+	/// legitimately return buffered HTTP or MCP bodies.
+	pub const GRPC_MAX_DECODING_MESSAGE_SIZE: usize = usize::MAX;
+
 	pub fn tls_handshake_timeout() -> Duration {
 		Duration::from_secs(15)
 	}

--- a/crates/agentgateway/src/mcp/guardrails/client.rs
+++ b/crates/agentgateway/src/mcp/guardrails/client.rs
@@ -256,6 +256,7 @@ fn eval_to_value(
 
 fn build_client(remote: &Remote, client: PolicyClient) -> ExtMcpClient<GrpcReferenceChannel> {
 	ExtMcpClient::new(remote.target.grpc_channel(client))
+		.max_decoding_message_size(crate::defaults::GRPC_MAX_DECODING_MESSAGE_SIZE)
 }
 
 // Snapshot the incoming request headers for the policy server, applying the


### PR DESCRIPTION
This allows large bodies to be sent over. The no limit matches Envoy

Fixes #2720

Signed-off-by: John Howard <john.howard@solo.io>
