### PR TITLE
database: split or share based on whether config is the same

### DIFF
--- a/crates/agentgateway-app/src/commands/run.rs
+++ b/crates/agentgateway-app/src/commands/run.rs
@@ -60,9 +60,15 @@ pub(crate) fn execute(args: RunArgs) -> anyhow::Result<()> {
 			} else {
 				None
 			};
-			let request_log_store = match config.database.as_ref() {
+			let request_log_store = match config.logging.database.as_ref() {
 				Some(cfg) => {
-					let pool = config_resource_store.as_ref().map(|store| store.pool());
+					let pool = config_resource_store.as_ref().and_then(|store| {
+						config
+							.database
+							.as_ref()
+							.filter(|database| cfg == *database)
+							.map(|_| store.pool())
+					});
 					match agentgateway::telemetry::log_store::setup_with_pool(cfg, pool).await {
 						Ok(store) => Some(store),
 						Err(err) => {

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -360,15 +360,35 @@ pub fn parse_config(
 		})
 		.or(raw.model_catalog)
 		.unwrap_or_default();
-	let shared_database = raw.database.clone();
-	let database = shared_database
-		.clone()
-		.or_else(|| raw.logging.as_ref().and_then(|l| l.database.clone()));
+	let database = raw.database.clone();
+	let explicit_logging_database = raw.logging.as_ref().and_then(|l| l.database.clone());
+	if database
+		.as_ref()
+		.is_some_and(|database| database.max_connections == Some(0))
+	{
+		anyhow::bail!("config.database.maxConnections must be greater than zero");
+	}
+	if explicit_logging_database
+		.as_ref()
+		.is_some_and(|database| database.max_connections == Some(0))
+	{
+		anyhow::bail!("config.logging.database.maxConnections must be greater than zero");
+	}
+	let logging_database = explicit_logging_database.or_else(|| database.clone());
 	let storage = StorageConfig {
 		mode: raw.storage.clone().unwrap_or_default().mode,
 	};
-	if storage.mode == ConfigStoreMode::Hybrid && shared_database.is_none() {
+	if storage.mode == ConfigStoreMode::Hybrid && database.is_none() {
 		anyhow::bail!("config.storage.mode=hybrid requires config.database.url");
+	}
+	if storage.mode == ConfigStoreMode::Hybrid
+		&& database.as_ref().is_some_and(|database| {
+			(database.url.starts_with("postgres://") || database.url.starts_with("postgresql://"))
+				&& database.max_connections == Some(1)
+		}) {
+		anyhow::bail!(
+			"config.database.maxConnections must be at least 2 for PostgreSQL hybrid storage"
+		);
 	}
 
 	Ok(crate::Config {
@@ -523,10 +543,10 @@ pub fn parse_config(
 				.as_ref()
 				.and_then(|l| l.format.clone())
 				.unwrap_or_default(),
-			database: database.clone(),
+			database: logging_database.clone(),
 				fields: logging_fields(raw.logging.as_ref().and_then(|f| f.fields.clone()))
 					.ctx("invalid config.logging.fields")?,
-				database_fields: if database.is_some() {
+				database_fields: if logging_database.is_some() {
 					database_logging_fields(raw.standard_attributes.as_ref())
 						.ctx("invalid config.standardAttributes")?
 				} else {
@@ -1266,6 +1286,11 @@ config:
 			config.database.as_ref().map(|db| db.url.as_str()),
 			Some("sqlite::memory:")
 		);
+		assert_eq!(
+			config.logging.database.as_ref().map(|db| db.url.as_str()),
+			Some("sqlite::memory:")
+		);
+		assert_eq!(config.database.as_ref(), config.logging.database.as_ref());
 
 		let err = parse_config(
 			r#"
@@ -1304,6 +1329,98 @@ config:
 				.to_string()
 				.contains("config.storage.mode=hybrid requires config.database.url"),
 			"unexpected error: {err}"
+		);
+	}
+
+	#[test]
+	fn primary_and_logging_databases_can_differ() {
+		let _env_lock = lock_env();
+		let config = parse_config(
+			r#"
+config:
+  database:
+    url: "postgres://config.example/database"
+    maxConnections: 7
+  logging:
+    database:
+      url: "postgres://logs.example/database"
+      maxConnections: 11
+  storage:
+    mode: hybrid
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should preserve both databases");
+
+		let database = config.database.as_ref().expect("primary database");
+		let logging_database = config.logging.database.as_ref().expect("logging database");
+		assert_eq!(database.url, "postgres://config.example/database");
+		assert_eq!(database.max_connections, Some(7));
+		assert_eq!(logging_database.url, "postgres://logs.example/database");
+		assert_eq!(logging_database.max_connections, Some(11));
+		assert_ne!(database, logging_database);
+	}
+
+	#[test]
+	fn legacy_logging_database_does_not_become_primary_database() {
+		let _env_lock = lock_env();
+		let config = parse_config(
+			r#"
+config:
+  logging:
+    database:
+      url: "sqlite::memory:"
+"#
+			.to_string(),
+			None,
+		)
+		.expect("legacy logging database should parse");
+
+		assert!(config.database.is_none());
+		assert_eq!(
+			config.logging.database.as_ref().map(|db| db.url.as_str()),
+			Some("sqlite::memory:")
+		);
+	}
+
+	#[test]
+	fn database_pool_sizes_must_be_usable() {
+		let _env_lock = lock_env();
+		let err = parse_config(
+			r#"
+config:
+  database:
+    url: "sqlite::memory:"
+    maxConnections: 0
+"#
+			.to_string(),
+			None,
+		)
+		.expect_err("zero-sized pool should fail");
+		assert!(
+			err
+				.to_string()
+				.contains("config.database.maxConnections must be greater than zero")
+		);
+
+		let err = parse_config(
+			r#"
+config:
+  database:
+    url: "postgres://database.example/database"
+    maxConnections: 1
+  storage:
+    mode: hybrid
+"#
+			.to_string(),
+			None,
+		)
+		.expect_err("PostgreSQL hybrid pool needs a slot besides its listener");
+		assert!(
+			err
+				.to_string()
+				.contains("maxConnections must be at least 2 for PostgreSQL hybrid storage")
 		);
 	}
 

--- a/crates/agentgateway/src/database.rs
+++ b/crates/agentgateway/src/database.rs
@@ -11,10 +11,7 @@ pub enum DatabasePool {
 	Postgres(PgPool),
 }
 
-/// Default pool size when `maxConnections` is not set in config. Kept small
-/// since agentgateway opens a separate pool per store (request log + config
-/// store) per process; each replica's total connection usage is roughly
-/// `2 * max_connections`.
+/// Default pool size when `maxConnections` is not set in config.
 const DEFAULT_MAX_CONNECTIONS: u32 = 5;
 
 impl DatabasePool {
@@ -27,6 +24,10 @@ impl DatabasePool {
 		max_connections: Option<u32>,
 	) -> anyhow::Result<Self> {
 		let max_connections = max_connections.unwrap_or(DEFAULT_MAX_CONNECTIONS);
+		anyhow::ensure!(
+			max_connections > 0,
+			"database maxConnections must be greater than zero"
+		);
 		if url.starts_with("postgres://") || url.starts_with("postgresql://") {
 			let pool = PgPoolOptions::new()
 				.max_connections(max_connections)

--- a/crates/agentgateway/src/telemetry/log_store.rs
+++ b/crates/agentgateway/src/telemetry/log_store.rs
@@ -20,13 +20,15 @@ static REQUEST_LOG_STORE: OnceLock<RequestLogStore> = OnceLock::new();
 static REQUEST_LOG_STORE_BACKLOG: AtomicUsize = AtomicUsize::new(0);
 
 #[apply(schema!)]
+#[derive(Eq, PartialEq)]
 pub struct Config {
 	/// Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.
 	pub url: String,
 	/// Maximum number of connections to open in this database's connection pool. Defaults to 5.
-	/// Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which
-	/// is sized independently from the same field when both share the same `url`.
+	/// When the request log and config stores have matching database settings, they share one pool
+	/// with this limit.
 	#[serde(default)]
+	#[cfg_attr(feature = "schema", schemars(range(min = 1)))]
 	pub max_connections: Option<u32>,
 }
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -668,13 +668,13 @@
           "type": "string"
         },
         "maxConnections": {
-          "description": "Maximum number of connections to open in this database's connection pool. Defaults to 5.\nNote this pool is separate from the config store's pool (config.storage.mode=hybrid), which\nis sized independently from the same field when both share the same `url`.",
+          "description": "Maximum number of connections to open in this database's connection pool. Defaults to 5.\nWhen the request log and config stores have matching database settings, they share one pool\nwith this limit.",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
-          "minimum": 0,
+          "minimum": 1,
           "default": null
         }
       },

--- a/schema/config.md
+++ b/schema/config.md
@@ -34,7 +34,7 @@
 |`config.modelCatalog[].inline.providers.*.models.*.tiers[].rates.outputAudio`|string|Cost per 1M output audio tokens. Falls back to the output rate if unset.|
 |`config.database`|object|Primary database used by local runtime features.|
 |`config.database.url`|string|Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.|
-|`config.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5.<br>Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which<br>is sized independently from the same field when both share the same `url`.|
+|`config.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5.<br>When the request log and config stores have matching database settings, they share one pool<br>with this limit.|
 |`config.storage`|object|Controls whether UI-managed configuration is written to the config file or a DB overlay.|
 |`config.storage.mode`|enum|Possible values: `file`, `hybrid`.|
 |`config.caAddress`|string|Address of the Certificate Authority used to issue SPIFFE certificates.|
@@ -82,7 +82,7 @@
 |`config.logging.format`|enum|Log output format: `text` or `json`.<br>Possible values: `text`, `json`, `null`.|
 |`config.logging.database`|object|Log-store database configuration; enables request logging to a database backend.|
 |`config.logging.database.url`|string|Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.|
-|`config.logging.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5.<br>Note this pool is separate from the config store's pool (config.storage.mode=hybrid), which<br>is sized independently from the same field when both share the same `url`.|
+|`config.logging.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5.<br>When the request log and config stores have matching database settings, they share one pool<br>with this limit.|
 |`config.metrics`|object|Metrics configuration, including metric removal and custom fields.|
 |`config.metrics.remove`|[]string|Metric names to exclude from collection.|
 |`config.metrics.fields`|object|Custom fields to add to all metrics.|


### PR DESCRIPTION
This allows us to have different database for either of these; before
the split was accidentally one always override the other when we
introduced shared-pooling.

Signed-off-by: John Howard <john.howard@solo.io>
