### PR TITLE
llm: when using custom provider ref, override provider name

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -966,6 +966,13 @@ impl LocalLLMModels {
 			self.params.model = Some(model_override);
 		}
 		self.provider = provider.provider.clone();
+		if let LocalModelAIProvider::Builtin(LocalBuiltinModelAIProvider::Custom(custom)) =
+			&mut self.provider
+		{
+			custom
+				.provider_override
+				.get_or_insert_with(|| provider.name.clone());
+		}
 		if let Some(defaults) = provider.defaults.clone() {
 			self.defaults = merge_optional_maps(defaults.defaults, self.defaults.take());
 			self.overrides = merge_optional_maps(defaults.overrides, self.overrides.take());

--- a/crates/agentgateway/src/types/local_tests/llm_provider_reference_config.yaml
+++ b/crates/agentgateway/src/types/local_tests/llm_provider_reference_config.yaml
@@ -17,6 +17,13 @@ llm:
         minTokens: 1024
       transformation:
         model: llmRequest.model.stripPrefix("anthropic/")
+  - name: completions-shared
+    provider:
+      custom:
+        formats:
+        - type: completions
+    params:
+      baseUrl: https://llm.example.com/v1
   models:
   - name: anthropic/*
     provider:
@@ -28,3 +35,6 @@ llm:
     promptCaching:
       cacheMessages: true
       minTokens: 2048
+  - name: example/*
+    provider:
+      reference: completions-shared

--- a/crates/agentgateway/src/types/local_tests/llm_provider_reference_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_provider_reference_normalized.snap
@@ -78,6 +78,40 @@ backends:
             minTokens: 2048
             cacheMessageOffset: 0
   - backend:
+      ai:
+        name: "llm:model:example/*:1"
+        namespace: ""
+        target:
+          providers:
+            - active:
+                example/*:
+                  endpoint:
+                    name: example/*
+                    provider:
+                      custom:
+                        providerOverride: completions-shared
+                        formats:
+                          - type: completions
+                            path: ~
+                    hostOverride: "llm.example.com:443"
+                    pathOverride: ~
+                    pathPrefix: /v1
+                    tokenize: false
+                  info:
+                    health: 1
+                    requestLatency: 0
+                    pendingRequests: 0
+                    totalRequests: 0
+                    consecutiveFailures: 0
+                    timesEjected: 0
+                    evictedUntil: ~
+                  capacity: 1
+              rejected: {}
+    inlinePolicies:
+      - backendTLS:
+          systemRoots: true
+      - ai: {}
+  - backend:
       llmRouter:
         name: "llm:router"
         namespace: ""
@@ -89,6 +123,31 @@ backends:
               headerMatches: []
               backend:
                 backend: "/llm:model:anthropic/*:0"
+                weight: 1
+              policies:
+                llm:
+                  routes:
+                    "*": passthrough
+                    /v1/chat/completions: completions
+                    /v1/embeddings: embeddings
+                    /v1/images/edits: detect
+                    /v1/images/generations: detect
+                    /v1/images/variations: detect
+                    /v1/messages: messages
+                    /v1/rerank: rerank
+                    /v1/responses: responses
+                    /v1/responses/compact: detect
+                    /v2/rerank: rerank
+                    ":rawPredict": messages
+                    ":streamRawPredict": messages
+                authorization: ~
+              backendPolicies: []
+            - name: example/*
+              created: 0
+              visibility: public
+              headerMatches: []
+              backend:
+                backend: "/llm:model:example/*:1"
                 weight: 1
               policies:
                 llm:


### PR DESCRIPTION
This is a breaking change if you rely on the `custom` provider name for
a lookup in a custom model catalog entry.

Signed-off-by: John Howard <john.howard@solo.io>
