### PR TITLE
mcp: validate response body shape and log async errors

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -2345,6 +2345,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			prompt: None,
 			resource: None,
 			task: None,
+			error: None,
 		}),
 		backend: Some(BackendContext {
 			name: "my-backend".into(),

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -65,29 +65,37 @@ fn duplicate_names<'a>(enabled: bool, names: impl Iterator<Item = &'a str>) -> H
 fn per_target_deduped<T>(
 	streams: Vec<(Strng, ServerResult)>,
 	reject_duplicates: bool,
-	extract: impl Fn(ServerResult) -> Vec<T>,
+	extract: impl Fn(ServerResult) -> Result<Vec<T>, ClientError>,
 	name: impl for<'a> Fn(&'a T) -> &'a str,
-) -> Vec<(Strng, Vec<T>)> {
+) -> Result<Vec<(Strng, Vec<T>)>, ClientError> {
 	let per_target = streams
 		.into_iter()
-		.map(|(server_name, s)| (server_name, extract(s)))
-		.collect_vec();
+		.map(|(server_name, s)| Ok((server_name, extract(s)?)))
+		.collect::<Result<Vec<_>, ClientError>>()?;
 	let duplicates = duplicate_names(
 		reject_duplicates,
 		per_target
 			.iter()
 			.flat_map(|(_, items)| items.iter().map(&name)),
 	);
-	per_target
-		.into_iter()
-		.map(|(server_name, items)| {
-			let items = items
-				.into_iter()
-				.filter(|item| !duplicates.contains(name(item)))
-				.collect_vec();
-			(server_name, items)
-		})
-		.collect_vec()
+	Ok(
+		per_target
+			.into_iter()
+			.map(|(server_name, items)| {
+				let items = items
+					.into_iter()
+					.filter(|item| !duplicates.contains(name(item)))
+					.collect_vec();
+				(server_name, items)
+			})
+			.collect_vec(),
+	)
+}
+
+fn incompatible_upstream_result(method: &str) -> ClientError {
+	ClientError::new(anyhow::anyhow!(
+		"upstream returned a result incompatible with `{method}`"
+	))
 }
 
 /// Returns the byte length of an RFC 3986 scheme prefix ending at `:`, if present.
