### PR TITLE
mcp tasks support

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -2344,6 +2344,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			}),
 			prompt: None,
 			resource: None,
+			task: None,
 		}),
 		backend: Some(BackendContext {
 			name: "my-backend".into(),

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -162,6 +162,61 @@ pub(super) fn rewrite_resource_messages(
 	message
 }
 
+// Namespaces a task id as `<target>+<task id>`, mirroring `resource_uri`.
+fn task_id(default_target_name: Option<&String>, target: &str, task_id: &str) -> String {
+	if default_target_name.is_none() {
+		format!("{target}+{task_id}")
+	} else {
+		task_id.to_string()
+	}
+}
+
+// Rewrites task ids in outbound results/notifications so they round-trip through `parse_task_id`.
+pub(super) fn rewrite_task_messages(
+	default_target_name: Option<&String>,
+	target: &str,
+	mut message: ServerJsonRpcMessage,
+) -> ServerJsonRpcMessage {
+	if let ServerJsonRpcMessage::Response(resp) = &mut message {
+		match &mut resp.result {
+			ServerResult::CreateTaskResult(r) => {
+				r.task.task_id = task_id(default_target_name, target, &r.task.task_id);
+			},
+			ServerResult::GetTaskResult(r) => {
+				r.task.task.task_id = task_id(default_target_name, target, &r.task.task.task_id);
+			},
+			_ => {},
+		}
+	}
+	if let ServerJsonRpcMessage::Notification(notification) = &mut message
+		&& let ServerNotification::TaskStatusNotification(tsn) = &mut notification.notification
+	{
+		tsn.params.task.task.task_id =
+			task_id(default_target_name, target, &tsn.params.task.task.task_id);
+	}
+	message
+}
+
+// Reverse of `task_id`: splits `<target>+<task id>` into (target, task id).
+pub(super) fn parse_task_id<'a>(
+	upstreams: &'a upstream::UpstreamGroup,
+	task_id: &str,
+) -> Result<(&'a str, String), UpstreamError> {
+	if let Some(default) = upstreams.default_target_name.as_ref() {
+		Ok((default.as_str(), task_id.to_string()))
+	} else {
+		let plus_pos = task_id
+			.find('+')
+			.ok_or_else(|| UpstreamError::InvalidRequest("invalid task id".to_string()))?;
+		let service_name = &task_id[..plus_pos];
+		let original_id = &task_id[plus_pos + 1..];
+		let validated_name = upstreams
+			.get_name(service_name)
+			.ok_or_else(|| UpstreamError::InvalidRequest(format!("unknown service {service_name}")))?;
+		Ok((validated_name, original_id.to_string()))
+	}
+}
+
 /// What kind of name is being resolved to a target (`prefixMode: never`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ResolveKind {
@@ -271,6 +326,7 @@ impl Relay {
 		let policies = self.policies.clone();
 		stream.map_server_messages(move |message| {
 			let message = rewrite_resource_messages(default_target_name.as_ref(), &target, message);
+			let message = rewrite_task_messages(default_target_name.as_ref(), &target, message);
 
 			let mut resource_allowed = |uri: &str| {
 				// rewrite_tool_list_ui_meta extracts app URIs from tool metadata, apply RBAC against

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1183,32 +1183,43 @@ async fn mrtr_direct_server_request_fails_modern_call_cleanly() {
 	);
 }
 
-#[tokio::test]
-async fn legacy_meta_client_capabilities_are_stripped() {
+async fn assert_capability_forwarding(protocol_version: &str, modern: bool) {
 	let (mock, capture) = mock_mrtr_streamable_http_server().await;
 	let (_bind, io) = setup_proxy(&mock, false, false).await;
 	let client = reqwest::Client::new();
 	let url = format!("http://{io}/mcp");
+
+	// Modern requests need the full `_meta` block (SEP-2575); legacy doesn't.
+	let mut meta = serde_json::json!({
+		"io.modelcontextprotocol/clientCapabilities": {
+			"elicitation": {},
+			"tasks": {},
+			"extensions": {
+				"io.modelcontextprotocol/tasks": {},
+				"io.modelcontextprotocol/ui": {}
+			}
+		}
+	});
+	if modern {
+		meta["io.modelcontextprotocol/protocolVersion"] = protocol_version.into();
+		meta["io.modelcontextprotocol/clientInfo"] =
+			serde_json::json!({"name": "test-client", "version": "0.0.1"});
+	}
 
 	let body = serde_json::json!({
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "tools/call",
 		"params": {
-			"_meta": {"io.modelcontextprotocol/clientCapabilities": {
-				"elicitation": {},
-				"tasks": {},
-				"extensions": {
-					"io.modelcontextprotocol/tasks": {},
-					"io.modelcontextprotocol/ui": {}
-				}
-			}},
+			"_meta": meta,
 			"name": "guarded_echo",
 			"arguments": {}
 		}
 	});
 	let resp = mcp_json_post(&client, &url, &body)
-		.header("mcp-protocol-version", "2025-06-18")
+		.header("mcp-protocol-version", protocol_version)
+		.header("mcp-method", "tools/call")
+		.header("mcp-name", "guarded_echo")
 		.send()
 		.await
 		.unwrap();
@@ -1220,26 +1231,233 @@ async fn legacy_meta_client_capabilities_are_stripped() {
 		.find(|b| b["method"] == "tools/call")
 		.expect("upstream should see the tools/call");
 	let caps = &call["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"];
-	assert!(
-		caps.get("elicitation").is_none(),
-		"legacy requests must still have elicitation stripped, got {call}"
+
+	assert_eq!(
+		caps.get("elicitation").is_some(),
+		modern,
+		"elicitation forwarding mismatch, got {call}"
 	);
 	assert!(
 		caps.get("tasks").is_none(),
-		"legacy tasks must be stripped, got {call}"
+		"legacy top-level `tasks` field is not a real capability, got {call}"
 	);
-	assert!(
+	assert_eq!(
 		caps
 			.pointer("/extensions/io.modelcontextprotocol~1tasks")
-			.is_none(),
-		"modern tasks extension must be stripped, got {call}"
+			.is_some(),
+		modern,
+		"tasks extension forwarding mismatch, got {call}"
 	);
 	assert!(
 		caps
 			.pointer("/extensions/io.modelcontextprotocol~1ui")
 			.is_some(),
-		"other extensions must be preserved, got {call}"
+		"unrelated extensions must always be preserved, got {call}"
 	);
+}
+
+#[tokio::test]
+async fn legacy_meta_client_capabilities_are_stripped() {
+	assert_capability_forwarding("2025-06-18", false).await;
+}
+
+#[tokio::test]
+async fn modern_meta_tasks_capability_is_forwarded() {
+	assert_capability_forwarding("2026-07-28", true).await;
+}
+
+fn task_meta() -> serde_json::Value {
+	serde_json::json!({
+		"io.modelcontextprotocol/protocolVersion": "2026-07-28",
+		"io.modelcontextprotocol/clientInfo": {"name": "task-client", "version": "0.0.1"},
+		"io.modelcontextprotocol/clientCapabilities": {
+			"extensions": {"io.modelcontextprotocol/tasks": {}}
+		}
+	})
+}
+
+// Posts a modern request with SEP-2243 Mcp-Method/Mcp-Name headers set from `name`.
+async fn modern_request(
+	io: SocketAddr,
+	id: i64,
+	method: &str,
+	name: &str,
+	mut params: serde_json::Value,
+) -> serde_json::Value {
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+	// Modern requests need the standard `_meta` block (SEP-2575).
+	params["_meta"] = task_meta();
+	let body = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": id,
+		"method": method,
+		"params": params
+	});
+	let resp = mcp_json_post(&client, &url, &body)
+		.header("mcp-protocol-version", "2026-07-28")
+		.header("mcp-method", method)
+		.header("mcp-name", name)
+		.send()
+		.await
+		.unwrap();
+	let text = resp.text().await.unwrap();
+	terminal_message(&text, id)
+}
+
+#[tokio::test]
+async fn modern_task_round_trip_single_target() {
+	let mock = mock_task_streamable_http_server().await;
+	let (_bind, io) = setup_proxy(&mock, false, false).await;
+
+	let create = modern_request(
+		io,
+		1,
+		"tools/call",
+		"slow_job",
+		serde_json::json!({"_meta": task_meta(), "name": "slow_job", "arguments": {}}),
+	)
+	.await;
+	let result = &create["result"];
+	assert_eq!(result["resultType"], "task");
+	// Single-target (non-multiplexing): task IDs pass through unnamespaced.
+	assert_eq!(result["taskId"], "task-abc");
+
+	let get = modern_request(
+		io,
+		2,
+		"tasks/get",
+		"task-abc",
+		serde_json::json!({"taskId": "task-abc"}),
+	)
+	.await;
+	assert_eq!(get["result"]["status"], "completed");
+	assert_eq!(get["result"]["result"]["content"][0]["text"], "done");
+
+	let unknown = modern_request(
+		io,
+		3,
+		"tasks/get",
+		"nope",
+		serde_json::json!({"taskId": "nope"}),
+	)
+	.await;
+	assert_eq!(unknown["error"]["code"], -32602);
+
+	let cancel = modern_request(
+		io,
+		4,
+		"tasks/cancel",
+		"task-abc",
+		serde_json::json!({"taskId": "task-abc"}),
+	)
+	.await;
+	assert_eq!(cancel["result"]["resultType"], "complete");
+
+	let get_after_cancel = modern_request(
+		io,
+		5,
+		"tasks/get",
+		"task-abc",
+		serde_json::json!({"taskId": "task-abc"}),
+	)
+	.await;
+	assert_eq!(get_after_cancel["result"]["status"], "cancelled");
+}
+
+#[tokio::test]
+async fn modern_task_id_namespaced_when_multiplexing() {
+	let plain = mock_modern_streamable_http_server().await;
+	let tasks = mock_task_streamable_http_server().await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_multiplex_mcp_backend(
+			"mcp",
+			vec![("plain", plain.addr, false), ("tasks", tasks.addr, false)],
+			true,
+		)
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::new("/mcp")));
+	let io = t.serve_real_listener(strng::new("bind")).await;
+
+	let create = modern_request(
+		io,
+		1,
+		"tools/call",
+		"tasks_slow_job",
+		serde_json::json!({"_meta": task_meta(), "name": "tasks_slow_job", "arguments": {}}),
+	)
+	.await;
+	let result = &create["result"];
+	assert_eq!(result["resultType"], "task");
+	// Multiplexing: the owning target is namespaced into the task ID.
+	assert_eq!(result["taskId"], "tasks+task-abc");
+
+	let get = modern_request(
+		io,
+		2,
+		"tasks/get",
+		"tasks+task-abc",
+		serde_json::json!({"taskId": "tasks+task-abc"}),
+	)
+	.await;
+	assert_eq!(get["result"]["status"], "completed");
+	assert_eq!(get["result"]["taskId"], "tasks+task-abc");
+
+	// A syntactically valid but unknown service prefix is rejected locally.
+	let bogus_service = modern_request(
+		io,
+		3,
+		"tasks/get",
+		"doesnotexist+task-abc",
+		serde_json::json!({"taskId": "doesnotexist+task-abc"}),
+	)
+	.await;
+	assert_eq!(bogus_service["error"]["code"], -32602);
+
+	// A real service that isn't the task's owner never learns about it upstream.
+	let wrong_service = modern_request(
+		io,
+		4,
+		"tasks/get",
+		"plain+task-abc",
+		serde_json::json!({"taskId": "plain+task-abc"}),
+	)
+	.await;
+	assert!(
+		wrong_service.get("error").is_some(),
+		"the non-owning target must not resolve the task, got {wrong_service}"
+	);
+}
+
+// A caller denied access to a target by CEL policy must stay denied on tasks/*, not just
+// on the tools/call that created the task.
+#[tokio::test]
+async fn task_methods_respect_mcp_authorization_deny_policy() {
+	let mock = mock_task_streamable_http_server().await;
+	let deny_all_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![],
+		vec![Arc::new(cel::Expression::new_strict("true").unwrap())],
+		vec![],
+	)));
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		false,
+		false,
+		vec![BackendTrafficPolicy::McpAuthorization(deny_all_policy)],
+	)
+	.await;
+
+	let get = modern_request(
+		io,
+		1,
+		"tasks/get",
+		"task-abc",
+		serde_json::json!({"taskId": "task-abc"}),
+	)
+	.await;
+	assert_eq!(get["error"]["code"], -32602);
+	assert_eq!(get["error"]["message"], "Unknown task: task-abc");
 }
 
 #[tokio::test]
