### PR TITLE
crypto: add crypto module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,7 +416,7 @@ jobs:
           - os: blacksmith-4vcpu-ubuntu-2404-arm
             target: aarch64-unknown-linux-musl
             # arm64 musl fails with jemalloc: https://github.com/tikv/jemallocator/issues/146
-            extra_cargo_args: "--no-default-features --features agentgateway-app/mimalloc,agentgateway-app/tls-aws-lc"
+            extra_cargo_args: "--no-default-features --features agentgateway-app/mimalloc,agentgateway-app/crypto-aws-lc"
             name: linux-arm
           - os: macos-26
             target: aarch64-apple-darwin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,6 @@ dependencies = [
  "serde_urlencoded",
  "serde_with",
  "serde_yaml",
- "sha2 0.11.0",
  "shellexpand",
  "socket2",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,6 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "openapiv3",
- "openssl",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -317,7 +316,6 @@ dependencies = [
  "rust_decimal",
  "rustls",
  "rustls-native-certs",
- "rustls-openssl",
  "rustls-pki-types",
  "schemars 1.2.1",
  "secrecy",
@@ -2721,21 +2719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,47 +4598,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -6165,17 +6111,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-openssl"
-version = "0.3.1"
+name = "rustls-pemfile"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce63aeefbba181bc32fe7519a3d7edcdfa9fc2aa1f5e7f152493a25275ec14a"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "foreign-types",
- "once_cell",
- "openssl",
- "openssl-sys",
- "rustls",
- "zeroize",
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6111,15 +6111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,6 @@ aws-types = "1.3"
 aws-smithy-eventstream = "0.61"
 aws-smithy-types = "1.3"
 aws-lc-rs = "1.17"
-openssl = "0.10"
-rustls-openssl = { version = "0.3", features = ["tls12"] }
 axum = { version = "0.8", features = ["macros"] }
 axum-core = "0.5"
 axum-extra = { version = "0.12", features = ["json-lines", "typed-header"] }
@@ -126,7 +124,7 @@ indexmap = { version = "2.13", features = ["serde"] }
 insta = { version = "1.47", features = ["json", "redactions", "filters", "yaml"] }
 ipnet = { version = "2.12", features = ["serde"] }
 itertools = "0.15"
-jsonwebtoken = { version = "10.4", features = ["aws_lc_rs"] }
+jsonwebtoken = { version = "10.4" }
 lazy_static = "1.5"
 libc = "0.2"
 notify = "8.2"

--- a/crates/agentgateway-app/Cargo.toml
+++ b/crates/agentgateway-app/Cargo.toml
@@ -20,7 +20,6 @@ mimalloc = ["dep:mimalloc", "agentgateway/mimalloc"]
 # Builds that pass `--no-default-features` (e.g. arm64 musl, which drops jemalloc) MUST re-add one
 # of these, otherwise the agentgateway crypto code will fail to compile.
 crypto-aws-lc = ["agentgateway/crypto-aws-lc"]
-crypto-openssl = ["agentgateway/crypto-openssl"]
 schema = ["agentgateway/schema"]
 
 [dependencies]

--- a/crates/agentgateway-app/Cargo.toml
+++ b/crates/agentgateway-app/Cargo.toml
@@ -13,14 +13,14 @@ bench = false
 [features]
 # Jemalloc has been found to have the highest throughput and best ability to return memory to the system
 # This comes at the small cost of a few mb memory overhead relative to others (most notable in an empty setup).
-default = ["jemalloc", "mimalloc", "tls-aws-lc"]
+default = ["jemalloc", "mimalloc", "crypto-aws-lc"]
 jemalloc = ["dep:tikv-jemallocator", "agentgateway/jemalloc"]
 mimalloc = ["dep:mimalloc", "agentgateway/mimalloc"]
-# TLS crypto provider passthroughs. A provider must be selected; `tls-aws-lc` is the default.
+# Crypto provider passthroughs. A provider must be selected; `crypto-aws-lc` is the default.
 # Builds that pass `--no-default-features` (e.g. arm64 musl, which drops jemalloc) MUST re-add one
-# of these, otherwise the agentgateway TLS code will fail to compile.
-tls-aws-lc = ["agentgateway/tls-aws-lc"]
-tls-openssl = ["agentgateway/tls-openssl"]
+# of these, otherwise the agentgateway crypto code will fail to compile.
+crypto-aws-lc = ["agentgateway/crypto-aws-lc"]
+crypto-openssl = ["agentgateway/crypto-openssl"]
 schema = ["agentgateway/schema"]
 
 [dependencies]

--- a/crates/agentgateway-app/src/lib.rs
+++ b/crates/agentgateway-app/src/lib.rs
@@ -126,6 +126,9 @@ pub fn run() -> anyhow::Result<()> {
 			pprof_alloc::configure_with_default(Allocator::System)?;
 		}
 	}
+	// Install the process-global crypto providers for the compiled-in backend
+	// (currently the JWT provider) before any cryptographic work.
+	agentgateway::crypto::init();
 	let args = Cli::parse();
 	match args.command {
 		#[cfg(target_os = "linux")]

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -129,7 +129,6 @@ serde_urlencoded.workspace = true
 serde_with.workspace = true
 serde_yaml.workspace = true
 serde-untagged.workspace = true
-sha2.workspace = true
 stacker.workspace = true
 shellexpand.workspace = true
 socket2.workspace = true

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -12,8 +12,10 @@ path = "src/lib.rs"
 default = ["jemalloc", "mimalloc", "crypto-aws-lc"]
 jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
 mimalloc = ["pprof-alloc/allocator-mimalloc", "dep:mimalloc"]
-crypto-aws-lc = ["rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs"]
-crypto-openssl = ["dep:openssl", "dep:rustls-openssl"]
+# Crypto provider selection. `crypto-aws-lc` (the default) is currently the only
+# backend; it pulls in aws-lc-rs. Selecting a different backend in the future
+# drops aws-lc-rs entirely.
+crypto-aws-lc = ["dep:aws-lc-rs", "rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs", "jsonwebtoken/aws_lc_rs"]
 ui = []
 schema = ["schemars", "agent-core/schema", "agent-llm/schema"]
 internal_benches = ["divan"]
@@ -37,9 +39,7 @@ aws-config.workspace = true
 aws-credential-types.workspace = true
 aws-sigv4.workspace = true
 aws-types.workspace = true
-aws-lc-rs.workspace = true
-openssl = { workspace = true, optional = true }
-rustls-openssl = { workspace = true, optional = true }
+aws-lc-rs = { workspace = true, optional = true }
 aws-smithy-eventstream.workspace = true
 aws-smithy-types.workspace = true
 axum-core.workspace = true

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -9,11 +9,11 @@ publish = { workspace = true }
 path = "src/lib.rs"
 
 [features]
-default = ["jemalloc", "mimalloc", "tls-aws-lc"]
+default = ["jemalloc", "mimalloc", "crypto-aws-lc"]
 jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
 mimalloc = ["pprof-alloc/allocator-mimalloc", "dep:mimalloc"]
-tls-aws-lc = ["rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs"]
-tls-openssl = ["dep:openssl", "dep:rustls-openssl"]
+crypto-aws-lc = ["rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs"]
+crypto-openssl = ["dep:openssl", "dep:rustls-openssl"]
 ui = []
 schema = ["schemars", "agent-core/schema", "agent-llm/schema"]
 internal_benches = ["divan"]

--- a/crates/agentgateway/src/crypto/aead.rs
+++ b/crates/agentgateway/src/crypto/aead.rs
@@ -1,0 +1,112 @@
+//! Authenticated encryption (AEAD) primitives.
+//!
+//! This is the single seam through which agentgateway performs symmetric
+//! authenticated encryption. It is currently backed by `aws-lc-rs`, which is
+//! always linked regardless of the selected TLS provider feature. Additional
+//! backends (e.g. SymCrypt) plug in here behind `#[cfg]` without changing call
+//! sites.
+
+use aws_lc_rs::aead::{AES_256_GCM, Aad, Nonce, RandomizedNonceKey};
+
+/// Length in bytes of the AES-256-GCM nonce that [`Aes256Gcm::seal`] prepends to
+/// each sealed message.
+const NONCE_LEN: usize = 12;
+
+/// AES-256-GCM authenticated encryption keyed with a caller-provided 32-byte key.
+///
+/// [`seal`](Aes256Gcm::seal) generates a fresh random nonce per message and
+/// returns `nonce || ciphertext || tag`; [`open`](Aes256Gcm::open) expects that
+/// same framing.
+#[derive(Debug)]
+pub struct Aes256Gcm {
+	key: RandomizedNonceKey,
+}
+
+impl Aes256Gcm {
+	/// Creates an AES-256-GCM key from 32 bytes of key material.
+	pub fn new(key: &[u8]) -> Result<Self, AeadError> {
+		let key = RandomizedNonceKey::new(&AES_256_GCM, key).map_err(|_| AeadError::InvalidKey)?;
+		Ok(Self { key })
+	}
+
+	/// Seals `plaintext`, returning `nonce || ciphertext || tag`.
+	pub fn seal(&self, plaintext: &[u8]) -> Result<Vec<u8>, AeadError> {
+		let mut in_out = plaintext.to_vec();
+		// Generates a random nonce and appends the authentication tag in place.
+		let nonce = self
+			.key
+			.seal_in_place_append_tag(Aad::empty(), &mut in_out)
+			.map_err(|_| AeadError::EncryptionFailed)?;
+
+		let mut result = nonce.as_ref().to_vec();
+		result.extend_from_slice(&in_out);
+		Ok(result)
+	}
+
+	/// Opens data framed as `nonce || ciphertext || tag`, returning the plaintext.
+	pub fn open(&self, data: &[u8]) -> Result<Vec<u8>, AeadError> {
+		if data.len() < NONCE_LEN {
+			return Err(AeadError::InvalidFormat);
+		}
+
+		let (nonce_bytes, ciphertext) = data.split_at(NONCE_LEN);
+		let nonce =
+			Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| AeadError::InvalidFormat)?;
+		let mut in_out = ciphertext.to_vec();
+		let plaintext = self
+			.key
+			.open_in_place(nonce, Aad::empty(), &mut in_out)
+			.map_err(|_| AeadError::DecryptionFailed)?;
+		Ok(plaintext.to_vec())
+	}
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AeadError {
+	#[error("invalid key")]
+	InvalidKey,
+	#[error("encryption failed")]
+	EncryptionFailed,
+	#[error("decryption failed")]
+	DecryptionFailed,
+	#[error("invalid format")]
+	InvalidFormat,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{AeadError, Aes256Gcm};
+
+	#[test]
+	fn round_trip() {
+		let key = Aes256Gcm::new(&[7u8; 32]).expect("key");
+		let sealed = key.seal(b"hello world").expect("seal");
+		assert_ne!(sealed, b"hello world");
+		assert_eq!(key.open(&sealed).expect("open"), b"hello world");
+	}
+
+	#[test]
+	fn short_input_fails_cleanly() {
+		let key = Aes256Gcm::new(&[0u8; 32]).expect("key");
+		assert!(matches!(key.open(&[0u8; 11]), Err(AeadError::InvalidFormat)));
+	}
+
+	#[test]
+	fn tampered_ciphertext_fails() {
+		let key = Aes256Gcm::new(&[1u8; 32]).expect("key");
+		let mut sealed = key.seal(b"secret").expect("seal");
+		let last = sealed.len() - 1;
+		sealed[last] ^= 0xff;
+		assert!(matches!(
+			key.open(&sealed),
+			Err(AeadError::DecryptionFailed)
+		));
+	}
+
+	#[test]
+	fn wrong_key_fails() {
+		let sealed = Aes256Gcm::new(&[1u8; 32]).expect("key").seal(b"x").expect("seal");
+		let other = Aes256Gcm::new(&[2u8; 32]).expect("key");
+		assert!(matches!(other.open(&sealed), Err(AeadError::DecryptionFailed)));
+	}
+}

--- a/crates/agentgateway/src/crypto/aead.rs
+++ b/crates/agentgateway/src/crypto/aead.rs
@@ -1,11 +1,11 @@
 //! Authenticated encryption (AEAD) primitives.
 //!
 //! This is the single seam through which agentgateway performs symmetric
-//! authenticated encryption. It is currently backed by `aws-lc-rs`, which is
-//! always linked regardless of the selected TLS provider feature. Additional
-//! backends (e.g. SymCrypt) plug in here behind `#[cfg]` without changing call
-//! sites.
+//! authenticated encryption. The backend is selected by the `crypto-*` feature;
+//! `crypto-aws-lc` (the default) backs it with `aws-lc-rs`. Additional backends
+//! plug in here behind `#[cfg]` without changing call sites.
 
+#[cfg(feature = "crypto-aws-lc")]
 use aws_lc_rs::aead::{AES_256_GCM, Aad, Nonce, RandomizedNonceKey};
 
 /// Length in bytes of the AES-256-GCM nonce that [`Aes256Gcm::seal`] prepends to
@@ -17,11 +17,13 @@ const NONCE_LEN: usize = 12;
 /// [`seal`](Aes256Gcm::seal) generates a fresh random nonce per message and
 /// returns `nonce || ciphertext || tag`; [`open`](Aes256Gcm::open) expects that
 /// same framing.
+#[cfg(feature = "crypto-aws-lc")]
 #[derive(Debug)]
 pub struct Aes256Gcm {
 	key: RandomizedNonceKey,
 }
 
+#[cfg(feature = "crypto-aws-lc")]
 impl Aes256Gcm {
 	/// Creates an AES-256-GCM key from 32 bytes of key material.
 	pub fn new(key: &[u8]) -> Result<Self, AeadError> {

--- a/crates/agentgateway/src/crypto/aead.rs
+++ b/crates/agentgateway/src/crypto/aead.rs
@@ -90,7 +90,10 @@ mod tests {
 	#[test]
 	fn short_input_fails_cleanly() {
 		let key = Aes256Gcm::new(&[0u8; 32]).expect("key");
-		assert!(matches!(key.open(&[0u8; 11]), Err(AeadError::InvalidFormat)));
+		assert!(matches!(
+			key.open(&[0u8; 11]),
+			Err(AeadError::InvalidFormat)
+		));
 	}
 
 	#[test]
@@ -107,8 +110,14 @@ mod tests {
 
 	#[test]
 	fn wrong_key_fails() {
-		let sealed = Aes256Gcm::new(&[1u8; 32]).expect("key").seal(b"x").expect("seal");
+		let sealed = Aes256Gcm::new(&[1u8; 32])
+			.expect("key")
+			.seal(b"x")
+			.expect("seal");
 		let other = Aes256Gcm::new(&[2u8; 32]).expect("key");
-		assert!(matches!(other.open(&sealed), Err(AeadError::DecryptionFailed)));
+		assert!(matches!(
+			other.open(&sealed),
+			Err(AeadError::DecryptionFailed)
+		));
 	}
 }

--- a/crates/agentgateway/src/crypto/digest.rs
+++ b/crates/agentgateway/src/crypto/digest.rs
@@ -1,0 +1,76 @@
+//! Cryptographic hash functions.
+//!
+//! This is the seam for hashing within the `agentgateway` crate. It is
+//! currently backed by `aws-lc-rs`, which is always linked regardless of the
+//! selected TLS provider feature. Additional backends (e.g. SymCrypt) plug in
+//! here behind `#[cfg]` without changing call sites.
+//!
+//! Note: hashing in sibling crates (`agent-celx`, `htpasswd-verify-fork`) still
+//! uses the RustCrypto crates directly, as they cannot depend on this crate.
+//! Consolidating those requires a shared crypto crate and is tracked separately.
+
+use aws_lc_rs::digest::{self, Context, SHA256};
+
+/// Length in bytes of a SHA-256 digest.
+pub const SHA256_LEN: usize = 32;
+
+/// Computes the SHA-256 digest of `data` in one shot.
+pub fn sha256(data: &[u8]) -> [u8; SHA256_LEN] {
+	to_array(digest::digest(&SHA256, data).as_ref())
+}
+
+/// Incremental SHA-256 hasher, for data supplied in multiple pieces.
+pub struct Sha256(Context);
+
+impl Sha256 {
+	/// Creates a new, empty SHA-256 hasher.
+	pub fn new() -> Self {
+		Self(Context::new(&SHA256))
+	}
+
+	/// Adds `data` to the running digest.
+	pub fn update(&mut self, data: impl AsRef<[u8]>) {
+		self.0.update(data.as_ref());
+	}
+
+	/// Consumes the hasher and returns the final digest.
+	pub fn finalize(self) -> [u8; SHA256_LEN] {
+		to_array(self.0.finish().as_ref())
+	}
+}
+
+impl Default for Sha256 {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+fn to_array(bytes: &[u8]) -> [u8; SHA256_LEN] {
+	let mut out = [0u8; SHA256_LEN];
+	out.copy_from_slice(bytes);
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{Sha256, sha256};
+
+	// SHA-256("abc") known-answer vector (FIPS 180-4).
+	const ABC: [u8; 32] = [
+		0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+		0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad,
+	];
+
+	#[test]
+	fn one_shot_matches_known_answer() {
+		assert_eq!(sha256(b"abc"), ABC);
+	}
+
+	#[test]
+	fn incremental_matches_one_shot() {
+		let mut h = Sha256::new();
+		h.update(b"a");
+		h.update(b"bc");
+		assert_eq!(h.finalize(), ABC);
+	}
+}

--- a/crates/agentgateway/src/crypto/digest.rs
+++ b/crates/agentgateway/src/crypto/digest.rs
@@ -1,27 +1,31 @@
 //! Cryptographic hash functions.
 //!
-//! This is the seam for hashing within the `agentgateway` crate. It is
-//! currently backed by `aws-lc-rs`, which is always linked regardless of the
-//! selected TLS provider feature. Additional backends (e.g. SymCrypt) plug in
-//! here behind `#[cfg]` without changing call sites.
+//! This is the seam for hashing within the `agentgateway` crate. The backend is
+//! selected by the `crypto-*` feature; `crypto-aws-lc` (the default) backs it
+//! with `aws-lc-rs`. Additional backends plug in here behind `#[cfg]` without
+//! changing call sites.
 //!
 //! Note: hashing in sibling crates (`agent-celx`, `htpasswd-verify-fork`) still
 //! uses the RustCrypto crates directly, as they cannot depend on this crate.
 //! Consolidating those requires a shared crypto crate and is tracked separately.
 
+#[cfg(feature = "crypto-aws-lc")]
 use aws_lc_rs::digest::{self, Context, SHA256};
 
 /// Length in bytes of a SHA-256 digest.
 pub const SHA256_LEN: usize = 32;
 
 /// Computes the SHA-256 digest of `data` in one shot.
+#[cfg(feature = "crypto-aws-lc")]
 pub fn sha256(data: &[u8]) -> [u8; SHA256_LEN] {
 	to_array(digest::digest(&SHA256, data).as_ref())
 }
 
 /// Incremental SHA-256 hasher, for data supplied in multiple pieces.
+#[cfg(feature = "crypto-aws-lc")]
 pub struct Sha256(Context);
 
+#[cfg(feature = "crypto-aws-lc")]
 impl Sha256 {
 	/// Creates a new, empty SHA-256 hasher.
 	pub fn new() -> Self {
@@ -39,12 +43,14 @@ impl Sha256 {
 	}
 }
 
+#[cfg(feature = "crypto-aws-lc")]
 impl Default for Sha256 {
 	fn default() -> Self {
 		Self::new()
 	}
 }
 
+#[cfg(feature = "crypto-aws-lc")]
 fn to_array(bytes: &[u8]) -> [u8; SHA256_LEN] {
 	let mut out = [0u8; SHA256_LEN];
 	out.copy_from_slice(bytes);

--- a/crates/agentgateway/src/crypto/jwt.rs
+++ b/crates/agentgateway/src/crypto/jwt.rs
@@ -1,0 +1,19 @@
+//! JWT crypto seam.
+//!
+//! JWT crypto lives inside the `jsonwebtoken` crate, which routes its
+//! `encode`/`decode` through its own process-global provider. Rather than
+//! wrapping those calls, this module just selects which provider is active for
+//! the compiled-in `crypto-*` backend, via [`init`].
+
+/// Installs the process-global JWT crypto provider for the compiled-in backend.
+///
+/// Call once at startup, before any JWT signing or verification. Idempotent.
+pub fn init() {
+	#[cfg(feature = "crypto-aws-lc")]
+	{
+		// aws-lc-rs is already jsonwebtoken's default; installing explicitly keeps
+		// the choice in this seam. A backend with no built-in provider (e.g.
+		// SymCrypt) would install a custom one here instead.
+		let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
+	}
+}

--- a/crates/agentgateway/src/crypto/mod.rs
+++ b/crates/agentgateway/src/crypto/mod.rs
@@ -1,0 +1,37 @@
+//! Central cryptography module.
+//!
+//! Policy: all cryptographic operations in agentgateway SHOULD go through this
+//! module so that the underlying crypto backend is pluggable and auditable. The
+//! active backend is selected at compile time via mutually-exclusive `tls-*`
+//! features (see [`CRYPTO_BACKEND`]).
+//!
+//! Some operations cannot yet be routed through a pluggable backend (for
+//! example certificate generation via `rcgen`, or legacy password hashing).
+//! Such documented exceptions must be guarded with the appropriate
+//! `#[cfg(feature = ...)]` so the backend in use stays explicit.
+
+// Exactly one crypto backend must be selected at compile time.
+#[cfg(not(any(feature = "tls-aws-lc", feature = "tls-openssl")))]
+compile_error!(
+	"no crypto backend selected: enable exactly one of the `tls-aws-lc` or `tls-openssl` features"
+);
+
+#[cfg(all(feature = "tls-aws-lc", feature = "tls-openssl"))]
+compile_error!(
+	"multiple crypto backends selected: enable exactly one of the `tls-aws-lc` or `tls-openssl` features"
+);
+
+pub mod aead;
+pub mod digest;
+pub mod provider;
+pub mod rand;
+
+pub use provider::{provider, provider_with_cipher_suites, provider_with_options};
+
+/// Human-readable name of the crypto backend compiled into this binary. Useful
+/// for startup logging and diagnostics.
+#[cfg(feature = "tls-aws-lc")]
+pub const CRYPTO_BACKEND: &str = "aws-lc-rs";
+
+#[cfg(feature = "tls-openssl")]
+pub const CRYPTO_BACKEND: &str = "openssl";

--- a/crates/agentgateway/src/crypto/mod.rs
+++ b/crates/agentgateway/src/crypto/mod.rs
@@ -11,14 +11,14 @@
 //! `#[cfg(feature = ...)]` so the backend in use stays explicit.
 
 // Exactly one crypto backend must be selected at compile time.
-#[cfg(not(any(feature = "tls-aws-lc", feature = "tls-openssl")))]
+#[cfg(not(any(feature = "crypto-aws-lc", feature = "crypto-openssl")))]
 compile_error!(
-	"no crypto backend selected: enable exactly one of the `tls-aws-lc` or `tls-openssl` features"
+	"no crypto backend selected: enable exactly one of the `crypto-aws-lc` or `crypto-openssl` features"
 );
 
-#[cfg(all(feature = "tls-aws-lc", feature = "tls-openssl"))]
+#[cfg(all(feature = "crypto-aws-lc", feature = "crypto-openssl"))]
 compile_error!(
-	"multiple crypto backends selected: enable exactly one of the `tls-aws-lc` or `tls-openssl` features"
+	"multiple crypto backends selected: enable exactly one of the `crypto-aws-lc` or `crypto-openssl` features"
 );
 
 pub mod aead;
@@ -30,8 +30,8 @@ pub use provider::{provider, provider_with_cipher_suites, provider_with_options}
 
 /// Human-readable name of the crypto backend compiled into this binary. Useful
 /// for startup logging and diagnostics.
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 pub const CRYPTO_BACKEND: &str = "aws-lc-rs";
 
-#[cfg(feature = "tls-openssl")]
+#[cfg(feature = "crypto-openssl")]
 pub const CRYPTO_BACKEND: &str = "openssl";

--- a/crates/agentgateway/src/crypto/mod.rs
+++ b/crates/agentgateway/src/crypto/mod.rs
@@ -2,36 +2,37 @@
 //!
 //! Policy: all cryptographic operations in agentgateway SHOULD go through this
 //! module so that the underlying crypto backend is pluggable and auditable. The
-//! active backend is selected at compile time via mutually-exclusive `tls-*`
-//! features (see [`CRYPTO_BACKEND`]).
+//! active backend is selected at compile time via `crypto-*` features (see
+//! [`CRYPTO_BACKEND`]).
 //!
 //! Some operations cannot yet be routed through a pluggable backend (for
 //! example certificate generation via `rcgen`, or legacy password hashing).
 //! Such documented exceptions must be guarded with the appropriate
 //! `#[cfg(feature = ...)]` so the backend in use stays explicit.
 
-// Exactly one crypto backend must be selected at compile time.
-#[cfg(not(any(feature = "crypto-aws-lc", feature = "crypto-openssl")))]
-compile_error!(
-	"no crypto backend selected: enable exactly one of the `crypto-aws-lc` or `crypto-openssl` features"
-);
-
-#[cfg(all(feature = "crypto-aws-lc", feature = "crypto-openssl"))]
-compile_error!(
-	"multiple crypto backends selected: enable exactly one of the `crypto-aws-lc` or `crypto-openssl` features"
-);
+// A crypto backend must be selected at compile time. `crypto-aws-lc` is currently
+// the only backend; as additional providers are added this becomes an
+// exactly-one-of guard.
+#[cfg(not(feature = "crypto-aws-lc"))]
+compile_error!("no crypto backend selected: enable the `crypto-aws-lc` feature");
 
 pub mod aead;
 pub mod digest;
-pub mod provider;
+pub mod jwt;
 pub mod rand;
+pub mod tls;
 
-pub use provider::{provider, provider_with_cipher_suites, provider_with_options};
+pub use tls::{provider, provider_with_cipher_suites, provider_with_options};
+
+/// Initializes process-global crypto state for the compiled-in backend.
+///
+/// Call once at startup, before any cryptographic operation that depends on an
+/// installed provider (currently JWT signing/verification via [`jwt`]).
+pub fn init() {
+	jwt::init();
+}
 
 /// Human-readable name of the crypto backend compiled into this binary. Useful
 /// for startup logging and diagnostics.
 #[cfg(feature = "crypto-aws-lc")]
 pub const CRYPTO_BACKEND: &str = "aws-lc-rs";
-
-#[cfg(feature = "crypto-openssl")]
-pub const CRYPTO_BACKEND: &str = "openssl";

--- a/crates/agentgateway/src/crypto/provider.rs
+++ b/crates/agentgateway/src/crypto/provider.rs
@@ -1,0 +1,66 @@
+//! Construction of the rustls [`CryptoProvider`] for the compiled-in backend.
+//!
+//! This is the single place where the concrete crypto backend is selected. All
+//! TLS configuration should obtain its provider from here (via [`provider`] or
+//! [`provider_with_options`]) rather than referencing a backend crate directly.
+
+use std::sync::Arc;
+
+use rustls::crypto::CryptoProvider;
+
+use crate::transport::tls::{
+	CipherSuite, DEFAULT_CIPHER_SUITES, DEFAULT_KEY_EXCHANGE_GROUPS, KeyExchangeGroup,
+};
+
+/// Returns a [`CryptoProvider`] for the compiled-in backend using the default
+/// cipher suites and key exchange groups.
+pub fn provider() -> Arc<CryptoProvider> {
+	provider_with_options(&[], &[])
+}
+
+/// Returns a [`CryptoProvider`] restricted to the given cipher suites and key
+/// exchange groups. An empty slice means "use the backend defaults".
+pub fn provider_with_options(
+	cipher_suites: &[CipherSuite],
+	key_exchange_groups: &[KeyExchangeGroup],
+) -> Arc<CryptoProvider> {
+	let cipher_suites = if cipher_suites.is_empty() {
+		DEFAULT_CIPHER_SUITES.to_vec()
+	} else {
+		cipher_suites
+			.iter()
+			.map(CipherSuite::to_supported_cipher_suite)
+			.collect()
+	};
+
+	let key_exchange_groups = if key_exchange_groups.is_empty() {
+		DEFAULT_KEY_EXCHANGE_GROUPS.to_vec()
+	} else {
+		key_exchange_groups
+			.iter()
+			.map(KeyExchangeGroup::to_supported_kx_group)
+			.collect()
+	};
+
+	let mut provider = default_crypto_provider();
+	// Restrict negotiation to our allowlist.
+	provider.cipher_suites = cipher_suites;
+	provider.kx_groups = key_exchange_groups;
+	Arc::new(provider)
+}
+
+/// Returns a [`CryptoProvider`] restricted to the given cipher suites, using the
+/// default key exchange groups.
+pub fn provider_with_cipher_suites(cipher_suites: &[CipherSuite]) -> Arc<CryptoProvider> {
+	provider_with_options(cipher_suites, &[])
+}
+
+#[cfg(feature = "tls-aws-lc")]
+fn default_crypto_provider() -> CryptoProvider {
+	rustls::crypto::aws_lc_rs::default_provider()
+}
+
+#[cfg(feature = "tls-openssl")]
+fn default_crypto_provider() -> CryptoProvider {
+	rustls_openssl::default_provider()
+}

--- a/crates/agentgateway/src/crypto/provider.rs
+++ b/crates/agentgateway/src/crypto/provider.rs
@@ -55,12 +55,12 @@ pub fn provider_with_cipher_suites(cipher_suites: &[CipherSuite]) -> Arc<CryptoP
 	provider_with_options(cipher_suites, &[])
 }
 
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 fn default_crypto_provider() -> CryptoProvider {
 	rustls::crypto::aws_lc_rs::default_provider()
 }
 
-#[cfg(feature = "tls-openssl")]
+#[cfg(feature = "crypto-openssl")]
 fn default_crypto_provider() -> CryptoProvider {
 	rustls_openssl::default_provider()
 }

--- a/crates/agentgateway/src/crypto/rand.rs
+++ b/crates/agentgateway/src/crypto/rand.rs
@@ -1,0 +1,47 @@
+//! Cryptographically-secure random number generation.
+//!
+//! This is the single seam for CSPRNG output in agentgateway. It is currently
+//! backed by `aws-lc-rs`, which is always linked regardless of the selected TLS
+//! provider feature. Additional backends (e.g. SymCrypt) plug in here behind
+//! `#[cfg]` without changing call sites.
+
+use aws_lc_rs::rand::{SecureRandom, SystemRandom};
+
+/// Fills `dest` with cryptographically-secure random bytes.
+///
+/// Returns [`RandError`] only if the system CSPRNG fails, which callers should
+/// treat as unrecoverable.
+pub fn fill(dest: &mut [u8]) -> Result<(), RandError> {
+	SystemRandom::new().fill(dest).map_err(|_| RandError)
+}
+
+/// Returns `len` cryptographically-secure random bytes.
+pub fn bytes(len: usize) -> Result<Vec<u8>, RandError> {
+	let mut out = vec![0u8; len];
+	fill(&mut out)?;
+	Ok(out)
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("secure random generation failed")]
+pub struct RandError;
+
+#[cfg(test)]
+mod tests {
+	use super::{bytes, fill};
+
+	#[test]
+	fn fill_produces_nonzero_and_distinct() {
+		let mut a = [0u8; 32];
+		let mut b = [0u8; 32];
+		fill(&mut a).expect("fill a");
+		fill(&mut b).expect("fill b");
+		assert_ne!(a, [0u8; 32], "output should not be all zeros");
+		assert_ne!(a, b, "two draws should differ");
+	}
+
+	#[test]
+	fn bytes_returns_requested_len() {
+		assert_eq!(bytes(16).expect("bytes").len(), 16);
+	}
+}

--- a/crates/agentgateway/src/crypto/rand.rs
+++ b/crates/agentgateway/src/crypto/rand.rs
@@ -1,21 +1,24 @@
 //! Cryptographically-secure random number generation.
 //!
-//! This is the single seam for CSPRNG output in agentgateway. It is currently
-//! backed by `aws-lc-rs`, which is always linked regardless of the selected TLS
-//! provider feature. Additional backends (e.g. SymCrypt) plug in here behind
-//! `#[cfg]` without changing call sites.
+//! This is the single seam for CSPRNG output in agentgateway. The backend is
+//! selected by the `crypto-*` feature; `crypto-aws-lc` (the default) backs it
+//! with `aws-lc-rs`. Additional backends plug in here behind `#[cfg]` without
+//! changing call sites.
 
+#[cfg(feature = "crypto-aws-lc")]
 use aws_lc_rs::rand::{SecureRandom, SystemRandom};
 
 /// Fills `dest` with cryptographically-secure random bytes.
 ///
 /// Returns [`RandError`] only if the system CSPRNG fails, which callers should
 /// treat as unrecoverable.
+#[cfg(feature = "crypto-aws-lc")]
 pub fn fill(dest: &mut [u8]) -> Result<(), RandError> {
 	SystemRandom::new().fill(dest).map_err(|_| RandError)
 }
 
 /// Returns `len` cryptographically-secure random bytes.
+#[cfg(feature = "crypto-aws-lc")]
 pub fn bytes(len: usize) -> Result<Vec<u8>, RandError> {
 	let mut out = vec![0u8; len];
 	fill(&mut out)?;

--- a/crates/agentgateway/src/crypto/tls.rs
+++ b/crates/agentgateway/src/crypto/tls.rs
@@ -59,8 +59,3 @@ pub fn provider_with_cipher_suites(cipher_suites: &[CipherSuite]) -> Arc<CryptoP
 fn default_crypto_provider() -> CryptoProvider {
 	rustls::crypto::aws_lc_rs::default_provider()
 }
-
-#[cfg(feature = "crypto-openssl")]
-fn default_crypto_provider() -> CryptoProvider {
-	rustls_openssl::default_provider()
-}

--- a/crates/agentgateway/src/http/apikey.rs
+++ b/crates/agentgateway/src/http/apikey.rs
@@ -3,7 +3,6 @@ use std::hash::Hash;
 use ::cel::Value;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Deserializer, Serializer};
-use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
 use crate::http::Request;
@@ -111,7 +110,7 @@ pub struct APIKeyHash(
 
 impl APIKeyHash {
 	pub fn from_raw_key(key: &str) -> Self {
-		let digest = Sha256::digest(key.as_bytes());
+		let digest = crate::crypto::digest::sha256(key.as_bytes());
 		APIKeyHash(hex::encode(digest))
 	}
 

--- a/crates/agentgateway/src/http/auth/oauth/cache.rs
+++ b/crates/agentgateway/src/http/auth/oauth/cache.rs
@@ -5,10 +5,10 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use quick_cache::sync::{Cache, EntryAction, EntryResult};
 use secrecy::{ExposeSecret, SecretString};
-use sha2::{Digest, Sha256};
 
 use super::transport::TokenEndpointResponse;
 use super::{ExchangeRequest, decode_unverified_jwt_claims};
+use crate::crypto::digest::Sha256;
 
 pub(super) const DEFAULT_CACHE_CAPACITY: usize = 8192;
 pub(super) const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(300);
@@ -134,7 +134,7 @@ impl CacheKeyDigest {
 	}
 
 	fn finish(self) -> TokenCacheKey {
-		TokenCacheKey(self.0.finalize().into())
+		TokenCacheKey(self.0.finalize())
 	}
 }
 

--- a/crates/agentgateway/src/http/auth/oauth/client_auth.rs
+++ b/crates/agentgateway/src/http/auth/oauth/client_auth.rs
@@ -8,7 +8,6 @@ use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use rustls::pki_types::PrivateKeyDer;
 use rustls::pki_types::pem::PemObject;
 use secrecy::{ExposeSecret, SecretString};
-use sha2::{Digest, Sha256};
 use tracing::warn;
 
 use crate::serdes::FileOrInline;
@@ -366,7 +365,7 @@ fn load_certificate_headers(
 		},
 		CertificateHeader::X5tS256 => CertificateHeaders {
 			x5c: None,
-			x5t_s256: Some(URL_SAFE_NO_PAD.encode(Sha256::digest(leaf.contents()))),
+			x5t_s256: Some(URL_SAFE_NO_PAD.encode(crate::crypto::digest::sha256(leaf.contents()))),
 		},
 	})
 }

--- a/crates/agentgateway/src/http/oidc/callback.rs
+++ b/crates/agentgateway/src/http/oidc/callback.rs
@@ -51,8 +51,8 @@ pub(super) fn start_login(
 	let nonce = generate_nonce();
 	let pkce_verifier = generate_pkce_verifier();
 	let code_challenge = {
-		let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, pkce_verifier.as_bytes());
-		base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest.as_ref())
+		let digest = crate::crypto::digest::sha256(pkce_verifier.as_bytes());
+		base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest)
 	};
 	let original_uri = normalize_original_uri(req.uri().path_and_query());
 	let transaction = TransactionState {

--- a/crates/agentgateway/src/http/oidc/session.rs
+++ b/crates/agentgateway/src/http/oidc/session.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 
 use base64::Engine;
 use cookie::{Cookie, SameSite};
-use rand::RngExt;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Serialize, Serializer};
 
@@ -221,9 +220,9 @@ pub enum CookieSecureMode {
 }
 
 pub(super) fn derive_cookie_names(policy_id: &PolicyId) -> (String, String) {
-	let digest = aws_lc_rs::digest::digest(&aws_lc_rs::digest::SHA256, policy_id.as_str().as_bytes());
+	let digest = crate::crypto::digest::sha256(policy_id.as_str().as_bytes());
 	let mut hex = String::with_capacity(32);
-	for byte in digest.as_ref().iter().take(8) {
+	for byte in digest.iter().take(8) {
 		let _ = write!(&mut hex, "{byte:02x}");
 	}
 	(
@@ -271,7 +270,7 @@ fn is_safe_local_redirect_target(target: &str) -> bool {
 
 fn random_token(bytes: usize) -> String {
 	let mut random = vec![0; bytes];
-	rand::rng().fill(random.as_mut_slice());
+	crate::crypto::rand::fill(&mut random).expect("secure RNG must not fail");
 	base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(random)
 }
 

--- a/crates/agentgateway/src/http/sessionpersistence.rs
+++ b/crates/agentgateway/src/http/sessionpersistence.rs
@@ -151,56 +151,40 @@ mod base64 {
 }
 
 mod aes {
-	use aws_lc_rs::aead::{AES_256_GCM, Aad, Nonce, RandomizedNonceKey};
 	use base64::Engine;
 	use base64::engine::general_purpose::STANDARD;
 
+	use crate::crypto::aead::{AeadError, Aes256Gcm};
+
 	#[derive(Debug)]
 	pub struct Encoder {
-		key: RandomizedNonceKey,
+		key: Aes256Gcm,
 	}
 
 	impl Encoder {
 		/// Create from a 32-byte key
 		pub fn new(key: &[u8]) -> Result<Self, Error> {
-			let key = RandomizedNonceKey::new(&AES_256_GCM, key).map_err(|_| Error::InvalidKey)?;
+			let key = Aes256Gcm::new(key).map_err(|_| Error::InvalidKey)?;
 			Ok(Self { key })
 		}
 
 		/// Encrypt and base64 encode
 		pub fn encrypt(&self, plaintext: &str) -> Result<String, Error> {
-			let mut in_out: Vec<u8> = plaintext.as_bytes().to_vec();
-			// Seal automatically generates a random nonce and prepends it
-			let nonce = self
+			let sealed = self
 				.key
-				.seal_in_place_append_tag(Aad::empty(), &mut in_out)
+				.seal(plaintext.as_bytes())
 				.map_err(|_| Error::EncryptionFailed)?;
-
-			// Format: nonce || ciphertext+tag
-			let mut result = nonce.as_ref().to_vec();
-			result.extend_from_slice(&in_out);
-			// Base64 encode
-			Ok(STANDARD.encode(&result))
+			// Format: nonce || ciphertext+tag, base64 encoded
+			Ok(STANDARD.encode(&sealed))
 		}
 
 		/// Decode and decrypt
 		pub fn decrypt(&self, encoded: &str) -> Result<Vec<u8>, Error> {
-			// Base64 decode
 			let data = STANDARD.decode(encoded).map_err(|_| Error::InvalidFormat)?;
-			if data.len() < 12 {
-				return Err(Error::InvalidFormat);
-			}
-
-			// Extract nonce and ciphertext
-			let (nonce_bytes, ciphertext) = data.split_at(12);
-			let nonce =
-				Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| Error::InvalidFormat)?;
-			let mut in_out = ciphertext.to_vec();
-			let plaintext = self
-				.key
-				.open_in_place(nonce, Aad::empty(), &mut in_out)
-				.map_err(|_| Error::DecryptionFailed)?;
-			Ok(plaintext.to_vec())
+			self.key.open(&data).map_err(|e| match e {
+				AeadError::InvalidFormat => Error::InvalidFormat,
+				_ => Error::DecryptionFailed,
+			})
 		}
 	}
 

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -29,6 +29,7 @@ pub mod client;
 pub mod config;
 pub mod config_store;
 pub mod control;
+pub mod crypto;
 pub mod database;
 pub mod http;
 pub mod json;

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -1238,6 +1238,7 @@ pub fn setup_proxy_test(cfg: &str) -> anyhow::Result<TestBind> {
 }
 
 pub fn setup_proxy_test_with_config(config: crate::Config) -> TestBind {
+	crate::crypto::init();
 	let encoder = config.session_encoder.clone();
 	let stores = Stores::new(config.ipv6_enabled, config.threading_mode);
 	let client = client::Client::new(&config.dns, None, Default::default(), None);

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -378,8 +378,8 @@ pub async fn simple_mock() -> MockServer {
 // Spawn a mock TLS server. It will always respond on h2,http/1.1 ALPN
 // Note: wiremock generates test certs via rcgen (which uses aws_lc_rs internally).
 // The OpenSSL KeyProvider cannot parse the DER keys that aws_lc_rs produces,
-// so this function is only available with the tls-aws-lc feature.
-#[cfg(feature = "tls-aws-lc")]
+// so this function is only available with the crypto-aws-lc feature.
+#[cfg(feature = "crypto-aws-lc")]
 pub async fn tls_mock() -> (MockServer, MockTlsCertificates) {
 	let _ = rustls::crypto::CryptoProvider::install_default(Arc::unwrap_or_clone(tls::provider()));
 	let certs = wiremock::tls_certs::MockTlsCertificates::random();

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use agent_core::strng;
 use agent_core::strng::Strng;
 use futures_util::TryFutureExt;
-use rustls::crypto::{CryptoProvider, SupportedKxGroup};
+use rustls::crypto::SupportedKxGroup;
 use rustls::server::ParsedCertificate;
 use rustls::{ServerConfig, SupportedCipherSuite};
 use rustls_pki_types::{CertificateDer, InvalidDnsNameError, ServerName};
@@ -18,6 +18,10 @@ use crate::apply;
 use crate::serdes::schema;
 use crate::transport::stream::Socket;
 use crate::types::discovery::Identity;
+
+// Provider construction lives in the central `crypto` module; re-export here so
+// existing `transport::tls::provider*` call sites keep working unchanged.
+pub use crate::crypto::provider::{provider, provider_with_cipher_suites, provider_with_options};
 
 pub static ALL_TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] =
 	&[&rustls::version::TLS12, &rustls::version::TLS13];
@@ -258,10 +262,6 @@ impl KeyExchangeGroup {
 	}
 }
 
-pub fn provider() -> Arc<CryptoProvider> {
-	provider_with_options(&[], &[])
-}
-
 /// Returns a shared rustls `KeyLog`. On release builds this always returns
 /// `NoKeyLog` so TLS session secrets can never be logged in production. On
 /// debug builds, honors `SSLKEYLOGFILE` (NSS keylog format) for use with
@@ -293,49 +293,6 @@ pub fn warn_if_key_log_enabled() {
 	{
 		warn!("SSLKEYLOGFILE={path}; TLS session secrets will be written to disk (debug build only).");
 	}
-}
-
-pub fn provider_with_options(
-	cipher_suites: &[CipherSuite],
-	key_exchange_groups: &[KeyExchangeGroup],
-) -> Arc<CryptoProvider> {
-	let cipher_suites = if cipher_suites.is_empty() {
-		DEFAULT_CIPHER_SUITES.to_vec()
-	} else {
-		cipher_suites
-			.iter()
-			.map(CipherSuite::to_supported_cipher_suite)
-			.collect()
-	};
-
-	let key_exchange_groups = if key_exchange_groups.is_empty() {
-		DEFAULT_KEY_EXCHANGE_GROUPS.to_vec()
-	} else {
-		key_exchange_groups
-			.iter()
-			.map(KeyExchangeGroup::to_supported_kx_group)
-			.collect()
-	};
-
-	let mut provider = default_crypto_provider();
-	// Restrict negotiation to our allowlist.
-	provider.cipher_suites = cipher_suites;
-	provider.kx_groups = key_exchange_groups;
-	Arc::new(provider)
-}
-
-#[cfg(feature = "tls-aws-lc")]
-fn default_crypto_provider() -> CryptoProvider {
-	rustls::crypto::aws_lc_rs::default_provider()
-}
-
-#[cfg(feature = "tls-openssl")]
-fn default_crypto_provider() -> CryptoProvider {
-	rustls_openssl::default_provider()
-}
-
-pub fn provider_with_cipher_suites(cipher_suites: &[CipherSuite]) -> Arc<CryptoProvider> {
-	provider_with_options(cipher_suites, &[])
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -15,13 +15,12 @@ use tracing::warn;
 use x509_parser::certificate::X509Certificate;
 
 use crate::apply;
-use crate::serdes::schema;
-use crate::transport::stream::Socket;
-use crate::types::discovery::Identity;
-
 // Provider construction lives in the central `crypto` module; re-export here so
 // existing `transport::tls::provider*` call sites keep working unchanged.
 pub use crate::crypto::tls::{provider, provider_with_cipher_suites, provider_with_options};
+use crate::serdes::schema;
+use crate::transport::stream::Socket;
+use crate::types::discovery::Identity;
 
 pub static ALL_TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] =
 	&[&rustls::version::TLS12, &rustls::version::TLS13];

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -21,7 +21,7 @@ use crate::types::discovery::Identity;
 
 // Provider construction lives in the central `crypto` module; re-export here so
 // existing `transport::tls::provider*` call sites keep working unchanged.
-pub use crate::crypto::provider::{provider, provider_with_cipher_suites, provider_with_options};
+pub use crate::crypto::tls::{provider, provider_with_cipher_suites, provider_with_options};
 
 pub static ALL_TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] =
 	&[&rustls::version::TLS12, &rustls::version::TLS13];
@@ -42,19 +42,6 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
-/// All currently supported cipher suites (OpenSSL provider).
-#[cfg(feature = "crypto-openssl")]
-pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
-	// TLS 1.3 cipher suites
-	rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
-	rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
-	// TLS 1.2 cipher suites
-	rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-	rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-];
-
 // Default cipher suites to use if user does not specify cipher suites
 #[cfg(feature = "crypto-aws-lc")]
 pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
@@ -66,31 +53,12 @@ pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 ];
 
-#[cfg(feature = "crypto-openssl")]
-pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
-	rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
-	rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
-	rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-	rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-];
-
 #[cfg(feature = "crypto-aws-lc")]
 pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
 	KeyExchangeGroup::X25519.to_supported_kx_group(),
 	KeyExchangeGroup::P256.to_supported_kx_group(),
 	KeyExchangeGroup::P384.to_supported_kx_group(),
 	KeyExchangeGroup::X25519_MLKEM768.to_supported_kx_group(),
-];
-
-#[cfg(feature = "crypto-openssl")]
-pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
-	rustls_openssl::kx_group::X25519,
-	rustls_openssl::kx_group::SECP256R1,
-	rustls_openssl::kx_group::SECP384R1,
-	#[cfg(ossl350)]
-	rustls_openssl::kx_group::X25519MLKEM768,
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -181,39 +149,6 @@ impl CipherSuite {
 			},
 		}
 	}
-
-	#[cfg(feature = "crypto-openssl")]
-	pub fn to_supported_cipher_suite(&self) -> SupportedCipherSuite {
-		match self {
-			// TLS 1.3 cipher suites
-			CipherSuite::TLS_AES_256_GCM_SHA384 => rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
-			CipherSuite::TLS_AES_128_GCM_SHA256 => rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
-			// ChaCha20 is not universally available in OpenSSL; fall back to AES
-			CipherSuite::TLS_CHACHA20_POLY1305_SHA256 => {
-				rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256
-			},
-
-			// TLS 1.2 cipher suites
-			CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => {
-				rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-			},
-			CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => {
-				rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-			},
-			CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => {
-				rustls_openssl::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-			},
-			CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => {
-				rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-			},
-			CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => {
-				rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-			},
-			CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => {
-				rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-			},
-		}
-	}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -245,19 +180,6 @@ impl KeyExchangeGroup {
 			KeyExchangeGroup::P256 => rustls::crypto::aws_lc_rs::kx_group::SECP256R1,
 			KeyExchangeGroup::P384 => rustls::crypto::aws_lc_rs::kx_group::SECP384R1,
 			KeyExchangeGroup::X25519_MLKEM768 => rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768,
-		}
-	}
-
-	#[cfg(feature = "crypto-openssl")]
-	pub fn to_supported_kx_group(&self) -> &'static dyn SupportedKxGroup {
-		match self {
-			KeyExchangeGroup::X25519 => rustls_openssl::kx_group::X25519,
-			KeyExchangeGroup::P256 => rustls_openssl::kx_group::SECP256R1,
-			KeyExchangeGroup::P384 => rustls_openssl::kx_group::SECP384R1,
-			#[cfg(ossl350)]
-			KeyExchangeGroup::X25519_MLKEM768 => rustls_openssl::kx_group::X25519MLKEM768,
-			#[cfg(not(ossl350))]
-			KeyExchangeGroup::X25519_MLKEM768 => rustls_openssl::kx_group::X25519,
 		}
 	}
 }

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -27,7 +27,7 @@ pub static ALL_TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] =
 	&[&rustls::version::TLS12, &rustls::version::TLS13];
 
 /// All currently supported cipher suites.
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	// TLS 1.3 cipher suites
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
@@ -43,7 +43,7 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 ];
 
 /// All currently supported cipher suites (OpenSSL provider).
