### PR TITLE
connect: scope internal bind lookup based on IP

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -734,9 +734,15 @@ impl Gateway {
 					};
 					let binds = inputs.stores.read_binds();
 					let (target_address, bind) = if let Ok(addr) = authority.parse::<SocketAddr>() {
-						// Match an exact bind for this address; otherwise fall back to the internal
-						// wildcard bind, preserving the requested address as the tunnel target.
-						let Some(bind) = binds.find_bind(addr).or_else(|| binds.find_wildcard_bind()) else {
+						// CONNECT re-entry must not expose a bind scoped to a concrete address
+						// (for example, a loopback-only listener). Match only an unspecified-address
+						// bind for this port; otherwise fall back to the explicit internal wildcard
+						// bind, preserving the requested address as the tunnel target.
+						let Some(bind) = binds
+							.find_bind(addr)
+							.filter(|b| b.address.ip().is_unspecified())
+							.or_else(|| binds.find_wildcard_bind())
+						else {
 							return Ok(ProxyError::BindNotFound.into_response_with_grpc(false));
 						};
 						(addr, bind)

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -1498,11 +1498,16 @@ impl Store {
 			.cloned()
 	}
 
+	/// Finds a wildcard-address bind by port.
+	///
+	/// This is used when a CONNECT authority contains a hostname rather than an IP address. Since
+	/// the hostname is not resolved here, it must not be allowed to select a bind scoped to a
+	/// concrete address (for example, a loopback-only listener) merely because the ports match.
 	pub fn find_bind_by_port(&self, port: u16) -> Option<Arc<Bind>> {
 		self
 			.binds
 			.values()
-			.find(|b| b.address.port() == port)
+			.find(|b| b.address.ip().is_unspecified() && b.address.port() == port)
 			.cloned()
 	}
 

--- a/crates/agentgateway/tests/tests/connect.rs
+++ b/crates/agentgateway/tests/tests/connect.rs
@@ -211,7 +211,7 @@ async fn incoming_connect_tunnel_reenters_bind_flow() {
 	outer.key = strng::literal!("outer");
 	outer.address = "127.0.0.1:15008".parse().unwrap();
 	let mut inner = simple_bind();
-	inner.address = "127.0.0.1:18080".parse().unwrap();
+	inner.address = "0.0.0.0:18080".parse().unwrap();
 	let t = setup_proxy_test("{}")
 		.unwrap()
 		.with_backend(*mock.address())
@@ -275,6 +275,7 @@ async fn incoming_connect_tunnel_reenters_internal_bind() {
 	outer.address = outer_addr;
 	let mut inner = simple_bind();
 	inner.address = inner_addr;
+	inner.address.set_ip("0.0.0.0".parse().unwrap());
 	// The inner bind is routing-only: it must not open a listener socket.
 	inner.mode = BindMode::Internal;
 	let t = setup_proxy_test("{}")
@@ -405,7 +406,7 @@ async fn incoming_connect_tunnel_exposes_connect_headers_to_cel() {
 		outer.key = strng::literal!("outer");
 		outer.address = "127.0.0.1:15008".parse().unwrap();
 		let mut inner = simple_bind();
-		inner.address = "127.0.0.1:18080".parse().unwrap();
+		inner.address = "0.0.0.0:18080".parse().unwrap();
 		let mut t = setup_proxy_test("{}")
 			.unwrap()
 			.with_backend(*mock.address())
@@ -511,7 +512,7 @@ async fn connect_tunnel_terminates_outer_tls() {
 
 		// INNER plain bind, re-entered by the CONNECT authority port.
 		let mut inner = simple_bind();
-		inner.address = "127.0.0.1:18083".parse().unwrap();
+		inner.address = "0.0.0.0:18083".parse().unwrap();
 
 		let mut t = setup_proxy_test("{}")
 			.unwrap()
@@ -698,7 +699,7 @@ async fn connect_tunnel_obo_exchange_injects_token() {
 	outer.key = strng::literal!("outer");
 	outer.address = "127.0.0.1:15008".parse().unwrap();
 	let mut inner = simple_bind();
-	inner.address = "127.0.0.1:18080".parse().unwrap();
+	inner.address = "0.0.0.0:18080".parse().unwrap();
 	let mut t = setup_proxy_test("{}")
 		.unwrap()
 		.with_backend(*upstream.address())
@@ -1009,7 +1010,7 @@ async fn connect_tunnel_dynamic_ca_obo_dynamic_backend() {
 	// Inner bind terminates TLS with the dynamic CA (empty hostname = match any SNI).
 	let inner = Bind {
 		key: BIND_KEY,
-		address: "127.0.0.1:18082".parse().unwrap(),
+		address: "0.0.0.0:18082".parse().unwrap(),
 		listeners: ListenerSet::from_list([Listener {
 			key: LISTENER_KEY,
 			name: Default::default(),


### PR DESCRIPTION
This is a theoretical issue as there is no user config that exposes the
bind address, but good future proofing.

Signed-off-by: John Howard <john.howard@solo.io>
