### PR TITLE
promptGuard: apply guard to merged consecutive text blocks

### DIFF
--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1,6 +1,7 @@
 use ::http::HeaderMap;
 use bytes::Bytes;
 use http_body_util::BodyExt as _;
+use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -1295,7 +1296,18 @@ impl Policy {
 						Action::Mask => {
 							let replacement = format!("<{}>", results[0].entity_type);
 							let buf = working.get_or_insert_with(|| original_content.to_string());
-							for range in merge_ranges_desc(results.into_iter().map(|r| r.start..r.end)) {
+							// Replace in reverse order to avoid index shifting, coalescing overlaps
+							for range in results
+								.into_iter()
+								.map(|r| r.start..r.end)
+								.sorted_unstable_by(|a, b| b.start.cmp(&a.start).then_with(|| a.end.cmp(&b.end)))
+								.coalesce(|a, b| {
+									if b.end > a.start {
+										Ok(b.start..std::cmp::max(a.end, b.end))
+									} else {
+										Err((a, b))
+									}
+								}) {
 								buf.replace_range(range, &replacement);
 							}
 						},
@@ -1410,24 +1422,6 @@ impl Policy {
 enum RegexResult {
 	Mask(String),
 	Reject,
-}
-
-/// merge overlapping ranges, end-of-text-first so replacing doesn't shift pending offsets:
-/// `[1..3, 2..5, 7..9]` -> `[7..9, 1..5]`
-fn merge_ranges_desc(
-	ranges: impl Iterator<Item = std::ops::Range<usize>>,
-) -> Vec<std::ops::Range<usize>> {
-	let mut rs: Vec<_> = ranges.filter(|r| !r.is_empty()).collect();
-	rs.sort_unstable_by(|a, b| a.start.cmp(&b.start).then_with(|| a.end.cmp(&b.end)));
-	let mut out: Vec<std::ops::Range<usize>> = Vec::new();
-	for r in rs {
-		match out.last_mut() {
-			Some(last) if r.start < last.end => last.end = last.end.max(r.end),
-			_ => out.push(r),
-		}
-	}
-	out.reverse();
-	out
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1309,8 +1309,7 @@ impl Policy {
 						}
 						continue;
 					}
-					// skip zero-width matches (e.g. `a*`): they mask nothing, and replacing them
-					// inserts placeholders at every position
+					// zero-width matches (e.g. `a*`) mask nothing; replacing them inserts placeholders
 					let ranges: Vec<std::ops::Range<usize>> = pattern
 						.find_iter(content)
 						.map(|m| m.range())
@@ -1413,9 +1412,8 @@ enum RegexResult {
 	Reject,
 }
 
-/// Merge overlapping ranges (a single recognizer's patterns can hit the same span) and return
-/// them end-of-text-first, so each replacement leaves the offsets of the still-pending (earlier)
-/// ranges valid.
+/// merge overlapping ranges, end-of-text-first so replacing doesn't shift pending offsets:
+/// `[1..3, 2..5, 7..9]` -> `[7..9, 1..5]`
 fn merge_ranges_desc(
 	ranges: impl Iterator<Item = std::ops::Range<usize>>,
 ) -> Vec<std::ops::Range<usize>> {

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1,7 +1,6 @@
 use ::http::HeaderMap;
 use bytes::Bytes;
 use http_body_util::BodyExt as _;
-use itertools::Itertools;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -1296,18 +1295,7 @@ impl Policy {
 						Action::Mask => {
 							let replacement = format!("<{}>", results[0].entity_type);
 							let buf = working.get_or_insert_with(|| original_content.to_string());
-							// Replace in reverse order to avoid index shifting, coalescing overlaps
-							for range in results
-								.into_iter()
-								.map(|r| r.start..r.end)
-								.sorted_unstable_by(|a, b| b.start.cmp(&a.start).then_with(|| a.end.cmp(&b.end)))
-								.coalesce(|a, b| {
-									if b.end > a.start {
-										Ok(b.start..std::cmp::max(a.end, b.end))
-									} else {
-										Err((a, b))
-									}
-								}) {
+							for range in merge_ranges_desc(results.into_iter().map(|r| r.start..r.end)) {
 								buf.replace_range(range, &replacement);
 							}
 						},
@@ -1321,8 +1309,13 @@ impl Policy {
 						}
 						continue;
 					}
-					let ranges: Vec<std::ops::Range<usize>> =
-						pattern.find_iter(content).map(|m| m.range()).collect();
+					// skip zero-width matches (e.g. `a*`): they mask nothing, and replacing them
+					// inserts placeholders at every position
+					let ranges: Vec<std::ops::Range<usize>> = pattern
+						.find_iter(content)
+						.map(|m| m.range())
+						.filter(|r| !r.is_empty())
+						.collect();
 					if ranges.is_empty() {
 						continue;
 					}
@@ -1418,6 +1411,25 @@ impl Policy {
 enum RegexResult {
 	Mask(String),
 	Reject,
+}
+
+/// Merge overlapping ranges (a single recognizer's patterns can hit the same span) and return
+/// them end-of-text-first, so each replacement leaves the offsets of the still-pending (earlier)
+/// ranges valid.
+fn merge_ranges_desc(
+	ranges: impl Iterator<Item = std::ops::Range<usize>>,
+) -> Vec<std::ops::Range<usize>> {
+	let mut rs: Vec<_> = ranges.filter(|r| !r.is_empty()).collect();
+	rs.sort_unstable_by(|a, b| a.start.cmp(&b.start).then_with(|| a.end.cmp(&b.end)));
+	let mut out: Vec<std::ops::Range<usize>> = Vec::new();
+	for r in rs {
+		match out.last_mut() {
+			Some(last) if r.start < last.end => last.end = last.end.max(r.end),
+			_ => out.push(r),
+		}
+	}
+	out.reverse();
+	out
 }
 
 #[apply(schema!)]

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -1906,9 +1906,6 @@ fn test_apply_regex_response_preserves_tool_structure(
 	}
 }
 
-// Runs of consecutive text blocks are scanned as one joined string, so guard patterns spanning
-// adjacent blocks are detected. Non-text blocks (images, tools) are never scanned and break runs.
-// A run is only rewritten (collapsed into its last block) when a mask actually edits it.
 #[cfg(test)]
 #[rstest::rstest]
 #[case::completions_reject_across_blocks(
@@ -2003,22 +2000,32 @@ fn test_apply_regex_response_preserves_tool_structure(
 		]
 	}))
 )]