@@ -1535,8 +1753,8 @@ async fn modern_removed_and_unknown_methods_return_404() {
 	let client = reqwest::Client::new();
 	let url = format!("http://{io}/mcp");
 
-	// Removed and unknown methods 404 in transport validation; `tasks/list` is known but
-	// unimplemented and 404s via the InvalidMethod remap in session dispatch.
+	// Removed and unknown methods 404 in transport validation. `tasks/list` predates SEP-2663
+	// and is gone now, so it's genuinely unknown, same as any other unknown method.
 	for (i, method) in super::REMOVED_METHODS_2026_07_28
 		.iter()
 		.copied()
@@ -3590,6 +3808,132 @@ async fn mock_mrtr_streamable_http_server() -> (MockServer, BodyCapture) {
 		},
 		capture,
 	)
+}
+
+// SEP-2663 mock: `slow_job` returns a task for id "task-abc"; cancel flips it to "cancelled".
+async fn mock_task_streamable_http_server() -> MockServer {
+	agent_core::telemetry::testing::setup_test_logging();
+	let (tx, rx) = tokio::sync::oneshot::channel();
+	let cancelled = std::sync::Arc::new(std::sync::Mutex::new(false));
+	let router = axum::Router::new().route(
+		"/mcp",
+		axum::routing::post(move |body: axum::Json<serde_json::Value>| {
+			let cancelled = cancelled.clone();
+			async move {
+				let id = body.get("id").cloned().unwrap_or(serde_json::Value::Null);
+				let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+				let params = body.get("params").cloned().unwrap_or(serde_json::json!({}));
+				let result = match method {
+					"server/discover" => serde_json::json!({
+						"resultType": "complete",
+						"supportedVersions": ["2026-07-28"],
+						"capabilities": {
+							"tools": {},
+							"extensions": {"io.modelcontextprotocol/tasks": {}}
+						},
+						"serverInfo": {"name": "task-mock", "version": "0.0.1"}
+					}),
+					"tools/list" => serde_json::json!({
+						"resultType": "complete",
+						"tools": [
+							{"name": "slow_job", "description": "A slow job", "inputSchema": {"type": "object"}}
+						]
+					}),
+					"tools/call" => {
+						let name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+						if name != "slow_job" {
+							return axum::Json(serde_json::json!({
+								"jsonrpc": "2.0",
+								"id": id,
+								"error": {"code": -32602, "message": "unknown tool"}
+							}));
+						}
+						serde_json::json!({
+							"resultType": "task",
+							"taskId": "task-abc",
+							"status": "working",
+							"createdAt": "2025-11-25T10:30:00Z",
+							"lastUpdatedAt": "2025-11-25T10:30:00Z",
+							"ttlMs": 60000,
+							"pollIntervalMs": 1000
+						})
+					},
+					"tasks/get" => {
+						let task_id = params.get("taskId").and_then(|t| t.as_str()).unwrap_or("");
+						if task_id != "task-abc" {
+							return axum::Json(serde_json::json!({
+								"jsonrpc": "2.0",
+								"id": id,
+								"error": {"code": -32602, "message": "unknown task"}
+							}));
+						}
+						if *cancelled.lock().unwrap() {
+							serde_json::json!({
+								"resultType": "complete",
+								"taskId": "task-abc",
+								"status": "cancelled",
+								"createdAt": "2025-11-25T10:30:00Z",
+								"lastUpdatedAt": "2025-11-25T10:31:00Z",
+								"ttlMs": 60000
+							})
+						} else {
+							serde_json::json!({
+								"resultType": "complete",
+								"taskId": "task-abc",
+								"status": "completed",
+								"createdAt": "2025-11-25T10:30:00Z",
+								"lastUpdatedAt": "2025-11-25T10:31:00Z",
+								"ttlMs": 60000,
+								"result": {
+									"content": [{"type": "text", "text": "done"}],
+									"isError": false
+								}
+							})
+						}
+					},
+					"tasks/cancel" => {
+						let task_id = params.get("taskId").and_then(|t| t.as_str()).unwrap_or("");
+						if task_id != "task-abc" {
+							return axum::Json(serde_json::json!({
+								"jsonrpc": "2.0",
+								"id": id,
+								"error": {"code": -32602, "message": "unknown task"}
+							}));
+						}
+						*cancelled.lock().unwrap() = true;
+						serde_json::json!({"resultType": "complete"})
+					},
+					"tasks/update" => serde_json::json!({"resultType": "complete"}),
+					_ => {
+						return axum::Json(serde_json::json!({
+							"jsonrpc": "2.0",
+							"id": id,
+							"error": {"code": -32601, "message": method}
+						}));
+					},
+				};
+				axum::Json(serde_json::json!({
+					"jsonrpc": "2.0",
+					"id": id,
+					"result": result
+				}))
+			}
+		}),
+	);
+	let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let addr = tcp_listener.local_addr().unwrap();
+	tokio::spawn(async move {
+		let _ = axum::serve(tcp_listener, router)
+			.with_graceful_shutdown(async {
+				let _ = rx.await;
+			})
+			.await;
+	});
+	MockServer {
+		addr,
+		init_counter: std::sync::Arc::new(tokio::sync::Mutex::new(0)),
+		_cancel: tx,
+	}
 }
 
 type HeaderCapture = std::sync::Arc<std::sync::Mutex<Vec<http::HeaderMap>>>;

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -262,6 +262,7 @@ pub enum MCPOperation {
 	Prompt,
 	Resource,
 	ResourceTemplates,
+	Task,
 }
 
 impl EncodeLabelValue for MCPOperation {
@@ -277,6 +278,7 @@ impl Display for MCPOperation {
 			MCPOperation::Prompt => write!(f, "prompt"),
 			MCPOperation::Resource => write!(f, "resource"),
 			MCPOperation::ResourceTemplates => write!(f, "templates"),
+			MCPOperation::Task => write!(f, "task"),
 		}
 	}
 }
