### PR TITLE
config: drop MODEL_CATALOG_PATHS env var

### DIFF
--- a/controller/pkg/helm/agentgateway/templates/_helpers.tpl
+++ b/controller/pkg/helm/agentgateway/templates/_helpers.tpl
@@ -259,18 +259,6 @@ spec:
         - name: NETWORK
           value: {{ $gateway.istio.network | quote }}
         {{- end }}
-      {{- $catalogPaths := list }}
-      {{- range ($gateway.modelCatalog).sources }}
-      {{- if .configMap }}
-      {{- $catalogPaths = append $catalogPaths (printf "/etc/agentgateway/model-catalog/%s/%s.json" .configMap.name .configMap.name) }}
-      {{- end }}
-      {{- end }}
-      {{- if $catalogPaths }}
-        {{- if not (hasKey $userEnvNames "MODEL_CATALOG_PATHS") }}
-        - name: MODEL_CATALOG_PATHS
-          value: {{ $catalogPaths | join "," | quote }}
-        {{- end }}
-      {{- end }}
       {{- /* User-specified env vars */}}
       {{- with $gateway.env }}
         {{- toYaml . | nindent 8 }}

--- a/controller/pkg/helm/agentgateway/templates/configmap.yaml
+++ b/controller/pkg/helm/agentgateway/templates/configmap.yaml
@@ -12,8 +12,21 @@ data:
     {{- /* Start with rawConfig as base, then merge typed config on top */ -}}
     {{- $baseConfig := $gateway.rawConfig | default dict }}
     {{- $typedConfig := dict }}
+    {{- $typedRuntimeConfig := dict }}
     {{- with ($gateway.logging).format }}
-    {{- $typedConfig = dict "config" (dict "logging" (dict "format" .)) }}
+    {{- $_ := set $typedRuntimeConfig "logging" (dict "format" .) }}
+    {{- end }}
+    {{- $catalogSources := list }}
+    {{- range ($gateway.modelCatalog).sources }}
+    {{- if .configMap }}
+    {{- $catalogSources = append $catalogSources (dict "file" (printf "/etc/agentgateway/model-catalog/%s/%s.json" .configMap.name .configMap.name)) }}
+    {{- end }}
+    {{- end }}
+    {{- if $catalogSources }}
+    {{- $_ := set $typedRuntimeConfig "modelCatalog" $catalogSources }}
+    {{- end }}
+    {{- if $typedRuntimeConfig }}
+    {{- $_ := set $typedConfig "config" $typedRuntimeConfig }}
     {{- end }}
     {{- /* Merge: typed config takes precedence over rawConfig */ -}}
     {{- $finalConfig := merge $typedConfig $baseConfig }}

--- a/controller/test/deployer/internal_helm_test.go
+++ b/controller/test/deployer/internal_helm_test.go
@@ -574,10 +574,10 @@ wIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBtestcertdata
 			InputFile: "agentgateway-model-catalog-configmap",
 			Validate: func(t *testing.T, outputYaml string) {
 				t.Helper()
-				assert.Contains(t, outputYaml, "MODEL_CATALOG_PATHS",
-					"deployment should set MODEL_CATALOG_PATHS to the mounted ConfigMap file path")
+				assert.Contains(t, outputYaml, "modelCatalog:",
+					"generated config should include the model catalog")
 				assert.Contains(t, outputYaml, "/etc/agentgateway/model-catalog/my-model-costs/my-model-costs.json",
-					"MODEL_CATALOG_PATHS should point to the ConfigMap mount path")
+					"config.modelCatalog should point to the ConfigMap mount path")
 				assert.Contains(t, outputYaml, "mountPath: /etc/agentgateway/model-catalog/my-model-costs",
 					"deployment should have a directory volume mount for the model catalog ConfigMap so kubelet's atomic symlink swap on update is visible")
 				assert.NotContains(t, outputYaml, "subPath: my-model-costs.json",

--- a/controller/test/deployer/testdata/agentgateway-model-catalog-configmap-out.yaml
+++ b/controller/test/deployer/testdata/agentgateway-model-catalog-configmap-out.yaml
@@ -14,7 +14,9 @@ metadata:
 apiVersion: v1
 data:
   config.yaml: |
-    config: {}
+    config:
+      modelCatalog:
+      - file: /etc/agentgateway/model-catalog/my-model-costs/my-model-costs.json
 kind: ConfigMap
 metadata:
   labels:
@@ -72,7 +74,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 864542ed2e0b0de7cfd066cda1995c0816d7b62bfd2ec96fd7eaa6f50f2624aa
+        checksum/config: 724fc4b8c62bb05cf4a8dc68843732c420d60a343e880ec355605150ad5cde27
         checksum/session-key: 2a8abfa8cb9906290437854193ca6bca41d4d4e26d1d454bd66a35158095e737
         prometheus.io/path: /metrics
         prometheus.io/port: "15020"
@@ -134,8 +136,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
-        - name: MODEL_CATALOG_PATHS
-          value: /etc/agentgateway/model-catalog/my-model-costs/my-model-costs.json
         image: cr.agentgateway.dev/agentgateway:99.99.99
         name: agentgateway
         ports:

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -353,16 +353,7 @@ pub fn parse_config(
 	let dynamic_ca_cert_cache =
 		parse_dynamic_ca_cert_cache_config().ctx("invalid dynamic CA cert cache config")?;
 
-	let model_catalog_sources = parse::<String>("MODEL_CATALOG_PATHS")?
-		.map(|s| {
-			s.split(',')
-				.map(|p| PathBuf::from(p.trim()))
-				.filter(|p| !p.as_os_str().is_empty())
-				.map(|file| crate::ModelCatalogSource::File { file })
-				.collect::<Vec<_>>()
-		})
-		.or(raw.model_catalog)
-		.unwrap_or_default();
+	let model_catalog_sources = raw.model_catalog.unwrap_or_default();
 	let database = raw.database.clone();
 	let explicit_logging_database = raw.logging.as_ref().and_then(|l| l.database.clone());
 	if database


### PR DESCRIPTION
This can be configured via config and it is complex to properly support
given we have dynamic reloading.

Fixes https://github.com/agentgateway/agentgateway/issues/2762

Signed-off-by: John Howard <john.howard@solo.io>
