### PR TITLE
auth: consolidate duplicated jwtSign / oauth token exchange code

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -82,6 +82,67 @@ func (Protocol) EnumDescriptor() ([]byte, []int) {
 	return file_resource_proto_rawDescGZIP(), []int{0}
 }
 
+type JwtSigningAlg int32
+
+const (
+	JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED JwtSigningAlg = 0
+	JwtSigningAlg_RS256                       JwtSigningAlg = 1
+	JwtSigningAlg_RS384                       JwtSigningAlg = 2
+	JwtSigningAlg_RS512                       JwtSigningAlg = 3
+	JwtSigningAlg_ES256                       JwtSigningAlg = 4
+	JwtSigningAlg_ES384                       JwtSigningAlg = 5
+	JwtSigningAlg_PS256                       JwtSigningAlg = 6
+)
+
+// Enum value maps for JwtSigningAlg.
+var (
+	JwtSigningAlg_name = map[int32]string{
+		0: "JWT_SIGNING_ALG_UNSPECIFIED",
+		1: "RS256",
+		2: "RS384",
+		3: "RS512",
+		4: "ES256",
+		5: "ES384",
+		6: "PS256",
+	}
+	JwtSigningAlg_value = map[string]int32{
+		"JWT_SIGNING_ALG_UNSPECIFIED": 0,
+		"RS256":                       1,
+		"RS384":                       2,
+		"RS512":                       3,
+		"ES256":                       4,
+		"ES384":                       5,
+		"PS256":                       6,
+	}
+)
+
+func (x JwtSigningAlg) Enum() *JwtSigningAlg {
+	p := new(JwtSigningAlg)
+	*p = x
+	return p
+}
+
+func (x JwtSigningAlg) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (JwtSigningAlg) Descriptor() protoreflect.EnumDescriptor {
+	return file_resource_proto_enumTypes[1].Descriptor()
+}
+
+func (JwtSigningAlg) Type() protoreflect.EnumType {
+	return &file_resource_proto_enumTypes[1]
+}
+
+func (x JwtSigningAlg) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use JwtSigningAlg.Descriptor instead.
+func (JwtSigningAlg) EnumDescriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{1}
+}
+
 // Protocol defines the bind-level protocol to use. Individual listeners will have more details about this.
 // For instance, a Bind protocol TLS may have TLS termination and TLS passthrough listeners.
 // However, it indicates we need to process TLS
@@ -118,11 +179,11 @@ func (x Bind_Protocol) String() string {
 }
 
 func (Bind_Protocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[1].Descriptor()
+	return file_resource_proto_enumTypes[2].Descriptor()
 }
 
 func (Bind_Protocol) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[1]
+	return &file_resource_proto_enumTypes[2]
 }
 
 func (x Bind_Protocol) Number() protoreflect.EnumNumber {
@@ -174,11 +235,11 @@ func (x Bind_TunnelProtocol) String() string {
 }
 
 func (Bind_TunnelProtocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[2].Descriptor()
+	return file_resource_proto_enumTypes[3].Descriptor()
 }
 
 func (Bind_TunnelProtocol) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[2]
+	return &file_resource_proto_enumTypes[3]
 }
 
 func (x Bind_TunnelProtocol) Number() protoreflect.EnumNumber {
@@ -225,11 +286,11 @@ func (x Bind_Mode) String() string {
 }
 
 func (Bind_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[3].Descriptor()
+	return file_resource_proto_enumTypes[4].Descriptor()
 }
 
 func (Bind_Mode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[3]
+	return &file_resource_proto_enumTypes[4]
 }
 
 func (x Bind_Mode) Number() protoreflect.EnumNumber {
@@ -271,11 +332,11 @@ func (x Policy_Inheritance) String() string {
 }
 
 func (Policy_Inheritance) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[4].Descriptor()
+	return file_resource_proto_enumTypes[5].Descriptor()
 }
 
 func (Policy_Inheritance) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[4]
+	return &file_resource_proto_enumTypes[5]
 }
 
 func (x Policy_Inheritance) Number() protoreflect.EnumNumber {
@@ -320,11 +381,11 @@ func (x TLSConfig_CertificateSource) String() string {
 }
 
 func (TLSConfig_CertificateSource) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[5].Descriptor()
+	return file_resource_proto_enumTypes[6].Descriptor()
 }
 
 func (TLSConfig_CertificateSource) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[5]
+	return &file_resource_proto_enumTypes[6]
 }
 
 func (x TLSConfig_CertificateSource) Number() protoreflect.EnumNumber {
@@ -369,11 +430,11 @@ func (x TLSConfig_TLSVersion) String() string {
 }
 
 func (TLSConfig_TLSVersion) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[6].Descriptor()
+	return file_resource_proto_enumTypes[7].Descriptor()
 }
 
 func (TLSConfig_TLSVersion) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[6]
+	return &file_resource_proto_enumTypes[7]
 }
 
 func (x TLSConfig_TLSVersion) Number() protoreflect.EnumNumber {
@@ -420,11 +481,11 @@ func (x TLSConfig_MTLSMode) String() string {
 }
 
 func (TLSConfig_MTLSMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[7].Descriptor()
+	return file_resource_proto_enumTypes[8].Descriptor()
 }
 
 func (TLSConfig_MTLSMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[7]
+	return &file_resource_proto_enumTypes[8]
 }
 
 func (x TLSConfig_MTLSMode) Number() protoreflect.EnumNumber {
@@ -494,11 +555,11 @@ func (x TLSConfig_CipherSuite) String() string {
 }
 
 func (TLSConfig_CipherSuite) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[8].Descriptor()
+	return file_resource_proto_enumTypes[9].Descriptor()
 }
 
 func (TLSConfig_CipherSuite) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[8]
+	return &file_resource_proto_enumTypes[9]
 }
 
 func (x TLSConfig_CipherSuite) Number() protoreflect.EnumNumber {
@@ -551,11 +612,11 @@ func (x TLSConfig_KeyExchangeGroup) String() string {
 }
 
 func (TLSConfig_KeyExchangeGroup) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[9].Descriptor()
+	return file_resource_proto_enumTypes[10].Descriptor()
 }
 
 func (TLSConfig_KeyExchangeGroup) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[9]
+	return &file_resource_proto_enumTypes[10]
 }
 
 func (x TLSConfig_KeyExchangeGroup) Number() protoreflect.EnumNumber {
@@ -565,67 +626,6 @@ func (x TLSConfig_KeyExchangeGroup) Number() protoreflect.EnumNumber {
 // Deprecated: Use TLSConfig_KeyExchangeGroup.Descriptor instead.
 func (TLSConfig_KeyExchangeGroup) EnumDescriptor() ([]byte, []int) {
 	return file_resource_proto_rawDescGZIP(), []int{15, 4}
-}
-
-type JwtSign_SigningAlg int32
-
-const (
-	JwtSign_SIGNING_ALG_UNSPECIFIED JwtSign_SigningAlg = 0 // defaults to RS256
-	JwtSign_RS256                   JwtSign_SigningAlg = 1
-	JwtSign_RS384                   JwtSign_SigningAlg = 2
-	JwtSign_RS512                   JwtSign_SigningAlg = 3
-	JwtSign_ES256                   JwtSign_SigningAlg = 4
-	JwtSign_ES384                   JwtSign_SigningAlg = 5
-	JwtSign_PS256                   JwtSign_SigningAlg = 6
-)
-
-// Enum value maps for JwtSign_SigningAlg.
-var (
-	JwtSign_SigningAlg_name = map[int32]string{
-		0: "SIGNING_ALG_UNSPECIFIED",
-		1: "RS256",
-		2: "RS384",
-		3: "RS512",
-		4: "ES256",
-		5: "ES384",
-		6: "PS256",
-	}
-	JwtSign_SigningAlg_value = map[string]int32{
-		"SIGNING_ALG_UNSPECIFIED": 0,
-		"RS256":                   1,
-		"RS384":                   2,
-		"RS512":                   3,
-		"ES256":                   4,
-		"ES384":                   5,
-		"PS256":                   6,
-	}
-)
-
-func (x JwtSign_SigningAlg) Enum() *JwtSign_SigningAlg {
-	p := new(JwtSign_SigningAlg)
-	*p = x
-	return p
-}
-
-func (x JwtSign_SigningAlg) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (JwtSign_SigningAlg) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[10].Descriptor()
-}
-
-func (JwtSign_SigningAlg) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[10]
-}
-
-func (x JwtSign_SigningAlg) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use JwtSign_SigningAlg.Descriptor instead.
-func (JwtSign_SigningAlg) EnumDescriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{24, 0}
 }
 
 type FrontendPolicySpec_HTTP_HTTPHeaderCase int32
@@ -2630,67 +2630,6 @@ func (OAuthClientAuth_Method) EnumDescriptor() ([]byte, []int) {
 	return file_resource_proto_rawDescGZIP(), []int{67, 0}
 }
 
-type OAuthClientAuth_PrivateKeyJwt_SigningAlg int32
-
-const (
-	OAuthClientAuth_PrivateKeyJwt_SIGNING_ALG_UNSPECIFIED OAuthClientAuth_PrivateKeyJwt_SigningAlg = 0 // defaults to RS256
-	OAuthClientAuth_PrivateKeyJwt_RS256                   OAuthClientAuth_PrivateKeyJwt_SigningAlg = 1
-	OAuthClientAuth_PrivateKeyJwt_RS384                   OAuthClientAuth_PrivateKeyJwt_SigningAlg = 2
-	OAuthClientAuth_PrivateKeyJwt_RS512                   OAuthClientAuth_PrivateKeyJwt_SigningAlg = 3
-	OAuthClientAuth_PrivateKeyJwt_ES256                   OAuthClientAuth_PrivateKeyJwt_SigningAlg = 4
-	OAuthClientAuth_PrivateKeyJwt_ES384                   OAuthClientAuth_PrivateKeyJwt_SigningAlg = 5
-	OAuthClientAuth_PrivateKeyJwt_PS256                   OAuthClientAuth_PrivateKeyJwt_SigningAlg = 6
-)
-
-// Enum value maps for OAuthClientAuth_PrivateKeyJwt_SigningAlg.
-var (
-	OAuthClientAuth_PrivateKeyJwt_SigningAlg_name = map[int32]string{
-		0: "SIGNING_ALG_UNSPECIFIED",
-		1: "RS256",
-		2: "RS384",
-		3: "RS512",
-		4: "ES256",
-		5: "ES384",
-		6: "PS256",
-	}
-	OAuthClientAuth_PrivateKeyJwt_SigningAlg_value = map[string]int32{
-		"SIGNING_ALG_UNSPECIFIED": 0,
-		"RS256":                   1,
-		"RS384":                   2,
-		"RS512":                   3,
-		"ES256":                   4,
-		"ES384":                   5,
-		"PS256":                   6,
-	}
-)
-
-func (x OAuthClientAuth_PrivateKeyJwt_SigningAlg) Enum() *OAuthClientAuth_PrivateKeyJwt_SigningAlg {
-	p := new(OAuthClientAuth_PrivateKeyJwt_SigningAlg)
-	*p = x
-	return p
-}
-
-func (x OAuthClientAuth_PrivateKeyJwt_SigningAlg) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (OAuthClientAuth_PrivateKeyJwt_SigningAlg) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[50].Descriptor()
-}
-
-func (OAuthClientAuth_PrivateKeyJwt_SigningAlg) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[50]
-}
-
-func (x OAuthClientAuth_PrivateKeyJwt_SigningAlg) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use OAuthClientAuth_PrivateKeyJwt_SigningAlg.Descriptor instead.
-func (OAuthClientAuth_PrivateKeyJwt_SigningAlg) EnumDescriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{67, 0, 0}
-}
-
 type OAuthClientAuth_PrivateKeyJwt_CertificateHeader int32
 
 const (
@@ -2724,11 +2663,11 @@ func (x OAuthClientAuth_PrivateKeyJwt_CertificateHeader) String() string {
 }
 
 func (OAuthClientAuth_PrivateKeyJwt_CertificateHeader) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[51].Descriptor()
+	return file_resource_proto_enumTypes[50].Descriptor()
 }
 
 func (OAuthClientAuth_PrivateKeyJwt_CertificateHeader) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[51]
+	return &file_resource_proto_enumTypes[50]
 }
 
 func (x OAuthClientAuth_PrivateKeyJwt_CertificateHeader) Number() protoreflect.EnumNumber {
@@ -2737,7 +2676,7 @@ func (x OAuthClientAuth_PrivateKeyJwt_CertificateHeader) Number() protoreflect.E
 
 // Deprecated: Use OAuthClientAuth_PrivateKeyJwt_CertificateHeader.Descriptor instead.
 func (OAuthClientAuth_PrivateKeyJwt_CertificateHeader) EnumDescriptor() ([]byte, []int) {
-	return file_resource_proto_rawDescGZIP(), []int{67, 0, 1}
+	return file_resource_proto_rawDescGZIP(), []int{67, 0, 0}
 }
 
 type OAuthTokenExchange_GrantType int32
@@ -2773,11 +2712,11 @@ func (x OAuthTokenExchange_GrantType) String() string {
 }
 
 func (OAuthTokenExchange_GrantType) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[52].Descriptor()
+	return file_resource_proto_enumTypes[51].Descriptor()
 }
 
 func (OAuthTokenExchange_GrantType) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[52]
+	return &file_resource_proto_enumTypes[51]
 }
 
 func (x OAuthTokenExchange_GrantType) Number() protoreflect.EnumNumber {
@@ -2819,11 +2758,11 @@ func (x ModelRoute_ConcreteModel_ModelVisibility) String() string {
 }
 
 func (ModelRoute_ConcreteModel_ModelVisibility) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[53].Descriptor()
+	return file_resource_proto_enumTypes[52].Descriptor()
 }
 
 func (ModelRoute_ConcreteModel_ModelVisibility) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[53]
