### PR TITLE
client: avoid waiting on hung h2 connections

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -488,6 +488,7 @@ impl Client {
 		let mut b = agent_pool::Client::<_, PoolKey>::builder(::hyper_util::rt::TokioExecutor::new());
 		b.pool_timer(hyper_util::rt::tokio::TokioTimer::new());
 		b.pool_idle_timeout(backend_config.pool_idle_timeout);
+		b.connect_timeout(backend_config.connect_timeout);
 		b.timer(hyper_util::rt::tokio::TokioTimer::new());
 		b.http1_preserve_header_case(true);
 		if let Some(pool_max) = backend_config.pool_max_size {
@@ -670,14 +671,21 @@ impl Client {
 			let buffer_limit = http::buffer_limit(&req);
 			let to = req.extensions().get::<BackendRequestTimeout>().cloned();
 			let call = client.request(req);
+			let map_error = |err: agent_pool::Error| {
+				if err.is_connect_timeout() {
+					ProxyError::UpstreamCallTimeout
+				} else {
+					ProxyError::UpstreamCallFailed(err)
+				}
+			};
 			let resp = if let Some(to) = to {
 				match tokio::time::timeout(to.0, call).await {
 					Err(_) => Err(ProxyError::UpstreamCallTimeout),
-					Ok(Err(e)) => Err(ProxyError::UpstreamCallFailed(e)),
+					Ok(Err(err)) => Err(map_error(err)),
 					Ok(Ok(resp)) => Ok(resp),
 				}
 			} else {
-				call.await.map_err(ProxyError::UpstreamCallFailed)
+				call.await.map_err(map_error)
 			};
 			let dur = format!("{}ms", start.elapsed().as_millis());
 			// If version changed due to ALPN negotiation, make sure we get the real version

--- a/crates/pool/src/blackbox_tests.rs
+++ b/crates/pool/src/blackbox_tests.rs
@@ -54,6 +54,29 @@ impl Service<http::Extensions> for TestConnector {
 	}
 }
 
+#[derive(Clone)]
+struct StallOnceConnector {
+	inner: TestConnector,
+	attempts: Arc<AtomicUsize>,
+}
+
+impl Service<http::Extensions> for StallOnceConnector {
+	type Response = TokioIo<TcpStream>;
+	type Error = io::Error;
+	type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+	fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		Poll::Ready(Ok(()))
+	}
+
+	fn call(&mut self, req: http::Extensions) -> Self::Future {
+		if self.attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+			return Box::pin(std::future::pending());
+		}
+		self.inner.call(req)
+	}
+}
+
 struct BlockingEosBody {
 	release: oneshot::Receiver<()>,
 	done: bool,
@@ -463,6 +486,54 @@ async fn released_response_bodies_allow_reuse_without_new_connection() {
 		1,
 		"released response bodies should let the client reuse the original h2 connection",
 	);
+
+	server.shutdown().await;
+}
+
+#[tokio::test]
+async fn connection_timeout_releases_pool_capacity() {
+	let (server, _response_txs) = TestServer::spawn(1, 0).await;
+	let uri: Uri = format!("http://{}/", server.addr).parse().expect("uri");
+	let key = TestKey {
+		authority: uri.authority().expect("authority").clone(),
+	};
+	let mut builder = Client::<(), TestKey>::builder(TokioExecutor::new());
+	builder.pool_timer(TokioTimer::new());
+	builder.pool_expected_http2_capacity(1);
+	builder.connect_timeout(Duration::from_millis(100));
+	let attempts = Arc::new(AtomicUsize::new(0));
+	let client: Client<_, TestKey> = builder.build(StallOnceConnector {
+		inner: TestConnector { addr: server.addr },
+		attempts: attempts.clone(),
+	});
+
+	let err = tokio::time::timeout(
+		Duration::from_secs(1),
+		client.request(make_h2_request(
+			&uri,
+			&key,
+			axum_core::body::Body::new(Empty::<Bytes>::new()),
+		)),
+	)
+	.await
+	.expect("connection timeout did not fire")
+	.expect_err("stalled handshake unexpectedly succeeded");
+	assert!(err.is_connect_timeout(), "unexpected error: {err:?}");
+
+	let response = tokio::time::timeout(
+		Duration::from_secs(1),
+		client.request(make_h2_request(
+			&uri,
+			&key,
+			axum_core::body::Body::new(Empty::<Bytes>::new()),
+		)),
+	)
+	.await
+	.expect("recovery request timed out")
+	.expect("recovery request failed");
+	assert_eq!(response.status(), 200);
+	server.wait_for_accepted(1).await;
+	assert_eq!(attempts.load(Ordering::SeqCst), 2);
 
 	server.shutdown().await;
 }

