### PR TITLE
bump rmcp to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
  "reqwest 0.12.28",
  "reqwest 0.13.4",
  "rmcp 0.10.0",
- "rmcp 3.0.0-beta.5",
+ "rmcp 3.1.0",
  "rstest",
  "rust_decimal",
  "rustls",
@@ -5979,9 +5979,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0-beta.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183443f6b17ddf54d22fc37dcc2160f1e9ca09430d2be086ee2eb76b8c936412"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -5997,7 +5997,7 @@ dependencies = [
  "process-wrap",
  "rand 0.10.2",
  "reqwest 0.13.4",
- "rmcp-macros 3.0.0-beta.5",
+ "rmcp-macros 3.1.0",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -6027,9 +6027,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.0-beta.5"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f519766077846d7347a3c068a920dd702018b34fb24a46c4f1bc487a7e0dfa71"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -109,7 +109,7 @@ libc.workspace = true
 rcgen.workspace = true
 regex.workspace = true
 
-rmcp = { version = "3.0.0-beta.5", features = [
+rmcp = { version = "3.1.0", features = [
     "client",
     "server",
     "base64",
@@ -196,7 +196,7 @@ rstest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 which.workspace = true
-rmcp = { version = "3.0.0-beta.5", features = [
+rmcp = { version = "3.1.0", features = [
     "client",
     "server",
     "base64",


### PR DESCRIPTION
Bump to latest stable release https://github.com/modelcontextprotocol/rust-sdk/releases/tag/rmcp-v3.1.0

```
Added
classify authorization-required errors (https://github.com/modelcontextprotocol/rust-sdk/pull/1056)
add strict stateless protocol metadata validation (https://github.com/modelcontextprotocol/rust-sdk/pull/1091)
SEP-2260 stream-based enforcement of client receive-side request association (https://github.com/modelcontextprotocol/rust-sdk/pull/1055)
Fixed
(model) decode metadata-bearing input-required results affecting mrtr (https://github.com/modelcontextprotocol/rust-sdk/pull/1097)
require metadata for modern HTTP requests (https://github.com/modelcontextprotocol/rust-sdk/pull/1089)
honor supported_protocol_versions when negotiating initialize (https://github.com/modelcontextprotocol/rust-sdk/pull/1093)
Other
document the ping utility with examples (https://github.com/modelcontextprotocol/rust-sdk/pull/1106)
complete Tier 1 feature docs and finalize roadmap (https://github.com/modelcontextprotocol/rust-sdk/pull/1101)
(conformance) meeting requirements for tier 1 (https://github.com/modelcontextprotocol/rust-sdk/pull/1087)
```