-#[cfg(feature = "tls-openssl")]
+#[cfg(feature = "crypto-openssl")]
 pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	// TLS 1.3 cipher suites
 	rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
@@ -56,7 +56,7 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 ];
 
 // Default cipher suites to use if user does not specify cipher suites
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
@@ -66,7 +66,7 @@ pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 ];
 
-#[cfg(feature = "tls-openssl")]
+#[cfg(feature = "crypto-openssl")]
 pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls_openssl::cipher_suite::TLS13_AES_256_GCM_SHA384,
 	rustls_openssl::cipher_suite::TLS13_AES_128_GCM_SHA256,
@@ -76,7 +76,7 @@ pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls_openssl::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 ];
 
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
 	KeyExchangeGroup::X25519.to_supported_kx_group(),
 	KeyExchangeGroup::P256.to_supported_kx_group(),
@@ -84,7 +84,7 @@ pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
 	KeyExchangeGroup::X25519_MLKEM768.to_supported_kx_group(),
 ];
 
-#[cfg(feature = "tls-openssl")]
+#[cfg(feature = "crypto-openssl")]
 pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
 	rustls_openssl::kx_group::X25519,
 	rustls_openssl::kx_group::SECP256R1,
@@ -146,7 +146,7 @@ impl CipherSuite {
 		}
 	}
 
