### PR TITLE
listener/tls: add authority key ID to dynamic CA certificates

### DIFF
--- a/crates/agentgateway/src/types/dynamic_ca_cert.rs
+++ b/crates/agentgateway/src/types/dynamic_ca_cert.rs
@@ -46,6 +46,7 @@ impl DynamicCa {
 		params.is_ca = rcgen::IsCa::NoCa;
 		params.key_usages = vec![rcgen::KeyUsagePurpose::DigitalSignature];
 		params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ServerAuth];
+		params.use_authority_key_identifier_extension = true;
 
 		let leaf_key = KeyPair::generate()?;
 		let leaf_cert = params.signed_by(&leaf_key, &self.issuer)?;
@@ -203,7 +204,50 @@ pub(crate) fn build_dynamic_ca_tls_config_with_profile(
 
 #[cfg(test)]
 mod tests {
+	use rcgen::{BasicConstraints, IsCa, KeyUsagePurpose};
+	use x509_parser::extensions::ParsedExtension;
+	use x509_parser::prelude::{FromDer, X509Certificate};
+
 	use super::*;
+
+	fn ca_params(common_name: &str) -> CertificateParams {
+		let mut params = CertificateParams::default();
+		params
+			.distinguished_name
+			.push(DnType::CommonName, common_name);
+		params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+		params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+		params
+	}
+
+	fn subject_key_identifier(cert_der: &[u8]) -> Vec<u8> {
+		let (_, cert) = X509Certificate::from_der(cert_der).expect("parse certificate");
+		cert
+			.extensions()
+			.iter()
+			.find_map(|extension| match extension.parsed_extension() {
+				ParsedExtension::SubjectKeyIdentifier(key_identifier) => Some(key_identifier.0.to_vec()),
+				_ => None,
+			})
+			.expect("certificate has a subject key identifier")
+	}
+
+	fn authority_key_identifier(cert_der: &[u8]) -> Vec<u8> {
+		let (_, cert) = X509Certificate::from_der(cert_der).expect("parse certificate");
+		cert
+			.extensions()
+			.iter()
+			.find_map(|extension| match extension.parsed_extension() {
+				ParsedExtension::AuthorityKeyIdentifier(authority_key_identifier) => {
+					authority_key_identifier
+						.key_identifier
+						.as_ref()
+						.map(|key_identifier| key_identifier.0.to_vec())
+				},
+				_ => None,
+			})
+			.expect("certificate has an authority key identifier")
+	}
 
 	fn test_resolver() -> DynamicCaCertResolver {
 		let ca_key = rcgen::KeyPair::generate().expect("generate CA key");
@@ -251,5 +295,64 @@ mod tests {
 			.expect("generate replacement cert");
 
 		assert!(!Arc::ptr_eq(&first, &second));
+	}
+
+	#[test]
+	fn leaf_authority_key_identifier_matches_self_signed_ca() {
+		let ca_key = KeyPair::generate().expect("generate CA key");
+		let ca_cert = ca_params("dynamic CA")
+			.self_signed(&ca_key)
+			.expect("generate CA cert");
+		let dynamic_ca =
+			DynamicCa::from_pem(ca_cert.pem().as_bytes(), ca_key.serialize_pem().as_bytes())
+				.expect("parse CA");
+
+		let (leaf_der, _) = dynamic_ca
+			.generate_leaf_cert("example.com")
+			.expect("generate leaf");
+
+		assert_eq!(
+			authority_key_identifier(&leaf_der),
+			subject_key_identifier(ca_cert.der())
+		);
+	}
+
+	#[test]
+	fn intermediate_ca_signs_leaf_and_is_served_in_chain() {
+		let root_key = KeyPair::generate().expect("generate root key");
+		let root_params = ca_params("root CA");
+		let root_cert = root_params
+			.self_signed(&root_key)
+			.expect("generate root cert");
+		let root_issuer = Issuer::new(root_params, root_key);
+
+		let intermediate_key = KeyPair::generate().expect("generate intermediate key");
+		let mut intermediate_params = ca_params("dynamic intermediate CA");
+		intermediate_params.use_authority_key_identifier_extension = true;
+		let intermediate_cert = intermediate_params
+			.signed_by(&intermediate_key, &root_issuer)
+			.expect("generate intermediate cert");
+		let intermediate_der = intermediate_cert.der().to_vec();
+		let dynamic_ca = DynamicCa::from_pem(
+			intermediate_cert.pem().as_bytes(),
+			intermediate_key.serialize_pem().as_bytes(),
+		)
+		.expect("parse intermediate CA");
+		let resolver = DynamicCaCertResolver {
+			ca: Arc::new(dynamic_ca),
+			provider: tls::provider_with_options(&[], &[]),
+			cache: Cache::new(crate::DynamicCaCertCacheConfig::default().capacity),
+			cache_ttl: crate::DynamicCaCertCacheConfig::default().ttl,
+		};
+
+		let certified_key = resolver
+			.generate_certified_key("example.com")
+			.expect("generate certified key");
+		assert_eq!(certified_key.cert.len(), 2);
+		assert_eq!(certified_key.cert[1].as_ref(), intermediate_der);
+
+		let leaf_aki = authority_key_identifier(certified_key.cert[0].as_ref());
+		assert_eq!(leaf_aki, subject_key_identifier(&intermediate_der));
+		assert_ne!(leaf_aki, subject_key_identifier(root_cert.der()));
 	}
 }


### PR DESCRIPTION
Enable the Authority Key Identifier extension on per-SNI certificates minted by the dynamic CA so strict RFC 5280 clients can validate the generated chain.

Add coverage for self-signed and intermediate signing CAs.

Testing done:
- cargo test -p agentgateway dynamic_ca_cert
- Sent a Python 3.14 httpx https request through a dynamic CA listener
- Verified the generated chain with OpenSSL strict verification