### PR TITLE
auth: fix examples for explicit OAuth subject tokens

### DIFF
--- a/crates/agentgateway/src/http/auth/oauth/mod.rs
+++ b/crates/agentgateway/src/http/auth/oauth/mod.rs
@@ -349,7 +349,7 @@ impl OAuthTokenExchangeAuth {
 		// Extract everything up front so a bad request fails before we touch it.
 		let subject_token =
 			extract_subject_token(&self.subject_token.source, req).ok_or_else(|| {
-				debug!("oauth token exchange subject token missing");
+				debug!(source=?self.subject_token.source, "oauth token exchange subject token missing");
 				ProxyError::InvalidRequest
 			})?;
 		let actor = self

--- a/crates/agentgateway/src/http/auth/oauth/tests.rs
+++ b/crates/agentgateway/src/http/auth/oauth/tests.rs
@@ -210,6 +210,20 @@ fn incoming_request() -> crate::http::Request {
 		.unwrap()
 }
 
+#[test]
+fn missing_subject_token_is_invalid_request() {
+	let auth = auth(Arc::new(SimpleBackendReference::Invalid));
+	let req = ::http::Request::builder()
+		.uri("http://upstream/")
+		.body(Body::empty())
+		.unwrap();
+
+	assert!(matches!(
+		auth.build_exchange_request(&req),
+		Err(ProxyError::InvalidRequest)
+	));
+}
+
 async fn sent_form_params(mock: &MockServer) -> HashMap<String, String> {
 	let req = &mock.received_requests().await.unwrap()[0];
 	form_urlencoded::parse(&req.body).into_owned().collect()

--- a/examples/traffic-cross-app-access/keycloak/gateway.yaml
+++ b/examples/traffic-cross-app-access/keycloak/gateway.yaml
@@ -28,6 +28,10 @@ binds:
 
         backendAuth:
           crossAppAccess:
+            # jwtAuth removes the validated credential, so read its raw token explicitly.
+            subjectToken:
+              source:
+                expression: jwt.rawToken.unredacted()
             # Leg 1 — the user's IdP token endpoint, authenticated as the requesting client.
             identityProvider:
               host: localhost:8480

--- a/examples/traffic-cross-app-access/okta-auth0/gateway.yaml
+++ b/examples/traffic-cross-app-access/okta-auth0/gateway.yaml
@@ -48,6 +48,10 @@ binds:
         # --- Steps 2-4: exchange identity for a backend token and attach it ----
         backendAuth:
           crossAppAccess:
+            # jwtAuth removes the validated credential, so read its raw token explicitly.
+            subjectToken:
+              source:
+                expression: jwt.rawToken.unredacted()
             # Leg 1: the user's Okta IdP (org authorization server).
             # Performs the RFC 8693 token exchange that mints the ID-JAG.
             identityProvider:

--- a/examples/traffic-cross-app-access/xaa-dev/gateway.yaml
+++ b/examples/traffic-cross-app-access/xaa-dev/gateway.yaml
@@ -35,6 +35,10 @@ binds:
 
         backendAuth:
           crossAppAccess:
+            # jwtAuth removes the validated credential, so read its raw token explicitly.
+            subjectToken:
+              source:
+                expression: jwt.rawToken.unredacted()
             # Leg 1 — IdenX token endpoint (requesting-app client credentials).
             identityProvider:
               # `https://` host = HTTPS with TLS auto-configured (no :443 + backendTLS needed).

--- a/examples/traffic-token-exchange/jwt-authz-grant/README.md
+++ b/examples/traffic-token-exchange/jwt-authz-grant/README.md
@@ -161,6 +161,20 @@ Gotchas:
 - Use `clientSecretPost` to put the client credentials in the body (matching the
   curl above). The default `clientSecretBasic` would send them as an
   `Authorization: Basic` header instead.
+- If the route also uses `jwtAuth`, it removes the validated credential from
+  its original location. Read the validated raw token explicitly for the
+  backend exchange:
+
+  ```yaml
+  jwtAuth:
+    # issuer, audiences, and jwks...
+  backendAuth:
+    oauthTokenExchange:
+      # host, path, and client auth...
+      subjectToken:
+        source:
+          expression: jwt.rawToken.unredacted()
+  ```
 
 ---
 


### PR DESCRIPTION
fix #2774 