-#[case::non_text_block_breaks_the_run(
+#[case::mask_preserves_non_text_block_between_runs(
 	ChatFmt::Anthropic,
-	Action::Reject,
+	Action::Mask,
 	ssn_only(),
 	serde_json::json!({
 		"model": "claude-sonnet-5",
 		"max_tokens": 1024,
 		"messages": [
 			{"role": "user", "content": [
-				{"type": "text", "text": "my ssn is 123-45"},
+				{"type": "text", "text": "my ssn is 123-45-6789"},
 				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
-				{"type": "text", "text": "6789 thanks"}
+				{"type": "text", "text": "thanks"}
 			]}
 		]
 	}),
-	Expect::Unchanged
+	Expect::Masked(serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "my ssn is <SSN>"},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+				{"type": "text", "text": "thanks"}
+			]}
+		]
+	}))
 )]
 #[case::untouched_run_is_not_collapsed(
 	ChatFmt::Completions,
@@ -2076,12 +2083,10 @@ fn test_apply_regex_text_runs(
 	}
 }
 
-#[test]
 #[cfg(test)]
+#[test]
 fn test_merge_ranges_desc_is_transitive() {
-	// a touching pair plus an overlapping third must fully merge; the previous itertools
-	// coalesce was not transitive and emitted overlapping ranges here, which the replace loop
-	// then applied with stale offsets
+	// a touching pair must not break the merge chain
 	assert_eq!(
 		super::merge_ranges_desc([7..11, 6..7, 6..11].into_iter()),
 		vec![6..11]
@@ -2094,7 +2099,7 @@ fn test_merge_ranges_desc_is_transitive() {
 }
 
 #[cfg(test)]
-#[rstest::rstest]
+#[test]
 fn test_zero_width_pattern_is_a_noop() {
 	let (outcome, actual) = run_apply_regex(
 		ChatFmt::Completions,

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -1905,3 +1905,173 @@ fn test_apply_regex_response_preserves_tool_structure(
 		None => assert!(matches!(outcome, GuardrailOutcome::Rejected(_))),
 	}
 }
+
+// Runs of consecutive text blocks are scanned as one joined string, so guard patterns spanning
+// adjacent blocks are detected. Non-text blocks (images, tools) are never scanned and break runs.
+// A run is only rewritten (collapsed into its last block) when a mask actually edits it.
+#[cfg(test)]
+#[rstest::rstest]
+#[case::completions_reject_across_blocks(
+	ChatFmt::Completions,
+	Action::Reject,
+	vec![RegexRule::Regex { pattern: regex::Regex::new("secret token").unwrap() }],
+	serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "Please use this secret"},
+				{"type": "text", "text": "token to authenticate"}
+			]}
+		]
+	}),
+	Expect::Rejected
+)]
+#[case::anthropic_reject_across_blocks(
+	ChatFmt::Anthropic,
+	Action::Reject,
+	vec![RegexRule::Regex { pattern: regex::Regex::new("secret token").unwrap() }],
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "Please use this secret"},
+				{"type": "text", "text": "token to authenticate"}
+			]}
+		]
+	}),
+	Expect::Rejected
+)]
+#[case::responses_reject_across_blocks(
+	ChatFmt::Responses,
+	Action::Reject,
+	vec![RegexRule::Regex { pattern: regex::Regex::new("secret\ntoken").unwrap() }],
+	serde_json::json!({
+		"model": "gpt-4o",
+		"input": [
+			{"role": "user", "content": [
+				{"type": "input_text", "text": "Please use this secret"},
+				{"type": "input_text", "text": "token to authenticate"}
+			]}
+		]
+	}),
+	Expect::Rejected
+)]
+#[case::completions_mask_collapses_run(
+	ChatFmt::Completions,
+	Action::Mask,
+	vec![RegexRule::Regex { pattern: regex::Regex::new("secret token").unwrap() }],
+	serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "Please use this secret"},
+				{"type": "text", "text": "token to authenticate"}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "Please use this <masked> to authenticate"}
+			]}
+		]
+	}))
+)]
+#[case::anthropic_mask_collapsed_run_keeps_last_blocks_cache_control(
+	ChatFmt::Anthropic,
+	Action::Mask,
+	email_and_ssn(),
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact admin@example.com"},
+				{"type": "text", "text": "for help", "cache_control": {"type": "ephemeral"}}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact <EMAIL_ADDRESS> for help", "cache_control": {"type": "ephemeral"}}
+			]}
+		]
+	}))
+)]
+#[case::non_text_block_breaks_the_run(
+	ChatFmt::Anthropic,
+	Action::Reject,
+	ssn_only(),
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "my ssn is 123-45"},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+				{"type": "text", "text": "6789 thanks"}
+			]}
+		]
+	}),
+	Expect::Unchanged
+)]
+#[case::untouched_run_is_not_collapsed(
+	ChatFmt::Completions,
+	Action::Mask,
+	ssn_only(),
+	serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "no pii"},
+				{"type": "text", "text": "in here"}
+			]},
+			{"role": "user", "content": "my ssn is 123-45-6789"}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "no pii"},
+				{"type": "text", "text": "in here"}
+			]},
+			{"role": "user", "content": "my ssn is <SSN>"}
+		]
+	}))
+)]
+#[case::no_match_across_separate_messages(
+	ChatFmt::Completions,
+	Action::Reject,
+	vec![RegexRule::Regex { pattern: regex::Regex::new("secret token").unwrap() }],
+	serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": "Please use this secret"},
+			{"role": "user", "content": "token to authenticate"}
+		]
+	}),
+	Expect::Unchanged
+)]
+fn test_apply_regex_text_runs(
+	#[case] fmt: ChatFmt,
+	#[case] action: Action,
+	#[case] rules: Vec<RegexRule>,
+	#[case] input: serde_json::Value,
+	#[case] expected: Expect,
+) {
+	let (outcome, actual) = run_apply_regex(fmt, action, rules, input);
+	match expected {
+		Expect::Masked(expected) => {
+			assert!(matches!(outcome, GuardrailOutcome::Masked));
+			assert_eq!(actual, expected);
+		},
+		Expect::Rejected => assert!(matches!(outcome, GuardrailOutcome::Rejected(_))),
+		Expect::Unchanged => assert!(matches!(outcome, GuardrailOutcome::None)),
+	}
+}

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -2085,21 +2085,6 @@ fn test_apply_regex_text_runs(
 
 #[cfg(test)]
 #[test]
-fn test_merge_ranges_desc_is_transitive() {
-	// a touching pair must not break the merge chain
-	assert_eq!(
-		super::merge_ranges_desc([7..11, 6..7, 6..11].into_iter()),
-		vec![6..11]
-	);
-	// adjacent ranges stay separate; empty ranges are dropped
-	assert_eq!(
-		super::merge_ranges_desc([0..2, 2..4, 3..3].into_iter()),
-		vec![2..4, 0..2]
-	);
-}
-
-#[cfg(test)]
-#[test]
 fn test_zero_width_pattern_is_a_noop() {
 	let (outcome, actual) = run_apply_regex(
 		ChatFmt::Completions,

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -2075,3 +2075,44 @@ fn test_apply_regex_text_runs(
 		Expect::Unchanged => assert!(matches!(outcome, GuardrailOutcome::None)),
 	}
 }
+
+#[test]
+#[cfg(test)]
+fn test_merge_ranges_desc_is_transitive() {
+	// a touching pair plus an overlapping third must fully merge; the previous itertools
+	// coalesce was not transitive and emitted overlapping ranges here, which the replace loop
+	// then applied with stale offsets
+	assert_eq!(
+		super::merge_ranges_desc([7..11, 6..7, 6..11].into_iter()),
+		vec![6..11]
+	);
+	// adjacent ranges stay separate; empty ranges are dropped
+	assert_eq!(
+		super::merge_ranges_desc([0..2, 2..4, 3..3].into_iter()),
+		vec![2..4, 0..2]
+	);
+}
+
+#[cfg(test)]
+#[rstest::rstest]
+fn test_zero_width_pattern_is_a_noop() {
+	let (outcome, actual) = run_apply_regex(
+		ChatFmt::Completions,
+		Action::Mask,
+		vec![RegexRule::Regex {
+			pattern: regex::Regex::new("z*").unwrap(),
+		}],
+		serde_json::json!({
+			"model": "gpt-4o",
+			"messages": [{"role": "user", "content": "hello world"}]
+		}),
+	);
+	assert!(matches!(outcome, GuardrailOutcome::None));
+	assert_eq!(
+		actual,
+		serde_json::json!({
+			"model": "gpt-4o",
+			"messages": [{"role": "user", "content": "hello world"}]
+		})
+	);
+}

--- a/crates/llm/src/types/completions.rs
+++ b/crates/llm/src/types/completions.rs
@@ -408,11 +408,7 @@ impl super::RequestType for Request {
 			match &mut msg.content {
 				Some(Content::Text(text)) => f(text),
 				Some(Content::Array(parts)) => {
-					for part in parts {
-						if let Some(text) = &mut part.text {
-							f(text);
-						}
-					}
+					super::scan_text_runs(parts, " ", |p| p.text.as_mut(), f);
 				},
 				None => {},
 			}

--- a/crates/llm/src/types/messages.rs
+++ b/crates/llm/src/types/messages.rs
@@ -261,11 +261,15 @@ impl RequestType for Request {
 		match &mut self.system {
 			Some(TextBlock::Text(text)) => f(text),
 			Some(TextBlock::Array(parts)) => {
-				for part in parts {
-					if let TextPart::Text { text, .. } = part {
-						f(text);
-					}
-				}
+				crate::types::scan_text_runs(
+					parts,
+					"\n",
+					|p| match p {
+						TextPart::Text { text, .. } => Some(text),
+						TextPart::Unknown(_) => None,
+					},
+					f,
+				);
 			},
 			None => {},
 		}
@@ -273,13 +277,16 @@ impl RequestType for Request {
 			match &mut msg.content {
 				Some(ContentBlock::Text(text)) => f(text),
 				Some(ContentBlock::Array(parts)) => {
-					for part in parts {
-						match part {
-							ContentPart::Text { text, .. } => f(text),
+					crate::types::scan_text_runs(
+						parts,
+						" ",
+						|p| match p {
+							ContentPart::Text { text, .. } => Some(text),
 							// TODO opt-in setting to apply guards to tool results
-							ContentPart::Unknown(_) => {},
-						}
-					}
+							ContentPart::Unknown(_) => None,
+						},
+						f,
+					);
 				},
 				None => {},
 			}

--- a/crates/llm/src/types/mod.rs
+++ b/crates/llm/src/types/mod.rs
@@ -13,7 +13,7 @@ use agent_core::prelude::Strng;
 use agent_core::strng;
 use serde::Serialize;
 
-use crate::{apply, AIError, LLMRequest, LLMResponse};
+use crate::{AIError, LLMRequest, LLMResponse, apply};
 
 pub enum ChatRequest<'a> {
 	Completions(&'a completions::Request),
@@ -64,7 +64,7 @@ pub(crate) fn scan_text_runs<T>(
 		let mut joined = String::new();
 		let mut end = i;
 
-    // join until we hit non-text or the end of the list
+		// join until we hit non-text or the end of the list
 		while let Some(text) = parts.get_mut(end).and_then(&mut text_of) {
 			if end > i {
 				joined.push_str(sep);
@@ -77,7 +77,7 @@ pub(crate) fn scan_text_runs<T>(
 			continue;
 		}
 
-    // don't collapse the run into a single part if `f` wouldn't mutate it
+		// don't collapse the run into a single part if `f` wouldn't mutate it
 		let original = joined.clone();
 		f(&mut joined);
 		if joined == original {
@@ -85,7 +85,7 @@ pub(crate) fn scan_text_runs<T>(
 			continue;
 		}
 
-    // collapse the run's text into the last part, and remove the others
+		// collapse the run's text into the last part, and remove the others
 		if let Some(text) = text_of(&mut parts[end - 1]) {
 			*text = joined;
 		}

--- a/crates/llm/src/types/mod.rs
+++ b/crates/llm/src/types/mod.rs
@@ -50,6 +50,69 @@ pub trait RequestType: Send + Sync {
 	fn visit_text_mut(&mut self, f: &mut dyn FnMut(&mut String));
 }
 
+/// Scan each maximal run of consecutive text parts as one `sep`-joined string, so guard patterns
+/// spanning adjacent text blocks still match. Parts where `text_of` returns `None` (images, tool
+/// blocks) are never scanned and act as run boundaries.
+///
+/// If the guard edits the joined text, the run collapses into its last part (where
+/// `cache_control` conventionally lives), which receives the edited text. Untouched runs keep
+/// their original parts byte-identical, and single-part runs are scanned in place with no copying.
+pub(crate) fn scan_text_runs<T>(
+	parts: &mut Vec<T>,
+	sep: &str,
+	mut text_of: impl FnMut(&mut T) -> Option<&mut String>,
+	f: &mut dyn FnMut(&mut String),
+) {
+	fn flush<T>(
+		out: &mut Vec<T>,
+		run: &mut Vec<T>,
+		sep: &str,
+		text_of: &mut impl FnMut(&mut T) -> Option<&mut String>,
+		f: &mut dyn FnMut(&mut String),
+	) {
+		if run.len() == 1 {
+			let mut part = run.pop().expect("run has one part");
+			f(text_of(&mut part).expect("run parts have text"));
+			out.push(part);
+			return;
+		}
+		let mut joined = String::new();
+		for part in run.iter_mut() {
+			if !joined.is_empty() {
+				joined.push_str(sep);
+			}
+			joined.push_str(text_of(part).expect("run parts have text"));
+		}
+		let original = joined.clone();
+		f(&mut joined);
+		if joined == original {
+			out.append(run);
+			return;
+		}
+		let mut last = run.pop().expect("run has parts");
+		run.clear();
+		*text_of(&mut last).expect("run parts have text") = joined;
+		out.push(last);
+	}
+
+	let mut out: Vec<T> = Vec::with_capacity(parts.len());
+	let mut run: Vec<T> = Vec::new();
+	for mut part in parts.drain(..) {
+		if text_of(&mut part).is_some() {
+			run.push(part);
+		} else {
+			if !run.is_empty() {
+				flush(&mut out, &mut run, sep, &mut text_of, f);
+			}
+			out.push(part);
+		}
+	}
+	if !run.is_empty() {
+		flush(&mut out, &mut run, sep, &mut text_of, f);
+	}
+	*parts = out;
+}
+
 /// SimpleChatCompletionMessage is a simplified chat message
 #[apply(schema!)]
 #[derive(Eq, PartialEq, cel::DynamicType)]

--- a/crates/llm/src/types/mod.rs
+++ b/crates/llm/src/types/mod.rs
@@ -13,7 +13,7 @@ use agent_core::prelude::Strng;
 use agent_core::strng;
 use serde::Serialize;
 
-use crate::{AIError, LLMRequest, LLMResponse, apply};
+use crate::{apply, AIError, LLMRequest, LLMResponse};
 
 pub enum ChatRequest<'a> {
 	Completions(&'a completions::Request),
@@ -50,67 +50,48 @@ pub trait RequestType: Send + Sync {
 	fn visit_text_mut(&mut self, f: &mut dyn FnMut(&mut String));
 }
 
-/// Scan each maximal run of consecutive text parts as one `sep`-joined string, so guard patterns
-/// spanning adjacent text blocks still match. Parts where `text_of` returns `None` (images, tool
-/// blocks) are never scanned and act as run boundaries.
-///
-/// If the guard edits the joined text, the run collapses into its last part (where
-/// `cache_control` conventionally lives), which receives the edited text. Untouched runs keep
-/// their original parts byte-identical, and single-part runs are scanned in place with no copying.
+/// Scan runs of consecutive text parts as one `sep`-joined string: `[t1, t2, img, t3]` scans
+/// `"t1{sep}t2"` then `"t3"`. An edited run collapses into its last part (keeping its other
+/// fields, e.g. `cache_control`); untouched runs pass through unchanged.
 pub(crate) fn scan_text_runs<T>(
 	parts: &mut Vec<T>,
 	sep: &str,
 	mut text_of: impl FnMut(&mut T) -> Option<&mut String>,
 	f: &mut dyn FnMut(&mut String),
 ) {
-	fn flush<T>(
-		out: &mut Vec<T>,
-		run: &mut Vec<T>,
-		sep: &str,
-		text_of: &mut impl FnMut(&mut T) -> Option<&mut String>,
-		f: &mut dyn FnMut(&mut String),
-	) {
-		if run.len() == 1 {
-			let mut part = run.pop().expect("run has one part");
-			f(text_of(&mut part).expect("run parts have text"));
-			out.push(part);
-			return;
-		}
+	let mut i = 0;
+	while i < parts.len() {
 		let mut joined = String::new();
-		for part in run.iter_mut() {
-			if !joined.is_empty() {
+		let mut end = i;
+
+    // join until we hit non-text or the end of the list
+		while let Some(text) = parts.get_mut(end).and_then(&mut text_of) {
+			if end > i {
 				joined.push_str(sep);
 			}
-			joined.push_str(text_of(part).expect("run parts have text"));
+			joined.push_str(text);
+			end += 1;
 		}
+		if end == i {
+			i += 1;
+			continue;
+		}
+
+    // don't collapse the run into a single part if `f` wouldn't mutate it
 		let original = joined.clone();
 		f(&mut joined);
 		if joined == original {
-			out.append(run);
-			return;
+			i = end;
+			continue;
 		}
-		let mut last = run.pop().expect("run has parts");
-		run.clear();
-		*text_of(&mut last).expect("run parts have text") = joined;
-		out.push(last);
-	}
 
-	let mut out: Vec<T> = Vec::with_capacity(parts.len());
-	let mut run: Vec<T> = Vec::new();
-	for mut part in parts.drain(..) {
-		if text_of(&mut part).is_some() {
-			run.push(part);
-		} else {
-			if !run.is_empty() {
-				flush(&mut out, &mut run, sep, &mut text_of, f);
-			}
-			out.push(part);
+    // collapse the run's text into the last part, and remove the others
+		if let Some(text) = text_of(&mut parts[end - 1]) {
+			*text = joined;
 		}
+		parts.drain(i..end - 1);
+		i += 1;
 	}
-	if !run.is_empty() {
-		flush(&mut out, &mut run, sep, &mut text_of, f);
-	}
-	*parts = out;
 }
 
 /// SimpleChatCompletionMessage is a simplified chat message

--- a/crates/llm/src/types/mod.rs
+++ b/crates/llm/src/types/mod.rs
@@ -59,6 +59,13 @@ pub(crate) fn scan_text_runs<T>(
 	mut text_of: impl FnMut(&mut T) -> Option<&mut String>,
 	f: &mut dyn FnMut(&mut String),
 ) {
+	if let [part] = parts.as_mut_slice() {
+		if let Some(text) = text_of(part) {
+			f(text);
+		}
+		return;
+	}
+
 	let mut i = 0;
 	while i < parts.len() {
 		let mut joined = String::new();

--- a/crates/llm/src/types/responses.rs
+++ b/crates/llm/src/types/responses.rs
@@ -80,23 +80,29 @@ impl RawInputItem {
 		if self.0.get("role").is_some() {
 			match self.0.get_mut("content") {
 				Some(Value::String(text)) => f(text),
-				Some(Value::Array(parts)) => visit_text_parts(parts, f),
+				Some(Value::Array(parts)) => {
+					crate::types::scan_text_runs(
+						parts,
+						"\n",
+						|part| {
+							if !matches!(
+								part.get("type").and_then(|t| t.as_str()),
+								Some("input_text" | "output_text")
+							) {
+								return None;
+							}
+							match part.get_mut("text") {
+								Some(Value::String(text)) => Some(text),
+								_ => None,
+							}
+						},
+						f,
+					);
+				},
 				_ => {},
 			}
 		}
 		// TODO opt-in setting to apply guards to tool results
-	}
-}
-
-fn visit_text_parts(parts: &mut [Value], f: &mut dyn FnMut(&mut String)) {
-	for part in parts {
-		if matches!(
-			part.get("type").and_then(|t| t.as_str()),
-			Some("input_text" | "output_text")
-		) && let Some(Value::String(text)) = part.get_mut("text")
-		{
-			f(text);
-		}
 	}
 }
 


### PR DESCRIPTION
```json
{
    "model": "gpt-4o",
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "Please use this secret"
          },
          {
            "type": "text",
            "text": "token to authenticate"
          }
        ]
      }
    ]
  }
```

#2732 made us scan each block separately meaning a match across blocks would be missed; this restores that behavior

also fixes a small bug: zero-length regex matches (`a*`) could insert <masked> at every position 