-	#[cfg(feature = "tls-aws-lc")]
+	#[cfg(feature = "crypto-aws-lc")]
 	pub const fn to_supported_cipher_suite(&self) -> SupportedCipherSuite {
 		match self {
 			// TLS 1.3 cipher suites
@@ -182,7 +182,7 @@ impl CipherSuite {
 		}
 	}
 
-	#[cfg(feature = "tls-openssl")]
+	#[cfg(feature = "crypto-openssl")]
 	pub fn to_supported_cipher_suite(&self) -> SupportedCipherSuite {
 		match self {
 			// TLS 1.3 cipher suites
@@ -238,7 +238,7 @@ impl KeyExchangeGroup {
 		}
 	}
 
-	#[cfg(feature = "tls-aws-lc")]
+	#[cfg(feature = "crypto-aws-lc")]
 	pub const fn to_supported_kx_group(&self) -> &'static dyn SupportedKxGroup {
 		match self {
 			KeyExchangeGroup::X25519 => rustls::crypto::aws_lc_rs::kx_group::X25519,
@@ -248,7 +248,7 @@ impl KeyExchangeGroup {
 		}
 	}
 
-	#[cfg(feature = "tls-openssl")]
+	#[cfg(feature = "crypto-openssl")]
 	pub fn to_supported_kx_group(&self) -> &'static dyn SupportedKxGroup {
 		match self {
 			KeyExchangeGroup::X25519 => rustls_openssl::kx_group::X25519,

--- a/crates/agentgateway/tests/common/hbone_server.rs
+++ b/crates/agentgateway/tests/common/hbone_server.rs
@@ -44,8 +44,6 @@ impl HboneTestServer {
 	pub async fn new(mode: Mode, name: &str, waypoint_message: Vec<u8>, port: u16) -> Self {
 		#[cfg(feature = "crypto-aws-lc")]
 		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-		#[cfg(feature = "crypto-openssl")]
-		let _ = rustls_openssl::default_provider().install_default();
 
 		let addr = SocketAddr::from(([127, 0, 0, 1], port));
 		let listener = TcpListener::bind(addr).await.unwrap();

--- a/crates/agentgateway/tests/common/hbone_server.rs
+++ b/crates/agentgateway/tests/common/hbone_server.rs
@@ -42,8 +42,9 @@ pub struct HboneTestServer {
 impl HboneTestServer {
 	/// Creates a new HBONE test server. If port is 0, the OS will assign an available port.
 	pub async fn new(mode: Mode, name: &str, waypoint_message: Vec<u8>, port: u16) -> Self {
-		#[cfg(feature = "crypto-aws-lc")]
-		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+		let _ = rustls::crypto::CryptoProvider::install_default(Arc::unwrap_or_clone(
+			agentgateway::transport::tls::provider(),
+		));
 
 		let addr = SocketAddr::from(([127, 0, 0, 1], port));
 		let listener = TcpListener::bind(addr).await.unwrap();

--- a/crates/agentgateway/tests/common/hbone_server.rs
+++ b/crates/agentgateway/tests/common/hbone_server.rs
@@ -42,9 +42,9 @@ pub struct HboneTestServer {
 impl HboneTestServer {
 	/// Creates a new HBONE test server. If port is 0, the OS will assign an available port.
 	pub async fn new(mode: Mode, name: &str, waypoint_message: Vec<u8>, port: u16) -> Self {
-		#[cfg(feature = "tls-aws-lc")]
+		#[cfg(feature = "crypto-aws-lc")]
 		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-		#[cfg(feature = "tls-openssl")]
+		#[cfg(feature = "crypto-openssl")]
 		let _ = rustls_openssl::default_provider().install_default();
 
 		let addr = SocketAddr::from(([127, 0, 0, 1], port));

--- a/crates/agentgateway/tests/tests/connect.rs
+++ b/crates/agentgateway/tests/tests/connect.rs
@@ -53,7 +53,7 @@ async fn tunnel_absolute_form() {
 }
 
 #[tokio::test]
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 async fn tunnel_connect() {
 	let (mock, _certs) = tls_mock().await;
 	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -909,7 +909,7 @@ async fn connect_tunnel_obo_exchange_injects_token() {
 /// minting a trusted per-SNI cert, (3) `ConnectHeaders` surviving
 /// `maybe_terminate_tls` into the OBO body, and (4) the decrypted request flowing
 /// into the `dynamic: {}` backend path.
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 #[tokio::test]
 async fn connect_tunnel_dynamic_ca_obo_dynamic_backend() {
 	use std::collections::HashMap;

--- a/crates/agentgateway/tests/tests/tls.rs
+++ b/crates/agentgateway/tests/tests/tls.rs
@@ -210,7 +210,7 @@ async fn tls_connection_drains_when_listener_changes() {
 }
 
 #[tokio::test]
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 async fn tls_backend_connection() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = agentgateway::http::backendtls::ResolvedBackendTLS {
@@ -243,7 +243,7 @@ async fn tls_backend_connection() {
 }
 
 #[tokio::test]
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 async fn tls_backend_connection_alpn() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = agentgateway::http::backendtls::ResolvedBackendTLS {
@@ -285,7 +285,7 @@ async fn tls_backend_connection_alpn() {
 }
 
 #[tokio::test]
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 async fn tls_backend_http2_version() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = agentgateway::http::backendtls::ResolvedBackendTLS {
@@ -327,7 +327,7 @@ async fn tls_backend_http2_version() {
 }
 
 #[tokio::test]
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 async fn tls_backend_http1_version() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = agentgateway::http::backendtls::ResolvedBackendTLS {
@@ -369,7 +369,7 @@ async fn tls_backend_http1_version() {
 }
 
 #[tokio::test]
-#[cfg(feature = "tls-aws-lc")]
+#[cfg(feature = "crypto-aws-lc")]
 async fn tls_backend_version_with_alpn() {
 	let (mock, certs) = tls_mock().await;
 	let backend_tls = agentgateway::http::backendtls::ResolvedBackendTLS {


### PR DESCRIPTION
Completes P0 of https://github.com/agentgateway/agentgateway/issues/2641

Changes:

- Rename the crypto flag from `tls-{provider-name}` to `crypto-{provider-name}`
- Drop support for the openssl provider
- Created the `crypto` module containing wrappers for various crypto function calls around the codebase: `aaed`, `digest`, `jwt`, and `rand`
- Moved the `rustls` crypto provider selection logic into `crypto/tls.rs` 
- Added `jsonwebtoken` provider selection in `crypto/jwt.rs`

This adds the base functions which other crypto providers can implement to serve as the source for all cryptography in agentgateway. Default will always be `aws-lc`. The `crypto-*` flag will control which provider implements the crypto module functions, the crypto provider selected for rustls + jsonwebtoken, and eventually the provider for rcgen (when they add that).