@@ -314,6 +316,8 @@ pub struct MCPInfo {
 	pub prompt: Option<ResourceId>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub resource: Option<ResourceId>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub task: Option<ResourceId>,
 }
 
 impl MCPInfo {
@@ -323,6 +327,7 @@ impl MCPInfo {
 			&& self.tool.is_none()
 			&& self.prompt.is_none()
 			&& self.resource.is_none()
+			&& self.task.is_none()
 	}
 
 	pub fn resource_type(&self) -> Option<MCPOperation> {
@@ -332,6 +337,8 @@ impl MCPInfo {
 			Some(MCPOperation::Prompt)
 		} else if self.resource.is_some() {
 			Some(MCPOperation::Resource)
+		} else if self.task.is_some() {
+			Some(MCPOperation::Task)
 		} else {
 			None
 		}
@@ -344,6 +351,7 @@ impl MCPInfo {
 			.map(|tool| tool.target.as_str())
 			.or_else(|| self.prompt.as_ref().map(ResourceId::target))
 			.or_else(|| self.resource.as_ref().map(ResourceId::target))
+			.or_else(|| self.task.as_ref().map(ResourceId::target))
 	}
 
 	pub fn resource_name(&self) -> Option<&str> {
@@ -353,11 +361,13 @@ impl MCPInfo {
 			.map(|tool| tool.name.as_str())
 			.or_else(|| self.prompt.as_ref().map(ResourceId::name))
 			.or_else(|| self.resource.as_ref().map(ResourceId::name))
+			.or_else(|| self.task.as_ref().map(ResourceId::name))
 	}
 
 	pub fn set_tool(&mut self, target: String, name: String) {
 		self.prompt = None;
 		self.resource = None;
+		self.task = None;
 		match self.tool.as_mut() {
 			Some(tool) => {
 				tool.target = target;
@@ -376,13 +386,22 @@ impl MCPInfo {
 	pub fn set_prompt(&mut self, target: String, name: String) {
 		self.tool = None;
 		self.resource = None;
+		self.task = None;
 		self.prompt = Some(ResourceId::new(target, name));
 	}
 
 	pub fn set_resource(&mut self, target: String, name: String) {
 		self.tool = None;
 		self.prompt = None;
+		self.task = None;
 		self.resource = Some(ResourceId::new(target, name));
+	}
+
+	pub fn set_task(&mut self, target: String, task_id: String) {
+		self.tool = None;
+		self.prompt = None;
+		self.resource = None;
+		self.task = Some(ResourceId::new(target, task_id));
 	}
 
 	pub fn capture_call_arguments(
@@ -426,6 +445,10 @@ impl From<&ResourceType> for MCPInfo {
 			},
 			ResourceType::Resource(resource) => Self {
 				resource: Some(resource.clone()),
+				..Default::default()
+			},
+			ResourceType::Task(task) => Self {
+				task: Some(task.clone()),
 				..Default::default()
 			},
 		}

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -472,7 +472,10 @@ impl From<&ResourceType> for MCPInfo {
 				..Default::default()
 			},
 			ResourceType::Task(task) => Self {
-				task: Some(MCPTask::new(task.target().to_string(), task.name().to_string())),
+				task: Some(MCPTask::new(
+					task.target().to_string(),
+					task.name().to_string(),
+				)),
 				..Default::default()
 			},
 		}

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -388,6 +388,17 @@ impl MCPInfo {
 			.or_else(|| self.task.as_ref().map(MCPTask::name))
 	}
 
+	/// Like [`Self::resource_name`], but omits task IDs, which are unique per request and would
+	/// grow the metric label set without bound.
+	pub fn metric_resource_name(&self) -> Option<&str> {
+		self
+			.tool
+			.as_ref()
+			.map(|tool| tool.name.as_str())
+			.or_else(|| self.prompt.as_ref().map(ResourceId::name))
+			.or_else(|| self.resource.as_ref().map(ResourceId::name))
+	}
+
 	pub fn set_tool(&mut self, target: String, name: String) {
 		self.prompt = None;
 		self.resource = None;

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -305,6 +305,30 @@ pub struct MCPTool {
 #[apply(schema!)]
 #[derive(Default, PartialEq, ::cel::DynamicType)]
 #[dynamic(rename_all = "camelCase")]
+pub struct MCPTask {
+	/// The target handling the task.
+	pub target: String,
+	/// The task ID.
+	pub name: String,
+}
+
+impl MCPTask {
+	pub fn new(target: String, name: String) -> Self {
+		Self { target, name }
+	}
+
+	pub fn target(&self) -> &str {
+		&self.target
+	}
+
+	pub fn name(&self) -> &str {
+		&self.name
+	}
+}
+
+#[apply(schema!)]
+#[derive(Default, PartialEq, ::cel::DynamicType)]
+#[dynamic(rename_all = "camelCase")]
 pub struct MCPInfo {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub method_name: Option<String>,
@@ -317,7 +341,7 @@ pub struct MCPInfo {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub resource: Option<ResourceId>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub task: Option<ResourceId>,
+	pub task: Option<MCPTask>,
 }
 
 impl MCPInfo {
@@ -351,7 +375,7 @@ impl MCPInfo {
 			.map(|tool| tool.target.as_str())
 			.or_else(|| self.prompt.as_ref().map(ResourceId::target))
 			.or_else(|| self.resource.as_ref().map(ResourceId::target))
-			.or_else(|| self.task.as_ref().map(ResourceId::target))
+			.or_else(|| self.task.as_ref().map(MCPTask::target))
 	}
 
 	pub fn resource_name(&self) -> Option<&str> {
@@ -361,7 +385,7 @@ impl MCPInfo {
 			.map(|tool| tool.name.as_str())
 			.or_else(|| self.prompt.as_ref().map(ResourceId::name))
 			.or_else(|| self.resource.as_ref().map(ResourceId::name))
-			.or_else(|| self.task.as_ref().map(ResourceId::name))
+			.or_else(|| self.task.as_ref().map(MCPTask::name))
 	}
 
 	pub fn set_tool(&mut self, target: String, name: String) {
@@ -401,7 +425,7 @@ impl MCPInfo {
 		self.tool = None;
 		self.prompt = None;
 		self.resource = None;
-		self.task = Some(ResourceId::new(target, task_id));
+		self.task = Some(MCPTask::new(target, task_id));
 	}
 
 	pub fn capture_call_arguments(
@@ -448,7 +472,7 @@ impl From<&ResourceType> for MCPInfo {
 				..Default::default()
 			},
 			ResourceType::Task(task) => Self {
-				task: Some(task.clone()),
+				task: Some(MCPTask::new(task.target().to_string(), task.name().to_string())),
 				..Default::default()
 			},
 		}

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -72,6 +72,8 @@ pub enum ResourceType {
 	Prompt(ResourceId),
 	/// The resource being accessed
 	Resource(ResourceId),
+	/// The task being accessed (SEP-2663); `name` is the task ID.
+	Task(ResourceId),
 }
 
 impl cel::DynamicType for ResourceType {
@@ -80,6 +82,7 @@ impl cel::DynamicType for ResourceType {
 			ResourceType::Tool(t) => ("tool", t),
 			ResourceType::Prompt(t) => ("prompt", t),
 			ResourceType::Resource(t) => ("resource", t),
+			ResourceType::Task(t) => ("task", t),
 		};
 		Value::Map(MapValue::Borrow(VecMap::from_iter([(
 			KeyRef::String(n.into()),
@@ -92,6 +95,7 @@ impl cel::DynamicType for ResourceType {
 			(ResourceType::Tool(t), "tool") => Some(t.materialize()),
 			(ResourceType::Prompt(t), "prompt") => Some(t.materialize()),
 			(ResourceType::Resource(t), "resource") => Some(t.materialize()),
+			(ResourceType::Task(t), "task") => Some(t.materialize()),
 			_ => None,
 		}
 	}

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -238,6 +238,35 @@ impl Session {
 		Ok(())
 	}
 
+	// task_id here is the resolved upstream id, not the client-visible `target+id` form.
+	fn authorize_task_request(
+		&self,
+		service_name: &str,
+		task_id: &str,
+		method: &str,
+		span: &mut SpanWriteOnDrop,
+		log: &AsyncLog<mcp::MCPInfo>,
+		cel: &rbac::CelExecWrapper,
+	) -> Result<(), UpstreamError> {
+		span.rename_span(format!("{method} {service_name}"));
+		log.non_atomic_mutate(|l| {
+			l.set_task(service_name.to_string(), task_id.to_string());
+		});
+		if !self.relay.policies.validate(
+			&rbac::ResourceType::Task(rbac::ResourceId::new(
+				service_name.to_string(),
+				task_id.to_string(),
+			)),
+			cel,
+		) {
+			return Err(UpstreamError::Authorization {
+				resource_type: "task".to_string(),
+				resource_name: task_id.to_string(),
+			});
+		}
+		Ok(())
+	}
+
 	#[allow(clippy::too_many_arguments)]
 	async fn authorize_with_ctx<P>(
 		&self,
@@ -656,11 +685,47 @@ impl Session {
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 
-					ClientRequest::GetTaskRequest(_)
-					| ClientRequest::UpdateTaskRequest(_)
-					| ClientRequest::CancelTaskRequest(_) => {
-						// TODO(https://github.com/agentgateway/agentgateway/issues/404)
-						Err(UpstreamError::InvalidMethod(r.request.method().to_string()))
+					ClientRequest::GetTaskRequest(gtr) => {
+						let (service_name, original_id) =
+							mcp::handler::parse_task_id(&self.relay.upstreams, &gtr.params.task_id)?;
+						self.authorize_task_request(
+							service_name,
+							&original_id,
+							&method,
+							&mut span,
+							&log,
+							&cel,
+						)?;
+						gtr.params.task_id = original_id;
+						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
+					},
+					ClientRequest::UpdateTaskRequest(utr) => {
+						let (service_name, original_id) =
+							mcp::handler::parse_task_id(&self.relay.upstreams, &utr.params.task_id)?;
+						self.authorize_task_request(
+							service_name,
+							&original_id,
+							&method,
+							&mut span,
+							&log,
+							&cel,
+						)?;
+						utr.params.task_id = original_id;
+						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
+					},
+					ClientRequest::CancelTaskRequest(ctr) => {
+						let (service_name, original_id) =
+							mcp::handler::parse_task_id(&self.relay.upstreams, &ctr.params.task_id)?;
+						self.authorize_task_request(
+							service_name,
+							&original_id,
+							&method,
+							&mut span,
+							&log,
+							&cel,
+						)?;
+						ctr.params.task_id = original_id;
+						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::CustomRequest(_) => {
 						let method = r.request.method();
@@ -733,19 +798,18 @@ impl Session {
 		capabilities: &mut rmcp::model::ClientCapabilities,
 		ctx: &IncomingRequestContext,
 	) {
-		// TODO implement MCP tasks
-		if let Some(extensions) = capabilities.extensions.as_mut() {
-			extensions.remove("io.modelcontextprotocol/tasks");
-			if extensions.is_empty() {
-				capabilities.extensions = None;
-			}
-		}
-
 		if !mcp::handler::ctx_downstream_modern(ctx) {
 			// Legacy clients require reverse JSON-RPC routing for these capabilities.
 			capabilities.roots = None;
 			capabilities.sampling = None;
 			capabilities.elicitation = None;
+			// The tasks extension (SEP-2663) is undefined for legacy protocol versions.
+			if let Some(extensions) = capabilities.extensions.as_mut() {
+				extensions.remove(rmcp::model::TASKS_EXTENSION_ID);
+				if extensions.is_empty() {
+					capabilities.extensions = None;
+				}
+			}
 		}
 	}
 

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -421,6 +421,9 @@ fn message_name(message: &ClientJsonRpcMessage) -> Option<&str> {
 		ClientRequest::ReadResourceRequest(r) => Some(&r.params.uri),
 		ClientRequest::SubscribeRequest(r) => Some(&r.params.uri),
 		ClientRequest::UnsubscribeRequest(r) => Some(&r.params.uri),
+		ClientRequest::GetTaskRequest(r) => Some(&r.params.task_id),
+		ClientRequest::UpdateTaskRequest(r) => Some(&r.params.task_id),
+		ClientRequest::CancelTaskRequest(r) => Some(&r.params.task_id),
 		_ => None,
 	}
 }

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -701,10 +701,23 @@ impl Handler {
 					BuildInfo::new().version.to_string(),
 				)),
 			),
-			ClientRequest::GetTaskRequest(_)
-			| ClientRequest::UpdateTaskRequest(_)
-			| ClientRequest::CancelTaskRequest(_) => {
-				return Err(UpstreamError::InvalidRequest("unknown task".to_string()));
+			ClientRequest::GetTaskRequest(r) => {
+				return Err(UpstreamError::InvalidRequest(format!(
+					"unknown task {}",
+					r.params.task_id
+				)));
+			},
+			ClientRequest::UpdateTaskRequest(r) => {
+				return Err(UpstreamError::InvalidRequest(format!(
+					"unknown task {}",
+					r.params.task_id
+				)));
+			},
+			ClientRequest::CancelTaskRequest(r) => {
+				return Err(UpstreamError::InvalidRequest(format!(
+					"unknown task {}",
+					r.params.task_id
+				)));
 			},
 			ClientRequest::ReadResourceRequest(_) => {
 				Messages::from_result(id, ReadResourceResult::new(vec![]))

--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -704,7 +704,7 @@ impl Handler {
 			ClientRequest::GetTaskRequest(_)
 			| ClientRequest::UpdateTaskRequest(_)
 			| ClientRequest::CancelTaskRequest(_) => {
-				return Err(UpstreamError::InvalidMethod(method.to_string()));
+				return Err(UpstreamError::InvalidRequest("unknown task".to_string()));
 			},
 			ClientRequest::ReadResourceRequest(_) => {
 				Messages::from_result(id, ReadResourceResult::new(vec![]))

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1272,7 +1272,7 @@ impl Drop for DropOnLog {
 						method: mcp.method_name.as_ref().map(RichStrng::from).into(),
 						resource_type: mcp.resource_type().into(),
 						server: mcp.target_name().map(RichStrng::from).into(),
-						resource: mcp.resource_name().map(RichStrng::from).into(),
+						resource: mcp.metric_resource_name().map(RichStrng::from).into(),
 
 						route: route_identifier.clone(),
 						custom: custom_metric_fields.clone(),

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -985,6 +985,25 @@
             }
           },
           "additionalProperties": false
+        },
+        "task": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "target": {
+              "description": "The target of the resource",
+              "type": "string",
+              "default": ""
+            },
+            "name": {
+              "description": "The name of the resource",
+              "type": "string",
+              "default": ""
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -993,17 +993,19 @@
           ],
           "properties": {
             "target": {
-              "description": "The target of the resource",
-              "type": "string",
-              "default": ""
+              "description": "The target handling the task.",
+              "type": "string"
             },
             "name": {
-              "description": "The name of the resource",
-              "type": "string",
-              "default": ""
+              "description": "The task ID.",
+              "type": "string"
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "required": [
+            "target",
+            "name"
+          ]
         }
       },
       "additionalProperties": false

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -139,6 +139,9 @@
 |`mcp.resource`|object||
 |`mcp.resource.target`|string|The target of the resource|
 |`mcp.resource.name`|string|The name of the resource|
+|`mcp.task`|object||
+|`mcp.task.target`|string|The target of the resource|
+|`mcp.task.name`|string|The name of the resource|
 |`backend`|object|`backend` contains information about the backend being used.|
 |`backend.name`|string|The name of the backend being used. For example, `my-service` or `service/my-namespace/my-service:8080`.|
 |`backend.type`|enum|The type of backend.<br>Possible values: `ai`, `mcp`, `static`, `dynamic`, `service`, `unknown`.|

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -140,8 +140,8 @@
 |`mcp.resource.target`|string|The target of the resource|
 |`mcp.resource.name`|string|The name of the resource|
 |`mcp.task`|object||
-|`mcp.task.target`|string|The target of the resource|
-|`mcp.task.name`|string|The name of the resource|
+|`mcp.task.target`|string|The target handling the task.|
+|`mcp.task.name`|string|The task ID.|
 |`backend`|object|`backend` contains information about the backend being used.|
 |`backend.name`|string|The name of the backend being used. For example, `my-service` or `service/my-namespace/my-service:8080`.|
 |`backend.type`|enum|The type of backend.<br>Possible values: `ai`, `mcp`, `static`, `dynamic`, `service`, `unknown`.|

--- a/schema/config.json
+++ b/schema/config.json
@@ -7740,7 +7740,7 @@
       ]
     },
     "McpPrefixMode": {
-      "description": "Controls how upstream tool/prompt names are exposed to clients. Does not affect\ntask IDs (SEP-2663), which are always target-namespaced when multiplexing since\nthere's no `tasks/list` to resolve an unprefixed one against.",
+      "description": "Controls how upstream tool/prompt names are exposed to clients.",
       "oneOf": [
         {
           "description": "Prefix names with the target name only when there are multiple targets.",

--- a/schema/config.json
+++ b/schema/config.json
@@ -7740,7 +7740,7 @@
       ]
     },
     "McpPrefixMode": {
-      "description": "Controls how upstream tool/prompt names are exposed to clients.",
+      "description": "Controls how upstream tool/prompt names are exposed to clients. Does not affect\ntask IDs (SEP-2663), which are always target-namespaced when multiplexing since\nthere's no `tasks/list` to resolve an unprefixed one against.",
       "oneOf": [
         {
           "description": "Prefix names with the target name only when there are multiple targets.",


### PR DESCRIPTION
* route task methods (get/update/cancel)
* multiplex task IDs
* enforce RBAC on task methods
* thread task ID into Mcp-Name header 
* properly advertise the capability (don't strip it)

fixes #2554 

note this isn't well supported by the SDKs, it only last week made it into rust-sdk:
* https://github.com/modelcontextprotocol/typescript-sdk/issues/2189
* https://github.com/modelcontextprotocol/python-sdk/issues/2806

so I don't think merging this is super urgent