--- a/crates/pool/src/client.rs
+++ b/crates/pool/src/client.rs
@@ -15,7 +15,8 @@ use std::task::{self, Context, Poll, ready};
 use std::time::Duration;
 
 use axum_core::BoxError;
-use futures_util::future::{FutureExt, TryFutureExt};
+use futures_util::future::{Either, FutureExt, TryFutureExt, select};
+use futures_util::pin_mut;
 use http::uri::Scheme;
 use hyper::body::{Body, Bytes, Frame, SizeHint};
 use hyper::header::{HOST, HeaderValue};
@@ -42,6 +43,8 @@ pub struct Client<C, PK: Key> {
 	h1_builder: hyper::client::conn::http1::Builder,
 	h2_builder: hyper::client::conn::http2::Builder<Exec>,
 	pool: pool::Pool<PK>,
+	connect_timeout: Option<Duration>,
+	timer: timer::Timer,
 }
 
 /// Client errors
@@ -55,6 +58,7 @@ pub struct Error {
 enum ErrorKind {
 	Canceled,
 	Connect,
+	ConnectTimeout,
 	SendRequest,
 	NoPoolKey,
 	WaitCanceled,
@@ -391,6 +395,29 @@ where
 	}
 
 	async fn connect_to(&self, version: Version, pk: PK) -> Result<pool::HttpConnection, Error> {
+		let Some(timeout) = self.connect_timeout else {
+			return self.connect_to_inner(version, pk).await;
+		};
+		let connect = self.connect_to_inner(version, pk);
+		let sleep = self.timer.sleep(timeout);
+		pin_mut!(connect);
+		match select(connect, sleep).await {
+			Either::Left((res, _)) => res,
+			Either::Right(_) => Err(e!(
+				ConnectTimeout,
+				std::io::Error::new(
+					std::io::ErrorKind::TimedOut,
+					format!("connection establishment timed out after {timeout:?}"),
+				)
+			)),
+		}
+	}
+
+	async fn connect_to_inner(
+		&self,
+		version: Version,
+		pk: PK,
+	) -> Result<pool::HttpConnection, Error> {
 		let executor = self.exec.clone();
 		let is_ver_h2 = if version == Version::HTTP_2 {
 			// Explicitly HTTP2
@@ -533,6 +560,8 @@ impl<C: Clone, PK: pool::Key> Clone for Client<C, PK> {
 			h2_builder: self.h2_builder.clone(),
 			connector: self.connector.clone(),
 			pool: self.pool.clone(),
+			connect_timeout: self.connect_timeout,
+			timer: self.timer.clone(),
 		}
 	}
 }
@@ -781,6 +810,7 @@ pub struct Builder {
 	h2_builder: hyper::client::conn::http2::Builder<Exec>,
 	pool_config: pool::Config,
 	pool_timer: Option<timer::Timer>,
+	connect_timeout: Option<Duration>,
 }
 
 impl Builder {
@@ -800,8 +830,22 @@ impl Builder {
 				expected_http2_capacity: pool::DEFAULT_EXPECTED_HTTP2_CAPACITY,
 			},
 			pool_timer: None,
+			connect_timeout: None,
 		}
 	}
+
+	/// Set a timeout for establishing a connection, including the connector,
+	/// HTTP handshake, and initial sender readiness.
+	///
+	/// The default is no timeout.
+	pub fn connect_timeout<D>(&mut self, val: D) -> &mut Self
+	where
+		D: Into<Option<Duration>>,
+	{
+		self.connect_timeout = val.into();
+		self
+	}
+
 	/// Set an optional timeout for idle sockets being kept-alive.
 	/// A `Timer` is required for this to take effect. See `Builder::pool_timer`
 	///
@@ -1221,7 +1265,9 @@ impl Builder {
 			h1_builder: self.h1_builder.clone(),
 			h2_builder: self.h2_builder.clone(),
 			connector,
-			pool: pool::Pool::<PK>::new(self.pool_config, exec, timer),
+			pool: pool::Pool::<PK>::new(self.pool_config, exec, timer.clone()),
+			connect_timeout: self.connect_timeout,
+			timer,
 		}
 	}
 }
@@ -1268,6 +1314,11 @@ impl StdError for Error {
 }
 
 impl Error {
+	/// Returns true if establishing the connection exceeded its configured timeout.
+	pub fn is_connect_timeout(&self) -> bool {
+		matches!(self.kind, ErrorKind::ConnectTimeout)
+	}
+
 	/// Returns the info of the client connection on which this error occurred.
 	pub fn connect_info(&self) -> Option<&Connected> {
 		self.connect_info.as_ref()


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/2712

The issue was that while we had a TCP connection level timeout, we didn't have a
timeout for the full handshake. We would mark pending connections as "to
be shared once complete" but they would never complete causing up to 100
requests to be stuck on the connection to complete when it never would.

Signed-off-by: John Howard <john.howard@solo.io>