+	return &file_resource_proto_enumTypes[52]
 }
 
 func (x ModelRoute_ConcreteModel_ModelVisibility) Number() protoreflect.EnumNumber {
@@ -5050,7 +4989,7 @@ type JwtSign struct {
 	// algorithms; EC keys are used with ES* algorithms.
 	SigningKey string `protobuf:"bytes,1,opt,name=signing_key,json=signingKey,proto3" json:"signing_key,omitempty"`
 	// JWS signing algorithm. Defaults to RS256.
-	Alg JwtSign_SigningAlg `protobuf:"varint,2,opt,name=alg,proto3,enum=agentgateway.dev.resource.JwtSign_SigningAlg" json:"alg,omitempty"`
+	Alg JwtSigningAlg `protobuf:"varint,2,opt,name=alg,proto3,enum=agentgateway.dev.resource.JwtSigningAlg" json:"alg,omitempty"`
 	// Optional JWS key ID header.
 	Kid *string `protobuf:"bytes,3,opt,name=kid,proto3,oneof" json:"kid,omitempty"`
 	// Static claims added to every token (e.g. iss, sub, aud). iat, exp, and
@@ -5102,11 +5041,11 @@ func (x *JwtSign) GetSigningKey() string {
 	return ""
 }
 
-func (x *JwtSign) GetAlg() JwtSign_SigningAlg {
+func (x *JwtSign) GetAlg() JwtSigningAlg {
 	if x != nil {
 		return x.Alg
 	}
-	return JwtSign_SIGNING_ALG_UNSPECIFIED
+	return JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED
 }
 
 func (x *JwtSign) GetKid() string {
@@ -16041,7 +15980,7 @@ type OAuthClientAuth_PrivateKeyJwt struct {
 	// algorithms; EC keys are used with ES* algorithms.
 	SigningKey string `protobuf:"bytes,1,opt,name=signing_key,json=signingKey,proto3" json:"signing_key,omitempty"`
 	// JWS signing algorithm. Defaults to RS256.
-	Alg OAuthClientAuth_PrivateKeyJwt_SigningAlg `protobuf:"varint,2,opt,name=alg,proto3,enum=agentgateway.dev.resource.OAuthClientAuth_PrivateKeyJwt_SigningAlg" json:"alg,omitempty"`
+	Alg JwtSigningAlg `protobuf:"varint,2,opt,name=alg,proto3,enum=agentgateway.dev.resource.JwtSigningAlg" json:"alg,omitempty"`
 	// Optional JWS key ID header.
 	Kid *string `protobuf:"bytes,3,opt,name=kid,proto3,oneof" json:"kid,omitempty"`
 	// Audience for the client assertion, typically the token endpoint URL.
@@ -16095,11 +16034,11 @@ func (x *OAuthClientAuth_PrivateKeyJwt) GetSigningKey() string {
 	return ""
 }
 
-func (x *OAuthClientAuth_PrivateKeyJwt) GetAlg() OAuthClientAuth_PrivateKeyJwt_SigningAlg {
+func (x *OAuthClientAuth_PrivateKeyJwt) GetAlg() JwtSigningAlg {
 	if x != nil {
 		return x.Alg
 	}
-	return OAuthClientAuth_PrivateKeyJwt_SIGNING_ALG_UNSPECIFIED
+	return JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED
 }
 
 func (x *OAuthClientAuth_PrivateKeyJwt) GetKid() string {
@@ -17170,27 +17109,18 @@ const file_resource_proto_rawDesc = "" +
 	"\x16authorization_location\x18\x01 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\"\x86\x01\n" +
 	"\x03Key\x12\x16\n" +
 	"\x06secret\x18\x01 \x01(\tR\x06secret\x12g\n" +
-	"\x16authorization_location\x18\x02 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\"\xb5\x04\n" +
+	"\x16authorization_location\x18\x02 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\"\xc3\x03\n" +
 	"\aJwtSign\x12\x1f\n" +
 	"\vsigning_key\x18\x01 \x01(\tR\n" +
-	"signingKey\x12?\n" +
-	"\x03alg\x18\x02 \x01(\x0e2-.agentgateway.dev.resource.JwtSign.SigningAlgR\x03alg\x12\x15\n" +
+	"signingKey\x12:\n" +
+	"\x03alg\x18\x02 \x01(\x0e2(.agentgateway.dev.resource.JwtSigningAlgR\x03alg\x12\x15\n" +
 	"\x03kid\x18\x03 \x01(\tH\x00R\x03kid\x88\x01\x01\x12F\n" +
 	"\x06claims\x18\x04 \x03(\v2..agentgateway.dev.resource.JwtSign.ClaimsEntryR\x06claims\x120\n" +
 	"\x03ttl\x18\x05 \x01(\v2\x19.google.protobuf.DurationH\x01R\x03ttl\x88\x01\x01\x12g\n" +
 	"\x16authorization_location\x18\x06 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\x1aQ\n" +
 	"\vClaimsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
-	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01\"k\n" +
-	"\n" +
-	"SigningAlg\x12\x1b\n" +
-	"\x17SIGNING_ALG_UNSPECIFIED\x10\x00\x12\t\n" +
-	"\x05RS256\x10\x01\x12\t\n" +
-	"\x05RS384\x10\x02\x12\t\n" +
-	"\x05RS512\x10\x03\x12\t\n" +
-	"\x05ES256\x10\x04\x12\t\n" +
-	"\x05ES384\x10\x05\x12\t\n" +
-	"\x05PS256\x10\x06B\x06\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01B\x06\n" +
 	"\x04_kidB\x06\n" +
 	"\x04_ttl\"\xa5\x02\n" +
 	"\x03Gcp\x12#\n" +
@@ -18222,29 +18152,20 @@ const file_resource_proto_rawDesc = "" +
 	"\bhostname\x18\x02 \x01(\tR\bhostnameB\x06\n" +
 	"\x04kind\"$\n" +
 	"\x04Alpn\x12\x1c\n" +
-	"\tprotocols\x18\x01 \x03(\tR\tprotocols\"\xaa\a\n" +
+	"\tprotocols\x18\x01 \x03(\tR\tprotocols\"\xa2\x06\n" +
 	"\x0fOAuthClientAuth\x12\x1b\n" +
 	"\tclient_id\x18\x01 \x01(\tR\bclientId\x12(\n" +
 	"\rclient_secret\x18\x02 \x01(\tH\x00R\fclientSecret\x88\x01\x01\x12I\n" +
 	"\x06method\x18\x03 \x01(\x0e21.agentgateway.dev.resource.OAuthClientAuth.MethodR\x06method\x12`\n" +
-	"\x0fprivate_key_jwt\x18\x04 \x01(\v28.agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwtR\rprivateKeyJwt\x1a\xaf\x04\n" +
+	"\x0fprivate_key_jwt\x18\x04 \x01(\v28.agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwtR\rprivateKeyJwt\x1a\xa7\x03\n" +
 	"\rPrivateKeyJwt\x12\x1f\n" +
 	"\vsigning_key\x18\x01 \x01(\tR\n" +
-	"signingKey\x12U\n" +
-	"\x03alg\x18\x02 \x01(\x0e2C.agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.SigningAlgR\x03alg\x12\x15\n" +
+	"signingKey\x12:\n" +
+	"\x03alg\x18\x02 \x01(\x0e2(.agentgateway.dev.resource.JwtSigningAlgR\x03alg\x12\x15\n" +
 	"\x03kid\x18\x03 \x01(\tH\x00R\x03kid\x88\x01\x01\x12-\n" +
 	"\x12assertion_audience\x18\x04 \x01(\tR\x11assertionAudience\x12 \n" +
 	"\vcertificate\x18\x05 \x01(\tR\vcertificate\x12y\n" +
-	"\x12certificate_header\x18\x06 \x01(\x0e2J.agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeaderR\x11certificateHeader\"k\n" +
-	"\n" +
-	"SigningAlg\x12\x1b\n" +
-	"\x17SIGNING_ALG_UNSPECIFIED\x10\x00\x12\t\n" +
-	"\x05RS256\x10\x01\x12\t\n" +
-	"\x05RS384\x10\x02\x12\t\n" +
-	"\x05RS512\x10\x03\x12\t\n" +
-	"\x05ES256\x10\x04\x12\t\n" +
-	"\x05ES384\x10\x05\x12\t\n" +
-	"\x05PS256\x10\x06\"N\n" +
+	"\x12certificate_header\x18\x06 \x01(\x0e2J.agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeaderR\x11certificateHeader\"N\n" +
 	"\x11CertificateHeader\x12\"\n" +
 	"\x1eCERTIFICATE_HEADER_UNSPECIFIED\x10\x00\x12\a\n" +
 	"\x03X5C\x10\x01\x12\f\n" +
@@ -18365,7 +18286,15 @@ const file_resource_proto_rawDesc = "" +
 	"\x05HTTPS\x10\x02\x12\a\n" +
 	"\x03TLS\x10\x03\x12\a\n" +
 	"\x03TCP\x10\x04\x12\t\n" +
-	"\x05HBONE\x10\x05B1Z/github.com/agentgateway/agentgateway/go/api;apib\x06proto3"
+	"\x05HBONE\x10\x05*r\n" +
+	"\rJwtSigningAlg\x12\x1f\n" +
+	"\x1bJWT_SIGNING_ALG_UNSPECIFIED\x10\x00\x12\t\n" +
+	"\x05RS256\x10\x01\x12\t\n" +
+	"\x05RS384\x10\x02\x12\t\n" +
+	"\x05RS512\x10\x03\x12\t\n" +
+	"\x05ES256\x10\x04\x12\t\n" +
+	"\x05ES384\x10\x05\x12\t\n" +
+	"\x05PS256\x10\x06B1Z/github.com/agentgateway/agentgateway/go/api;apib\x06proto3"
 
 var (
 	file_resource_proto_rawDescOnce sync.Once
@@ -18379,20 +18308,20 @@ func file_resource_proto_rawDescGZIP() []byte {
 	return file_resource_proto_rawDescData
 }
 
-var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 54)
+var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 53)
 var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 206)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),                                               // 0: agentgateway.dev.resource.Protocol
-	(Bind_Protocol)(0),                                          // 1: agentgateway.dev.resource.Bind.Protocol
-	(Bind_TunnelProtocol)(0),                                    // 2: agentgateway.dev.resource.Bind.TunnelProtocol
-	(Bind_Mode)(0),                                              // 3: agentgateway.dev.resource.Bind.Mode
-	(Policy_Inheritance)(0),                                     // 4: agentgateway.dev.resource.Policy.Inheritance
-	(TLSConfig_CertificateSource)(0),                            // 5: agentgateway.dev.resource.TLSConfig.CertificateSource
-	(TLSConfig_TLSVersion)(0),                                   // 6: agentgateway.dev.resource.TLSConfig.TLSVersion
-	(TLSConfig_MTLSMode)(0),                                     // 7: agentgateway.dev.resource.TLSConfig.MTLSMode
-	(TLSConfig_CipherSuite)(0),                                  // 8: agentgateway.dev.resource.TLSConfig.CipherSuite
-	(TLSConfig_KeyExchangeGroup)(0),                             // 9: agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
-	(JwtSign_SigningAlg)(0),                                     // 10: agentgateway.dev.resource.JwtSign.SigningAlg
+	(JwtSigningAlg)(0),                                          // 1: agentgateway.dev.resource.JwtSigningAlg
+	(Bind_Protocol)(0),                                          // 2: agentgateway.dev.resource.Bind.Protocol
+	(Bind_TunnelProtocol)(0),                                    // 3: agentgateway.dev.resource.Bind.TunnelProtocol
+	(Bind_Mode)(0),                                              // 4: agentgateway.dev.resource.Bind.Mode
+	(Policy_Inheritance)(0),                                     // 5: agentgateway.dev.resource.Policy.Inheritance
+	(TLSConfig_CertificateSource)(0),                            // 6: agentgateway.dev.resource.TLSConfig.CertificateSource
+	(TLSConfig_TLSVersion)(0),                                   // 7: agentgateway.dev.resource.TLSConfig.TLSVersion
+	(TLSConfig_MTLSMode)(0),                                     // 8: agentgateway.dev.resource.TLSConfig.MTLSMode
+	(TLSConfig_CipherSuite)(0),                                  // 9: agentgateway.dev.resource.TLSConfig.CipherSuite
+	(TLSConfig_KeyExchangeGroup)(0),                             // 10: agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
 	(FrontendPolicySpec_HTTP_HTTPHeaderCase)(0),                 // 11: agentgateway.dev.resource.FrontendPolicySpec.HTTP.HTTPHeaderCase
 	(FrontendPolicySpec_Logging_OtlpAccessLog_Protocol)(0),      // 12: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
 	(FrontendPolicySpec_Tracing_Protocol)(0),                    // 13: agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
@@ -18432,593 +18361,592 @@ var file_resource_proto_goTypes = []any{
 	(MCPBackend_FailureMode)(0),                                 // 47: agentgateway.dev.resource.MCPBackend.FailureMode
 	(MCPTarget_Protocol)(0),                                     // 48: agentgateway.dev.resource.MCPTarget.Protocol
 	(OAuthClientAuth_Method)(0),                                 // 49: agentgateway.dev.resource.OAuthClientAuth.Method
-	(OAuthClientAuth_PrivateKeyJwt_SigningAlg)(0),               // 50: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.SigningAlg
-	(OAuthClientAuth_PrivateKeyJwt_CertificateHeader)(0),        // 51: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
-	(OAuthTokenExchange_GrantType)(0),                           // 52: agentgateway.dev.resource.OAuthTokenExchange.GrantType
-	(ModelRoute_ConcreteModel_ModelVisibility)(0),               // 53: agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
-	(*Resource)(nil),                                            // 54: agentgateway.dev.resource.Resource
-	(*Bind)(nil),                                                // 55: agentgateway.dev.resource.Bind
-	(*RouteName)(nil),                                           // 56: agentgateway.dev.resource.RouteName
-	(*ListenerName)(nil),                                        // 57: agentgateway.dev.resource.ListenerName
-	(*ResourceName)(nil),                                        // 58: agentgateway.dev.resource.ResourceName
-	(*TypedResourceName)(nil),                                   // 59: agentgateway.dev.resource.TypedResourceName
-	(*Listener)(nil),                                            // 60: agentgateway.dev.resource.Listener
-	(*Route)(nil),                                               // 61: agentgateway.dev.resource.Route
-	(*RouteGroup)(nil),                                          // 62: agentgateway.dev.resource.RouteGroup
-	(*TCPRoute)(nil),                                            // 63: agentgateway.dev.resource.TCPRoute
-	(*ConditionalPolicies)(nil),                                 // 64: agentgateway.dev.resource.ConditionalPolicies
-	(*ConditionalPolicy)(nil),                                   // 65: agentgateway.dev.resource.ConditionalPolicy
-	(*Policy)(nil),                                              // 66: agentgateway.dev.resource.Policy
-	(*Backend)(nil),                                             // 67: agentgateway.dev.resource.Backend
-	(*GuardrailBackend)(nil),                                    // 68: agentgateway.dev.resource.GuardrailBackend
-	(*TLSConfig)(nil),                                           // 69: agentgateway.dev.resource.TLSConfig
-	(*Timeout)(nil),                                             // 70: agentgateway.dev.resource.Timeout
-	(*Retry)(nil),                                               // 71: agentgateway.dev.resource.Retry
-	(*Delay)(nil),                                               // 72: agentgateway.dev.resource.Delay
-	(*BackendAuthPolicy)(nil),                                   // 73: agentgateway.dev.resource.BackendAuthPolicy
-	(*BackendAuthCredential)(nil),                               // 74: agentgateway.dev.resource.BackendAuthCredential
-	(*AuthorizationLocation)(nil),                               // 75: agentgateway.dev.resource.AuthorizationLocation
-	(*Passthrough)(nil),                                         // 76: agentgateway.dev.resource.Passthrough
-	(*Key)(nil),                                                 // 77: agentgateway.dev.resource.Key
-	(*JwtSign)(nil),                                             // 78: agentgateway.dev.resource.JwtSign
-	(*Gcp)(nil),                                                 // 79: agentgateway.dev.resource.Gcp
-	(*Aws)(nil),                                                 // 80: agentgateway.dev.resource.Aws
-	(*Azure)(nil),                                               // 81: agentgateway.dev.resource.Azure
-	(*AwsExplicitConfig)(nil),                                   // 82: agentgateway.dev.resource.AwsExplicitConfig
-	(*AwsImplicit)(nil),                                         // 83: agentgateway.dev.resource.AwsImplicit
-	(*AwsAssumeRole)(nil),                                       // 84: agentgateway.dev.resource.AwsAssumeRole
-	(*AwsSessionTag)(nil),                                       // 85: agentgateway.dev.resource.AwsSessionTag
-	(*AzureExplicitConfig)(nil),                                 // 86: agentgateway.dev.resource.AzureExplicitConfig
-	(*AzureClientSecret)(nil),                                   // 87: agentgateway.dev.resource.AzureClientSecret
-	(*AzureManagedIdentityCredential)(nil),                      // 88: agentgateway.dev.resource.AzureManagedIdentityCredential
-	(*AzureWorkloadIdentityCredential)(nil),                     // 89: agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	(*AzureDeveloperImplicit)(nil),                              // 90: agentgateway.dev.resource.AzureDeveloperImplicit
-	(*AzureImplicit)(nil),                                       // 91: agentgateway.dev.resource.AzureImplicit
-	(*RouteMatch)(nil),                                          // 92: agentgateway.dev.resource.RouteMatch
-	(*PathMatch)(nil),                                           // 93: agentgateway.dev.resource.PathMatch
-	(*QueryMatch)(nil),                                          // 94: agentgateway.dev.resource.QueryMatch
-	(*MethodMatch)(nil),                                         // 95: agentgateway.dev.resource.MethodMatch
-	(*HeaderMatch)(nil),                                         // 96: agentgateway.dev.resource.HeaderMatch
-	(*CORS)(nil),                                                // 97: agentgateway.dev.resource.CORS
-	(*DirectResponse)(nil),                                      // 98: agentgateway.dev.resource.DirectResponse
-	(*ExpressionHeader)(nil),                                    // 99: agentgateway.dev.resource.ExpressionHeader
-	(*HeaderModifier)(nil),                                      // 100: agentgateway.dev.resource.HeaderModifier
-	(*RequestMirrors)(nil),                                      // 101: agentgateway.dev.resource.RequestMirrors
-	(*RequestRedirect)(nil),                                     // 102: agentgateway.dev.resource.RequestRedirect
-	(*UrlRewrite)(nil),                                          // 103: agentgateway.dev.resource.UrlRewrite
-	(*Header)(nil),                                              // 104: agentgateway.dev.resource.Header
-	(*RouteBackend)(nil),                                        // 105: agentgateway.dev.resource.RouteBackend
-	(*PolicyTarget)(nil),                                        // 106: agentgateway.dev.resource.PolicyTarget
-	(*KeepaliveConfig)(nil),                                     // 107: agentgateway.dev.resource.KeepaliveConfig
-	(*FrontendPolicySpec)(nil),                                  // 108: agentgateway.dev.resource.FrontendPolicySpec
-	(*JWTValidationOptions)(nil),                                // 109: agentgateway.dev.resource.JWTValidationOptions
-	(*TrafficPolicySpec)(nil),                                   // 110: agentgateway.dev.resource.TrafficPolicySpec
-	(*BackendPolicySpec)(nil),                                   // 111: agentgateway.dev.resource.BackendPolicySpec
-	(*StaticBackend)(nil),                                       // 112: agentgateway.dev.resource.StaticBackend
-	(*DynamicForwardProxy)(nil),                                 // 113: agentgateway.dev.resource.DynamicForwardProxy
-	(*AwsBackend)(nil),                                          // 114: agentgateway.dev.resource.AwsBackend
-	(*AwsAgentCoreBackend)(nil),                                 // 115: agentgateway.dev.resource.AwsAgentCoreBackend
-	(*AIBackend)(nil),                                           // 116: agentgateway.dev.resource.AIBackend
-	(*MCPBackend)(nil),                                          // 117: agentgateway.dev.resource.MCPBackend
-	(*MCPTarget)(nil),                                           // 118: agentgateway.dev.resource.MCPTarget
-	(*BackendReference)(nil),                                    // 119: agentgateway.dev.resource.BackendReference
-	(*Alpn)(nil),                                                // 120: agentgateway.dev.resource.Alpn
-	(*OAuthClientAuth)(nil),                                     // 121: agentgateway.dev.resource.OAuthClientAuth
-	(*OAuthTokenExchange)(nil),                                  // 122: agentgateway.dev.resource.OAuthTokenExchange
-	(*CrossAppAccessAuth)(nil),                                  // 123: agentgateway.dev.resource.CrossAppAccessAuth
-	(*ModelRoute)(nil),                                          // 124: agentgateway.dev.resource.ModelRoute
-	(*GuardrailBackend_Bedrock)(nil),                            // 125: agentgateway.dev.resource.GuardrailBackend.Bedrock
-	(*GuardrailBackend_GoogleModelArmor)(nil),                   // 126: agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
-	(*GuardrailBackend_AzureContentSafety)(nil),                 // 127: agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
-	(*GuardrailBackend_OpenAIModeration)(nil),                   // 128: agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
-	(*AuthorizationLocation_Header)(nil),                        // 129: agentgateway.dev.resource.AuthorizationLocation.Header
-	(*AuthorizationLocation_QueryParameter)(nil),                // 130: agentgateway.dev.resource.AuthorizationLocation.QueryParameter
-	(*AuthorizationLocation_Cookie)(nil),                        // 131: agentgateway.dev.resource.AuthorizationLocation.Cookie
-	nil,                                                         // 132: agentgateway.dev.resource.JwtSign.ClaimsEntry
-	(*Gcp_AccessToken)(nil),                                     // 133: agentgateway.dev.resource.Gcp.AccessToken
-	(*Gcp_IdToken)(nil),                                         // 134: agentgateway.dev.resource.Gcp.IdToken
-	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 135: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	(*RequestMirrors_Mirror)(nil),                               // 136: agentgateway.dev.resource.RequestMirrors.Mirror
-	(*PolicyTarget_ServiceTarget)(nil),                          // 137: agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	(*PolicyTarget_BackendTarget)(nil),                          // 138: agentgateway.dev.resource.PolicyTarget.BackendTarget
-	(*PolicyTarget_GatewayTarget)(nil),                          // 139: agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	(*PolicyTarget_RouteTarget)(nil),                            // 140: agentgateway.dev.resource.PolicyTarget.RouteTarget
-	(*PolicyTarget_ListenerSetTarget)(nil),                      // 141: agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
-	(*FrontendPolicySpec_HTTP)(nil),                             // 142: agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	(*FrontendPolicySpec_TLS)(nil),                              // 143: agentgateway.dev.resource.FrontendPolicySpec.TLS
-	(*FrontendPolicySpec_TCP)(nil),                              // 144: agentgateway.dev.resource.FrontendPolicySpec.TCP
-	(*FrontendPolicySpec_NetworkAuthorization)(nil),             // 145: agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
-	(*FrontendPolicySpec_Logging)(nil),                          // 146: agentgateway.dev.resource.FrontendPolicySpec.Logging
-	(*FrontendPolicySpec_Tracing)(nil),                          // 147: agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 148: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	(*FrontendPolicySpec_ProxyProtocol)(nil),                    // 149: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
-	(*FrontendPolicySpec_Connect)(nil),                          // 150: agentgateway.dev.resource.FrontendPolicySpec.Connect
-	(*FrontendPolicySpec_Metrics)(nil),                          // 151: agentgateway.dev.resource.FrontendPolicySpec.Metrics
-	(*FrontendPolicySpec_Logging_Field)(nil),                    // 152: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 153: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 154: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	(*FrontendPolicySpec_Metrics_Field)(nil),                    // 155: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
-	(*FrontendPolicySpec_Metrics_Fields)(nil),                   // 156: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
-	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 157: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 158: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 159: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	(*TrafficPolicySpec_RBAC)(nil),                              // 160: agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	(*TrafficPolicySpec_JWTProvider)(nil),                       // 161: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	(*TrafficPolicySpec_JWT)(nil),                               // 162: agentgateway.dev.resource.TrafficPolicySpec.JWT
-	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 163: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	(*TrafficPolicySpec_APIKey)(nil),                            // 164: agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 165: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 166: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	(*TrafficPolicySpec_BodyTransformation)(nil),                // 167: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	(*TrafficPolicySpec_CSRF)(nil),                              // 168: agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	(*TrafficPolicySpec_ExtProc)(nil),                           // 169: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	(*TrafficPolicySpec_HostRewrite)(nil),                       // 170: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	(*TrafficPolicySpec_Buffer)(nil),                            // 171: agentgateway.dev.resource.TrafficPolicySpec.Buffer
-	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 172: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 173: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 174: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	(*TrafficPolicySpec_ExternalAuth_Cache)(nil),                // 175: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
-	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 176: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 177: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	nil,                                   // 178: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	nil,                                   // 179: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	nil,                                   // 180: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	nil,                                   // 181: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	(*TrafficPolicySpec_JWT_MCP)(nil),     // 182: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
-	(*TrafficPolicySpec_APIKey_User)(nil), // 183: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 184: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	nil, // 185: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	nil, // 186: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	nil, // 187: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 188: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	(*TrafficPolicySpec_ExtProc_ProcessingOptions)(nil),         // 189: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
-	nil, // 190: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	nil, // 191: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	(*TrafficPolicySpec_Buffer_BufferBody)(nil),     // 192: agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
-	(*BackendPolicySpec_Ai)(nil),                    // 193: agentgateway.dev.resource.BackendPolicySpec.Ai
-	(*BackendPolicySpec_A2A)(nil),                   // 194: agentgateway.dev.resource.BackendPolicySpec.A2a
-	(*BackendPolicySpec_InferenceRouting)(nil),      // 195: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	(*BackendPolicySpec_Eviction)(nil),              // 196: agentgateway.dev.resource.BackendPolicySpec.Eviction
-	(*BackendPolicySpec_Health)(nil),                // 197: agentgateway.dev.resource.BackendPolicySpec.Health
-	(*BackendPolicySpec_BackendTLS)(nil),            // 198: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	(*BackendPolicySpec_BackendHTTP)(nil),           // 199: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	(*BackendPolicySpec_BackendTunnel)(nil),         // 200: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	(*BackendPolicySpec_BackendTCP)(nil),            // 201: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	(*BackendPolicySpec_McpAuthorization)(nil),      // 202: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	(*BackendPolicySpec_McpAuthentication)(nil),     // 203: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	(*BackendPolicySpec_McpGuardrails)(nil),         // 204: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
-	(*BackendPolicySpec_Ai_Message)(nil),            // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),   // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	(*BackendPolicySpec_Ai_RegexRule)(nil),          // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	(*BackendPolicySpec_Ai_RegexRules)(nil),         // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	(*BackendPolicySpec_Ai_Webhook)(nil),            // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	(*BackendPolicySpec_Ai_Moderation)(nil),         // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil),  // 211: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),   // 212: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	(*BackendPolicySpec_Ai_AzureContentSafety)(nil), // 213: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	(*BackendPolicySpec_Ai_RequestRejection)(nil),   // 214: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	(*BackendPolicySpec_Ai_ResponseGuard)(nil),      // 215: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	(*BackendPolicySpec_Ai_RequestGuard)(nil),       // 216: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	(*BackendPolicySpec_Ai_PromptGuard)(nil),        // 217: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	(*BackendPolicySpec_Ai_PromptCaching)(nil),      // 218: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	nil, // 219: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	nil, // 220: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	nil, // 221: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	nil, // 222: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	nil, // 223: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	nil, // 224: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
-	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 225: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	nil, // 226: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	(*BackendPolicySpec_McpGuardrails_Remote)(nil),    // 227: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	(*BackendPolicySpec_McpGuardrails_Processor)(nil), // 228: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	nil,                                                // 229: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	nil,                                                // 230: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
-	(*AIBackend_HostOverride)(nil),                     // 231: agentgateway.dev.resource.AIBackend.HostOverride
-	(*AIBackend_OpenAI)(nil),                           // 232: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),                           // 233: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),                           // 234: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),                        // 235: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),                          // 236: agentgateway.dev.resource.AIBackend.Bedrock
-	(*AIBackend_AzureOpenAI)(nil),                      // 237: agentgateway.dev.resource.AIBackend.AzureOpenAI
-	(*AIBackend_Azure)(nil),                            // 238: agentgateway.dev.resource.AIBackend.Azure
-	(*AIBackend_ProviderFormatConfig)(nil),             // 239: agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	(*AIBackend_Custom)(nil),                           // 240: agentgateway.dev.resource.AIBackend.Custom
-	(*AIBackend_Provider)(nil),                         // 241: agentgateway.dev.resource.AIBackend.Provider
-	(*AIBackend_ProviderGroup)(nil),                    // 242: agentgateway.dev.resource.AIBackend.ProviderGroup
-	(*BackendReference_Service)(nil),                   // 243: agentgateway.dev.resource.BackendReference.Service
-	(*OAuthClientAuth_PrivateKeyJwt)(nil),              // 244: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt
-	(*OAuthTokenExchange_TokenSpec)(nil),               // 245: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec
-	(*OAuthTokenExchange_ActorToken)(nil),              // 246: agentgateway.dev.resource.OAuthTokenExchange.ActorToken
-	nil,                                                // 247: agentgateway.dev.resource.OAuthTokenExchange.AdditionalParamsEntry
-	(*OAuthTokenExchange_TokenCache)(nil),              // 248: agentgateway.dev.resource.OAuthTokenExchange.TokenCache
-	(*OAuthTokenExchange_TokenCache_InMemory)(nil),     // 249: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
-	(*CrossAppAccessAuth_Endpoint)(nil),                // 250: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
-	(*CrossAppAccessAuth_SubjectToken)(nil),            // 251: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken
-	(*ModelRoute_Match)(nil),                           // 252: agentgateway.dev.resource.ModelRoute.Match
-	(*ModelRoute_VirtualModel)(nil),                    // 253: agentgateway.dev.resource.ModelRoute.VirtualModel
-	(*ModelRoute_ConcreteModel)(nil),                   // 254: agentgateway.dev.resource.ModelRoute.ConcreteModel
-	(*ModelRoute_VirtualModel_Weighted)(nil),           // 255: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
-	(*ModelRoute_VirtualModel_Conditional)(nil),        // 256: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
-	(*ModelRoute_VirtualModel_Failover)(nil),           // 257: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
-	(*ModelRoute_VirtualModel_Weighted_Target)(nil),    // 258: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
-	(*ModelRoute_VirtualModel_Conditional_Target)(nil), // 259: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
-	(*workloadapi.Workload)(nil),                       // 260: istio.workload.Workload
-	(*workloadapi.Service)(nil),                        // 261: istio.workload.Service
-	(*workloadapi.NamespacedHostname)(nil),             // 262: istio.workload.NamespacedHostname
-	(*durationpb.Duration)(nil),                        // 263: google.protobuf.Duration
-	(*structpb.Value)(nil),                             // 264: google.protobuf.Value
-	(*structpb.Struct)(nil),                            // 265: google.protobuf.Struct
+	(OAuthClientAuth_PrivateKeyJwt_CertificateHeader)(0),        // 50: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
+	(OAuthTokenExchange_GrantType)(0),                           // 51: agentgateway.dev.resource.OAuthTokenExchange.GrantType
+	(ModelRoute_ConcreteModel_ModelVisibility)(0),               // 52: agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
+	(*Resource)(nil),                                            // 53: agentgateway.dev.resource.Resource
+	(*Bind)(nil),                                                // 54: agentgateway.dev.resource.Bind
+	(*RouteName)(nil),                                           // 55: agentgateway.dev.resource.RouteName
+	(*ListenerName)(nil),                                        // 56: agentgateway.dev.resource.ListenerName
+	(*ResourceName)(nil),                                        // 57: agentgateway.dev.resource.ResourceName
+	(*TypedResourceName)(nil),                                   // 58: agentgateway.dev.resource.TypedResourceName
+	(*Listener)(nil),                                            // 59: agentgateway.dev.resource.Listener
+	(*Route)(nil),                                               // 60: agentgateway.dev.resource.Route
+	(*RouteGroup)(nil),                                          // 61: agentgateway.dev.resource.RouteGroup
+	(*TCPRoute)(nil),                                            // 62: agentgateway.dev.resource.TCPRoute
+	(*ConditionalPolicies)(nil),                                 // 63: agentgateway.dev.resource.ConditionalPolicies
+	(*ConditionalPolicy)(nil),                                   // 64: agentgateway.dev.resource.ConditionalPolicy
+	(*Policy)(nil),                                              // 65: agentgateway.dev.resource.Policy
+	(*Backend)(nil),                                             // 66: agentgateway.dev.resource.Backend
+	(*GuardrailBackend)(nil),                                    // 67: agentgateway.dev.resource.GuardrailBackend
+	(*TLSConfig)(nil),                                           // 68: agentgateway.dev.resource.TLSConfig
+	(*Timeout)(nil),                                             // 69: agentgateway.dev.resource.Timeout
+	(*Retry)(nil),                                               // 70: agentgateway.dev.resource.Retry
+	(*Delay)(nil),                                               // 71: agentgateway.dev.resource.Delay
+	(*BackendAuthPolicy)(nil),                                   // 72: agentgateway.dev.resource.BackendAuthPolicy
+	(*BackendAuthCredential)(nil),                               // 73: agentgateway.dev.resource.BackendAuthCredential
+	(*AuthorizationLocation)(nil),                               // 74: agentgateway.dev.resource.AuthorizationLocation
+	(*Passthrough)(nil),                                         // 75: agentgateway.dev.resource.Passthrough
+	(*Key)(nil),                                                 // 76: agentgateway.dev.resource.Key
+	(*JwtSign)(nil),                                             // 77: agentgateway.dev.resource.JwtSign
+	(*Gcp)(nil),                                                 // 78: agentgateway.dev.resource.Gcp
+	(*Aws)(nil),                                                 // 79: agentgateway.dev.resource.Aws
+	(*Azure)(nil),                                               // 80: agentgateway.dev.resource.Azure
+	(*AwsExplicitConfig)(nil),                                   // 81: agentgateway.dev.resource.AwsExplicitConfig
+	(*AwsImplicit)(nil),                                         // 82: agentgateway.dev.resource.AwsImplicit
+	(*AwsAssumeRole)(nil),                                       // 83: agentgateway.dev.resource.AwsAssumeRole
+	(*AwsSessionTag)(nil),                                       // 84: agentgateway.dev.resource.AwsSessionTag
+	(*AzureExplicitConfig)(nil),                                 // 85: agentgateway.dev.resource.AzureExplicitConfig
+	(*AzureClientSecret)(nil),                                   // 86: agentgateway.dev.resource.AzureClientSecret
+	(*AzureManagedIdentityCredential)(nil),                      // 87: agentgateway.dev.resource.AzureManagedIdentityCredential
+	(*AzureWorkloadIdentityCredential)(nil),                     // 88: agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	(*AzureDeveloperImplicit)(nil),                              // 89: agentgateway.dev.resource.AzureDeveloperImplicit
+	(*AzureImplicit)(nil),                                       // 90: agentgateway.dev.resource.AzureImplicit
+	(*RouteMatch)(nil),                                          // 91: agentgateway.dev.resource.RouteMatch
+	(*PathMatch)(nil),                                           // 92: agentgateway.dev.resource.PathMatch
+	(*QueryMatch)(nil),                                          // 93: agentgateway.dev.resource.QueryMatch
+	(*MethodMatch)(nil),                                         // 94: agentgateway.dev.resource.MethodMatch
+	(*HeaderMatch)(nil),                                         // 95: agentgateway.dev.resource.HeaderMatch
+	(*CORS)(nil),                                                // 96: agentgateway.dev.resource.CORS
+	(*DirectResponse)(nil),                                      // 97: agentgateway.dev.resource.DirectResponse
+	(*ExpressionHeader)(nil),                                    // 98: agentgateway.dev.resource.ExpressionHeader
+	(*HeaderModifier)(nil),                                      // 99: agentgateway.dev.resource.HeaderModifier
+	(*RequestMirrors)(nil),                                      // 100: agentgateway.dev.resource.RequestMirrors
+	(*RequestRedirect)(nil),                                     // 101: agentgateway.dev.resource.RequestRedirect
+	(*UrlRewrite)(nil),                                          // 102: agentgateway.dev.resource.UrlRewrite
+	(*Header)(nil),                                              // 103: agentgateway.dev.resource.Header
+	(*RouteBackend)(nil),                                        // 104: agentgateway.dev.resource.RouteBackend
+	(*PolicyTarget)(nil),                                        // 105: agentgateway.dev.resource.PolicyTarget
+	(*KeepaliveConfig)(nil),                                     // 106: agentgateway.dev.resource.KeepaliveConfig
+	(*FrontendPolicySpec)(nil),                                  // 107: agentgateway.dev.resource.FrontendPolicySpec
+	(*JWTValidationOptions)(nil),                                // 108: agentgateway.dev.resource.JWTValidationOptions
+	(*TrafficPolicySpec)(nil),                                   // 109: agentgateway.dev.resource.TrafficPolicySpec
+	(*BackendPolicySpec)(nil),                                   // 110: agentgateway.dev.resource.BackendPolicySpec
+	(*StaticBackend)(nil),                                       // 111: agentgateway.dev.resource.StaticBackend
+	(*DynamicForwardProxy)(nil),                                 // 112: agentgateway.dev.resource.DynamicForwardProxy
+	(*AwsBackend)(nil),                                          // 113: agentgateway.dev.resource.AwsBackend
+	(*AwsAgentCoreBackend)(nil),                                 // 114: agentgateway.dev.resource.AwsAgentCoreBackend
+	(*AIBackend)(nil),                                           // 115: agentgateway.dev.resource.AIBackend
+	(*MCPBackend)(nil),                                          // 116: agentgateway.dev.resource.MCPBackend
+	(*MCPTarget)(nil),                                           // 117: agentgateway.dev.resource.MCPTarget
+	(*BackendReference)(nil),                                    // 118: agentgateway.dev.resource.BackendReference
+	(*Alpn)(nil),                                                // 119: agentgateway.dev.resource.Alpn
+	(*OAuthClientAuth)(nil),                                     // 120: agentgateway.dev.resource.OAuthClientAuth
+	(*OAuthTokenExchange)(nil),                                  // 121: agentgateway.dev.resource.OAuthTokenExchange
+	(*CrossAppAccessAuth)(nil),                                  // 122: agentgateway.dev.resource.CrossAppAccessAuth
+	(*ModelRoute)(nil),                                          // 123: agentgateway.dev.resource.ModelRoute
+	(*GuardrailBackend_Bedrock)(nil),                            // 124: agentgateway.dev.resource.GuardrailBackend.Bedrock
+	(*GuardrailBackend_GoogleModelArmor)(nil),                   // 125: agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
+	(*GuardrailBackend_AzureContentSafety)(nil),                 // 126: agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
+	(*GuardrailBackend_OpenAIModeration)(nil),                   // 127: agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
+	(*AuthorizationLocation_Header)(nil),                        // 128: agentgateway.dev.resource.AuthorizationLocation.Header
+	(*AuthorizationLocation_QueryParameter)(nil),                // 129: agentgateway.dev.resource.AuthorizationLocation.QueryParameter
+	(*AuthorizationLocation_Cookie)(nil),                        // 130: agentgateway.dev.resource.AuthorizationLocation.Cookie
+	nil,                                                         // 131: agentgateway.dev.resource.JwtSign.ClaimsEntry
+	(*Gcp_AccessToken)(nil),                                     // 132: agentgateway.dev.resource.Gcp.AccessToken
+	(*Gcp_IdToken)(nil),                                         // 133: agentgateway.dev.resource.Gcp.IdToken
+	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 134: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	(*RequestMirrors_Mirror)(nil),                               // 135: agentgateway.dev.resource.RequestMirrors.Mirror
+	(*PolicyTarget_ServiceTarget)(nil),                          // 136: agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	(*PolicyTarget_BackendTarget)(nil),                          // 137: agentgateway.dev.resource.PolicyTarget.BackendTarget
+	(*PolicyTarget_GatewayTarget)(nil),                          // 138: agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	(*PolicyTarget_RouteTarget)(nil),                            // 139: agentgateway.dev.resource.PolicyTarget.RouteTarget
+	(*PolicyTarget_ListenerSetTarget)(nil),                      // 140: agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
+	(*FrontendPolicySpec_HTTP)(nil),                             // 141: agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	(*FrontendPolicySpec_TLS)(nil),                              // 142: agentgateway.dev.resource.FrontendPolicySpec.TLS
+	(*FrontendPolicySpec_TCP)(nil),                              // 143: agentgateway.dev.resource.FrontendPolicySpec.TCP
+	(*FrontendPolicySpec_NetworkAuthorization)(nil),             // 144: agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
+	(*FrontendPolicySpec_Logging)(nil),                          // 145: agentgateway.dev.resource.FrontendPolicySpec.Logging
+	(*FrontendPolicySpec_Tracing)(nil),                          // 146: agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 147: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	(*FrontendPolicySpec_ProxyProtocol)(nil),                    // 148: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
+	(*FrontendPolicySpec_Connect)(nil),                          // 149: agentgateway.dev.resource.FrontendPolicySpec.Connect
+	(*FrontendPolicySpec_Metrics)(nil),                          // 150: agentgateway.dev.resource.FrontendPolicySpec.Metrics
+	(*FrontendPolicySpec_Logging_Field)(nil),                    // 151: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 152: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 153: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	(*FrontendPolicySpec_Metrics_Field)(nil),                    // 154: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
+	(*FrontendPolicySpec_Metrics_Fields)(nil),                   // 155: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
+	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 156: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 157: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 158: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	(*TrafficPolicySpec_RBAC)(nil),                              // 159: agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	(*TrafficPolicySpec_JWTProvider)(nil),                       // 160: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	(*TrafficPolicySpec_JWT)(nil),                               // 161: agentgateway.dev.resource.TrafficPolicySpec.JWT
+	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 162: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	(*TrafficPolicySpec_APIKey)(nil),                            // 163: agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 164: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 165: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	(*TrafficPolicySpec_BodyTransformation)(nil),                // 166: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	(*TrafficPolicySpec_CSRF)(nil),                              // 167: agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	(*TrafficPolicySpec_ExtProc)(nil),                           // 168: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	(*TrafficPolicySpec_HostRewrite)(nil),                       // 169: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	(*TrafficPolicySpec_Buffer)(nil),                            // 170: agentgateway.dev.resource.TrafficPolicySpec.Buffer
+	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 171: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 172: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 173: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	(*TrafficPolicySpec_ExternalAuth_Cache)(nil),                // 174: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
+	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 175: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 176: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	nil,                                   // 177: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	nil,                                   // 178: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	nil,                                   // 179: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	nil,                                   // 180: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	(*TrafficPolicySpec_JWT_MCP)(nil),     // 181: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
+	(*TrafficPolicySpec_APIKey_User)(nil), // 182: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 183: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	nil, // 184: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	nil, // 185: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	nil, // 186: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 187: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	(*TrafficPolicySpec_ExtProc_ProcessingOptions)(nil),         // 188: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
+	nil, // 189: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	nil, // 190: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	(*TrafficPolicySpec_Buffer_BufferBody)(nil),     // 191: agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
+	(*BackendPolicySpec_Ai)(nil),                    // 192: agentgateway.dev.resource.BackendPolicySpec.Ai
+	(*BackendPolicySpec_A2A)(nil),                   // 193: agentgateway.dev.resource.BackendPolicySpec.A2a
+	(*BackendPolicySpec_InferenceRouting)(nil),      // 194: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	(*BackendPolicySpec_Eviction)(nil),              // 195: agentgateway.dev.resource.BackendPolicySpec.Eviction
+	(*BackendPolicySpec_Health)(nil),                // 196: agentgateway.dev.resource.BackendPolicySpec.Health
+	(*BackendPolicySpec_BackendTLS)(nil),            // 197: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	(*BackendPolicySpec_BackendHTTP)(nil),           // 198: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	(*BackendPolicySpec_BackendTunnel)(nil),         // 199: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	(*BackendPolicySpec_BackendTCP)(nil),            // 200: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	(*BackendPolicySpec_McpAuthorization)(nil),      // 201: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	(*BackendPolicySpec_McpAuthentication)(nil),     // 202: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	(*BackendPolicySpec_McpGuardrails)(nil),         // 203: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
+	(*BackendPolicySpec_Ai_Message)(nil),            // 204: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),   // 205: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	(*BackendPolicySpec_Ai_RegexRule)(nil),          // 206: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	(*BackendPolicySpec_Ai_RegexRules)(nil),         // 207: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	(*BackendPolicySpec_Ai_Webhook)(nil),            // 208: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	(*BackendPolicySpec_Ai_Moderation)(nil),         // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil),  // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),   // 211: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	(*BackendPolicySpec_Ai_AzureContentSafety)(nil), // 212: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	(*BackendPolicySpec_Ai_RequestRejection)(nil),   // 213: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	(*BackendPolicySpec_Ai_ResponseGuard)(nil),      // 214: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	(*BackendPolicySpec_Ai_RequestGuard)(nil),       // 215: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	(*BackendPolicySpec_Ai_PromptGuard)(nil),        // 216: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	(*BackendPolicySpec_Ai_PromptCaching)(nil),      // 217: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	nil, // 218: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	nil, // 219: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	nil, // 220: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	nil, // 221: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	nil, // 222: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	nil, // 223: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
+	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 224: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	nil, // 225: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	(*BackendPolicySpec_McpGuardrails_Remote)(nil),    // 226: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	(*BackendPolicySpec_McpGuardrails_Processor)(nil), // 227: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	nil,                                                // 228: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	nil,                                                // 229: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	(*AIBackend_HostOverride)(nil),                     // 230: agentgateway.dev.resource.AIBackend.HostOverride
+	(*AIBackend_OpenAI)(nil),                           // 231: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),                           // 232: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),                           // 233: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),                        // 234: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),                          // 235: agentgateway.dev.resource.AIBackend.Bedrock
+	(*AIBackend_AzureOpenAI)(nil),                      // 236: agentgateway.dev.resource.AIBackend.AzureOpenAI
+	(*AIBackend_Azure)(nil),                            // 237: agentgateway.dev.resource.AIBackend.Azure
+	(*AIBackend_ProviderFormatConfig)(nil),             // 238: agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	(*AIBackend_Custom)(nil),                           // 239: agentgateway.dev.resource.AIBackend.Custom
+	(*AIBackend_Provider)(nil),                         // 240: agentgateway.dev.resource.AIBackend.Provider
+	(*AIBackend_ProviderGroup)(nil),                    // 241: agentgateway.dev.resource.AIBackend.ProviderGroup
+	(*BackendReference_Service)(nil),                   // 242: agentgateway.dev.resource.BackendReference.Service
+	(*OAuthClientAuth_PrivateKeyJwt)(nil),              // 243: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt
+	(*OAuthTokenExchange_TokenSpec)(nil),               // 244: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec
+	(*OAuthTokenExchange_ActorToken)(nil),              // 245: agentgateway.dev.resource.OAuthTokenExchange.ActorToken
+	nil,                                                // 246: agentgateway.dev.resource.OAuthTokenExchange.AdditionalParamsEntry
+	(*OAuthTokenExchange_TokenCache)(nil),              // 247: agentgateway.dev.resource.OAuthTokenExchange.TokenCache
+	(*OAuthTokenExchange_TokenCache_InMemory)(nil),     // 248: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
+	(*CrossAppAccessAuth_Endpoint)(nil),                // 249: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
+	(*CrossAppAccessAuth_SubjectToken)(nil),            // 250: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken
+	(*ModelRoute_Match)(nil),                           // 251: agentgateway.dev.resource.ModelRoute.Match
+	(*ModelRoute_VirtualModel)(nil),                    // 252: agentgateway.dev.resource.ModelRoute.VirtualModel
+	(*ModelRoute_ConcreteModel)(nil),                   // 253: agentgateway.dev.resource.ModelRoute.ConcreteModel
+	(*ModelRoute_VirtualModel_Weighted)(nil),           // 254: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
+	(*ModelRoute_VirtualModel_Conditional)(nil),        // 255: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
+	(*ModelRoute_VirtualModel_Failover)(nil),           // 256: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
+	(*ModelRoute_VirtualModel_Weighted_Target)(nil),    // 257: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
+	(*ModelRoute_VirtualModel_Conditional_Target)(nil), // 258: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
+	(*workloadapi.Workload)(nil),                       // 259: istio.workload.Workload
+	(*workloadapi.Service)(nil),                        // 260: istio.workload.Service
+	(*workloadapi.NamespacedHostname)(nil),             // 261: istio.workload.NamespacedHostname
+	(*durationpb.Duration)(nil),                        // 262: google.protobuf.Duration
+	(*structpb.Value)(nil),                             // 263: google.protobuf.Value
+	(*structpb.Struct)(nil),                            // 264: google.protobuf.Struct
 }
 var file_resource_proto_depIdxs = []int32{
-	55,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
-	60,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
-	61,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
-	67,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
-	66,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
-	63,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
-	260, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
-	261, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
-	62,  // 8: agentgateway.dev.resource.Resource.route_group:type_name -> agentgateway.dev.resource.RouteGroup
-	124, // 9: agentgateway.dev.resource.Resource.model_route:type_name -> agentgateway.dev.resource.ModelRoute
-	1,   // 10: agentgateway.dev.resource.Bind.protocol:type_name -> agentgateway.dev.resource.Bind.Protocol
-	2,   // 11: agentgateway.dev.resource.Bind.tunnel_protocol:type_name -> agentgateway.dev.resource.Bind.TunnelProtocol
-	3,   // 12: agentgateway.dev.resource.Bind.mode:type_name -> agentgateway.dev.resource.Bind.Mode
-	58,  // 13: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
-	57,  // 14: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
+	54,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
+	59,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
+	60,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
+	66,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
+	65,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
+	62,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
+	259, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
+	260, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
+	61,  // 8: agentgateway.dev.resource.Resource.route_group:type_name -> agentgateway.dev.resource.RouteGroup
+	123, // 9: agentgateway.dev.resource.Resource.model_route:type_name -> agentgateway.dev.resource.ModelRoute
+	2,   // 10: agentgateway.dev.resource.Bind.protocol:type_name -> agentgateway.dev.resource.Bind.Protocol
+	3,   // 11: agentgateway.dev.resource.Bind.tunnel_protocol:type_name -> agentgateway.dev.resource.Bind.TunnelProtocol
+	4,   // 12: agentgateway.dev.resource.Bind.mode:type_name -> agentgateway.dev.resource.Bind.Mode
+	57,  // 13: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
+	56,  // 14: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
 	0,   // 15: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
-	69,  // 16: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
-	262, // 17: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
-	56,  // 18: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
-	92,  // 19: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
-	105, // 20: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	110, // 21: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	262, // 22: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
-	56,  // 23: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
-	105, // 24: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	65,  // 25: agentgateway.dev.resource.ConditionalPolicies.policies:type_name -> agentgateway.dev.resource.ConditionalPolicy
-	110, // 26: agentgateway.dev.resource.ConditionalPolicy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	59,  // 27: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
-	106, // 28: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
-	4,   // 29: agentgateway.dev.resource.Policy.inheritance:type_name -> agentgateway.dev.resource.Policy.Inheritance
-	110, // 30: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	111, // 31: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	108, // 32: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
-	64,  // 33: agentgateway.dev.resource.Policy.conditional:type_name -> agentgateway.dev.resource.ConditionalPolicies
-	58,  // 34: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
-	112, // 35: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
-	116, // 36: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
-	117, // 37: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
-	113, // 38: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
-	114, // 39: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
-	68,  // 40: agentgateway.dev.resource.Backend.guardrail:type_name -> agentgateway.dev.resource.GuardrailBackend
-	111, // 41: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	125, // 42: agentgateway.dev.resource.GuardrailBackend.bedrock:type_name -> agentgateway.dev.resource.GuardrailBackend.Bedrock
-	126, // 43: agentgateway.dev.resource.GuardrailBackend.google_model_armor:type_name -> agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
-	127, // 44: agentgateway.dev.resource.GuardrailBackend.azure_content_safety:type_name -> agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
-	128, // 45: agentgateway.dev.resource.GuardrailBackend.openai_moderation:type_name -> agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
-	8,   // 46: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
-	6,   // 47: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	6,   // 48: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	7,   // 49: agentgateway.dev.resource.TLSConfig.mtls_mode:type_name -> agentgateway.dev.resource.TLSConfig.MTLSMode
-	9,   // 50: agentgateway.dev.resource.TLSConfig.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
-	5,   // 51: agentgateway.dev.resource.TLSConfig.certificate_source:type_name -> agentgateway.dev.resource.TLSConfig.CertificateSource
-	263, // 52: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
-	263, // 53: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
-	263, // 54: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
-	76,  // 55: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
-	77,  // 56: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
-	79,  // 57: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
-	80,  // 58: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
-	81,  // 59: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
-	122, // 60: agentgateway.dev.resource.BackendAuthPolicy.oauth_token_exchange:type_name -> agentgateway.dev.resource.OAuthTokenExchange
-	123, // 61: agentgateway.dev.resource.BackendAuthPolicy.cross_app_access:type_name -> agentgateway.dev.resource.CrossAppAccessAuth
-	78,  // 62: agentgateway.dev.resource.BackendAuthPolicy.jwt_sign:type_name -> agentgateway.dev.resource.JwtSign
-	74,  // 63: agentgateway.dev.resource.BackendAuthPolicy.credentials:type_name -> agentgateway.dev.resource.BackendAuthCredential
-	75,  // 64: agentgateway.dev.resource.BackendAuthCredential.location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	129, // 65: agentgateway.dev.resource.AuthorizationLocation.header:type_name -> agentgateway.dev.resource.AuthorizationLocation.Header
-	130, // 66: agentgateway.dev.resource.AuthorizationLocation.query_parameter:type_name -> agentgateway.dev.resource.AuthorizationLocation.QueryParameter
-	131, // 67: agentgateway.dev.resource.AuthorizationLocation.cookie:type_name -> agentgateway.dev.resource.AuthorizationLocation.Cookie
-	75,  // 68: agentgateway.dev.resource.Passthrough.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	75,  // 69: agentgateway.dev.resource.Key.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	10,  // 70: agentgateway.dev.resource.JwtSign.alg:type_name -> agentgateway.dev.resource.JwtSign.SigningAlg
-	132, // 71: agentgateway.dev.resource.JwtSign.claims:type_name -> agentgateway.dev.resource.JwtSign.ClaimsEntry
-	263, // 72: agentgateway.dev.resource.JwtSign.ttl:type_name -> google.protobuf.Duration
-	75,  // 73: agentgateway.dev.resource.JwtSign.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	133, // 74: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
-	134, // 75: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
-	82,  // 76: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
-	83,  // 77: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
-	84,  // 78: agentgateway.dev.resource.Aws.assume_role:type_name -> agentgateway.dev.resource.AwsAssumeRole
-	86,  // 79: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
-	90,  // 80: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
-	91,  // 81: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
-	85,  // 82: agentgateway.dev.resource.AwsAssumeRole.tags:type_name -> agentgateway.dev.resource.AwsSessionTag
-	87,  // 83: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
-	88,  // 84: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
-	89,  // 85: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	135, // 86: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	93,  // 87: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
-	96,  // 88: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
-	95,  // 89: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
-	94,  // 90: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	263, // 91: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
-	99,  // 92: agentgateway.dev.resource.DirectResponse.headers:type_name -> agentgateway.dev.resource.ExpressionHeader
-	104, // 93: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
-	104, // 94: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
-	136, // 95: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
-	119, // 96: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
-	111, // 97: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	139, // 98: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	140, // 99: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
-	138, // 100: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
-	137, // 101: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	141, // 102: agentgateway.dev.resource.PolicyTarget.listener_set:type_name -> agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
-	263, // 103: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
-	263, // 104: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
-	144, // 105: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
-	143, // 106: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
-	142, // 107: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	146, // 108: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
-	147, // 109: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	145, // 110: agentgateway.dev.resource.FrontendPolicySpec.network_authorization:type_name -> agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
-	149, // 111: agentgateway.dev.resource.FrontendPolicySpec.proxy_protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
-	151, // 112: agentgateway.dev.resource.FrontendPolicySpec.metrics:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics
-	150, // 113: agentgateway.dev.resource.FrontendPolicySpec.connect:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect
+	68,  // 16: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
+	261, // 17: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
+	55,  // 18: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
+	91,  // 19: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
+	104, // 20: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	109, // 21: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	261, // 22: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
+	55,  // 23: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
+	104, // 24: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	64,  // 25: agentgateway.dev.resource.ConditionalPolicies.policies:type_name -> agentgateway.dev.resource.ConditionalPolicy
+	109, // 26: agentgateway.dev.resource.ConditionalPolicy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	58,  // 27: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
+	105, // 28: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
+	5,   // 29: agentgateway.dev.resource.Policy.inheritance:type_name -> agentgateway.dev.resource.Policy.Inheritance
+	109, // 30: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	110, // 31: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	107, // 32: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
+	63,  // 33: agentgateway.dev.resource.Policy.conditional:type_name -> agentgateway.dev.resource.ConditionalPolicies
+	57,  // 34: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
+	111, // 35: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
+	115, // 36: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
+	116, // 37: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
+	112, // 38: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
+	113, // 39: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
+	67,  // 40: agentgateway.dev.resource.Backend.guardrail:type_name -> agentgateway.dev.resource.GuardrailBackend
+	110, // 41: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	124, // 42: agentgateway.dev.resource.GuardrailBackend.bedrock:type_name -> agentgateway.dev.resource.GuardrailBackend.Bedrock
+	125, // 43: agentgateway.dev.resource.GuardrailBackend.google_model_armor:type_name -> agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
+	126, // 44: agentgateway.dev.resource.GuardrailBackend.azure_content_safety:type_name -> agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
+	127, // 45: agentgateway.dev.resource.GuardrailBackend.openai_moderation:type_name -> agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
+	9,   // 46: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
+	7,   // 47: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	7,   // 48: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	8,   // 49: agentgateway.dev.resource.TLSConfig.mtls_mode:type_name -> agentgateway.dev.resource.TLSConfig.MTLSMode
+	10,  // 50: agentgateway.dev.resource.TLSConfig.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
+	6,   // 51: agentgateway.dev.resource.TLSConfig.certificate_source:type_name -> agentgateway.dev.resource.TLSConfig.CertificateSource
+	262, // 52: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
+	262, // 53: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
+	262, // 54: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	75,  // 55: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
+	76,  // 56: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
+	78,  // 57: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
+	79,  // 58: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
+	80,  // 59: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
+	121, // 60: agentgateway.dev.resource.BackendAuthPolicy.oauth_token_exchange:type_name -> agentgateway.dev.resource.OAuthTokenExchange
+	122, // 61: agentgateway.dev.resource.BackendAuthPolicy.cross_app_access:type_name -> agentgateway.dev.resource.CrossAppAccessAuth
+	77,  // 62: agentgateway.dev.resource.BackendAuthPolicy.jwt_sign:type_name -> agentgateway.dev.resource.JwtSign
+	73,  // 63: agentgateway.dev.resource.BackendAuthPolicy.credentials:type_name -> agentgateway.dev.resource.BackendAuthCredential
+	74,  // 64: agentgateway.dev.resource.BackendAuthCredential.location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	128, // 65: agentgateway.dev.resource.AuthorizationLocation.header:type_name -> agentgateway.dev.resource.AuthorizationLocation.Header
+	129, // 66: agentgateway.dev.resource.AuthorizationLocation.query_parameter:type_name -> agentgateway.dev.resource.AuthorizationLocation.QueryParameter
+	130, // 67: agentgateway.dev.resource.AuthorizationLocation.cookie:type_name -> agentgateway.dev.resource.AuthorizationLocation.Cookie
+	74,  // 68: agentgateway.dev.resource.Passthrough.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	74,  // 69: agentgateway.dev.resource.Key.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	1,   // 70: agentgateway.dev.resource.JwtSign.alg:type_name -> agentgateway.dev.resource.JwtSigningAlg
+	131, // 71: agentgateway.dev.resource.JwtSign.claims:type_name -> agentgateway.dev.resource.JwtSign.ClaimsEntry
+	262, // 72: agentgateway.dev.resource.JwtSign.ttl:type_name -> google.protobuf.Duration
+	74,  // 73: agentgateway.dev.resource.JwtSign.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	132, // 74: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
+	133, // 75: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
+	81,  // 76: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
+	82,  // 77: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
+	83,  // 78: agentgateway.dev.resource.Aws.assume_role:type_name -> agentgateway.dev.resource.AwsAssumeRole
+	85,  // 79: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
+	89,  // 80: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
+	90,  // 81: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
+	84,  // 82: agentgateway.dev.resource.AwsAssumeRole.tags:type_name -> agentgateway.dev.resource.AwsSessionTag
+	86,  // 83: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
+	87,  // 84: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
+	88,  // 85: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	134, // 86: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	92,  // 87: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
+	95,  // 88: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
+	94,  // 89: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
+	93,  // 90: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
+	262, // 91: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	98,  // 92: agentgateway.dev.resource.DirectResponse.headers:type_name -> agentgateway.dev.resource.ExpressionHeader
+	103, // 93: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
+	103, // 94: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
+	135, // 95: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
+	118, // 96: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
+	110, // 97: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	138, // 98: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	139, // 99: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
+	137, // 100: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
+	136, // 101: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	140, // 102: agentgateway.dev.resource.PolicyTarget.listener_set:type_name -> agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
+	262, // 103: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
+	262, // 104: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
+	143, // 105: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
+	142, // 106: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
+	141, // 107: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	145, // 108: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
+	146, // 109: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	144, // 110: agentgateway.dev.resource.FrontendPolicySpec.network_authorization:type_name -> agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
+	148, // 111: agentgateway.dev.resource.FrontendPolicySpec.proxy_protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
+	150, // 112: agentgateway.dev.resource.FrontendPolicySpec.metrics:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics
+	149, // 113: agentgateway.dev.resource.FrontendPolicySpec.connect:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect
 	17,  // 114: agentgateway.dev.resource.TrafficPolicySpec.phase:type_name -> agentgateway.dev.resource.TrafficPolicySpec.PolicyPhase
-	70,  // 115: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
-	71,  // 116: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
-	158, // 117: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	159, // 118: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	160, // 119: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	162, // 120: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
-	165, // 121: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	157, // 122: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	168, // 123: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	169, // 124: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	100, // 125: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	100, // 126: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	102, // 127: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	103, // 128: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
-	101, // 129: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	98,  // 130: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
-	97,  // 131: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
-	163, // 132: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	164, // 133: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	170, // 134: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	171, // 135: agentgateway.dev.resource.TrafficPolicySpec.buffer:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer
-	72,  // 136: agentgateway.dev.resource.TrafficPolicySpec.delay:type_name -> agentgateway.dev.resource.Delay
-	194, // 137: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
-	195, // 138: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	198, // 139: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	73,  // 140: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	202, // 141: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	203, // 142: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	193, // 143: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	100, // 144: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	100, // 145: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	102, // 146: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	101, // 147: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	199, // 148: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	201, // 149: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	165, // 150: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	197, // 151: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
-	200, // 152: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	159, // 153: agentgateway.dev.resource.BackendPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	204, // 154: agentgateway.dev.resource.BackendPolicySpec.mcp_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
-	115, // 155: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
-	242, // 156: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
-	118, // 157: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	69,  // 115: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
+	70,  // 116: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
+	157, // 117: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	158, // 118: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	159, // 119: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	161, // 120: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
+	164, // 121: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	156, // 122: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	167, // 123: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	168, // 124: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	99,  // 125: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	99,  // 126: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	101, // 127: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	102, // 128: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
+	100, // 129: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	97,  // 130: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
+	96,  // 131: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
+	162, // 132: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	163, // 133: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	169, // 134: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	170, // 135: agentgateway.dev.resource.TrafficPolicySpec.buffer:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer
+	71,  // 136: agentgateway.dev.resource.TrafficPolicySpec.delay:type_name -> agentgateway.dev.resource.Delay
+	193, // 137: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
+	194, // 138: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	197, // 139: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	72,  // 140: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	201, // 141: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	202, // 142: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	192, // 143: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	99,  // 144: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	99,  // 145: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	101, // 146: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	100, // 147: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	198, // 148: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	200, // 149: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	164, // 150: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	196, // 151: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
+	199, // 152: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	158, // 153: agentgateway.dev.resource.BackendPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	203, // 154: agentgateway.dev.resource.BackendPolicySpec.mcp_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
+	114, // 155: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
+	241, // 156: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
+	117, // 157: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
 	45,  // 158: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
 	46,  // 159: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
 	47,  // 160: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
-	119, // 161: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	118, // 161: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
 	48,  // 162: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	243, // 163: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
+	242, // 163: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
 	49,  // 164: agentgateway.dev.resource.OAuthClientAuth.method:type_name -> agentgateway.dev.resource.OAuthClientAuth.Method
-	244, // 165: agentgateway.dev.resource.OAuthClientAuth.private_key_jwt:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt
-	119, // 166: agentgateway.dev.resource.OAuthTokenExchange.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
-	52,  // 167: agentgateway.dev.resource.OAuthTokenExchange.grant_type:type_name -> agentgateway.dev.resource.OAuthTokenExchange.GrantType
-	245, // 168: agentgateway.dev.resource.OAuthTokenExchange.subject_token:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenSpec
-	246, // 169: agentgateway.dev.resource.OAuthTokenExchange.actor_token:type_name -> agentgateway.dev.resource.OAuthTokenExchange.ActorToken
-	247, // 170: agentgateway.dev.resource.OAuthTokenExchange.additional_params:type_name -> agentgateway.dev.resource.OAuthTokenExchange.AdditionalParamsEntry
-	121, // 171: agentgateway.dev.resource.OAuthTokenExchange.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
-	75,  // 172: agentgateway.dev.resource.OAuthTokenExchange.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	248, // 173: agentgateway.dev.resource.OAuthTokenExchange.cache:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache
-	250, // 174: agentgateway.dev.resource.CrossAppAccessAuth.identity_provider:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
-	250, // 175: agentgateway.dev.resource.CrossAppAccessAuth.resource_authorization_server:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
-	248, // 176: agentgateway.dev.resource.CrossAppAccessAuth.cache:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache
-	251, // 177: agentgateway.dev.resource.CrossAppAccessAuth.subject_token:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken
-	252, // 178: agentgateway.dev.resource.ModelRoute.match:type_name -> agentgateway.dev.resource.ModelRoute.Match
-	253, // 179: agentgateway.dev.resource.ModelRoute.virtual_model:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel
-	254, // 180: agentgateway.dev.resource.ModelRoute.concrete_model:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel
-	193, // 181: agentgateway.dev.resource.ModelRoute.ai_policy:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	160, // 182: agentgateway.dev.resource.ModelRoute.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	264, // 183: agentgateway.dev.resource.JwtSign.ClaimsEntry.value:type_name -> google.protobuf.Value
-	119, // 184: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	263, // 185: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
-	263, // 186: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
-	263, // 187: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
-	263, // 188: agentgateway.dev.resource.FrontendPolicySpec.HTTP.max_connection_duration:type_name -> google.protobuf.Duration
+	243, // 165: agentgateway.dev.resource.OAuthClientAuth.private_key_jwt:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt
+	118, // 166: agentgateway.dev.resource.OAuthTokenExchange.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
+	51,  // 167: agentgateway.dev.resource.OAuthTokenExchange.grant_type:type_name -> agentgateway.dev.resource.OAuthTokenExchange.GrantType
+	244, // 168: agentgateway.dev.resource.OAuthTokenExchange.subject_token:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenSpec
+	245, // 169: agentgateway.dev.resource.OAuthTokenExchange.actor_token:type_name -> agentgateway.dev.resource.OAuthTokenExchange.ActorToken
+	246, // 170: agentgateway.dev.resource.OAuthTokenExchange.additional_params:type_name -> agentgateway.dev.resource.OAuthTokenExchange.AdditionalParamsEntry
+	120, // 171: agentgateway.dev.resource.OAuthTokenExchange.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
+	74,  // 172: agentgateway.dev.resource.OAuthTokenExchange.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	247, // 173: agentgateway.dev.resource.OAuthTokenExchange.cache:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache
+	249, // 174: agentgateway.dev.resource.CrossAppAccessAuth.identity_provider:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
+	249, // 175: agentgateway.dev.resource.CrossAppAccessAuth.resource_authorization_server:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
+	247, // 176: agentgateway.dev.resource.CrossAppAccessAuth.cache:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache
+	250, // 177: agentgateway.dev.resource.CrossAppAccessAuth.subject_token:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken
+	251, // 178: agentgateway.dev.resource.ModelRoute.match:type_name -> agentgateway.dev.resource.ModelRoute.Match
+	252, // 179: agentgateway.dev.resource.ModelRoute.virtual_model:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel
+	253, // 180: agentgateway.dev.resource.ModelRoute.concrete_model:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel
+	192, // 181: agentgateway.dev.resource.ModelRoute.ai_policy:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	159, // 182: agentgateway.dev.resource.ModelRoute.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	263, // 183: agentgateway.dev.resource.JwtSign.ClaimsEntry.value:type_name -> google.protobuf.Value
+	118, // 184: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	262, // 185: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
+	262, // 186: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
+	262, // 187: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
+	262, // 188: agentgateway.dev.resource.FrontendPolicySpec.HTTP.max_connection_duration:type_name -> google.protobuf.Duration
 	11,  // 189: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_header_case:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP.HTTPHeaderCase
-	263, // 190: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
-	120, // 191: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	8,   // 192: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
-	6,   // 193: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	6,   // 194: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
-	9,   // 195: agentgateway.dev.resource.FrontendPolicySpec.TLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
-	107, // 196: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	153, // 197: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	154, // 198: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	119, // 199: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	148, // 200: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	148, // 201: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	262, // 190: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
+	119, // 191: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	9,   // 192: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
+	7,   // 193: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	7,   // 194: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
+	10,  // 195: agentgateway.dev.resource.FrontendPolicySpec.TLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
+	106, // 196: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	152, // 197: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	153, // 198: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	118, // 199: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	147, // 200: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	147, // 201: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
 	13,  // 202: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
 	14,  // 203: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.version:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Version
 	15,  // 204: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Mode
 	16,  // 205: agentgateway.dev.resource.FrontendPolicySpec.Connect.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect.Mode
-	156, // 206: agentgateway.dev.resource.FrontendPolicySpec.Metrics.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
-	152, // 207: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	119, // 208: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	111, // 209: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	155, // 206: agentgateway.dev.resource.FrontendPolicySpec.Metrics.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
+	151, // 207: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	118, // 208: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	110, // 209: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
 	12,  // 210: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
-	153, // 211: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	155, // 212: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
-	172, // 213: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	119, // 214: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	152, // 211: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	154, // 212: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
+	171, // 213: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	118, // 214: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
 	19,  // 215: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
-	263, // 216: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	262, // 216: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
 	20,  // 217: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
-	119, // 218: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	176, // 219: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	177, // 220: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	118, // 218: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	175, // 219: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	176, // 220: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
 	21,  // 221: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
-	174, // 222: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	175, // 223: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.cache:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
-	109, // 224: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	173, // 222: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	174, // 223: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.cache:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
+	108, // 224: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
 	22,  // 225: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
-	161, // 226: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	182, // 227: agentgateway.dev.resource.TrafficPolicySpec.JWT.mcp:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
-	75,  // 228: agentgateway.dev.resource.TrafficPolicySpec.JWT.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	160, // 226: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	181, // 227: agentgateway.dev.resource.TrafficPolicySpec.JWT.mcp:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
+	74,  // 228: agentgateway.dev.resource.TrafficPolicySpec.JWT.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
 	23,  // 229: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
-	75,  // 230: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	183, // 231: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	74,  // 230: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	182, // 231: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
 	24,  // 232: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
-	75,  // 233: agentgateway.dev.resource.TrafficPolicySpec.APIKey.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	184, // 234: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	184, // 235: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	119, // 236: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
+	74,  // 233: agentgateway.dev.resource.TrafficPolicySpec.APIKey.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	183, // 234: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	183, // 235: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	118, // 236: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
 	25,  // 237: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
-	186, // 238: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	187, // 239: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	190, // 240: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	189, // 241: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.processing_options:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
+	185, // 238: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	186, // 239: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	189, // 240: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	188, // 241: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.processing_options:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
 	28,  // 242: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
-	192, // 243: agentgateway.dev.resource.TrafficPolicySpec.Buffer.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
-	192, // 244: agentgateway.dev.resource.TrafficPolicySpec.Buffer.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
-	173, // 245: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	191, // 243: agentgateway.dev.resource.TrafficPolicySpec.Buffer.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
+	191, // 244: agentgateway.dev.resource.TrafficPolicySpec.Buffer.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
+	172, // 245: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
 	18,  // 246: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
-	178, // 247: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	179, // 248: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	180, // 249: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	181, // 250: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	177, // 247: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	178, // 248: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	179, // 249: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	180, // 250: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
 	38,  // 251: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	225, // 252: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	265, // 253: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
-	166, // 254: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	166, // 255: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	167, // 256: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	185, // 257: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	191, // 258: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	224, // 252: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	264, // 253: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
+	165, // 254: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	165, // 255: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	166, // 256: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	184, // 257: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	190, // 258: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
 	26,  // 259: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
 	26,  // 260: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
 	27,  // 261: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	27,  // 262: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	27,  // 263: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	27,  // 264: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
-	188, // 265: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	187, // 265: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
 	29,  // 266: agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.FailureMode
-	217, // 267: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	219, // 268: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	220, // 269: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	221, // 270: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	206, // 271: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	222, // 272: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	218, // 273: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	223, // 274: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	119, // 275: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	216, // 267: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	218, // 268: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	219, // 269: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	220, // 270: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	205, // 271: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	221, // 272: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	217, // 273: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	222, // 274: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	118, // 275: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
 	35,  // 276: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	263, // 277: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
-	196, // 278: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
+	262, // 277: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
+	195, // 278: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
 	36,  // 279: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	120, // 280: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
-	9,   // 281: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
+	119, // 280: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	10,  // 281: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
 	37,  // 282: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	263, // 283: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	119, // 284: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
-	107, // 285: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	263, // 286: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	262, // 283: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
+	118, // 284: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
+	106, // 285: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	262, // 286: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
 	38,  // 287: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	225, // 288: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	224, // 288: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
 	39,  // 289: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	109, // 290: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	75,  // 291: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	228, // 292: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	205, // 293: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	205, // 294: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	108, // 290: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	74,  // 291: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	227, // 292: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	204, // 293: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	204, // 294: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
 	30,  // 295: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
 	31,  // 296: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	207, // 297: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	119, // 298: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	224, // 299: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.headers:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
-	96,  // 300: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	206, // 297: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	118, // 298: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	223, // 299: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.headers:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
+	95,  // 300: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
 	33,  // 301: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
-	111, // 302: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	119, // 303: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	111, // 304: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	119, // 305: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	111, // 306: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	119, // 307: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	111, // 308: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	119, // 309: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	214, // 310: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	208, // 311: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	209, // 312: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	212, // 313: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	211, // 314: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	213, // 315: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	214, // 316: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	208, // 317: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	209, // 318: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	210, // 319: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	212, // 320: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	211, // 321: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	213, // 322: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	216, // 323: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	215, // 324: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	110, // 302: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	118, // 303: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	110, // 304: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	118, // 305: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	110, // 306: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	118, // 307: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	110, // 308: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	118, // 309: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	213, // 310: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	207, // 311: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	208, // 312: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	211, // 313: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	210, // 314: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	212, // 315: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	213, // 316: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	207, // 317: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	208, // 318: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	209, // 319: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	211, // 320: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	210, // 321: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	212, // 322: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	215, // 323: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	214, // 324: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
 	34,  // 325: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.streaming:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
 	32,  // 326: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	226, // 327: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	264, // 328: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	119, // 329: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
+	225, // 327: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	263, // 328: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	118, // 329: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
 	41,  // 330: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
-	229, // 331: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	227, // 332: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	230, // 333: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	228, // 331: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	226, // 332: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	229, // 333: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
 	40,  // 334: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
 	42,  // 335: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
 	43,  // 336: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
-	239, // 337: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	231, // 338: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	119, // 339: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	232, // 340: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	233, // 341: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	234, // 342: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	235, // 343: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	236, // 344: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	237, // 345: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	238, // 346: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
-	240, // 347: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
+	238, // 337: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	230, // 338: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	118, // 339: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	231, // 340: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	232, // 341: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	233, // 342: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	234, // 343: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	235, // 344: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	236, // 345: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	237, // 346: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
+	239, // 347: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
 	44,  // 348: agentgateway.dev.resource.AIBackend.Provider.provider_preset:type_name -> agentgateway.dev.resource.AIBackend.ProviderPreset
-	111, // 349: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	241, // 350: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	50,  // 351: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.alg:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.SigningAlg
-	51,  // 352: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.certificate_header:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
-	75,  // 353: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	75,  // 354: agentgateway.dev.resource.OAuthTokenExchange.ActorToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	249, // 355: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.in_memory:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
-	263, // 356: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory.default_ttl:type_name -> google.protobuf.Duration
-	119, // 357: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
-	121, // 358: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
-	75,  // 359: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	255, // 360: agentgateway.dev.resource.ModelRoute.VirtualModel.weighted:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
-	256, // 361: agentgateway.dev.resource.ModelRoute.VirtualModel.conditional:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
-	257, // 362: agentgateway.dev.resource.ModelRoute.VirtualModel.failover:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
-	53,  // 363: agentgateway.dev.resource.ModelRoute.ConcreteModel.model_visibility:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
-	119, // 364: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend:type_name -> agentgateway.dev.resource.BackendReference
-	111, // 365: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	258, // 366: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
-	259, // 367: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
-	119, // 368: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover.backend:type_name -> agentgateway.dev.resource.BackendReference
+	110, // 349: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	240, // 350: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	1,   // 351: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.alg:type_name -> agentgateway.dev.resource.JwtSigningAlg
+	50,  // 352: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.certificate_header:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
+	74,  // 353: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	74,  // 354: agentgateway.dev.resource.OAuthTokenExchange.ActorToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	248, // 355: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.in_memory:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
+	262, // 356: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory.default_ttl:type_name -> google.protobuf.Duration
+	118, // 357: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
+	120, // 358: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
+	74,  // 359: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	254, // 360: agentgateway.dev.resource.ModelRoute.VirtualModel.weighted:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
+	255, // 361: agentgateway.dev.resource.ModelRoute.VirtualModel.conditional:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
+	256, // 362: agentgateway.dev.resource.ModelRoute.VirtualModel.failover:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
+	52,  // 363: agentgateway.dev.resource.ModelRoute.ConcreteModel.model_visibility:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
+	118, // 364: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend:type_name -> agentgateway.dev.resource.BackendReference
+	110, // 365: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	257, // 366: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
+	258, // 367: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
+	118, // 368: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover.backend:type_name -> agentgateway.dev.resource.BackendReference
 	369, // [369:369] is the sub-list for method output_type
 	369, // [369:369] is the sub-list for method input_type
 	369, // [369:369] is the sub-list for extension type_name
@@ -19300,7 +19228,7 @@ func file_resource_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
-			NumEnums:      54,
+			NumEnums:      53,
 			NumMessages:   206,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -5000,8 +5000,12 @@ type JwtSign struct {
 	// Where the signed token is written. Defaults to the Authorization header
 	// with a "Bearer " prefix.
 	AuthorizationLocation *AuthorizationLocation `protobuf:"bytes,6,opt,name=authorization_location,json=authorizationLocation,proto3" json:"authorization_location,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Set by the control plane when jwtSign configuration cannot be translated.
+	// Control-plane-only: never set from user-facing config. When present, the
+	// data plane accepts the policy but rejects every request that uses it.
+	TranslationError *string `protobuf:"bytes,7,opt,name=translation_error,json=translationError,proto3,oneof" json:"translation_error,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *JwtSign) Reset() {
@@ -5074,6 +5078,13 @@ func (x *JwtSign) GetAuthorizationLocation() *AuthorizationLocation {
 		return x.AuthorizationLocation
 	}
 	return nil
+}
+
+func (x *JwtSign) GetTranslationError() string {
+	if x != nil && x.TranslationError != nil {
+		return *x.TranslationError
+	}
+	return ""
 }
 
 // GCP-specific backend authentication.
@@ -17109,7 +17120,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x16authorization_location\x18\x01 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\"\x86\x01\n" +
 	"\x03Key\x12\x16\n" +
 	"\x06secret\x18\x01 \x01(\tR\x06secret\x12g\n" +
-	"\x16authorization_location\x18\x02 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\"\xc3\x03\n" +
+	"\x16authorization_location\x18\x02 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\"\x8b\x04\n" +
 	"\aJwtSign\x12\x1f\n" +
 	"\vsigning_key\x18\x01 \x01(\tR\n" +
 	"signingKey\x12:\n" +
@@ -17117,12 +17128,14 @@ const file_resource_proto_rawDesc = "" +
 	"\x03kid\x18\x03 \x01(\tH\x00R\x03kid\x88\x01\x01\x12F\n" +
 	"\x06claims\x18\x04 \x03(\v2..agentgateway.dev.resource.JwtSign.ClaimsEntryR\x06claims\x120\n" +
 	"\x03ttl\x18\x05 \x01(\v2\x19.google.protobuf.DurationH\x01R\x03ttl\x88\x01\x01\x12g\n" +
-	"\x16authorization_location\x18\x06 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\x1aQ\n" +
+	"\x16authorization_location\x18\x06 \x01(\v20.agentgateway.dev.resource.AuthorizationLocationR\x15authorizationLocation\x120\n" +
+	"\x11translation_error\x18\a \x01(\tH\x02R\x10translationError\x88\x01\x01\x1aQ\n" +
 	"\vClaimsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12,\n" +
 	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x05value:\x028\x01B\x06\n" +
 	"\x04_kidB\x06\n" +
-	"\x04_ttl\"\xa5\x02\n" +
+	"\x04_ttlB\x14\n" +
+	"\x12_translation_error\"\xa5\x02\n" +
 	"\x03Gcp\x12#\n" +
 	"\n" +
 	"credential\x18\x03 \x01(\tH\x01R\n" +

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -1869,7 +1869,7 @@ type OAuthPrivateKeyJWT struct {
 
 	// JWS signing algorithm. Defaults to RS256.
 	// +optional
-	Alg *OAuthPrivateKeyJWTSigningAlgorithm `json:"alg,omitempty"`
+	Alg *JwtSigningAlg `json:"alg,omitempty"`
 
 	// Optional JWS key ID header.
 	// +optional
@@ -1890,15 +1890,15 @@ const (
 )
 
 // +k8s:enum
-type OAuthPrivateKeyJWTSigningAlgorithm string
+type JwtSigningAlg string
 
 const (
-	OAuthPrivateKeyJWTSigningAlgorithmRS256 OAuthPrivateKeyJWTSigningAlgorithm = "RS256"
-	OAuthPrivateKeyJWTSigningAlgorithmRS384 OAuthPrivateKeyJWTSigningAlgorithm = "RS384"
-	OAuthPrivateKeyJWTSigningAlgorithmRS512 OAuthPrivateKeyJWTSigningAlgorithm = "RS512"
-	OAuthPrivateKeyJWTSigningAlgorithmPS256 OAuthPrivateKeyJWTSigningAlgorithm = "PS256"
-	OAuthPrivateKeyJWTSigningAlgorithmES256 OAuthPrivateKeyJWTSigningAlgorithm = "ES256"
-	OAuthPrivateKeyJWTSigningAlgorithmES384 OAuthPrivateKeyJWTSigningAlgorithm = "ES384"
+	JwtSigningAlgRS256 JwtSigningAlg = "RS256"
+	JwtSigningAlgRS384 JwtSigningAlg = "RS384"
+	JwtSigningAlgRS512 JwtSigningAlg = "RS512"
+	JwtSigningAlgPS256 JwtSigningAlg = "PS256"
+	JwtSigningAlgES256 JwtSigningAlg = "ES256"
+	JwtSigningAlgES384 JwtSigningAlg = "ES384"
 )
 
 // JwtSignAuth signs a short-lived JWT with a private key on each request and
@@ -1911,7 +1911,7 @@ type JwtSignAuth struct {
 
 	// JWS signing algorithm. Defaults to RS256.
 	// +optional
-	Alg *OAuthPrivateKeyJWTSigningAlgorithm `json:"alg,omitempty"`
+	Alg *JwtSigningAlg `json:"alg,omitempty"`
 
 	// Optional JWS key ID header.
 	// +optional

--- a/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
+++ b/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
@@ -3320,7 +3320,7 @@ func (in *JwtSignAuth) DeepCopyInto(out *JwtSignAuth) {
 	out.SigningKeyRef = in.SigningKeyRef
 	if in.Alg != nil {
 		in, out := &in.Alg, &out.Alg
-		*out = new(OAuthPrivateKeyJWTSigningAlgorithm)
+		*out = new(JwtSigningAlg)
 		**out = **in
 	}
 	if in.KeyID != nil {
@@ -4344,7 +4344,7 @@ func (in *OAuthPrivateKeyJWT) DeepCopyInto(out *OAuthPrivateKeyJWT) {
 	}
 	if in.Alg != nil {
 		in, out := &in.Alg, &out.Alg
-		*out = new(OAuthPrivateKeyJWTSigningAlgorithm)
+		*out = new(JwtSigningAlg)
 		**out = **in
 	}
 	if in.KeyID != nil {

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -1268,7 +1268,7 @@ func buildOAuthPrivateKeyJWT(ctx PolicyCtx, auth *agentgateway.OAuthPrivateKeyJW
 
 	var errs []error
 	res := &api.OAuthClientAuth_PrivateKeyJwt{
-		Alg:               translateOAuthPrivateKeyJWTSigningAlg(auth.Alg),
+		Alg:               translateJWTSigningAlg(auth.Alg),
 		Kid:               auth.KeyID,
 		AssertionAudience: auth.AssertionAudience,
 		CertificateHeader: translateOAuthPrivateKeyJWTCertificateHeader(auth.CertificateHeader),
@@ -1356,26 +1356,18 @@ func translateOAuthClientAuthMethod(method *agentgateway.OAuthClientAuthMethod) 
 	}
 }
 
-func translateOAuthPrivateKeyJWTSigningAlg(alg *agentgateway.OAuthPrivateKeyJWTSigningAlgorithm) api.OAuthClientAuth_PrivateKeyJwt_SigningAlg {
+func translateJWTSigningAlg(alg *agentgateway.JwtSigningAlg) api.JwtSigningAlg {
 	if alg == nil {
-		return api.OAuthClientAuth_PrivateKeyJwt_SIGNING_ALG_UNSPECIFIED
+		return api.JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED
 	}
-	switch *alg {
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS256:
-		return api.OAuthClientAuth_PrivateKeyJwt_RS256
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS384:
-		return api.OAuthClientAuth_PrivateKeyJwt_RS384
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS512:
-		return api.OAuthClientAuth_PrivateKeyJwt_RS512
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmPS256:
-		return api.OAuthClientAuth_PrivateKeyJwt_PS256
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmES256:
-		return api.OAuthClientAuth_PrivateKeyJwt_ES256
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmES384:
-		return api.OAuthClientAuth_PrivateKeyJwt_ES384
-	default:
-		return api.OAuthClientAuth_PrivateKeyJwt_SIGNING_ALG_UNSPECIFIED
-	}
+	translated, _ := translateJWTSigningAlgValue(*alg)
+	return translated
+}
+
+func translateJWTSigningAlgValue(alg agentgateway.JwtSigningAlg) (api.JwtSigningAlg, bool) {
+	value, ok := api.JwtSigningAlg_value[string(alg)]
+	translated := api.JwtSigningAlg(value)
+	return translated, ok && translated != api.JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED
 }
 
 func translateOAuthPrivateKeyJWTCertificateHeader(header *agentgateway.OAuthPrivateKeyJWTCertificateHeader) api.OAuthClientAuth_PrivateKeyJwt_CertificateHeader {
@@ -1782,24 +1774,13 @@ func buildJwtSignAuthPolicy(ctx PolicyCtx, auth *agentgateway.JwtSignAuth, names
 // applies its RS256 default, but rejects unrecognized values instead of
 // silently signing with the wrong algorithm. Unrecognized values are normally
 // unreachable behind the CRD enum validation; this guards against version skew.
-func translateJwtSignSigningAlg(alg *agentgateway.OAuthPrivateKeyJWTSigningAlgorithm) (api.JwtSign_SigningAlg, error) {
+func translateJwtSignSigningAlg(alg *agentgateway.JwtSigningAlg) (api.JwtSigningAlg, error) {
 	if alg == nil {
-		return api.JwtSign_SIGNING_ALG_UNSPECIFIED, nil
+		return api.JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED, nil
 	}
-	switch *alg {
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS256:
-		return api.JwtSign_RS256, nil
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS384:
-		return api.JwtSign_RS384, nil
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS512:
-		return api.JwtSign_RS512, nil
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmES256:
-		return api.JwtSign_ES256, nil
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmES384:
-		return api.JwtSign_ES384, nil
-	case agentgateway.OAuthPrivateKeyJWTSigningAlgorithmPS256:
-		return api.JwtSign_PS256, nil
-	default:
-		return api.JwtSign_SIGNING_ALG_UNSPECIFIED, fmt.Errorf("unsupported jwtSign signing algorithm %q", *alg)
+	translated, ok := translateJWTSigningAlgValue(*alg)
+	if !ok {
+		return api.JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED, fmt.Errorf("unsupported jwtSign signing algorithm %q", *alg)
 	}
+	return translated, nil
 }

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 
 	jsonpb "google.golang.org/protobuf/encoding/protojson"
@@ -640,7 +641,7 @@ func translateMCPAuthenticationSpec(
 		errs = append(errs, err)
 	}
 
-	extraResourceMetadata, metadataErr := translateJSONValueMap(authnPolicy.ResourceMetadata)
+	extraResourceMetadata, metadataErr := translateJSONValueMap("resourceMetadata field", authnPolicy.ResourceMetadata)
 	if metadataErr != nil {
 		errs = append(errs, metadataErr)
 	}
@@ -672,7 +673,7 @@ func translateMCPAuthenticationSpec(
 }
 
 func translateJWTMCPConfig(mcp *agentgateway.JWTMCPConfig) (*api.TrafficPolicySpec_JWT_MCP, error) {
-	extraResourceMetadata, err := translateJSONValueMap(mcp.ResourceMetadata)
+	extraResourceMetadata, err := translateJSONValueMap("resourceMetadata field", mcp.ResourceMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -711,23 +712,28 @@ func translateMcpIDP(provider *agentgateway.McpIDP) api.BackendPolicySpec_McpAut
 	return api.BackendPolicySpec_McpAuthentication_UNSPECIFIED
 }
 
-func translateJSONValueMap(values map[string]apiextensionsv1.JSON) (map[string]*structpb.Value, error) {
+func translateJSONValueMap(valueContext string, values map[string]apiextensionsv1.JSON) (map[string]*structpb.Value, error) {
 	var errs []error
 	var translated map[string]*structpb.Value
-	for k, v := range values {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
 		if translated == nil {
 			translated = make(map[string]*structpb.Value)
 		}
 
 		proto := &structpb.Value{}
-		err := jsonpb.Unmarshal(v.Raw, proto)
-		if err != nil {
-			logger.Error("error converting json value", "key", k, "error", err)
-			errs = append(errs, err)
+		if err := jsonpb.Unmarshal(values[key].Raw, proto); err != nil {
+			logger.Error("error converting JSON value", "context", valueContext, "key", key)
+			errs = append(errs, fmt.Errorf("%s %q contains invalid JSON", valueContext, key))
 			continue
 		}
 
-		translated[k] = proto
+		translated[key] = proto
 	}
 	return translated, errors.Join(errs...)
 }
@@ -938,10 +944,17 @@ func translateBackendAuth(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy
 		}
 	} else if auth.JwtSign != nil {
 		jwtSignAuth, err := buildJwtSignAuthPolicy(ctx, auth.JwtSign, policy.Namespace)
-		translatedAuth = jwtSignAuth
 		if err != nil {
 			errs = append(errs, err)
+			jwtSignAuth = &api.BackendAuthPolicy{
+				Kind: &api.BackendAuthPolicy_JwtSign{
+					JwtSign: &api.JwtSign{
+						TranslationError: ptr.Of(err.Error()),
+					},
+				},
+			}
 		}
+		translatedAuth = jwtSignAuth
 	} else if auth.Passthrough != nil {
 		translatedAuth = &api.BackendAuthPolicy{
 			Kind: &api.BackendAuthPolicy_Passthrough{
@@ -1731,7 +1744,7 @@ func buildJwtSignAuthPolicy(ctx PolicyCtx, auth *agentgateway.JwtSignAuth, names
 			return nil, fmt.Errorf("jwtSign claim %q is reserved for the signer and cannot be configured", reserved)
 		}
 	}
-	claims, err := translateJSONValueMap(auth.Claims)
+	claims, err := translateJSONValueMap("jwtSign claim", auth.Claims)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -1739,14 +1752,16 @@ func buildJwtSignAuthPolicy(ctx PolicyCtx, auth *agentgateway.JwtSignAuth, names
 	var signingKey string
 	data, err := ctx.ResolveCredentialRef(auth.SigningKeyRef, namespace)
 	if err != nil {
-		errs = append(errs, err)
+		errs = append(errs, fmt.Errorf(
+			"failed to resolve jwtSign signing secret %s/%s",
+			namespace,
+			auth.SigningKeyRef.Name,
+		))
 	} else if value, exists := kubeutils.GetSecretDataValue(data, wellknown.SigningKey); !exists || value == "" {
 		errs = append(errs, fmt.Errorf("secret %s/%s missing %s value", namespace, auth.SigningKeyRef.Name, wellknown.SigningKey))
 	} else {
 		signingKey = value
 	}
-	// A jwtSign policy without its signing key cannot mint tokens; drop the
-	// policy entirely instead of shipping it with an empty key.
 	if len(errs) > 0 {
 		return nil, errors.Join(errs...)
 	}

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -3,8 +3,9 @@ package plugins
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
-	"sort"
+	slices0 "slices"
 	"strings"
 
 	jsonpb "google.golang.org/protobuf/encoding/protojson"
@@ -715,13 +716,7 @@ func translateMcpIDP(provider *agentgateway.McpIDP) api.BackendPolicySpec_McpAut
 func translateJSONValueMap(valueContext string, values map[string]apiextensionsv1.JSON) (map[string]*structpb.Value, error) {
 	var errs []error
 	var translated map[string]*structpb.Value
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
+	for _, key := range slices0.Sorted(maps.Keys(values)) {
 		if translated == nil {
 			translated = make(map[string]*structpb.Value)
 		}
@@ -949,7 +944,7 @@ func translateBackendAuth(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy
 			jwtSignAuth = &api.BackendAuthPolicy{
 				Kind: &api.BackendAuthPolicy_JwtSign{
 					JwtSign: &api.JwtSign{
-						TranslationError: ptr.Of(err.Error()),
+						TranslationError: new(err.Error()),
 					},
 				},
 			}

--- a/controller/pkg/agentgateway/plugins/jwt_sign_auth_test.go
+++ b/controller/pkg/agentgateway/plugins/jwt_sign_auth_test.go
@@ -11,25 +11,13 @@ import (
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 )
 
-// Every algorithm the CRD enum admits must translate to a proto value, or a
-// config that passes admission fails at translation time.
-func TestJwtSignTranslatesEveryCRDSigningAlg(t *testing.T) {
-	want := map[agentgateway.OAuthPrivateKeyJWTSigningAlgorithm]api.JwtSign_SigningAlg{
-		agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS256: api.JwtSign_RS256,
-		agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS384: api.JwtSign_RS384,
-		agentgateway.OAuthPrivateKeyJWTSigningAlgorithmRS512: api.JwtSign_RS512,
-		agentgateway.OAuthPrivateKeyJWTSigningAlgorithmPS256: api.JwtSign_PS256,
-		agentgateway.OAuthPrivateKeyJWTSigningAlgorithmES256: api.JwtSign_ES256,
-		agentgateway.OAuthPrivateKeyJWTSigningAlgorithmES384: api.JwtSign_ES384,
+func TestJwtSignNilSigningAlgDefaultsToUnspecified(t *testing.T) {
+	got, err := translateJwtSignSigningAlg(nil)
+	if err != nil {
+		t.Fatalf("translateJwtSignSigningAlg(nil) error = %v, want nil", err)
 	}
-	for alg, expected := range want {
-		got, err := translateJwtSignSigningAlg(&alg)
-		if err != nil {
-			t.Fatalf("translateJwtSignSigningAlg(%q) error = %v, want nil", alg, err)
-		}
-		if got != expected {
-			t.Fatalf("translateJwtSignSigningAlg(%q) = %v, want %v", alg, got, expected)
-		}
+	if got != api.JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED {
+		t.Fatalf("translateJwtSignSigningAlg(nil) = %v, want JWT_SIGNING_ALG_UNSPECIFIED", got)
 	}
 }
 
@@ -39,7 +27,7 @@ func TestJwtSignTranslatesEveryCRDSigningAlg(t *testing.T) {
 // that rejection instead of still emitting a policy with the wrong alg.
 func TestJwtSignRejectsUnsupportedSigningAlg(t *testing.T) {
 	ctx := oauthTestPolicyCtx(t)
-	badAlg := agentgateway.OAuthPrivateKeyJWTSigningAlgorithm("HS256")
+	badAlg := agentgateway.JwtSigningAlg("HS256")
 	policy := &agentgateway.AgentgatewayPolicy{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
 		Spec: agentgateway.AgentgatewayPolicySpec{

--- a/controller/pkg/agentgateway/plugins/jwt_sign_auth_test.go
+++ b/controller/pkg/agentgateway/plugins/jwt_sign_auth_test.go
@@ -1,15 +1,60 @@
 package plugins
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/agentgateway/agentgateway/api"
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 )
+
+type jwtSignErrorCredentialResolver struct{}
+
+func (jwtSignErrorCredentialResolver) ResolveCredentialRef(
+	krt.HandlerContext,
+	agentgateway.LocalSecretObjectRef,
+	string,
+) (map[string][]byte, error) {
+	return nil, errors.New("resolver-secret-data-marker")
+}
+
+func jwtSignTestPolicy(auth *agentgateway.JwtSignAuth) *agentgateway.AgentgatewayPolicy {
+	return &agentgateway.AgentgatewayPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec: agentgateway.AgentgatewayPolicySpec{
+			Backend: &agentgateway.BackendFull{
+				BackendSimple: agentgateway.BackendSimple{
+					Auth: &agentgateway.BackendAuth{JwtSign: auth},
+				},
+			},
+		},
+	}
+}
+
+func translatedJwtSign(t *testing.T, policy *api.Policy) *api.JwtSign {
+	t.Helper()
+	if policy == nil {
+		t.Fatal("translated policy is nil")
+	}
+	jwtSign := policy.GetBackend().GetAuth().GetJwtSign()
+	if jwtSign == nil {
+		t.Fatal("translated policy kind is not jwtSign")
+	}
+	return jwtSign
+}
+
+func jwtSignSecret(data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "jwt-sign-secret"},
+		Data:       data,
+	}
+}
 
 func TestJwtSignNilSigningAlgDefaultsToUnspecified(t *testing.T) {
 	got, err := translateJwtSignSigningAlg(nil)
@@ -28,29 +73,22 @@ func TestJwtSignNilSigningAlgDefaultsToUnspecified(t *testing.T) {
 func TestJwtSignRejectsUnsupportedSigningAlg(t *testing.T) {
 	ctx := oauthTestPolicyCtx(t)
 	badAlg := agentgateway.JwtSigningAlg("HS256")
-	policy := &agentgateway.AgentgatewayPolicy{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
-		Spec: agentgateway.AgentgatewayPolicySpec{
-			Backend: &agentgateway.BackendFull{
-				BackendSimple: agentgateway.BackendSimple{
-					Auth: &agentgateway.BackendAuth{
-						JwtSign: &agentgateway.JwtSignAuth{
-							SigningKeyRef: agentgateway.LocalSecretObjectRef{Name: "jwt-sign-secret"},
-							Alg:           &badAlg,
-							Claims:        map[string]apiextensionsv1.JSON{"iss": {Raw: []byte(`"acct.user"`)}},
-						},
-					},
-				},
-			},
-		},
-	}
+	policy := jwtSignTestPolicy(&agentgateway.JwtSignAuth{
+		SigningKeyRef: agentgateway.LocalSecretObjectRef{Name: "jwt-sign-secret"},
+		Alg:           &badAlg,
+		Claims:        map[string]apiextensionsv1.JSON{"iss": {Raw: []byte(`"acct.user"`)}},
+	})
 
 	p, err := translateBackendAuth(ctx, policy, "default/jwt-sign")
 	if err == nil || !strings.Contains(err.Error(), "unsupported jwtSign signing algorithm") {
 		t.Fatalf("translateBackendAuth() error = %v, want unsupported signing algorithm error", err)
 	}
-	if p != nil {
-		t.Fatalf("translateBackendAuth() policy = %v, want nil policy on unsupported alg", p)
+	jwtSign := translatedJwtSign(t, p)
+	if jwtSign.TranslationError == nil || !strings.Contains(jwtSign.GetTranslationError(), "HS256") {
+		t.Fatalf("translationError = %q, want unsupported HS256 diagnostic", jwtSign.GetTranslationError())
+	}
+	if jwtSign.GetSigningKey() != "" || jwtSign.GetAlg() != api.JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED {
+		t.Fatalf("error-bearing jwtSign contains signing configuration: %+v", jwtSign)
 	}
 }
 
@@ -59,31 +97,85 @@ func TestJwtSignRejectsUnsupportedSigningAlg(t *testing.T) {
 func TestJwtSignRejectsReservedClaims(t *testing.T) {
 	ctx := oauthTestPolicyCtx(t)
 	for _, reserved := range []string{"iat", "exp", "nbf"} {
-		policy := &agentgateway.AgentgatewayPolicy{
-			ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
-			Spec: agentgateway.AgentgatewayPolicySpec{
-				Backend: &agentgateway.BackendFull{
-					BackendSimple: agentgateway.BackendSimple{
-						Auth: &agentgateway.BackendAuth{
-							JwtSign: &agentgateway.JwtSignAuth{
-								SigningKeyRef: agentgateway.LocalSecretObjectRef{Name: "jwt-sign-secret"},
-								Claims: map[string]apiextensionsv1.JSON{
-									"iss":    {Raw: []byte(`"acct.user"`)},
-									reserved: {Raw: []byte(`123`)},
-								},
-							},
-						},
-					},
-				},
+		policy := jwtSignTestPolicy(&agentgateway.JwtSignAuth{
+			SigningKeyRef: agentgateway.LocalSecretObjectRef{Name: "jwt-sign-secret"},
+			Claims: map[string]apiextensionsv1.JSON{
+				"iss":    {Raw: []byte(`"acct.user"`)},
+				reserved: {Raw: []byte(`123`)},
 			},
-		}
+		})
 
 		p, err := translateBackendAuth(ctx, policy, "default/jwt-sign")
 		if err == nil || !strings.Contains(err.Error(), "reserved for the signer") {
 			t.Fatalf("translateBackendAuth() error = %v, want reserved claim error for %q", err, reserved)
 		}
-		if p != nil {
-			t.Fatalf("translateBackendAuth() policy = %v, want nil policy on reserved claim %q", p, reserved)
+		jwtSign := translatedJwtSign(t, p)
+		if jwtSign.TranslationError == nil || !strings.Contains(jwtSign.GetTranslationError(), reserved) {
+			t.Fatalf("translationError = %q, want reserved claim %q", jwtSign.GetTranslationError(), reserved)
+		}
+	}
+}
+
+func TestJwtSignTranslationErrorSanitizesResolverError(t *testing.T) {
+	ctx := oauthTestPolicyCtx(t)
+	ctx.CredentialResolver = jwtSignErrorCredentialResolver{}
+	policy := jwtSignTestPolicy(&agentgateway.JwtSignAuth{
+		SigningKeyRef: agentgateway.LocalSecretObjectRef{Name: "jwt-sign-secret"},
+		Claims:        map[string]apiextensionsv1.JSON{"iss": {Raw: []byte(`"acct.user"`)}},
+	})
+
+	p, err := translateBackendAuth(ctx, policy, "default/jwt-sign")
+	want := "failed to resolve jwtSign signing secret default/jwt-sign-secret"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("translateBackendAuth() error = %v, want %q", err, want)
+	}
+	jwtSign := translatedJwtSign(t, p)
+	if jwtSign.TranslationError == nil || !strings.Contains(jwtSign.GetTranslationError(), want) {
+		t.Fatalf("translationError = %q, want %q", jwtSign.GetTranslationError(), want)
+	}
+	if jwtSign.GetSigningKey() != "" {
+		t.Fatal("error-bearing jwtSign must not contain a signing key")
+	}
+	if strings.Contains(err.Error(), "resolver-secret-data-marker") ||
+		strings.Contains(jwtSign.GetTranslationError(), "resolver-secret-data-marker") {
+		t.Fatal("translation diagnostic leaked resolver error details")
+	}
+}
+
+func TestJwtSignInvalidClaimDoesNotLeakValue(t *testing.T) {
+	const claimValueMarker = "claim-value-secret-marker"
+	ctx := oauthTestPolicyCtx(t, jwtSignSecret(map[string][]byte{
+		"signingKey": []byte("pem-value"),
+	}))
+	policy := jwtSignTestPolicy(&agentgateway.JwtSignAuth{
+		SigningKeyRef: agentgateway.LocalSecretObjectRef{Name: "jwt-sign-secret"},
+		Claims: map[string]apiextensionsv1.JSON{
+			"password": {Raw: []byte(claimValueMarker)},
+		},
+	})
+
+	p, err := translateBackendAuth(ctx, policy, "default/jwt-sign")
+	if err == nil || !strings.Contains(err.Error(), `jwtSign claim "password" contains invalid JSON`) {
+		t.Fatalf("translateBackendAuth() error = %v, want sanitized invalid claim error", err)
+	}
+	jwtSign := translatedJwtSign(t, p)
+	if strings.Contains(err.Error(), claimValueMarker) ||
+		strings.Contains(jwtSign.GetTranslationError(), claimValueMarker) {
+		t.Fatalf("diagnostic leaked claim value marker %q", claimValueMarker)
+	}
+}
+
+func TestJwtSignInvalidClaimErrorsAreDeterministic(t *testing.T) {
+	values := map[string]apiextensionsv1.JSON{
+		"z-last":  {Raw: []byte("invalid-z")},
+		"a-first": {Raw: []byte("invalid-a")},
+	}
+	const want = "jwtSign claim \"a-first\" contains invalid JSON\njwtSign claim \"z-last\" contains invalid JSON"
+
+	for range 10 {
+		_, err := translateJSONValueMap("jwtSign claim", values)
+		if err == nil || err.Error() != want {
+			t.Fatalf("translateJSONValueMap() error = %q, want %q", err, want)
 		}
 	}
 }

--- a/controller/pkg/agentgateway/plugins/oauth_auth_test.go
+++ b/controller/pkg/agentgateway/plugins/oauth_auth_test.go
@@ -371,7 +371,7 @@ func TestOAuthTokenExchangeClientAuthPrivateKeyJWT(t *testing.T) {
 					Name: "oauth-signing-key",
 				},
 				CertificateHeader: ptr.Of(agentgateway.OAuthPrivateKeyJWTCertificateHeaderX5TS256),
-				Alg:               ptr.Of(agentgateway.OAuthPrivateKeyJWTSigningAlgorithmPS256),
+				Alg:               ptr.Of(agentgateway.JwtSigningAlgPS256),
 				KeyID:             new("kid-1"),
 				AssertionAudience: "https://issuer.example.com/oauth/token",
 			},
@@ -401,7 +401,7 @@ func TestOAuthTokenExchangeClientAuthPrivateKeyJWT(t *testing.T) {
 	if privateKeyJWT.GetCertificateHeader() != api.OAuthClientAuth_PrivateKeyJwt_X5T_S256 {
 		t.Fatalf("certificate header = %v, want X5T_S256", privateKeyJWT.GetCertificateHeader())
 	}
-	if privateKeyJWT.GetAlg() != api.OAuthClientAuth_PrivateKeyJwt_PS256 {
+	if privateKeyJWT.GetAlg() != api.JwtSigningAlg_PS256 {
 		t.Fatalf("privateKeyJwt alg = %v, want PS256", privateKeyJWT.GetAlg())
 	}
 	if privateKeyJWT.GetKid() != "kid-1" {
@@ -409,6 +409,14 @@ func TestOAuthTokenExchangeClientAuthPrivateKeyJWT(t *testing.T) {
 	}
 	if privateKeyJWT.GetAssertionAudience() != "https://issuer.example.com/oauth/token" {
 		t.Fatalf("privateKeyJwt assertion audience = %q, want token endpoint URL", privateKeyJWT.GetAssertionAudience())
+	}
+}
+
+func TestOAuthPrivateKeyJWTUnknownSigningAlgDefaultsToUnspecified(t *testing.T) {
+	unknown := agentgateway.JwtSigningAlg("HS256")
+	got := translateJWTSigningAlg(&unknown)
+	if got != api.JwtSigningAlg_JWT_SIGNING_ALG_UNSPECIFIED {
+		t.Fatalf("translateJWTSigningAlg(%q) = %v, want JWT_SIGNING_ALG_UNSPECIFIED", unknown, got)
 	}
 }
 

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/jwtsignauth.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/jwtsignauth.yaml
@@ -80,6 +80,25 @@ output:
       backend:
         auth:
           jwtSign:
+            translationError: failed to resolve jwtSign signing secret default/jwt-sign-secret-missing
+      key: backend/default/jwt-sign-secret-not-found:backend-auth:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: jwt-sign-secret-not-found
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: test
+          namespace: default
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        auth:
+          jwtSign:
             claims:
               iss: acct.user
             signingKey: pem-value
@@ -164,15 +183,10 @@ status:
         namespace: default
       conditions:
       - lastTransitionTime: fake
-        message: secret default/jwt-sign-secret-missing not found
-        reason: Invalid
-        status: "False"
+        message: failed to resolve jwtSign signing secret default/jwt-sign-secret-missing
+        reason: PartiallyValid
+        status: "True"
         type: Accepted
-      - lastTransitionTime: fake
-        message: Policy is not attached due to invalid status
-        reason: Pending
-        status: "False"
-        type: Attached
       controllerName: agentgateway.dev/agentgateway
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayPolicy

--- a/controller/test/e2e/backendauth_test.go
+++ b/controller/test/e2e/backendauth_test.go
@@ -3,11 +3,17 @@
 package e2e_test
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/onsi/gomega"
+	"istio.io/istio/pkg/test/util/retry"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/base"
 	testmatchers "github.com/agentgateway/agentgateway/controller/test/gomega/matchers"
 	"github.com/agentgateway/agentgateway/controller/test/gomega/transforms"
@@ -18,6 +24,9 @@ func TestBackendAuth(tt *testing.T) {
 
 	t.Run("Credentials", func(t base.Test) {
 		testBackendAuthCredentials(t)
+	})
+	t.Run("InvalidJwtSign", func(t base.Test) {
+		testInvalidJwtSign(t)
 	})
 }
 
@@ -31,6 +40,42 @@ func testBackendAuthCredentials(t base.Test) {
 				gomega.HaveKeyWithValue("Dd-Api-Key", "primary-api-key"),
 				gomega.HaveKeyWithValue("Dd-Application-Key", "application-key"),
 			),
+		),
+	})
+}
+
+func testInvalidJwtSign(t base.Test) {
+	const missingSecret = "jwt-sign-secret-missing"
+	t.Apply(manifest("backendauth", "invalid-jwt-sign.yaml"))
+	t.HTTPRouteAccepted("route-backendauth-invalid-jwt-sign", base.Namespace)
+
+	retry.UntilSuccessOrFail(t, func() error {
+		policy := &agentgateway.AgentgatewayPolicy{}
+		if err := t.TestInstallation.ClusterContext.ControllerClient.Get(
+			t.Ctx,
+			types.NamespacedName{Name: "backendauth-invalid-jwt-sign", Namespace: base.Namespace},
+			policy,
+		); err != nil {
+			return err
+		}
+		for _, ancestor := range policy.Status.Ancestors {
+			for _, condition := range ancestor.Conditions {
+				if condition.Type == string(agentgateway.PolicyConditionAccepted) &&
+					condition.Status == metav1.ConditionTrue &&
+					condition.Reason == string(agentgateway.PolicyReasonPartiallyValid) &&
+					strings.Contains(condition.Message, missingSecret) {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("policy status does not report the missing jwtSign secret: %+v", policy.Status)
+	})
+
+	t.Send("invalid-jwt-sign.example.com", &testmatchers.HttpResponse{
+		StatusCode: http.StatusInternalServerError,
+		Body: gomega.And(
+			gomega.ContainSubstring("backend authentication failed: jwtSign configuration is invalid"),
+			gomega.Not(gomega.ContainSubstring(missingSecret)),
 		),
 	})
 }

--- a/controller/test/e2e/backendauth_test.go
+++ b/controller/test/e2e/backendauth_test.go
@@ -66,7 +66,7 @@ func testValidJwtSign(t base.Test) {
 }
 
 func testInvalidJwtSign(t base.Test) {
-	const missingSecret = "jwt-sign-secret-missing"
+	const missingKeyRef = "jwt-sign-secret-missing"
 	t.Apply(manifest("backendauth", "invalid-jwt-sign.yaml"))
 	t.HTTPRouteAccepted("route-backendauth-invalid-jwt-sign", base.Namespace)
 
@@ -84,7 +84,7 @@ func testInvalidJwtSign(t base.Test) {
 				if condition.Type == string(agentgateway.PolicyConditionAccepted) &&
 					condition.Status == metav1.ConditionTrue &&
 					condition.Reason == string(agentgateway.PolicyReasonPartiallyValid) &&
-					strings.Contains(condition.Message, missingSecret) {
+					strings.Contains(condition.Message, missingKeyRef) {
 					return nil
 				}
 			}
@@ -96,7 +96,7 @@ func testInvalidJwtSign(t base.Test) {
 		StatusCode: http.StatusInternalServerError,
 		Body: gomega.And(
 			gomega.ContainSubstring("backend authentication failed: jwtSign configuration is invalid"),
-			gomega.Not(gomega.ContainSubstring(missingSecret)),
+			gomega.Not(gomega.ContainSubstring(missingKeyRef)),
 		),
 	})
 }

--- a/controller/test/e2e/backendauth_test.go
+++ b/controller/test/e2e/backendauth_test.go
@@ -25,8 +25,13 @@ func TestBackendAuth(tt *testing.T) {
 	t.Run("Credentials", func(t base.Test) {
 		testBackendAuthCredentials(t)
 	})
-	t.Run("InvalidJwtSign", func(t base.Test) {
-		testInvalidJwtSign(t)
+	t.Run("JwtSign", func(t base.Test) {
+		t.Run("Valid", func(t base.Test) {
+			testValidJwtSign(t)
+		})
+		t.Run("Invalid", func(t base.Test) {
+			testInvalidJwtSign(t)
+		})
 	})
 }
 
@@ -39,6 +44,22 @@ func testBackendAuthCredentials(t base.Test) {
 			gomega.And(
 				gomega.HaveKeyWithValue("Dd-Api-Key", "primary-api-key"),
 				gomega.HaveKeyWithValue("Dd-Application-Key", "application-key"),
+			),
+		),
+	})
+}
+
+func testValidJwtSign(t base.Test) {
+	t.Apply(manifest("backendauth", "valid-jwt-sign.yaml"))
+	t.HTTPRouteAccepted("route-backendauth-valid-jwt-sign", base.Namespace)
+
+	t.Send("valid-jwt-sign.example.com", &testmatchers.HttpResponse{
+		StatusCode: http.StatusOK,
+		Body: gomega.WithTransform(
+			transforms.WithEchoHeaders(),
+			gomega.HaveKeyWithValue(
+				"Authorization",
+				gomega.MatchRegexp(`^Bearer [^.]+\.[^.]+\.[^.]+$`),
 			),
 		),
 	})

--- a/controller/test/e2e/testdata/backendauth/invalid-jwt-sign.yaml
+++ b/controller/test/e2e/testdata/backendauth/invalid-jwt-sign.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-backendauth-invalid-jwt-sign
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "invalid-jwt-sign.example.com"
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: backendauth-invalid-jwt-sign
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: route-backendauth-invalid-jwt-sign
+  backend:
+    auth:
+      jwtSign:
+        signingKeyRef:
+          name: jwt-sign-secret-missing
+        claims:
+          iss: acct.user

--- a/controller/test/e2e/testdata/backendauth/valid-jwt-sign.yaml
+++ b/controller/test/e2e/testdata/backendauth/valid-jwt-sign.yaml
@@ -1,0 +1,48 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-backendauth-valid-jwt-sign
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "valid-jwt-sign.example.com"
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jwt-sign-secret
+  namespace: agentgateway-base
+type: Opaque
+stringData:
+  signingKey: |
+    -----BEGIN PRIVATE KEY-----
+    MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg0LXKf6NEiyOsNdK/
+    hfGF0n9BjMruYI85lF6XCP5ukGehRANCAAQhNE/7eV7FklXXpqxHFNgKUbudzsDE
+    mvho95/6+KBFnO4P6nIufWypMhozVRCY16BhyM+9fM4nfPJxfWqlwE0M
+    -----END PRIVATE KEY-----
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: backendauth-valid-jwt-sign
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: route-backendauth-valid-jwt-sign
+  backend:
+    auth:
+      jwtSign:
+        signingKeyRef:
+          name: jwt-sign-secret
+        alg: ES256
+        claims:
+          iss: acct.user
+        ttl: 60s

--- a/crates/agentgateway/src/http/auth/jws.rs
+++ b/crates/agentgateway/src/http/auth/jws.rs
@@ -1,0 +1,121 @@
+use std::fmt;
+
+use anyhow::Context;
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use serde::Serialize;
+
+use crate::types::proto::agent as proto;
+use crate::{apply, schema_enum};
+
+#[apply(schema_enum!)]
+#[derive(Default)]
+pub enum JwtSigningAlg {
+	#[default]
+	#[serde(rename = "RS256")]
+	Rs256,
+	#[serde(rename = "RS384")]
+	Rs384,
+	#[serde(rename = "RS512")]
+	Rs512,
+	#[serde(rename = "PS256")]
+	Ps256,
+	#[serde(rename = "ES256")]
+	Es256,
+	#[serde(rename = "ES384")]
+	Es384,
+}
+
+impl JwtSigningAlg {
+	fn algorithm(self) -> Algorithm {
+		match self {
+			Self::Rs256 => Algorithm::RS256,
+			Self::Rs384 => Algorithm::RS384,
+			Self::Rs512 => Algorithm::RS512,
+			Self::Ps256 => Algorithm::PS256,
+			Self::Es256 => Algorithm::ES256,
+			Self::Es384 => Algorithm::ES384,
+		}
+	}
+
+	pub(crate) fn encoding_key(self, pem: &[u8]) -> anyhow::Result<EncodingKey> {
+		match self {
+			Self::Rs256 | Self::Rs384 | Self::Rs512 | Self::Ps256 => {
+				EncodingKey::from_rsa_pem(pem).context("failed to load RSA signing key")
+			},
+			Self::Es256 | Self::Es384 => {
+				EncodingKey::from_ec_pem(pem).context("failed to load EC signing key")
+			},
+		}
+	}
+
+	pub(crate) fn header(self, kid: Option<String>) -> Header {
+		let mut header = Header::new(self.algorithm());
+		header.kid = kid;
+		header
+	}
+}
+
+pub(crate) fn signing_alg_from_proto(alg: i32) -> Option<JwtSigningAlg> {
+	use proto::JwtSigningAlg as ProtoSigningAlg;
+
+	match ProtoSigningAlg::try_from(alg) {
+		Ok(ProtoSigningAlg::Unspecified | ProtoSigningAlg::Rs256) => Some(JwtSigningAlg::Rs256),
+		Ok(ProtoSigningAlg::Rs384) => Some(JwtSigningAlg::Rs384),
+		Ok(ProtoSigningAlg::Rs512) => Some(JwtSigningAlg::Rs512),
+		Ok(ProtoSigningAlg::Ps256) => Some(JwtSigningAlg::Ps256),
+		Ok(ProtoSigningAlg::Es256) => Some(JwtSigningAlg::Es256),
+		Ok(ProtoSigningAlg::Es384) => Some(JwtSigningAlg::Es384),
+		Err(_) => None,
+	}
+}
+
+#[derive(Clone)]
+pub(crate) struct SigningKey(EncodingKey);
+
+impl SigningKey {
+	pub(crate) fn from_pem(alg: JwtSigningAlg, pem: &[u8]) -> anyhow::Result<Self> {
+		alg.encoding_key(pem).map(Self)
+	}
+
+	pub(crate) fn encode<T: Serialize>(
+		&self,
+		header: &Header,
+		claims: &T,
+	) -> jsonwebtoken::errors::Result<String> {
+		jsonwebtoken::encode(header, claims, &self.0)
+	}
+}
+
+impl fmt::Debug for SigningKey {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.write_str("[REDACTED]")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn signing_alg_proto_mapping_defaults_and_rejects_unknown_values() {
+		use proto::JwtSigningAlg as ProtoSigningAlg;
+
+		let cases = [
+			(ProtoSigningAlg::Unspecified, JwtSigningAlg::Rs256),
+			(ProtoSigningAlg::Rs256, JwtSigningAlg::Rs256),
+			(ProtoSigningAlg::Rs384, JwtSigningAlg::Rs384),
+			(ProtoSigningAlg::Rs512, JwtSigningAlg::Rs512),
+			(ProtoSigningAlg::Ps256, JwtSigningAlg::Ps256),
+			(ProtoSigningAlg::Es256, JwtSigningAlg::Es256),
+			(ProtoSigningAlg::Es384, JwtSigningAlg::Es384),
+		];
+
+		for (proto, expected) in cases {
+			assert_eq!(
+				signing_alg_from_proto(proto as i32).expect("known algorithm should map"),
+				expected
+			);
+		}
+		assert_eq!(signing_alg_from_proto(i32::MAX), None);
+	}
+}

--- a/crates/agentgateway/src/http/auth/jwt_sign.rs
+++ b/crates/agentgateway/src/http/auth/jwt_sign.rs
@@ -33,13 +33,11 @@ fn ttl_secs_ceil(ttl: Duration) -> u64 {
 	ttl.as_secs() + u64::from(ttl.subsec_nanos() > 0)
 }
 
-/// The signing key, either parsed eagerly (inline PEM) or deferred to
-/// [`JwtSignAuth::resolve`] (file paths), so file-based keys register with the
-/// resource manager and reload when the file changes.
 #[derive(Clone)]
-enum ResolvableSigningKey {
+enum JwtSignState {
 	Parsed(SigningKey),
 	File(PathBuf),
+	Invalid(String),
 }
 
 /// Signs a short-lived JWT with a private key on each request and sends it to
@@ -51,7 +49,7 @@ enum ResolvableSigningKey {
 pub struct JwtSignAuth {
 	#[serde(skip)]
 	#[cfg_attr(feature = "schema", schemars(skip))]
-	signing_key: ResolvableSigningKey,
+	state: JwtSignState,
 	#[serde(default)]
 	alg: JwtSigningAlg,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -65,14 +63,22 @@ pub struct JwtSignAuth {
 
 impl fmt::Debug for JwtSignAuth {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		f.debug_struct("JwtSignAuth")
-			.field("signing_key", &"<redacted>")
-			.field("alg", &self.alg)
-			.field("kid", &self.kid)
-			.field("claims", &self.claims)
-			.field("ttl", &self.ttl)
-			.field("location", &self.location)
-			.finish()
+		let mut debug = f.debug_struct("JwtSignAuth");
+		match &self.state {
+			JwtSignState::Invalid(error) => {
+				debug.field("translation_error", error);
+			},
+			JwtSignState::Parsed(_) | JwtSignState::File(_) => {
+				debug
+					.field("signing_key", &"<redacted>")
+					.field("alg", &self.alg)
+					.field("kid", &self.kid)
+					.field("claims", &self.claims)
+					.field("ttl", &self.ttl)
+					.field("location", &self.location);
+			},
+		}
+		debug.finish()
 	}
 }
 
@@ -82,6 +88,12 @@ impl serde::Serialize for JwtSignAuth {
 		S: serde::Serializer,
 	{
 		use serde::ser::SerializeStruct;
+
+		if let JwtSignState::Invalid(error) = &self.state {
+			let mut state = serializer.serialize_struct("JwtSignAuth", 1)?;
+			state.serialize_field("translationError", error)?;
+			return state.end();
+		}
 
 		let mut state = serializer.serialize_struct("JwtSignAuth", 5)?;
 		state.serialize_field("alg", &self.alg)?;
@@ -136,14 +148,12 @@ impl TryFrom<RawJwtSignAuth> for JwtSignAuth {
 		// Inline keys are parsed eagerly so misconfigurations fail at parse
 		// time. File keys are deferred to `resolve`, which fetches through the
 		// resource manager so the file is watched and changes reload the config.
-		let signing_key = match raw.signing_key {
-			FileOrInline::Inline(pem) => {
-				ResolvableSigningKey::Parsed(parse_signing_key(raw.alg, pem.trim())?)
-			},
-			FileOrInline::File { file } => ResolvableSigningKey::File(file),
+		let state = match raw.signing_key {
+			FileOrInline::Inline(pem) => JwtSignState::Parsed(parse_signing_key(raw.alg, pem.trim())?),
+			FileOrInline::File { file } => JwtSignState::File(file),
 		};
 		Ok(Self {
-			signing_key,
+			state,
 			alg: raw.alg,
 			kid: raw.kid,
 			claims: raw.claims,
@@ -181,6 +191,18 @@ fn parse_signing_key(alg: JwtSigningAlg, pem: &str) -> Result<SigningKey, String
 }
 
 impl JwtSignAuth {
+	/// Returns a jwtSign configuration that always rejects requests
+	pub(crate) fn new_invalid(error: String) -> Self {
+		Self {
+			state: JwtSignState::Invalid(error),
+			alg: JwtSigningAlg::default(),
+			kid: None,
+			claims: BTreeMap::new(),
+			ttl: None,
+			location: None,
+		}
+	}
+
 	pub fn try_new(
 		signing_key_pem: &str,
 		alg: JwtSigningAlg,
@@ -190,9 +212,9 @@ impl JwtSignAuth {
 		location: Option<AuthorizationLocation>,
 	) -> Result<Self, String> {
 		validate_config(&claims, ttl)?;
-		let signing_key = ResolvableSigningKey::Parsed(parse_signing_key(alg, signing_key_pem)?);
+		let state = JwtSignState::Parsed(parse_signing_key(alg, signing_key_pem)?);
 		Ok(Self {
-			signing_key,
+			state,
 			alg,
 			kid,
 			claims,
@@ -205,22 +227,32 @@ impl JwtSignAuth {
 	/// registers the file so changes trigger a config reload. Inline keys are
 	/// already parsed and are left untouched.
 	pub async fn resolve(&mut self, resources: &ResourceFetcher) -> anyhow::Result<()> {
-		if let ResolvableSigningKey::File(path) = &self.signing_key {
-			let pem = resources
-				.fetch(ResourceRef::File(path.clone()))
-				.await
-				.context("failed to load jwtSign signingKey")?;
-			let pem = std::str::from_utf8(&pem).context("jwtSign signingKey is not valid UTF-8")?;
-			self.signing_key = ResolvableSigningKey::Parsed(
-				parse_signing_key(self.alg, pem.trim()).map_err(anyhow::Error::msg)?,
-			);
-		}
+		let JwtSignState::File(path) = &self.state else {
+			return Ok(());
+		};
+		let pem = resources
+			.fetch(ResourceRef::File(path.clone()))
+			.await
+			.context("failed to load jwtSign signingKey")?;
+		let pem = std::str::from_utf8(&pem).context("jwtSign signingKey is not valid UTF-8")?;
+		self.state =
+			JwtSignState::Parsed(parse_signing_key(self.alg, pem.trim()).map_err(anyhow::Error::msg)?);
 		Ok(())
 	}
 
 	pub(super) fn sign(&self) -> anyhow::Result<String> {
-		let ResolvableSigningKey::Parsed(signing_key) = &self.signing_key else {
-			anyhow::bail!("jwtSign file-based signingKey was not resolved at config load");
+		let signing_key = match &self.state {
+			JwtSignState::Parsed(signing_key) => signing_key,
+			JwtSignState::File(_) => {
+				anyhow::bail!("jwtSign file-based signingKey was not resolved at config load");
+			},
+			JwtSignState::Invalid(error) => {
+				tracing::debug!(
+					error = %error,
+					"rejecting request: jwtSign configuration is invalid"
+				);
+				anyhow::bail!("jwtSign configuration is invalid");
+			},
 		};
 		let now = SystemTime::now()
 			.duration_since(UNIX_EPOCH)

--- a/crates/agentgateway/src/http/auth/jwt_sign.rs
+++ b/crates/agentgateway/src/http/auth/jwt_sign.rs
@@ -1,12 +1,12 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::Context;
 
-use super::AuthorizationLocation;
 use super::jws::{JwtSigningAlg, SigningKey};
+use super::{AuthorizationLocation, jwt_claim_times, unix_timestamp_now};
 use crate::resource_manager::{ResourceFetcher, ResourceRef};
 use crate::serdes::FileOrInline;
 use crate::*;
@@ -15,23 +15,15 @@ use crate::*;
 /// exposure; upstreams like Snowflake cap `exp` at one hour anyway.
 const DEFAULT_TTL: Duration = Duration::from_secs(300);
 
-/// Backdate `iat` and extend `exp` by this amount so validators with slightly
-/// skewed clocks do not reject freshly minted tokens, matching Google's auth
-/// library behavior.
-const CLOCK_SKEW_FUDGE: Duration = Duration::from_secs(10);
+/// Backdate `iat` to tolerate validators whose clocks trail the gateway.
+/// Expiration still uses the configured lifetime measured from signing time.
+const ISSUED_AT_BACKDATE: Duration = Duration::from_secs(10);
 
 /// Time-based claims the signer owns; user-configured claims must not collide
 /// with these. `iat` and `exp` are always set by the signer. `nbf` is not
 /// emitted (validators treat `iat` as the issue time and a static `nbf` makes
 /// no sense for per-request tokens) but stays reserved.
 const RESERVED_CLAIMS: &[&str] = &["iat", "exp", "nbf"];
-
-/// Rounds a ttl up to the next whole second so a sub-second component (e.g.
-/// 1500ms) never yields a shorter lifetime than configured, in both the
-/// signed token and any serialized/debug representation of the config.
-fn ttl_secs_ceil(ttl: Duration) -> u64 {
-	ttl.as_secs() + u64::from(ttl.subsec_nanos() > 0)
-}
 
 #[derive(Clone)]
 enum JwtSignState {
@@ -99,14 +91,14 @@ impl serde::Serialize for JwtSignAuth {
 		state.serialize_field("alg", &self.alg)?;
 		state.serialize_field("kid", &self.kid)?;
 		state.serialize_field("claims", &self.claims)?;
-		state.serialize_field(
-			"ttl",
-			&self.ttl.map(|ttl| format!("{}s", ttl_secs_ceil(ttl))),
-		)?;
+		state.serialize_field("ttl", &self.ttl.map(SerializableDuration))?;
 		state.serialize_field("location", &self.location)?;
 		state.end()
 	}
 }
+
+#[derive(serde::Serialize)]
+struct SerializableDuration(#[serde(with = "crate::serdes::serde_dur")] Duration);
 
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -254,24 +246,16 @@ impl JwtSignAuth {
 				anyhow::bail!("jwtSign configuration is invalid");
 			},
 		};
-		let now = SystemTime::now()
-			.duration_since(UNIX_EPOCH)
-			.context("system clock is before the unix epoch")?
-			.as_secs();
+		let now = unix_timestamp_now()?;
 		let ttl = self.ttl.unwrap_or(DEFAULT_TTL);
-		let skew = CLOCK_SKEW_FUDGE.as_secs();
+		let times = jwt_claim_times(now, ttl, ISSUED_AT_BACKDATE)?;
 
 		let mut claims = serde_json::Map::with_capacity(self.claims.len() + RESERVED_CLAIMS.len());
 		for (key, value) in &self.claims {
 			claims.insert(key.clone(), value.clone());
 		}
-		let iat = now.saturating_sub(skew);
-		let exp = now
-			.checked_add(skew)
-			.and_then(|t| t.checked_add(ttl_secs_ceil(ttl)))
-			.context("jwtSign ttl overflows the exp timestamp")?;
-		claims.insert("iat".to_string(), iat.into());
-		claims.insert("exp".to_string(), exp.into());
+		claims.insert("iat".to_string(), times.issued_at.into());
+		claims.insert("exp".to_string(), times.expires_at.into());
 
 		let header = self.alg.header(self.kid.clone());
 		signing_key

--- a/crates/agentgateway/src/http/auth/jwt_sign.rs
+++ b/crates/agentgateway/src/http/auth/jwt_sign.rs
@@ -4,11 +4,9 @@ use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
-use jsonwebtoken::Header;
 
 use super::AuthorizationLocation;
-use super::oauth::SigningAlg;
-use super::oauth::client_auth::ParsedEncodingKey;
+use super::jws::{JwtSigningAlg, SigningKey};
 use crate::resource_manager::{ResourceFetcher, ResourceRef};
 use crate::serdes::FileOrInline;
 use crate::*;
@@ -39,8 +37,8 @@ fn ttl_secs_ceil(ttl: Duration) -> u64 {
 /// [`JwtSignAuth::resolve`] (file paths), so file-based keys register with the
 /// resource manager and reload when the file changes.
 #[derive(Clone)]
-enum SigningKey {
-	Parsed(ParsedEncodingKey),
+enum ResolvableSigningKey {
+	Parsed(SigningKey),
 	File(PathBuf),
 }
 
@@ -53,9 +51,9 @@ enum SigningKey {
 pub struct JwtSignAuth {
 	#[serde(skip)]
 	#[cfg_attr(feature = "schema", schemars(skip))]
-	signing_key: SigningKey,
+	signing_key: ResolvableSigningKey,
 	#[serde(default)]
-	alg: SigningAlg,
+	alg: JwtSigningAlg,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	kid: Option<String>,
 	claims: BTreeMap<String, serde_json::Value>,
@@ -107,7 +105,7 @@ struct RawJwtSignAuth {
 	signing_key: FileOrInline,
 	/// JWS signing algorithm. Defaults to RS256.
 	#[serde(default)]
-	alg: SigningAlg,
+	alg: JwtSigningAlg,
 	/// Optional JWS key ID header.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	kid: Option<String>,
@@ -139,8 +137,10 @@ impl TryFrom<RawJwtSignAuth> for JwtSignAuth {
 		// time. File keys are deferred to `resolve`, which fetches through the
 		// resource manager so the file is watched and changes reload the config.
 		let signing_key = match raw.signing_key {
-			FileOrInline::Inline(pem) => SigningKey::Parsed(parse_signing_key(raw.alg, pem.trim())?),
-			FileOrInline::File { file } => SigningKey::File(file),
+			FileOrInline::Inline(pem) => {
+				ResolvableSigningKey::Parsed(parse_signing_key(raw.alg, pem.trim())?)
+			},
+			FileOrInline::File { file } => ResolvableSigningKey::File(file),
 		};
 		Ok(Self {
 			signing_key,
@@ -175,24 +175,22 @@ fn validate_config(
 	Ok(())
 }
 
-fn parse_signing_key(alg: SigningAlg, pem: &str) -> Result<ParsedEncodingKey, String> {
-	alg
-		.encoding_key(pem.as_bytes())
-		.map(ParsedEncodingKey)
+fn parse_signing_key(alg: JwtSigningAlg, pem: &str) -> Result<SigningKey, String> {
+	SigningKey::from_pem(alg, pem.as_bytes())
 		.map_err(|e| format!("failed to parse jwtSign signingKey: {e}"))
 }
 
 impl JwtSignAuth {
 	pub fn try_new(
 		signing_key_pem: &str,
-		alg: SigningAlg,
+		alg: JwtSigningAlg,
 		kid: Option<String>,
 		claims: BTreeMap<String, serde_json::Value>,
 		ttl: Option<Duration>,
 		location: Option<AuthorizationLocation>,
 	) -> Result<Self, String> {
 		validate_config(&claims, ttl)?;
-		let signing_key = SigningKey::Parsed(parse_signing_key(alg, signing_key_pem)?);
+		let signing_key = ResolvableSigningKey::Parsed(parse_signing_key(alg, signing_key_pem)?);
 		Ok(Self {
 			signing_key,
 			alg,
@@ -207,20 +205,21 @@ impl JwtSignAuth {
 	/// registers the file so changes trigger a config reload. Inline keys are
 	/// already parsed and are left untouched.
 	pub async fn resolve(&mut self, resources: &ResourceFetcher) -> anyhow::Result<()> {
-		if let SigningKey::File(path) = &self.signing_key {
+		if let ResolvableSigningKey::File(path) = &self.signing_key {
 			let pem = resources
 				.fetch(ResourceRef::File(path.clone()))
 				.await
 				.context("failed to load jwtSign signingKey")?;
 			let pem = std::str::from_utf8(&pem).context("jwtSign signingKey is not valid UTF-8")?;
-			self.signing_key =
-				SigningKey::Parsed(parse_signing_key(self.alg, pem.trim()).map_err(anyhow::Error::msg)?);
+			self.signing_key = ResolvableSigningKey::Parsed(
+				parse_signing_key(self.alg, pem.trim()).map_err(anyhow::Error::msg)?,
+			);
 		}
 		Ok(())
 	}
 
 	pub(super) fn sign(&self) -> anyhow::Result<String> {
-		let SigningKey::Parsed(signing_key) = &self.signing_key else {
+		let ResolvableSigningKey::Parsed(signing_key) = &self.signing_key else {
 			anyhow::bail!("jwtSign file-based signingKey was not resolved at config load");
 		};
 		let now = SystemTime::now()
@@ -242,9 +241,9 @@ impl JwtSignAuth {
 		claims.insert("iat".to_string(), iat.into());
 		claims.insert("exp".to_string(), exp.into());
 
-		let mut header = Header::new(self.alg.algorithm());
-		header.kid = self.kid.clone();
-		jsonwebtoken::encode(&header, &serde_json::Value::Object(claims), &signing_key.0)
+		let header = self.alg.header(self.kid.clone());
+		signing_key
+			.encode(&header, &serde_json::Value::Object(claims))
 			.context("failed to sign backend JWT")
 	}
 }

--- a/crates/agentgateway/src/http/auth/mod.rs
+++ b/crates/agentgateway/src/http/auth/mod.rs
@@ -7,9 +7,10 @@ pub mod jwt_sign;
 pub mod oauth;
 
 use std::borrow::Cow;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ::http::HeaderValue;
+use anyhow::Context;
 pub use aws::{AwsAssumeRole, AwsAuth};
 pub use azure::AzureAuth;
 use cookie::Cookie;
@@ -33,6 +34,41 @@ use crate::types::agent::{BackendTarget, Target};
 use crate::*;
 
 const CLOUD_AUTH_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct JwtClaimTimes {
+	issued_at: u64,
+	expires_at: u64,
+}
+
+fn unix_timestamp_now() -> anyhow::Result<u64> {
+	SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.context("system clock is before the unix epoch")
+		.map(|duration| duration.as_secs())
+}
+
+fn jwt_claim_times(
+	now: u64,
+	lifetime: Duration,
+	issued_at_backdate: Duration,
+) -> anyhow::Result<JwtClaimTimes> {
+	let issued_at = now.saturating_sub(issued_at_backdate.as_secs());
+	let expires_at = now
+		.checked_add(numeric_date_seconds(lifetime))
+		.context("JWT lifetime overflows the exp timestamp")?;
+
+	Ok(JwtClaimTimes {
+		issued_at,
+		expires_at,
+	})
+}
+
+fn numeric_date_seconds(duration: Duration) -> u64 {
+	duration
+		.as_secs()
+		.saturating_add(u64::from(duration.subsec_nanos() > 0))
+}
 
 #[apply(schema!)]
 #[cfg_attr(feature = "schema", schemars(rename = "BackendAuth"))]

--- a/crates/agentgateway/src/http/auth/mod.rs
+++ b/crates/agentgateway/src/http/auth/mod.rs
@@ -2,6 +2,7 @@ pub mod aws;
 pub mod azure;
 mod copilot;
 pub mod gcp;
+pub(crate) mod jws;
 pub mod jwt_sign;
 pub mod oauth;
 
@@ -13,6 +14,8 @@ pub use aws::{AwsAssumeRole, AwsAuth};
 pub use azure::AzureAuth;
 use cookie::Cookie;
 pub use gcp::GcpAuth;
+pub use jws::JwtSigningAlg;
+pub(crate) use jws::signing_alg_from_proto;
 pub use jwt_sign::JwtSignAuth;
 pub use oauth::{
 	CrossAppAccessAuth, OAuthClientAuth, OAuthClientAuthMethod, OAuthGrantType,

--- a/crates/agentgateway/src/http/auth/oauth/client_auth.rs
+++ b/crates/agentgateway/src/http/auth/oauth/client_auth.rs
@@ -4,13 +4,13 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::Context;
 use base64::Engine;
 use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
-use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use rustls::pki_types::PrivateKeyDer;
 use rustls::pki_types::pem::PemObject;
 use secrecy::{ExposeSecret, SecretString};
 use sha2::{Digest, Sha256};
 use tracing::warn;
 
+use super::super::jws::{JwtSigningAlg, SigningKey, signing_alg_from_proto};
 use crate::serdes::FileOrInline;
 use crate::types::proto::{ProtoError, agent as proto};
 use crate::{apply, schema_enum, ser_redact};
@@ -130,7 +130,7 @@ enum RawOAuthClientAuth {
 		/// JWS certificate header emitted from `certificate`. Required when `certificate` is set.
 		certificate_header: Option<CertificateHeader>,
 		#[serde(default)]
-		alg: SigningAlg,
+		alg: JwtSigningAlg,
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		kid: Option<String>,
 		assertion_audience: String,
@@ -230,9 +230,9 @@ pub enum OAuthClientAuthMethod {
 pub struct PrivateKeyJwt {
 	#[serde(skip)]
 	#[cfg_attr(feature = "schema", schemars(skip))]
-	signing_key: ParsedEncodingKey,
+	signing_key: SigningKey,
 	#[serde(default)]
-	alg: SigningAlg,
+	alg: JwtSigningAlg,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	kid: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -274,7 +274,7 @@ pub(super) struct RawPrivateKeyJwt {
 	/// JWS certificate header emitted from `certificate`. Required when `certificate` is set.
 	pub(super) certificate_header: Option<CertificateHeader>,
 	#[serde(default)]
-	pub(super) alg: SigningAlg,
+	pub(super) alg: JwtSigningAlg,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub(super) kid: Option<String>,
 	pub(super) assertion_audience: String,
@@ -289,9 +289,7 @@ impl TryFrom<RawPrivateKeyJwt> for PrivateKeyJwt {
 		}
 		// TODO: file-based keys are loaded once at config load; consider reload/rotation (K8s secret remounts need a restart)
 		let signing_key_pem = raw.signing_key.expose_secret();
-		let signing_key = raw
-			.alg
-			.encoding_key(signing_key_pem.trim().as_bytes())
+		let signing_key = SigningKey::from_pem(raw.alg, signing_key_pem.trim().as_bytes())
 			.map_err(|e| format!("failed to parse oauth private_key_jwt signing_key: {e}"))?;
 		let certificate_headers = match (raw.certificate, raw.certificate_header) {
 			(Some(certificate), Some(certificate_header)) => {
@@ -310,7 +308,7 @@ impl TryFrom<RawPrivateKeyJwt> for PrivateKeyJwt {
 			(None, None) => CertificateHeaders::default(),
 		};
 		Ok(Self {
-			signing_key: ParsedEncodingKey(signing_key),
+			signing_key,
 			alg: raw.alg,
 			kid: raw.kid,
 			x5c: certificate_headers.x5c,
@@ -403,20 +401,6 @@ fn certificate_key_matches(
 	let (_, certificate) = x509_parser::parse_x509_certificate(leaf_certificate_der)
 		.map_err(|e| format!("failed to parse oauth private_key_jwt certificate: {e}"))?;
 	Ok(signing_key_spki.as_ref() == certificate.public_key().raw)
-}
-
-pub(crate) struct ParsedEncodingKey(pub(crate) EncodingKey);
-
-impl Clone for ParsedEncodingKey {
-	fn clone(&self) -> Self {
-		Self(self.0.clone())
-	}
-}
-
-impl fmt::Debug for ParsedEncodingKey {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		f.write_str("[REDACTED]")
-	}
 }
 
 impl OAuthClientAuth {
@@ -525,7 +509,8 @@ impl TryFrom<proto::o_auth_client_auth::PrivateKeyJwt> for PrivateKeyJwt {
 			certificate: (!private_key_jwt.certificate.is_empty())
 				.then_some(FileOrInline::Inline(private_key_jwt.certificate).into()),
 			certificate_header: certificate_header_from_proto(private_key_jwt.certificate_header)?,
-			alg: signing_alg_from_proto(private_key_jwt.alg)?,
+			alg: signing_alg_from_proto(private_key_jwt.alg)
+				.ok_or_else(|| ProtoError::EnumParse("unknown oauth private_key_jwt signing alg".into()))?,
 			kid: private_key_jwt.kid,
 			assertion_audience: private_key_jwt.assertion_audience,
 		})
@@ -541,65 +526,6 @@ pub enum CertificateHeader {
 	/// Send the leaf certificate's SHA-256 thumbprint in `x5t#S256`.
 	#[serde(rename = "x5t#S256")]
 	X5tS256,
-}
-
-#[apply(schema_enum!)]
-#[derive(Default)]
-pub enum SigningAlg {
-	#[default]
-	#[serde(rename = "RS256")]
-	Rs256,
-	#[serde(rename = "RS384")]
-	Rs384,
-	#[serde(rename = "RS512")]
-	Rs512,
-	#[serde(rename = "PS256")]
-	Ps256,
-	#[serde(rename = "ES256")]
-	Es256,
-	#[serde(rename = "ES384")]
-	Es384,
-}
-
-impl SigningAlg {
-	pub(crate) fn algorithm(self) -> Algorithm {
-		match self {
-			Self::Rs256 => Algorithm::RS256,
-			Self::Rs384 => Algorithm::RS384,
-			Self::Rs512 => Algorithm::RS512,
-			Self::Ps256 => Algorithm::PS256,
-			Self::Es256 => Algorithm::ES256,
-			Self::Es384 => Algorithm::ES384,
-		}
-	}
-
-	pub(crate) fn encoding_key(self, pem: &[u8]) -> anyhow::Result<EncodingKey> {
-		match self {
-			Self::Rs256 | Self::Rs384 | Self::Rs512 | Self::Ps256 => {
-				EncodingKey::from_rsa_pem(pem).context("failed to load RSA signing key")
-			},
-			Self::Es256 | Self::Es384 => {
-				EncodingKey::from_ec_pem(pem).context("failed to load EC signing key")
-			},
-		}
-	}
-}
-
-fn signing_alg_from_proto(alg: i32) -> Result<SigningAlg, ProtoError> {
-	use proto::o_auth_client_auth::private_key_jwt::SigningAlg as ProtoSigningAlg;
-
-	match ProtoSigningAlg::try_from(alg) {
-		Ok(ProtoSigningAlg::Unspecified) => Ok(SigningAlg::Rs256),
-		Ok(ProtoSigningAlg::Rs256) => Ok(SigningAlg::Rs256),
-		Ok(ProtoSigningAlg::Rs384) => Ok(SigningAlg::Rs384),
-		Ok(ProtoSigningAlg::Rs512) => Ok(SigningAlg::Rs512),
-		Ok(ProtoSigningAlg::Ps256) => Ok(SigningAlg::Ps256),
-		Ok(ProtoSigningAlg::Es256) => Ok(SigningAlg::Es256),
-		Ok(ProtoSigningAlg::Es384) => Ok(SigningAlg::Es384),
-		Err(_) => Err(ProtoError::EnumParse(
-			"unknown oauth private_key_jwt signing alg".into(),
-		)),
-	}
 }
 
 fn certificate_header_from_proto(header: i32) -> Result<Option<CertificateHeader>, ProtoError> {
@@ -645,10 +571,11 @@ pub(super) fn sign_client_assertion(
 		exp: now + CLIENT_ASSERTION_LIFETIME.as_secs(),
 	};
 
-	let mut header = Header::new(private_key.alg.algorithm());
-	header.kid = private_key.kid.clone();
+	let mut header = private_key.alg.header(private_key.kid.clone());
 	header.x5c = private_key.x5c.clone();
 	header.x5t_s256 = private_key.x5t_s256.clone();
-	jsonwebtoken::encode(&header, &claims, &private_key.signing_key.0)
+	private_key
+		.signing_key
+		.encode(&header, &claims)
 		.context("failed to sign client assertion")
 }

--- a/crates/agentgateway/src/http/auth/oauth/client_auth.rs
+++ b/crates/agentgateway/src/http/auth/oauth/client_auth.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use anyhow::Context;
 use base64::Engine;
@@ -11,6 +11,7 @@ use sha2::{Digest, Sha256};
 use tracing::warn;
 
 use super::super::jws::{JwtSigningAlg, SigningKey, signing_alg_from_proto};
+use super::super::{jwt_claim_times, unix_timestamp_now};
 use crate::serdes::FileOrInline;
 use crate::types::proto::{ProtoError, agent as proto};
 use crate::{apply, schema_enum, ser_redact};
@@ -556,19 +557,16 @@ pub(super) fn sign_client_assertion(
 		exp: u64,
 	}
 
-	let now = SystemTime::now()
-		.duration_since(UNIX_EPOCH)
-		.context("system clock is before the unix epoch")?
-		.as_secs();
-	let issued_at = now.saturating_sub(CLIENT_ASSERTION_CLOCK_SKEW.as_secs());
+	let now = unix_timestamp_now()?;
+	let times = jwt_claim_times(now, CLIENT_ASSERTION_LIFETIME, CLIENT_ASSERTION_CLOCK_SKEW)?;
 	let claims = ClientAssertionClaims {
 		iss: client_id,
 		sub: client_id,
 		aud: &private_key.assertion_audience,
 		jti: uuid::Uuid::new_v4().to_string(),
-		nbf: issued_at,
-		iat: issued_at,
-		exp: now + CLIENT_ASSERTION_LIFETIME.as_secs(),
+		nbf: times.issued_at,
+		iat: times.issued_at,
+		exp: times.expires_at,
 	};
 
 	let mut header = private_key.alg.header(private_key.kid.clone());

--- a/crates/agentgateway/src/http/auth/oauth/mod.rs
+++ b/crates/agentgateway/src/http/auth/oauth/mod.rs
@@ -30,7 +30,7 @@ mod transport;
 
 use cache::{InMemoryTokenCache, TokenCacheResult};
 use client_auth::sign_client_assertion;
-pub use client_auth::{OAuthClientAuth, OAuthClientAuthMethod, PrivateKeyJwt, SigningAlg};
+pub use client_auth::{OAuthClientAuth, OAuthClientAuthMethod, PrivateKeyJwt};
 pub use cross_app_access::CrossAppAccessAuth;
 pub(super) use transport::FetchError;
 

--- a/crates/agentgateway/src/http/auth/oauth/tests.rs
+++ b/crates/agentgateway/src/http/auth/oauth/tests.rs
@@ -709,7 +709,7 @@ async fn private_key_jwt_sends_client_assertion_form_fields() {
 	assert_eq!(claims.aud, "https://issuer.example/token");
 	assert!(!claims.jti.is_empty());
 	assert_eq!(claims.nbf, claims.iat);
-	assert!(claims.exp > claims.nbf);
+	assert_eq!(claims.exp - claims.iat, 310);
 }
 
 #[test]

--- a/crates/agentgateway/src/http/auth/oauth/tests.rs
+++ b/crates/agentgateway/src/http/auth/oauth/tests.rs
@@ -15,6 +15,7 @@ use super::cross_app_access::{
 };
 use super::*;
 use crate::http::Body;
+use crate::http::auth::JwtSigningAlg;
 use crate::http::oauth::{
 	CLIENT_ASSERTION_TYPE_JWT_BEARER, GRANT_TYPE_JWT_BEARER, GRANT_TYPE_TOKEN_EXCHANGE,
 	TOKEN_TYPE_ID, TOKEN_TYPE_ID_JAG, TOKEN_TYPE_JWT,
@@ -660,7 +661,7 @@ async fn private_key_jwt_sends_client_assertion_form_fields() {
 		signing_key: SecretString::from(TEST_EC_PRIVATE_KEY_PEM),
 		certificate: Some(FileOrInline::Inline(TEST_EC_CERT_PEM.to_string()).into()),
 		certificate_header: Some(CertificateHeader::X5c),
-		alg: SigningAlg::Es256,
+		alg: JwtSigningAlg::Es256,
 		kid: Some("kid-1".into()),
 		assertion_audience: "https://issuer.example/token".into(),
 	})
@@ -717,7 +718,7 @@ fn private_key_jwt_debug_redacts_key_and_certificate() {
 		signing_key: SecretString::from(TEST_EC_PRIVATE_KEY_PEM),
 		certificate: Some(FileOrInline::Inline(TEST_EC_CERT_PEM.to_string()).into()),
 		certificate_header: Some(CertificateHeader::X5c),
-		alg: SigningAlg::Es256,
+		alg: JwtSigningAlg::Es256,
 		kid: Some("kid-1".into()),
 		assertion_audience: "https://issuer.example/token".into(),
 	};
@@ -762,7 +763,7 @@ fn private_key_jwt_signs_with_ps256() {
 		signing_key: SecretString::from(signing_key.serialize_pem()),
 		certificate: None,
 		certificate_header: None,
-		alg: SigningAlg::Ps256,
+		alg: JwtSigningAlg::Ps256,
 		kid: None,
 		assertion_audience: "https://issuer.example/token".into(),
 	})
@@ -798,7 +799,7 @@ fn private_key_jwt_requires_certificate_and_header_together(
 			.then(|| FileOrInline::Inline(TEST_EC_CERT_PEM.to_string()))
 			.map(Into::into),
 		certificate_header: with_certificate_header.then_some(CertificateHeader::X5c),
-		alg: SigningAlg::Es256,
+		alg: JwtSigningAlg::Es256,
 		kid: None,
 		assertion_audience: "https://issuer.example/token".into(),
 	})
@@ -858,7 +859,7 @@ fn private_key_jwt_rejects_invalid_certificate_in_chain() {
 			FileOrInline::Inline(format!("{TEST_EC_CERT_PEM}{TEST_INVALID_CERT_PEM}")).into(),
 		),
 		certificate_header: Some(CertificateHeader::X5c),
-		alg: SigningAlg::Es256,
+		alg: JwtSigningAlg::Es256,
 		kid: None,
 		assertion_audience: "https://issuer.example/token".into(),
 	})
@@ -875,7 +876,7 @@ fn private_key_jwt_warns_but_accepts_mismatched_certificate() {
 		signing_key: SecretString::from(TEST_EC_PRIVATE_KEY_PEM),
 		certificate: Some(FileOrInline::Inline(TEST_MISMATCHED_CERT_PEM.to_string()).into()),
 		certificate_header: Some(CertificateHeader::X5c),
-		alg: SigningAlg::Es256,
+		alg: JwtSigningAlg::Es256,
 		kid: None,
 		assertion_audience: "https://issuer.example/token".into(),
 	})
@@ -1585,7 +1586,7 @@ fn private_key_jwt_client_auth_from_proto() {
 			signing_key: TEST_EC_PRIVATE_KEY_PEM.to_string(),
 			certificate: TEST_EC_CERT_PEM.to_string(),
 			certificate_header: proto::o_auth_client_auth::private_key_jwt::CertificateHeader::X5c as i32,
-			alg: proto::o_auth_client_auth::private_key_jwt::SigningAlg::Es256 as i32,
+			alg: proto::JwtSigningAlg::Es256 as i32,
 			kid: Some("kid-1".to_string()),
 			assertion_audience: "https://issuer.example/token".to_string(),
 		}),
@@ -1615,7 +1616,7 @@ fn private_key_jwt_serialization_omits_unset_optional_headers() {
 		signing_key: SecretString::from(TEST_EC_PRIVATE_KEY_PEM),
 		certificate: None,
 		certificate_header: None,
-		alg: SigningAlg::Es256,
+		alg: JwtSigningAlg::Es256,
 		kid: None,
 		assertion_audience: "https://issuer.example/token".into(),
 	})
@@ -1702,7 +1703,7 @@ fn private_key_jwt_serialization_omits_unset_optional_headers() {
 			method: proto::o_auth_client_auth::Method::PrivateKeyJwt as i32,
 			private_key_jwt: Some(proto::o_auth_client_auth::PrivateKeyJwt {
 				signing_key: TEST_EC_PRIVATE_KEY_PEM.to_string(),
-				alg: proto::o_auth_client_auth::private_key_jwt::SigningAlg::Es256 as i32,
+				alg: proto::JwtSigningAlg::Es256 as i32,
 				assertion_audience: "https://issuer.example/token".to_string(),
 				..Default::default()
 			}),
@@ -1719,7 +1720,7 @@ fn private_key_jwt_serialization_omits_unset_optional_headers() {
 			method: proto::o_auth_client_auth::Method::ClientSecretPost as i32,
 			private_key_jwt: Some(proto::o_auth_client_auth::PrivateKeyJwt {
 				signing_key: TEST_EC_PRIVATE_KEY_PEM.to_string(),
-				alg: proto::o_auth_client_auth::private_key_jwt::SigningAlg::Es256 as i32,
+				alg: proto::JwtSigningAlg::Es256 as i32,
 				assertion_audience: "https://issuer.example/token".to_string(),
 				..Default::default()
 			}),
@@ -1736,7 +1737,7 @@ fn private_key_jwt_serialization_omits_unset_optional_headers() {
 			private_key_jwt: Some(proto::o_auth_client_auth::PrivateKeyJwt {
 				signing_key: TEST_EC_PRIVATE_KEY_PEM.to_string(),
 				certificate: TEST_EC_CERT_PEM.to_string(),
-				alg: proto::o_auth_client_auth::private_key_jwt::SigningAlg::Es256 as i32,
+				alg: proto::JwtSigningAlg::Es256 as i32,
 				assertion_audience: "https://issuer.example/token".to_string(),
 				..Default::default()
 			}),

--- a/crates/agentgateway/src/http/auth/tests.rs
+++ b/crates/agentgateway/src/http/auth/tests.rs
@@ -8,6 +8,52 @@ use crate::llm::bedrock::AwsRegion;
 use crate::test_helpers::proxymock::setup_proxy_test;
 
 #[test]
+fn test_jwt_claim_times() {
+	let cases = [
+		(
+			100,
+			Duration::from_secs(300),
+			Duration::from_secs(10),
+			JwtClaimTimes {
+				issued_at: 90,
+				expires_at: 400,
+			},
+		),
+		(
+			100,
+			Duration::from_millis(1500),
+			Duration::from_secs(10),
+			JwtClaimTimes {
+				issued_at: 90,
+				expires_at: 102,
+			},
+		),
+		(
+			5,
+			Duration::from_secs(30),
+			Duration::from_secs(10),
+			JwtClaimTimes {
+				issued_at: 0,
+				expires_at: 35,
+			},
+		),
+	];
+
+	for (now, lifetime, issued_at_backdate, expected) in cases {
+		assert_eq!(
+			jwt_claim_times(now, lifetime, issued_at_backdate).unwrap(),
+			expected
+		);
+	}
+}
+
+#[test]
+fn test_jwt_claim_times_rejects_expiration_overflow() {
+	assert!(jwt_claim_times(u64::MAX, Duration::from_secs(1), Duration::from_secs(10)).is_err());
+	assert!(jwt_claim_times(1, Duration::new(u64::MAX, 1), Duration::from_secs(10)).is_err());
+}
+
+#[test]
 fn test_aws_auth_deserializes_assume_role() {
 	let implicit: AwsAuth = serde_json::from_value(serde_json::json!({
 		"assumeRole": {
@@ -1246,8 +1292,8 @@ async fn test_backend_auth_jwt_sign() {
 	assert_eq!(payload["sub"], "ACCT.USER");
 	let iat = payload["iat"].as_u64().expect("iat must be set");
 	let exp = payload["exp"].as_u64().expect("exp must be set");
-	// iat is backdated and exp extended by the 10s clock-skew fudge.
-	assert_eq!(exp - iat, 600 + 20);
+	// The lifetime starts at signing time while iat is backdated by 10s.
+	assert_eq!(exp - iat, 600 + 10);
 	assert!(
 		payload.get("nbf").is_none(),
 		"nbf must not be emitted; iat already conveys the issue time"
@@ -1303,11 +1349,10 @@ async fn test_backend_auth_jwt_sign_explicit_location() {
 	let (header, payload) = decode_jwt_parts(header_value.to_str().unwrap());
 	assert_eq!(header["alg"], "ES256");
 	assert!(header.get("kid").is_none_or(|kid| kid.is_null()));
-	// Default 300s lifetime applies when ttl is unset, plus the 10s
-	// clock-skew fudge on both iat and exp.
+	// Default 300s lifetime starts at signing time; iat is backdated 10s.
 	let iat = payload["iat"].as_u64().unwrap();
 	let exp = payload["exp"].as_u64().unwrap();
-	assert_eq!(exp - iat, 300 + 20);
+	assert_eq!(exp - iat, 300 + 10);
 	assert!(payload.get("nbf").is_none());
 
 	assert!(
@@ -1439,8 +1484,8 @@ async fn test_backend_auth_jwt_sign_rounds_up_sub_second_ttl() {
 	let exp = payload["exp"].as_u64().expect("exp must be set");
 	assert_eq!(
 		exp - iat,
-		2 + 20,
-		"a 1500ms ttl must round up to 2s (plus the clock-skew fudge on both ends), not truncate to 1s"
+		2 + 10,
+		"a 1500ms ttl must round up to 2s and iat must be backdated by 10s"
 	);
 }
 
@@ -1464,10 +1509,10 @@ fn test_jwt_sign_deserializes() {
 }
 
 #[test]
-fn test_jwt_sign_serialize_rounds_up_sub_second_ttl() {
+fn test_jwt_sign_serialization_preserves_fractional_ttl() {
 	let auth = jwt_sign_auth(None, Some(std::time::Duration::from_millis(1500)), None);
 	let value = serde_json::to_value(&auth).expect("jwtSign auth should serialize");
-	assert_eq!(value["jwtSign"]["ttl"], "2s");
+	assert_eq!(value["jwtSign"]["ttl"], "1.5s");
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/http/auth/tests.rs
+++ b/crates/agentgateway/src/http/auth/tests.rs
@@ -7,50 +7,31 @@ use crate::http::jwt::Claims;
 use crate::llm::bedrock::AwsRegion;
 use crate::test_helpers::proxymock::setup_proxy_test;
 
-#[test]
-fn test_jwt_claim_times() {
-	let cases = [
-		(
-			100,
-			Duration::from_secs(300),
-			Duration::from_secs(10),
-			JwtClaimTimes {
-				issued_at: 90,
-				expires_at: 400,
-			},
-		),
-		(
-			100,
-			Duration::from_millis(1500),
-			Duration::from_secs(10),
-			JwtClaimTimes {
-				issued_at: 90,
-				expires_at: 102,
-			},
-		),
-		(
-			5,
-			Duration::from_secs(30),
-			Duration::from_secs(10),
-			JwtClaimTimes {
-				issued_at: 0,
-				expires_at: 35,
-			},
-		),
-	];
-
-	for (now, lifetime, issued_at_backdate, expected) in cases {
-		assert_eq!(
-			jwt_claim_times(now, lifetime, issued_at_backdate).unwrap(),
-			expected
-		);
-	}
+#[rstest::rstest]
+#[case::normal(100, Duration::from_secs(300), Duration::from_secs(10), 90, 400)]
+#[case::fractional_lifetime(100, Duration::from_millis(1500), Duration::from_secs(10), 90, 102)]
+#[case::issued_at_underflow(5, Duration::from_secs(30), Duration::from_secs(10), 0, 35)]
+fn test_jwt_claim_times(
+	#[case] now: u64,
+	#[case] lifetime: Duration,
+	#[case] issued_at_backdate: Duration,
+	#[case] expected_issued_at: u64,
+	#[case] expected_expires_at: u64,
+) {
+	assert_eq!(
+		jwt_claim_times(now, lifetime, issued_at_backdate).unwrap(),
+		JwtClaimTimes {
+			issued_at: expected_issued_at,
+			expires_at: expected_expires_at,
+		}
+	);
 }
 
-#[test]
-fn test_jwt_claim_times_rejects_expiration_overflow() {
-	assert!(jwt_claim_times(u64::MAX, Duration::from_secs(1), Duration::from_secs(10)).is_err());
-	assert!(jwt_claim_times(1, Duration::new(u64::MAX, 1), Duration::from_secs(10)).is_err());
+#[rstest::rstest]
+#[case::timestamp(u64::MAX, Duration::from_secs(1))]
+#[case::rounded_lifetime(1, Duration::new(u64::MAX, 1))]
+fn test_jwt_claim_times_rejects_expiration_overflow(#[case] now: u64, #[case] lifetime: Duration) {
+	assert!(jwt_claim_times(now, lifetime, Duration::from_secs(10)).is_err());
 }
 
 #[test]

--- a/crates/agentgateway/src/http/auth/tests.rs
+++ b/crates/agentgateway/src/http/auth/tests.rs
@@ -1,3 +1,4 @@
+use http_body_util::BodyExt;
 use secrecy::SecretString;
 use serde_json::Map;
 
@@ -1467,6 +1468,75 @@ fn test_jwt_sign_serialize_rounds_up_sub_second_ttl() {
 	let auth = jwt_sign_auth(None, Some(std::time::Duration::from_millis(1500)), None);
 	let value = serde_json::to_value(&auth).expect("jwtSign auth should serialize");
 	assert_eq!(value["jwtSign"]["ttl"], "2s");
+}
+
+#[tokio::test]
+async fn test_invalid_jwt_sign_rejects_before_request_mutation() {
+	const DIAGNOSTIC_MARKER: &str = "secret default/private-signing-key not found";
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	req.headers_mut().insert(
+		http::header::AUTHORIZATION,
+		http::HeaderValue::from_static("Bearer client-supplied-token"),
+	);
+	let t = setup_proxy_test("{}").expect("setup proxy inputs");
+	let backend_info = BackendInfo {
+		call_target: Target::Address("0.0.0.0:80".parse().unwrap()),
+		target: BackendTarget::Backend {
+			name: Default::default(),
+			namespace: Default::default(),
+			section: None,
+		},
+		inputs: t.inputs(),
+	};
+	let auth = BackendAuth {
+		kind: Some(BackendAuthKind::JwtSign(Box::new(
+			JwtSignAuth::new_invalid(DIAGNOSTIC_MARKER.to_string()),
+		))),
+		credentials: vec![credential("x-api-key", "secondary-credential", None)],
+	};
+
+	let err = apply_backend_auth(&backend_info, &auth, &mut req)
+		.await
+		.expect_err("invalid jwtSign must reject the request");
+	assert!(matches!(err, ProxyError::BackendAuthenticationFailed(_)));
+	assert_eq!(
+		req.headers().get(http::header::AUTHORIZATION),
+		Some(&http::HeaderValue::from_static(
+			"Bearer client-supplied-token"
+		))
+	);
+	assert!(
+		req.headers().get("x-api-key").is_none(),
+		"additional credentials must not be applied after jwtSign rejects"
+	);
+
+	let rendered = err.to_string();
+	assert!(rendered.contains("jwtSign configuration is invalid"));
+	assert!(
+		!rendered.contains(DIAGNOSTIC_MARKER),
+		"client-facing error leaked the translation diagnostic: {rendered}"
+	);
+	let response = err.into_response_with_grpc(false);
+	let body = response
+		.into_body()
+		.collect()
+		.await
+		.expect("error response body should collect")
+		.to_bytes();
+	let body = String::from_utf8(body.to_vec()).expect("error response should be UTF-8");
+	assert!(
+		!body.contains(DIAGNOSTIC_MARKER),
+		"client-facing response leaked the translation diagnostic: {body}"
+	);
+}
+
+#[test]
+fn test_invalid_jwt_sign_serializes_only_translation_error() {
+	let auth = JwtSignAuth::new_invalid("recognizable diagnostic".to_string());
+	assert_eq!(
+		serde_json::to_value(auth).expect("invalid jwtSign should serialize"),
+		serde_json::json!({"translationError": "recognizable diagnostic"})
+	);
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/http/auth/tests.rs
+++ b/crates/agentgateway/src/http/auth/tests.rs
@@ -1179,7 +1179,7 @@ fn jwt_sign_auth(
 	BackendAuth::new(BackendAuthKind::JwtSign(Box::new(
 		JwtSignAuth::try_new(
 			TEST_JWT_SIGN_EC_KEY,
-			oauth::SigningAlg::Es256,
+			JwtSigningAlg::Es256,
 			kid,
 			claims,
 			ttl,
@@ -1325,7 +1325,7 @@ async fn test_backend_auth_jwt_sign_explicit_location() {
 fn test_jwt_sign_rejects_reserved_and_empty_claims() {
 	let reserved = JwtSignAuth::try_new(
 		TEST_JWT_SIGN_EC_KEY,
-		oauth::SigningAlg::Es256,
+		JwtSigningAlg::Es256,
 		None,
 		[("exp".to_string(), "123".into())].into_iter().collect(),
 		None,
@@ -1338,7 +1338,7 @@ fn test_jwt_sign_rejects_reserved_and_empty_claims() {
 
 	let reserved_nbf = JwtSignAuth::try_new(
 		TEST_JWT_SIGN_EC_KEY,
-		oauth::SigningAlg::Es256,
+		JwtSigningAlg::Es256,
 		None,
 		[("nbf".to_string(), "123".into())].into_iter().collect(),
 		None,
@@ -1351,7 +1351,7 @@ fn test_jwt_sign_rejects_reserved_and_empty_claims() {
 
 	let reserved_iat = JwtSignAuth::try_new(
 		TEST_JWT_SIGN_EC_KEY,
-		oauth::SigningAlg::Es256,
+		JwtSigningAlg::Es256,
 		None,
 		[("iat".to_string(), "123".into())].into_iter().collect(),
 		None,
@@ -1364,7 +1364,7 @@ fn test_jwt_sign_rejects_reserved_and_empty_claims() {
 
 	let empty = JwtSignAuth::try_new(
 		TEST_JWT_SIGN_EC_KEY,
-		oauth::SigningAlg::Es256,
+		JwtSigningAlg::Es256,
 		None,
 		Default::default(),
 		None,
@@ -1380,7 +1380,7 @@ fn test_jwt_sign_rejects_zero_ttl_and_bad_key() {
 
 	let zero_ttl = JwtSignAuth::try_new(
 		TEST_JWT_SIGN_EC_KEY,
-		oauth::SigningAlg::Es256,
+		JwtSigningAlg::Es256,
 		None,
 		claims.clone(),
 		Some(std::time::Duration::ZERO),
@@ -1392,7 +1392,7 @@ fn test_jwt_sign_rejects_zero_ttl_and_bad_key() {
 	// exp == iat, so they must be rejected too.
 	let sub_second_ttl = JwtSignAuth::try_new(
 		TEST_JWT_SIGN_EC_KEY,
-		oauth::SigningAlg::Es256,
+		JwtSigningAlg::Es256,
 		None,
 		claims.clone(),
 		Some(std::time::Duration::from_millis(500)),
@@ -1400,14 +1400,7 @@ fn test_jwt_sign_rejects_zero_ttl_and_bad_key() {
 	);
 	assert!(sub_second_ttl.is_err(), "sub-second ttl must be rejected");
 
-	let bad_key = JwtSignAuth::try_new(
-		"not a pem",
-		oauth::SigningAlg::Es256,
-		None,
-		claims,
-		None,
-		None,
-	);
+	let bad_key = JwtSignAuth::try_new("not a pem", JwtSigningAlg::Es256, None, claims, None, None);
 	assert!(bad_key.is_err(), "invalid PEM must be rejected");
 }
 
@@ -1495,7 +1488,7 @@ async fn test_backend_auth_jwt_sign_rsa() {
 	let auth = BackendAuth::new(BackendAuthKind::JwtSign(Box::new(
 		JwtSignAuth::try_new(
 			TEST_JWT_SIGN_RSA_KEY,
-			oauth::SigningAlg::Rs256,
+			JwtSigningAlg::Rs256,
 			None,
 			[
 				("iss".to_string(), "acct.user".into()),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1321,40 +1321,48 @@ fn backend_auth_kind_from_proto(
 			)?))
 		},
 		Some(proto::agent::backend_auth_policy::Kind::JwtSign(mut j)) => {
-			if let Some(error) = j.translation_error.take() {
-				// Match invalid TLS handling: accept the xDS resource with a warning,
-				// but retain a runtime configuration that rejects when used.
-				let error = if error.trim().is_empty() {
+			let jwt_sign = if let Some(error) = j.translation_error.take() {
+				Err(if error.trim().is_empty() {
 					"jwtSign configuration is invalid".to_string()
 				} else {
 					error
-				};
-				diagnostics.add_warning(format!(
-					"jwtSign configuration is invalid; requests using this policy will be rejected: {error}"
-				));
-				BackendAuthKind::JwtSign(Box::new(auth::jwt_sign::JwtSignAuth::new_invalid(error)))
+				})
 			} else {
-				let location = optional_authorization_location(j.authorization_location.as_ref())?;
-				let claims = j
-					.claims
-					.into_iter()
-					.map(|(key, value)| {
-						let value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
-						(key, value)
-					})
-					.collect();
-				BackendAuthKind::JwtSign(Box::new(
+				(|| {
+					let ttl = convert_jwt_sign_ttl(j.ttl.take())?;
+					let location = optional_authorization_location(j.authorization_location.as_ref())
+						.map_err(|error| error.to_string())?;
+					let alg = auth::signing_alg_from_proto(j.alg)
+						.ok_or_else(|| "unknown jwt_sign signing alg".to_string())?;
+					let claims = j
+						.claims
+						.into_iter()
+						.map(|(key, value)| {
+							let value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
+							(key, value)
+						})
+						.collect();
 					auth::jwt_sign::JwtSignAuth::try_new(
 						j.signing_key.trim(),
-						auth::signing_alg_from_proto(j.alg)
-							.ok_or_else(|| ProtoError::EnumParse("unknown jwt_sign signing alg".into()))?,
+						alg,
 						j.kid,
 						claims,
-						j.ttl.map(convert_duration),
+						ttl,
 						location,
 					)
-					.map_err(ProtoError::Generic)?,
-				))
+				})()
+			};
+
+			match jwt_sign {
+				Ok(jwt_sign) => BackendAuthKind::JwtSign(Box::new(jwt_sign)),
+				Err(error) => {
+					// Match invalid TLS handling: accept the xDS resource with a warning,
+					// but retain a runtime configuration that rejects when used.
+					diagnostics.add_warning(format!(
+						"jwtSign configuration is invalid; requests using this policy will be rejected: {error}"
+					));
+					BackendAuthKind::JwtSign(Box::new(auth::jwt_sign::JwtSignAuth::new_invalid(error)))
+				},
 			}
 		},
 		None => return Ok(None),
@@ -3032,6 +3040,22 @@ fn convert_duration(d: prost_types::Duration) -> Duration {
 	Duration::from_secs(d.seconds as u64) + Duration::from_nanos(d.nanos as u64)
 }
 
+fn convert_jwt_sign_ttl(ttl: Option<prost_types::Duration>) -> Result<Option<Duration>, String> {
+	const PROTOBUF_DURATION_MAX_SECONDS: i64 = 315_576_000_000;
+
+	ttl
+		.map(|ttl| {
+			if ttl.seconds < 0 || ttl.nanos < 0 {
+				return Err("jwtSign ttl must not be negative".to_string());
+			}
+			if ttl.seconds > PROTOBUF_DURATION_MAX_SECONDS || ttl.nanos >= 1_000_000_000 {
+				return Err("jwtSign ttl is not a valid protobuf duration".to_string());
+			}
+			Ok(Duration::new(ttl.seconds as u64, ttl.nanos as u32))
+		})
+		.transpose()
+}
+
 pub(crate) fn authorization_location(
 	diagnostics: &mut Diagnostics,
 	context: impl AsRef<str>,
@@ -3968,6 +3992,22 @@ mod tests {
 		jwt_sign
 	}
 
+	fn jwt_sign_proto_for_test() -> proto::agent::JwtSign {
+		proto::agent::JwtSign {
+			signing_key: "not a PEM key".to_string(),
+			alg: proto::agent::JwtSigningAlg::Es256 as i32,
+			claims: HashMap::from([(
+				"iss".to_string(),
+				prost_wkt_types::Value {
+					kind: Some(prost_wkt_types::value::Kind::StringValue(
+						"acct.user".to_string(),
+					)),
+				},
+			)]),
+			..Default::default()
+		}
+	}
+
 	fn test_policy_target() -> proto::agent::PolicyTarget {
 		proto::agent::PolicyTarget {
 			kind: Some(proto::agent::policy_target::Kind::Route(
@@ -4611,6 +4651,11 @@ mod tests {
 				proto::agent::JwtSign {
 					signing_key: "not a PEM key".to_string(),
 					alg: i32::MAX,
+					// translation_error takes precedence over normal field validation.
+					ttl: Some(prost_types::Duration {
+						seconds: -1,
+						nanos: 0,
+					}),
 					translation_error: Some(translation_error.to_string()),
 					..Default::default()
 				},
@@ -4623,6 +4668,96 @@ mod tests {
 			let warnings = diagnostics.into_warnings();
 			assert_eq!(warnings.len(), 1);
 			assert!(warnings[0].contains(expected));
+		}
+	}
+
+	#[test]
+	fn jwt_sign_conversion_errors_become_runtime_invalid() {
+		let invalid_key = jwt_sign_proto_for_test();
+		let mut unknown_alg = jwt_sign_proto_for_test();
+		unknown_alg.alg = i32::MAX;
+		let mut expression_location = jwt_sign_proto_for_test();
+		expression_location.authorization_location = Some(proto::agent::AuthorizationLocation {
+			kind: Some(proto::agent::authorization_location::Kind::Expression(
+				"request.headers['authorization']".to_string(),
+			)),
+		});
+
+		let cases = [
+			(
+				"invalid signing key",
+				invalid_key,
+				"failed to parse jwtSign signingKey",
+			),
+			(
+				"unknown algorithm",
+				unknown_alg,
+				"unknown jwt_sign signing alg",
+			),
+			(
+				"expression location",
+				expression_location,
+				"expression auth location is only supported for credential extraction",
+			),
+		];
+
+		for (name, jwt_sign, expected) in cases {
+			let mut diagnostics = Diagnostics::default();
+			let jwt_sign = jwt_sign_from_proto_for_test(jwt_sign, &mut diagnostics);
+			let serialized = serde_json::to_value(jwt_sign).expect("invalid jwtSign should serialize");
+			assert!(
+				serialized["translationError"]
+					.as_str()
+					.is_some_and(|error| error.contains(expected)),
+				"{name} did not produce the expected runtime-invalid diagnostic: {serialized}"
+			);
+			let warnings = diagnostics.into_warnings();
+			assert_eq!(warnings.len(), 1, "{name} should produce one warning");
+			assert!(warnings[0].contains(expected));
+		}
+	}
+
+	#[test]
+	fn jwt_sign_ttl_preserves_fractional_duration() {
+		assert_eq!(
+			convert_jwt_sign_ttl(Some(prost_types::Duration {
+				seconds: 1,
+				nanos: 500_000_000,
+			}))
+			.unwrap(),
+			Some(Duration::from_millis(1500))
+		);
+	}
+
+	#[test]
+	fn invalid_jwt_sign_ttl_becomes_runtime_invalid() {
+		let cases = [
+			prost_types::Duration {
+				seconds: -1,
+				nanos: 0,
+			},
+			prost_types::Duration {
+				seconds: 1,
+				nanos: 1_000_000_000,
+			},
+		];
+
+		for ttl in cases {
+			let mut diagnostics = Diagnostics::default();
+			let jwt_sign = jwt_sign_from_proto_for_test(
+				proto::agent::JwtSign {
+					ttl: Some(ttl),
+					..Default::default()
+				},
+				&mut diagnostics,
+			);
+			let serialized = serde_json::to_value(jwt_sign).expect("invalid jwtSign should serialize");
+			assert!(
+				serialized["translationError"]
+					.as_str()
+					.is_some_and(|error| error.contains("ttl"))
+			);
+			assert_eq!(diagnostics.into_warnings().len(), 1);
 		}
 	}
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1117,6 +1117,41 @@ fn backend_auth_credentials_from_proto(
 		.collect()
 }
 
+fn jwt_sign_from_proto(
+	mut jwt_sign: proto::agent::JwtSign,
+) -> Result<auth::jwt_sign::JwtSignAuth, String> {
+	if let Some(error) = jwt_sign.translation_error.take() {
+		return Err(if error.trim().is_empty() {
+			"jwtSign configuration is invalid".to_string()
+		} else {
+			error
+		});
+	}
+
+	let ttl = convert_jwt_sign_ttl(jwt_sign.ttl.take())?;
+	let location = optional_authorization_location(jwt_sign.authorization_location.as_ref())
+		.map_err(|error| error.to_string())?;
+	let alg = auth::signing_alg_from_proto(jwt_sign.alg)
+		.ok_or_else(|| "unknown jwt_sign signing alg".to_string())?;
+	let claims = jwt_sign
+		.claims
+		.into_iter()
+		.map(|(key, value)| {
+			let value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
+			(key, value)
+		})
+		.collect();
+
+	auth::jwt_sign::JwtSignAuth::try_new(
+		jwt_sign.signing_key.trim(),
+		alg,
+		jwt_sign.kid,
+		claims,
+		ttl,
+		location,
+	)
+}
+
 fn backend_auth_kind_from_proto(
 	s: proto::agent::BackendAuthPolicy,
 	diagnostics: &mut Diagnostics,
@@ -1320,50 +1355,19 @@ fn backend_auth_kind_from_proto(
 				diagnostics,
 			)?))
 		},
-		Some(proto::agent::backend_auth_policy::Kind::JwtSign(mut j)) => {
-			let jwt_sign = if let Some(error) = j.translation_error.take() {
-				Err(if error.trim().is_empty() {
-					"jwtSign configuration is invalid".to_string()
-				} else {
-					error
-				})
-			} else {
-				(|| {
-					let ttl = convert_jwt_sign_ttl(j.ttl.take())?;
-					let location = optional_authorization_location(j.authorization_location.as_ref())
-						.map_err(|error| error.to_string())?;
-					let alg = auth::signing_alg_from_proto(j.alg)
-						.ok_or_else(|| "unknown jwt_sign signing alg".to_string())?;
-					let claims = j
-						.claims
-						.into_iter()
-						.map(|(key, value)| {
-							let value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
-							(key, value)
-						})
-						.collect();
-					auth::jwt_sign::JwtSignAuth::try_new(
-						j.signing_key.trim(),
-						alg,
-						j.kid,
-						claims,
-						ttl,
-						location,
-					)
-				})()
-			};
-
-			match jwt_sign {
-				Ok(jwt_sign) => BackendAuthKind::JwtSign(Box::new(jwt_sign)),
+		Some(proto::agent::backend_auth_policy::Kind::JwtSign(jwt_sign)) => {
+			let jwt_sign = match jwt_sign_from_proto(jwt_sign) {
+				Ok(jwt_sign) => jwt_sign,
 				Err(error) => {
 					// Match invalid TLS handling: accept the xDS resource with a warning,
 					// but retain a runtime configuration that rejects when used.
 					diagnostics.add_warning(format!(
 						"jwtSign configuration is invalid; requests using this policy will be rejected: {error}"
 					));
-					BackendAuthKind::JwtSign(Box::new(auth::jwt_sign::JwtSignAuth::new_invalid(error)))
+					auth::jwt_sign::JwtSignAuth::new_invalid(error)
 				},
-			}
+			};
+			BackendAuthKind::JwtSign(Box::new(jwt_sign))
 		},
 		None => return Ok(None),
 	}))
@@ -4636,39 +4640,38 @@ mod tests {
 		Ok(())
 	}
 
-	#[test]
-	fn jwt_sign_translation_error_becomes_runtime_invalid() {
-		let cases = [
-			(
-				"secret default/recognizable-marker not found",
-				"secret default/recognizable-marker not found",
-			),
-			(" \t", "jwtSign configuration is invalid"),
-		];
-		for (translation_error, expected) in cases {
-			let mut diagnostics = Diagnostics::default();
-			let jwt_sign = jwt_sign_from_proto_for_test(
-				proto::agent::JwtSign {
-					signing_key: "not a PEM key".to_string(),
-					alg: i32::MAX,
-					// translation_error takes precedence over normal field validation.
-					ttl: Some(prost_types::Duration {
-						seconds: -1,
-						nanos: 0,
-					}),
-					translation_error: Some(translation_error.to_string()),
-					..Default::default()
-				},
-				&mut diagnostics,
-			);
-			assert_eq!(
-				serde_json::to_value(jwt_sign).expect("invalid jwtSign should serialize"),
-				json!({"translationError": expected})
-			);
-			let warnings = diagnostics.into_warnings();
-			assert_eq!(warnings.len(), 1);
-			assert!(warnings[0].contains(expected));
-		}
+	#[rstest::rstest]
+	#[case::diagnostic(
+		"secret default/recognizable-marker not found",
+		"secret default/recognizable-marker not found"
+	)]
+	#[case::empty(" \t", "jwtSign configuration is invalid")]
+	fn jwt_sign_translation_error_becomes_runtime_invalid(
+		#[case] translation_error: &str,
+		#[case] expected: &str,
+	) {
+		let mut diagnostics = Diagnostics::default();
+		let jwt_sign = jwt_sign_from_proto_for_test(
+			proto::agent::JwtSign {
+				signing_key: "not a PEM key".to_string(),
+				alg: i32::MAX,
+				// translation_error takes precedence over normal field validation.
+				ttl: Some(prost_types::Duration {
+					seconds: -1,
+					nanos: 0,
+				}),
+				translation_error: Some(translation_error.to_string()),
+				..Default::default()
+			},
+			&mut diagnostics,
+		);
+		assert_eq!(
+			serde_json::to_value(jwt_sign).expect("invalid jwtSign should serialize"),
+			json!({"translationError": expected})
+		);
+		let warnings = diagnostics.into_warnings();
+		assert_eq!(warnings.len(), 1);
+		assert!(warnings[0].contains(expected));
 	}
 
 	#[test]
@@ -4729,36 +4732,25 @@ mod tests {
 		);
 	}
 
-	#[test]
-	fn invalid_jwt_sign_ttl_becomes_runtime_invalid() {
-		let cases = [
-			prost_types::Duration {
-				seconds: -1,
-				nanos: 0,
+	#[rstest::rstest]
+	#[case::negative(-1, 0)]
+	#[case::invalid_nanos(1, 1_000_000_000)]
+	fn invalid_jwt_sign_ttl_becomes_runtime_invalid(#[case] seconds: i64, #[case] nanos: i32) {
+		let mut diagnostics = Diagnostics::default();
+		let jwt_sign = jwt_sign_from_proto_for_test(
+			proto::agent::JwtSign {
+				ttl: Some(prost_types::Duration { seconds, nanos }),
+				..Default::default()
 			},
-			prost_types::Duration {
-				seconds: 1,
-				nanos: 1_000_000_000,
-			},
-		];
-
-		for ttl in cases {
-			let mut diagnostics = Diagnostics::default();
-			let jwt_sign = jwt_sign_from_proto_for_test(
-				proto::agent::JwtSign {
-					ttl: Some(ttl),
-					..Default::default()
-				},
-				&mut diagnostics,
-			);
-			let serialized = serde_json::to_value(jwt_sign).expect("invalid jwtSign should serialize");
-			assert!(
-				serialized["translationError"]
-					.as_str()
-					.is_some_and(|error| error.contains("ttl"))
-			);
-			assert_eq!(diagnostics.into_warnings().len(), 1);
-		}
+			&mut diagnostics,
+		);
+		let serialized = serde_json::to_value(jwt_sign).expect("invalid jwtSign should serialize");
+		assert!(
+			serialized["translationError"]
+				.as_str()
+				.is_some_and(|error| error.contains("ttl"))
+		);
+		assert_eq!(diagnostics.into_warnings().len(), 1);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1333,7 +1333,8 @@ fn backend_auth_kind_from_proto(
 			BackendAuthKind::JwtSign(Box::new(
 				auth::jwt_sign::JwtSignAuth::try_new(
 					j.signing_key.trim(),
-					jwt_sign_alg_from_proto(j.alg)?,
+					auth::signing_alg_from_proto(j.alg)
+						.ok_or_else(|| ProtoError::EnumParse("unknown jwt_sign signing alg".into()))?,
 					j.kid,
 					claims,
 					j.ttl.map(convert_duration),
@@ -1344,22 +1345,6 @@ fn backend_auth_kind_from_proto(
 		},
 		None => return Ok(None),
 	}))
-}
-
-fn jwt_sign_alg_from_proto(alg: i32) -> Result<auth::oauth::SigningAlg, ProtoError> {
-	use auth::oauth::SigningAlg;
-	use proto::agent::jwt_sign::SigningAlg as ProtoSigningAlg;
-
-	match ProtoSigningAlg::try_from(alg) {
-		Ok(ProtoSigningAlg::Unspecified) => Ok(SigningAlg::Rs256),
-		Ok(ProtoSigningAlg::Rs256) => Ok(SigningAlg::Rs256),
-		Ok(ProtoSigningAlg::Rs384) => Ok(SigningAlg::Rs384),
-		Ok(ProtoSigningAlg::Rs512) => Ok(SigningAlg::Rs512),
-		Ok(ProtoSigningAlg::Es256) => Ok(SigningAlg::Es256),
-		Ok(ProtoSigningAlg::Es384) => Ok(SigningAlg::Es384),
-		Ok(ProtoSigningAlg::Ps256) => Ok(SigningAlg::Ps256),
-		Err(_) => Err(ProtoError::EnumParse("unknown jwt_sign signing alg".into())),
-	}
 }
 
 fn listener_protocol_from_proto(

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1320,28 +1320,42 @@ fn backend_auth_kind_from_proto(
 				diagnostics,
 			)?))
 		},
-		Some(proto::agent::backend_auth_policy::Kind::JwtSign(j)) => {
-			let location = optional_authorization_location(j.authorization_location.as_ref())?;
-			let claims = j
-				.claims
-				.into_iter()
-				.map(|(key, value)| {
-					let value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
-					(key, value)
-				})
-				.collect();
-			BackendAuthKind::JwtSign(Box::new(
-				auth::jwt_sign::JwtSignAuth::try_new(
-					j.signing_key.trim(),
-					auth::signing_alg_from_proto(j.alg)
-						.ok_or_else(|| ProtoError::EnumParse("unknown jwt_sign signing alg".into()))?,
-					j.kid,
-					claims,
-					j.ttl.map(convert_duration),
-					location,
-				)
-				.map_err(ProtoError::Generic)?,
-			))
+		Some(proto::agent::backend_auth_policy::Kind::JwtSign(mut j)) => {
+			if let Some(error) = j.translation_error.take() {
+				// Match invalid TLS handling: accept the xDS resource with a warning,
+				// but retain a runtime configuration that rejects when used.
+				let error = if error.trim().is_empty() {
+					"jwtSign configuration is invalid".to_string()
+				} else {
+					error
+				};
+				diagnostics.add_warning(format!(
+					"jwtSign configuration is invalid; requests using this policy will be rejected: {error}"
+				));
+				BackendAuthKind::JwtSign(Box::new(auth::jwt_sign::JwtSignAuth::new_invalid(error)))
+			} else {
+				let location = optional_authorization_location(j.authorization_location.as_ref())?;
+				let claims = j
+					.claims
+					.into_iter()
+					.map(|(key, value)| {
+						let value = serde_json::to_value(value).unwrap_or(serde_json::Value::Null);
+						(key, value)
+					})
+					.collect();
+				BackendAuthKind::JwtSign(Box::new(
+					auth::jwt_sign::JwtSignAuth::try_new(
+						j.signing_key.trim(),
+						auth::signing_alg_from_proto(j.alg)
+							.ok_or_else(|| ProtoError::EnumParse("unknown jwt_sign signing alg".into()))?,
+						j.kid,
+						claims,
+						j.ttl.map(convert_duration),
+						location,
+					)
+					.map_err(ProtoError::Generic)?,
+				))
+			}
 		},
 		None => return Ok(None),
 	}))
@@ -3935,6 +3949,25 @@ mod tests {
 	use crate::store::RequestPolicyTrait;
 	use crate::types::proto::agent::backend_policy_spec::Ai;
 
+	fn jwt_sign_from_proto_for_test(
+		jwt_sign: proto::agent::JwtSign,
+		diagnostics: &mut Diagnostics,
+	) -> Box<auth::jwt_sign::JwtSignAuth> {
+		let auth = backend_auth_kind_from_proto(
+			proto::agent::BackendAuthPolicy {
+				kind: Some(proto::agent::backend_auth_policy::Kind::JwtSign(jwt_sign)),
+				credentials: vec![],
+			},
+			diagnostics,
+		)
+		.expect("jwtSign policy conversion should succeed")
+		.expect("jwtSign kind should be present");
+		let BackendAuthKind::JwtSign(jwt_sign) = auth else {
+			panic!("expected jwtSign auth kind");
+		};
+		jwt_sign
+	}
+
 	fn test_policy_target() -> proto::agent::PolicyTarget {
 		proto::agent::PolicyTarget {
 			kind: Some(proto::agent::policy_target::Kind::Route(
@@ -4561,6 +4594,36 @@ mod tests {
 		};
 		assert_eq!(transformation.expressions().count(), 2);
 		Ok(())
+	}
+
+	#[test]
+	fn jwt_sign_translation_error_becomes_runtime_invalid() {
+		let cases = [
+			(
+				"secret default/recognizable-marker not found",
+				"secret default/recognizable-marker not found",
+			),
+			(" \t", "jwtSign configuration is invalid"),
+		];
+		for (translation_error, expected) in cases {
+			let mut diagnostics = Diagnostics::default();
+			let jwt_sign = jwt_sign_from_proto_for_test(
+				proto::agent::JwtSign {
+					signing_key: "not a PEM key".to_string(),
+					alg: i32::MAX,
+					translation_error: Some(translation_error.to_string()),
+					..Default::default()
+				},
+				&mut diagnostics,
+			);
+			assert_eq!(
+				serde_json::to_value(jwt_sign).expect("invalid jwtSign should serialize"),
+				json!({"translationError": expected})
+			);
+			let warnings = diagnostics.into_warnings();
+			assert_eq!(warnings.len(), 1);
+			assert!(warnings[0].contains(expected));
+		}
 	}
 
 	#[test]

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -398,25 +398,25 @@ message Key {
   AuthorizationLocation authorization_location = 2;
 }
 
+enum JwtSigningAlg {
+  JWT_SIGNING_ALG_UNSPECIFIED = 0;
+  RS256                   = 1;
+  RS384                   = 2;
+  RS512                   = 3;
+  ES256                   = 4;
+  ES384                   = 5;
+  PS256                   = 6;
+}
+
 // Signs a short-lived JWT with a private key on each request and sends it to
 // the backend. For upstreams that require per-request keypair JWTs (e.g. the
 // Snowflake SQL API) rather than a static credential.
 message JwtSign {
-  enum SigningAlg {
-    SIGNING_ALG_UNSPECIFIED = 0; // defaults to RS256
-    RS256                   = 1;
-    RS384                   = 2;
-    RS512                   = 3;
-    ES256                   = 4;
-    ES384                   = 5;
-    PS256                   = 6;
-  }
-
   // PEM-encoded private signing key. RSA keys are used with RS*/PS*
   // algorithms; EC keys are used with ES* algorithms.
   string signing_key = 1;
   // JWS signing algorithm. Defaults to RS256.
-  SigningAlg alg = 2;
+  JwtSigningAlg alg = 2;
   // Optional JWS key ID header.
   optional string kid = 3;
   // Static claims added to every token (e.g. iss, sub, aud). iat, exp, and
@@ -1875,16 +1875,6 @@ message OAuthClientAuth {
   }
 
   message PrivateKeyJwt {
-    enum SigningAlg {
-      SIGNING_ALG_UNSPECIFIED = 0; // defaults to RS256
-      RS256                   = 1;
-      RS384                   = 2;
-      RS512                   = 3;
-      ES256                   = 4;
-      ES384                   = 5;
-      PS256                   = 6;
-    }
-
     enum CertificateHeader {
       CERTIFICATE_HEADER_UNSPECIFIED = 0;
       X5C                            = 1;
@@ -1895,7 +1885,7 @@ message OAuthClientAuth {
     // algorithms; EC keys are used with ES* algorithms.
     string signing_key = 1;
     // JWS signing algorithm. Defaults to RS256.
-    SigningAlg alg = 2;
+    JwtSigningAlg alg = 2;
     // Optional JWS key ID header.
     optional string kid = 3;
     // Audience for the client assertion, typically the token endpoint URL.

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -427,6 +427,10 @@ message JwtSign {
   // Where the signed token is written. Defaults to the Authorization header
   // with a "Bearer " prefix.
   AuthorizationLocation authorization_location = 6;
+  // Set by the control plane when jwtSign configuration cannot be translated.
+  // Control-plane-only: never set from user-facing config. When present, the
+  // data plane accepts the policy but rejects every request that uses it.
+  optional string translation_error = 7;
 }
 
 // GCP-specific backend authentication.

--- a/schema/config.json
+++ b/schema/config.json
@@ -3545,7 +3545,7 @@
         },
         "alg": {
           "description": "JWS signing algorithm. Defaults to RS256.",
-          "$ref": "#/$defs/SigningAlg",
+          "$ref": "#/$defs/JwtSigningAlg",
           "default": "RS256"
         },
         "kid": {
@@ -3586,7 +3586,7 @@
         "claims"
       ]
     },
-    "SigningAlg": {
+    "JwtSigningAlg": {
       "type": "string",
       "enum": [
         "RS256",
@@ -3929,7 +3929,7 @@
               ]
             },
             "alg": {
-              "$ref": "#/$defs/SigningAlg",
+              "$ref": "#/$defs/JwtSigningAlg",
               "default": "RS256"
             },
             "kid": {


### PR DESCRIPTION
This aims to clean up some duplicated work across the recent token exchange private_key additions and the new jwtSign backendAuth type.

### Changes
  * Promotes the signing algorithm to shared API types used by both OAuth and `jwtSign`.
  * Moves shared Rust signing machinery into `auth::jws`:
      * Algorithm conversion
      * Private-key parsing
      * Protected-header construction
      * Token encoding
  * Keeps OAuth-specific claims and certificate handling within OAuth.
  * Carries controller translation failures through xDS as an invalid `jwtSign` state.
  * Rejects requests using invalid configurations before modifying credentials or request headers.
  * Keeps detailed diagnostics in policy status, config warnings, and debug logs while returning a generic error to clients.
  * Applies fail-closed handling to data-plane conversion failures such as invalid keys, algorithms, locations, and durations.
  * Shares JWT timestamp calculation between OAuth and `jwtSign`.
  * Treats the configured `jwtSign` lifetime as measured from signing time while backdating `iat` for clock tolerance.
  * Adds E2E coverage for both successful JWT injection and invalid-policy rejection.

Existing signing algorithms, enum values, `RS256` defaults, OAuth behavior, and Kubernetes serialization remain compatible.

follow up to #2515 