### PR TITLE
mcp: avoid logging synthetic session id

### DIFF
--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -39,6 +39,9 @@ pub struct Session {
 	relay: Arc<Relay>,
 	pub id: Arc<str>,
 	tx: Option<Sender<ServerJsonRpcMessage>>,
+	// Stateless requests still use Session internally, but this ID is not an MCP protocol session
+	// ID: it is neither registered nor sent to the client and must not appear in access logs.
+	synthetic: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -278,10 +281,10 @@ impl Session {
 	pub async fn delete_session(&self, parts: Parts) -> Result<Response, ProxyError> {
 		let ctx = IncomingRequestContext::new(&parts);
 		let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "delete_session");
-		let session_id = self.id.to_string();
+		let session_id = (!self.synthetic).then(|| self.id.to_string());
 		log.non_atomic_mutate(|l| {
 			// NOTE: l.method_name keep None to respect the metrics logic: not handle GET, DELETE.
-			l.session_id = Some(session_id);
+			l.session_id = session_id;
 		});
 		Self::handle_error(None, self.relay.send_fanout_deletion(ctx).await, false).await
 	}
@@ -335,10 +338,10 @@ impl Session {
 	pub async fn get_stream(&self, parts: Parts) -> Result<Response, ProxyError> {
 		let ctx = IncomingRequestContext::new(&parts);
 		let (_span, log, _cel) = mcp::handler::setup_request_log(parts, "get_stream");
-		let session_id = self.id.to_string();
+		let session_id = (!self.synthetic).then(|| self.id.to_string());
 		log.non_atomic_mutate(|l| {
 			// NOTE: l.method_name keep None to respect the metrics logic: which do not want to handle GET, DELETE.
-			l.session_id = Some(session_id);
+			l.session_id = session_id;
 		});
 		Self::handle_error(None, self.relay.send_fanout_get(ctx).await, false).await
 	}
@@ -386,10 +389,10 @@ impl Session {
 		let method = init_request.method.as_str().to_string();
 		let ctx = IncomingRequestContext::new(&parts);
 		let (_, log, _) = mcp::handler::setup_request_log(parts, &method);
-		let session_id = self.id.to_string();
+		let session_id = (!self.synthetic).then(|| self.id.to_string());
 		log.non_atomic_mutate(|l| {
 			l.method_name = Some(method.clone());
-			l.session_id = Some(session_id);
+			l.session_id = session_id;
 		});
 
 		self.strip_unsupported_client_capabilities(&mut init_request.params.capabilities, &ctx);
@@ -416,10 +419,10 @@ impl Session {
 		let method = initialized.method.as_str().to_string();
 		let ctx = IncomingRequestContext::new(&parts);
 		let (_, log, _) = mcp::handler::setup_request_log(parts, &method);
-		let session_id = self.id.to_string();
+		let session_id = (!self.synthetic).then(|| self.id.to_string());
 		log.non_atomic_mutate(|l| {
 			l.method_name = Some(method.clone());
-			l.session_id = Some(session_id);
+			l.session_id = session_id;
 		});
 
 		self
@@ -445,10 +448,10 @@ impl Session {
 				let method = r.request.method().to_string();
 				let mut ctx = IncomingRequestContext::new(&parts);
 				let (mut span, log, cel) = mcp::handler::setup_request_log(parts, &method);
-				let session_id = self.id.to_string();
+				let session_id = (!self.synthetic).then(|| self.id.to_string());
 				log.non_atomic_mutate(|l| {
 					l.method_name = Some(method.clone());
-					l.session_id = Some(session_id);
+					l.session_id = session_id;
 				});
 				self.strip_unsupported_client_capabilities_from_meta(&mut r.request, &ctx);
 				match &mut r.request {
@@ -712,10 +715,10 @@ impl Session {
 				};
 				let ctx = IncomingRequestContext::new(&parts);
 				let (_span, log, _cel) = mcp::handler::setup_request_log(parts, method);
-				let session_id = self.id.to_string();
+				let session_id = (!self.synthetic).then(|| self.id.to_string());
 				log.non_atomic_mutate(|l| {
 					l.method_name = Some(method.to_string());
-					l.session_id = Some(session_id);
+					l.session_id = session_id;
 				});
 				// TODO: the notification needs to be fanned out in some cases and sent to a single one in others
 				// however, we don't have a way to map to the correct service yet
@@ -829,6 +832,7 @@ impl SessionManager {
 			id: id.into(),
 			relay: Arc::new(relay),
 			tx: None,
+			synthetic: false,
 			encoder: self.encoder.clone(),
 		};
 		let mut sm = self.sessions.write().expect("write lock");
@@ -853,6 +857,7 @@ impl SessionManager {
 			id: id.clone(),
 			relay: Arc::new(relay),
 			tx: None,
+			synthetic: false,
 			encoder: self.encoder.clone(),
 		}
 	}
@@ -880,6 +885,7 @@ impl SessionManager {
 			id,
 			relay: Arc::new(relay),
 			tx: None,
+			synthetic: true,
 			encoder: self.encoder.clone(),
 		}
 	}
@@ -898,6 +904,7 @@ impl SessionManager {
 			id: id.clone(),
 			relay: Arc::new(relay),
 			tx: Some(tx),
+			synthetic: false,
 			encoder: self.encoder.clone(),
 		};
 		let mut sm = self.sessions.write().expect("write lock");


### PR DESCRIPTION
These are not the mcp-session-id so logging it as such is wrong

Signed-off-by: John Howard <john.howard@solo.io>