@@ -457,6 +465,19 @@ impl Relay {
 			let Some(result) = Self::first_response(con.generic_stream(req, ctx).await?).await? else {
 				return Ok(false);
 			};
+			if !matches!(
+				(kind, &result),
+				(ResolveKind::Tool, ServerResult::ListToolsResult(_))
+					| (ResolveKind::Prompt, ServerResult::ListPromptsResult(_))
+			) {
+				return Err(UpstreamError::InvalidRequest(format!(
+					"upstream returned a result incompatible with `{}`",
+					match kind {
+						ResolveKind::Tool => "tools/list",
+						ResolveKind::Prompt => "prompts/list",
+					}
+				)));
+			}
 			if kind.contains_name(&result, name) {
 				return Ok(true);
 			}
@@ -684,11 +705,11 @@ impl Relay {
 				streams,
 				reject_duplicates,
 				|s| match s {
-					ServerResult::ListToolsResult(ltr) => ltr.tools,
-					_ => vec![],
+					ServerResult::ListToolsResult(ltr) => Ok(ltr.tools),
+					_ => Err(incompatible_upstream_result("tools/list")),
 				},
 				|tool| tool.name.as_ref(),
-			);
+			)?;
 			let tools = per_target
 				.into_iter()
 				.flat_map(|(server_name, tools)| {
@@ -730,25 +751,14 @@ impl Relay {
 		Box::new(move |s, _cel| {
 			if !multiplexing {
 				// Happy case: we can forward everything
-				let res = s.into_iter().next().and_then(|(name, r)| match r {
-					ServerResult::InitializeResult(ir) => Some((name, ir)),
-					_ => None,
-				});
-				if let Some((name, ir)) = res {
-					upstreams.record_extensions(name.as_str(), ir.capabilities.extensions.as_ref());
-					return Ok(ir.into());
-				}
-				// If we got here in FailOpen mode, it means the only target failed.
-				// Return a default info response to keep the client session alive.
-				return Ok(
-					Self::get_info(
-						pv,
-						resource_subscribe,
-						Vec::new(),
-						upstreams.merged_extensions(&HashMap::new()),
-					)
-					.into(),
-				);
+				let Some((name, result)) = s.into_iter().next() else {
+					return Err(incompatible_upstream_result("initialize"));
+				};
+				let ServerResult::InitializeResult(ir) = result else {
+					return Err(incompatible_upstream_result("initialize"));
+				};
+				upstreams.record_extensions(name.as_str(), ir.capabilities.extensions.as_ref());
+				return Ok(ir.into());
 			}
 
 			// Multiplexing is more complex. We need to find the lowest protocol version
@@ -757,16 +767,17 @@ impl Relay {
 			let mut upstream_instructions: Vec<(String, String)> = Vec::new();
 
 			for (server_name, v) in s {
-				if let ServerResult::InitializeResult(r) = v {
-					upstreams.record_extensions(server_name.as_str(), r.capabilities.extensions.as_ref());
-					if r.protocol_version.to_string() < lowest_version.to_string() {
-						lowest_version = r.protocol_version;
-					}
-					if let Some(instructions) = r.instructions
-						&& !instructions.is_empty()
-					{
-						upstream_instructions.push((server_name.to_string(), instructions));
-					}
+				let ServerResult::InitializeResult(r) = v else {
+					return Err(incompatible_upstream_result("initialize"));
+				};
+				upstreams.record_extensions(server_name.as_str(), r.capabilities.extensions.as_ref());
+				if r.protocol_version.to_string() < lowest_version.to_string() {
+					lowest_version = r.protocol_version;
+				}
+				if let Some(instructions) = r.instructions
+					&& !instructions.is_empty()
+				{
+					upstream_instructions.push((server_name.to_string(), instructions));
 				}
 			}
 
@@ -790,29 +801,18 @@ impl Relay {
 			// does no version translation, so an old-only upstream must surface as-is and let
 			// the client fall back to `initialize`. Multiplexed: advertise the intersection.
 			if !multiplexing {
-				let res = s.into_iter().next().and_then(|(_, r)| match r {
-					ServerResult::DiscoverResult(dr) => Some(dr),
-					_ => None,
-				});
-				if let Some(dr) = res {
-					// Cache hints describe the gateway's presented server, not the upstream.
-					// Gateway routing/backend config can change without client invalidation.
-					return Ok(
-						dr.with_ttl_ms(0)
-							.with_cache_scope(CacheScope::Private)
-							.into(),
-					);
-				}
-				// In FailOpen, a default discovery response lets the client continue negotiation
-				// when no upstream discovery response is available.
-				// Include the recorded extensions from initialize responses.
+				let Some((_, result)) = s.into_iter().next() else {
+					return Err(incompatible_upstream_result("server/discover"));
+				};
+				let ServerResult::DiscoverResult(dr) = result else {
+					return Err(incompatible_upstream_result("server/discover"));
+				};
+				// Cache hints describe the gateway's presented server, not the upstream.
+				// Gateway routing/backend config can change without client invalidation.
 				return Ok(
-					Self::get_discovery(
-						resource_subscribe,
-						Vec::new(),
-						upstreams.merged_extensions(&HashMap::new()),
-					)
-					.into(),
+					dr.with_ttl_ms(0)
+						.with_cache_scope(CacheScope::Private)
+						.into(),
 				);
 			}
 
@@ -820,18 +820,19 @@ impl Relay {
 			let mut supported_versions = ProtocolVersion::KNOWN_VERSIONS.to_vec();
 			let mut upstream_extensions: HashMap<Strng, ExtensionCapabilities> = HashMap::new();
 			for (server_name, v) in s {
-				if let ServerResult::DiscoverResult(mut r) = v {
-					if let Some(ext) = r.capabilities.extensions.take()
-						&& !ext.is_empty()
-					{
-						upstream_extensions.insert(server_name.clone(), ext);
-					}
-					supported_versions.retain(|version| r.supported_versions.contains(version));
-					if let Some(instructions) = r.instructions
-						&& !instructions.is_empty()
-					{
-						upstream_instructions.push((server_name.to_string(), instructions));
-					}
+				let ServerResult::DiscoverResult(mut r) = v else {
+					return Err(incompatible_upstream_result("server/discover"));
+				};
+				if let Some(ext) = r.capabilities.extensions.take()
+					&& !ext.is_empty()
+				{
+					upstream_extensions.insert(server_name.clone(), ext);
+				}
+				supported_versions.retain(|version| r.supported_versions.contains(version));
+				if let Some(instructions) = r.instructions
+					&& !instructions.is_empty()
+				{
+					upstream_instructions.push((server_name.to_string(), instructions));
 				}
 			}
 
@@ -854,11 +855,11 @@ impl Relay {
 				streams,
 				reject_duplicates,
 				|s| match s {
-					ServerResult::ListPromptsResult(lpr) => lpr.prompts,
-					_ => vec![],
+					ServerResult::ListPromptsResult(lpr) => Ok(lpr.prompts),
+					_ => Err(incompatible_upstream_result("prompts/list")),
 				},
 				|prompt| prompt.name.as_str(),
-			);
+			)?;
 			let prompts = per_target
 				.into_iter()
 				.flat_map(|(server_name, prompts)| {
@@ -897,29 +898,34 @@ impl Relay {
 		Box::new(move |streams, cel| {
 			let resources = streams
 				.into_iter()
-				.flat_map(|(server_name, s)| {
+				.map(|(server_name, s)| {
 					let resources = match s {
 						ServerResult::ListResourcesResult(lrr) => lrr.resources,
-						_ => vec![],
+						_ => return Err(incompatible_upstream_result("resources/list")),
 					};
-					resources
-						.into_iter()
-						.filter(|r| {
-							policies.validate(
-								&rbac::ResourceType::Resource(rbac::ResourceId::new(
-									server_name.to_string(),
-									r.uri.to_string(),
-								)),
-								cel,
-							)
-						})
-						// Prefix URI with service name when multiplexing to avoid conflicts
-						.map(|mut r| {
-							r.uri = resource_uri(default_target_name.as_ref(), server_name.as_str(), &r.uri);
-							r
-						})
-						.collect_vec()
+					Ok(
+						resources
+							.into_iter()
+							.filter(|r| {
+								policies.validate(
+									&rbac::ResourceType::Resource(rbac::ResourceId::new(
+										server_name.to_string(),
+										r.uri.to_string(),
+									)),
+									cel,
+								)
+							})
+							// Prefix URI with service name when multiplexing to avoid conflicts
+							.map(|mut r| {
+								r.uri = resource_uri(default_target_name.as_ref(), server_name.as_str(), &r.uri);
+								r
+							})
+							.collect_vec(),
+					)
 				})
+				.collect::<Result<Vec<Vec<_>>, ClientError>>()?
+				.into_iter()
+				.flatten()
 				.collect_vec();
 			Ok(
 				ListResourcesResult {
@@ -938,33 +944,38 @@ impl Relay {
 		Box::new(move |streams, cel| {
 			let resource_templates = streams
 				.into_iter()
-				.flat_map(|(server_name, s)| {
+				.map(|(server_name, s)| {
 					let resource_templates = match s {
 						ServerResult::ListResourceTemplatesResult(lrr) => lrr.resource_templates,
-						_ => vec![],
+						_ => return Err(incompatible_upstream_result("resources/templates/list")),
 					};
-					resource_templates
-						.into_iter()
-						.filter(|rt| {
-							policies.validate(
-								&rbac::ResourceType::Resource(rbac::ResourceId::new(
-									server_name.to_string(),
-									rt.uri_template.to_string(),
-								)),
-								cel,
-							)
-						})
-						// Prefix uri_template with service name when multiplexing
-						.map(|mut rt| {
-							rt.uri_template = resource_uri(
-								default_target_name.as_ref(),
-								server_name.as_str(),
-								&rt.uri_template,
-							);
-							rt
-						})
-						.collect_vec()
+					Ok(
+						resource_templates
+							.into_iter()
+							.filter(|rt| {
+								policies.validate(
+									&rbac::ResourceType::Resource(rbac::ResourceId::new(
+										server_name.to_string(),
+										rt.uri_template.to_string(),
+									)),
+									cel,
+								)
+							})
+							// Prefix uri_template with service name when multiplexing
+							.map(|mut rt| {
+								rt.uri_template = resource_uri(
+									default_target_name.as_ref(),
+									server_name.as_str(),
+									&rt.uri_template,
+								);
+								rt
+							})
+							.collect_vec(),
+					)
 				})
+				.collect::<Result<Vec<Vec<_>>, ClientError>>()?
+				.into_iter()
+				.flatten()
 				.collect_vec();
 			Ok(
 				ListResourceTemplatesResult {
@@ -978,7 +989,15 @@ impl Relay {
 		})
 	}
 	pub fn merge_empty(&self) -> Box<MergeFn> {
-		Box::new(move |_, _cel| Ok(rmcp::model::ServerResult::empty(())))
+		Box::new(move |results, _cel| {
+			if results
+				.iter()
+				.any(|(_, result)| !matches!(result, ServerResult::EmptyResult(_)))
+			{
+				return Err(incompatible_upstream_result("empty-result method"));
+			}
+			Ok(rmcp::model::ServerResult::empty(()))
+		})
 	}
 
 	/// Opens the upstream streams shared by `subscriptions/listen` and request fanout.
@@ -1129,7 +1148,7 @@ impl Relay {
 						id,
 						futures::stream::once(async move { error.into_downstream_message(error_id) }),
 						service_names.and_then(|sn| self.build_guardrails_ctx(&r, &ctx, sn)),
-						None,
+						ctx.extensions().get::<AsyncLog<MCPInfo>>().cloned(),
 						&ctx,
 					);
 				},
@@ -1170,7 +1189,7 @@ impl Relay {
 			id,
 			body,
 			service_names.and_then(|sn| self.build_guardrails_ctx(&r, &ctx, sn)),
-			None,
+			ctx.extensions().get::<AsyncLog<MCPInfo>>().cloned(),
 			&ctx,
 		)
 	}
@@ -1188,6 +1207,7 @@ impl Relay {
 			)));
 		};
 		let guardrails = self.build_guardrails_ctx(&r, &ctx, vec![service_name.to_string()]);
+		let mcp_log = mcp_log.or_else(|| ctx.extensions().get::<AsyncLog<MCPInfo>>().cloned());
 		let cel = CelExecWrapper::new(ctx.as_request().map(|_| ()));
 		let stream = self.rewrite_outbound_server_messages(
 			service_name,
@@ -1338,7 +1358,7 @@ impl Relay {
 			id,
 			ms,
 			service_names.and_then(|sn| self.build_guardrails_ctx(&r, &ctx, sn)),
-			None,
+			ctx.extensions().get::<AsyncLog<MCPInfo>>().cloned(),
 			&ctx,
 		)
 	}
@@ -1810,7 +1830,7 @@ fn capture_terminal_mcp_payload(
 		},
 		ServerJsonRpcMessage::Error(error) if error.id.as_ref() == Some(request_id) => {
 			if let Some(log) = log {
-				log.non_atomic_mutate(|mcp| mcp.capture_call_error(&error.error));
+				log.non_atomic_mutate(|mcp| mcp.capture_error(&error.error));
 			}
 			true
 		},
@@ -1989,9 +2009,7 @@ mod tests {
 	#[tokio::test]
 	async fn messages_to_response_captures_json_rpc_error() {
 		let log = AsyncLog::default();
-		let mut info = MCPInfo::default();
-		info.set_tool("mcp".to_string(), "echo".to_string());
-		log.store(Some(info));
+		log.store(Some(MCPInfo::default()));
 
 		let stream = stream::iter(vec![Ok(ServerJsonRpcMessage::error(
 			ErrorData::internal_error("boom", None),
@@ -2002,16 +2020,7 @@ mod tests {
 		let _ = crate::http::read_resp_body(response).await.unwrap();
 
 		let info = log.take().unwrap();
-		assert!(info.tool.as_ref().unwrap().result.is_none());
-		assert_eq!(
-			info.tool.as_ref().unwrap().error.as_ref().unwrap()["code"],
-			-32603
-		);
-		assert!(
-			info.tool.as_ref().unwrap().error.as_ref().unwrap()["message"]
-				.as_str()
-				.unwrap()
-				.contains("boom")
-		);
+		assert_eq!(info.error.as_ref().unwrap().code, -32603);
+		assert_eq!(info.error.as_ref().unwrap().message, "boom");
 	}
 }

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -3291,6 +3291,8 @@ async fn tool_call_error_exposes_error_payload_to_access_log_cel() {
 	);
 	assert_eq!(log["mcp_args_cel"]["traceId"], trace_id);
 	assert_eq!(log["mcp_error_cel"]["code"], -32602);
+	assert_eq!(log["mcp.error.code"], -32602);
+	assert_eq!(log["mcp.error.message"], "tool not found");
 	assert!(
 		log["mcp_error_cel"]["message"]
 			.as_str()
@@ -3303,6 +3305,36 @@ async fn tool_call_error_exposes_error_payload_to_access_log_cel() {
 	);
 	assert!(log.get("gen_ai.tool.call.arguments").is_none());
 	assert!(log.get("gen_ai.tool.call.result").is_none());
+}
+
+#[tokio::test]
+async fn discover_error_is_recorded_in_access_log() {
+	let mock = mock_streamable_http_server_without_discover().await;
+	let (_t, io) = setup_access_log_mcp_proxy(&mock).await;
+	let body = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": "discover-log-test",
+		"method": "server/discover",
+		"params": { "_meta": modern_meta() }
+	});
+	let response = mcp_json_post(&reqwest::Client::new(), &format!("http://{io}/mcp"), &body)
+		.header("mcp-protocol-version", "2026-07-28")
+		.header("mcp-method", "server/discover")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(response.status(), reqwest::StatusCode::OK);
+	let message = read_response_message(response).await;
+	assert_eq!(message["error"]["code"], -32601);
+
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("mcp.method.name", "server/discover"),
+		("mcp.error.message", "server/discover"),
+	])
+	.await
+	.unwrap();
+	assert_eq!(log["mcp.error.code"], -32601);
 }
 
 #[tokio::test]
@@ -5663,7 +5695,7 @@ async fn test_runtime_fanout_fail_open_skips_jsonrpc_error_frames() {
 #[tokio::test]
 async fn test_runtime_fanout_fail_open_all_fail() {
 	use futures_util::StreamExt;
-	use rmcp::model::{ListToolsResult, RequestId};
+	use rmcp::model::RequestId;
 
 	use crate::mcp::mergestream::{MergeStream, Messages};
 
@@ -5672,19 +5704,9 @@ async fn test_runtime_fanout_fail_open_all_fail() {
 
 	let streams = vec![("bad1".into(), err_stream1), ("bad2".into(), err_stream2)];
 
-	let merge = Box::new(
-		|results: Vec<(Strng, rmcp::model::ServerResult)>, _cel: &_| {
-			// All failed, so results should be empty.
-			// Return an empty success result (idiomatic for FailOpen).
-			assert!(results.is_empty());
-			Ok(rmcp::model::ServerResult::ListToolsResult(
-				ListToolsResult {
-					tools: vec![],
-					..Default::default()
-				},
-			))
-		},
-	);
+	let merge = Box::new(|_: Vec<(Strng, rmcp::model::ServerResult)>, _cel: &_| {
+		panic!("merge must not run without a successful upstream")
+	});
 
 	let mut ms = MergeStream::new(
 		streams,
@@ -5697,11 +5719,7 @@ async fn test_runtime_fanout_fail_open_all_fail() {
 	let res = ms.next().await;
 	assert!(res.is_some());
 	let res = res.unwrap();
-	assert!(
-		res.is_ok(),
-		"expected success with FailOpen even if ALL upstreams error mid-request: {:?}",
-		res.err()
-	);
+	assert!(res.is_err(), "expected an error when ALL upstreams fail");
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/mcp/mergestream.rs
+++ b/crates/agentgateway/src/mcp/mergestream.rs
@@ -155,6 +155,7 @@ pub struct MergeStream {
 	// Present iff `merge` is; supplied to the merge fn for RBAC filtering.
 	cel: Option<CelExecWrapper>,
 	failure_mode: FailureMode,
+	first_failure: Option<Result<ServerJsonRpcMessage, ClientError>>,
 }
 
 impl MergeStream {
@@ -186,6 +187,7 @@ impl MergeStream {
 			merge,
 			cel,
 			failure_mode,
+			first_failure: None,
 		}
 	}
 
@@ -242,6 +244,9 @@ impl Stream for MergeStream {
 									"upstream JSON-RPC error, skipping (failure_mode=FailOpen): {:?}",
 									e
 								);
+								if self.first_failure.is_none() {
+									self.first_failure = Some(Ok(ServerJsonRpcMessage::Error(e)));
+								}
 								drop = true;
 							} else {
 								self.complete = true;
@@ -254,6 +259,9 @@ impl Stream for MergeStream {
 									"upstream stream error, skipping (failure_mode=FailOpen): {}",
 									e
 								);
+								if self.first_failure.is_none() {
+									self.first_failure = Some(Err(e));
+								}
 								drop = true;
 							} else {
 								self.complete = true;
@@ -267,6 +275,11 @@ impl Stream for MergeStream {
 					// Long-lived streams can end without a terminal response.
 					if self.failure_mode == FailureMode::FailOpen {
 						warn!("upstream stream ended unexpectedly, skipping (failure_mode=FailOpen)");
+						if self.first_failure.is_none() {
+							self.first_failure = Some(Err(ClientError::new(anyhow::anyhow!(
+								"upstream stream ended unexpectedly"
+							))));
+						}
 						drop = true;
 					} else {
 						self.complete = true;
@@ -292,6 +305,13 @@ impl Stream for MergeStream {
 		self.complete = true;
 
 		if self.merge.is_some() {
+			if self.terminal_messages.iter().all(Option::is_none) {
+				return Poll::Ready(Some(self.first_failure.take().unwrap_or_else(|| {
+					Err(ClientError::new(anyhow::anyhow!(
+						"all upstream streams failed"
+					)))
+				})));
+			}
 			Poll::Ready(Some(self.merge_terminal_messages()))
 		} else {
 			Poll::Ready(None)

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -303,6 +303,13 @@ pub struct MCPTool {
 }
 
 #[apply(schema!)]
+#[derive(Default, PartialEq)]
+pub struct MCPError {
+	pub code: i32,
+	pub message: String,
+}
+
+#[apply(schema!)]
 #[derive(Default, PartialEq, ::cel::DynamicType)]
 #[dynamic(rename_all = "camelCase")]
 pub struct MCPTask {
@@ -342,6 +349,12 @@ pub struct MCPInfo {
 	pub resource: Option<ResourceId>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub task: Option<MCPTask>,
+	// Terminal errors arrive while the response body is drained. Keep them out of CEL so policy
+	// evaluation cannot depend on asynchronous stream timing; they are emitted as access-log fields.
+	#[dynamic(skip)]
+	#[cfg_attr(feature = "schema", schemars(skip))]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub error: Option<MCPError>,
 }
 
 impl MCPInfo {
@@ -352,6 +365,7 @@ impl MCPInfo {
 			&& self.prompt.is_none()
 			&& self.resource.is_none()
 			&& self.task.is_none()
+			&& self.error.is_none()
 	}
 
 	pub fn resource_type(&self) -> Option<MCPOperation> {
@@ -456,7 +470,11 @@ impl MCPInfo {
 		}
 	}
 
-	pub fn capture_call_error<T: serde::Serialize>(&mut self, error: &T) {
+	pub fn capture_error(&mut self, error: &rmcp::ErrorData) {
+		self.error = Some(MCPError {
+			code: error.code.0,
+			message: error.message.to_string(),
+		});
 		if let Some(tool) = self.tool.as_mut() {
 			tool.error = serde_json::to_value(error).ok();
 		}

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -10,6 +10,7 @@ use agent_core::metrics::CustomField;
 use agent_core::strng::{RichStrng, Strng};
 use agent_core::telemetry::{
 	OptionExt, OtelLogSink, ValueBag, current_connection_id, current_request_id, debug, display,
+	quoted,
 };
 use agent_core::{Timestamp, strng};
 use bytes::Buf;
@@ -1443,6 +1444,20 @@ impl Drop for DropOnLog {
 						.as_ref()
 						.and_then(|m| m.session_id.as_ref())
 						.map(display),
+				),
+				(
+					"mcp.error.code",
+					mcp
+						.as_ref()
+						.and_then(|m| m.error.as_ref())
+						.map(|error| error.code.into()),
+				),
+				(
+					"mcp.error.message",
+					mcp
+						.as_ref()
+						.and_then(|m| m.error.as_ref())
+						.map(|error| quoted(&error.message)),
 				),
 				(
 					"inferencepool.selected_endpoint",


### PR DESCRIPTION
```
2026-07-28T21:52:06.403287Z	info	request gateway=default/default listener=listener0 route=default/route0 src.addr=127.0.0.1:37952 http.method=POST http.host=localhost http.path=/mcp http.version=HTTP/1.1 http.status=200 protocol=mcp mcp.method.name=server/discover mcp.session.id=46e4dbf9-3aa3-40f0-8dce-4329d6b1d09e mcp.error.code=-32603 mcp.error.message="http request failed: upstream returned a result incompatible with `server/discover`" duration=405ms
```

Signed-off-by: John Howard <john.howard@solo.io>
