### PR TITLE
Add AgentgatewayModel status reconciliation

### DIFF
--- a/controller/pkg/agentgateway/translator/builtin_helpers.go
+++ b/controller/pkg/agentgateway/translator/builtin_helpers.go
@@ -109,6 +109,8 @@ func GetStatus[I, IS any](spec I) IS {
 		return any(t.Status).(IS)
 	case *agentgateway.AgentgatewayBackend:
 		return any(t.Status).(IS)
+	case *agentgateway.AgentgatewayModel:
+		return any(t.Status).(IS)
 	default:
 		// For external resources (registered via extraGVKs), we don't introspect the object here.
 		// Returning the zero status ensures we always enqueue a write when desired status is set.

--- a/controller/pkg/agentgateway/translator/model_collections_test.go
+++ b/controller/pkg/agentgateway/translator/model_collections_test.go
@@ -66,6 +66,21 @@ func TestAgentgatewayModelSupportedKindsFeatureGate(t *testing.T) {
 	}
 }
 
+func TestGetAgentgatewayModelStatus(t *testing.T) {
+	model := &agentgateway.AgentgatewayModel{
+		Status: agentgateway.AgentgatewayModelStatus{
+			Parents: []gwv1.RouteParentStatus{{
+				ParentRef: gwv1.ParentReference{Name: "gateway"},
+			}},
+		},
+	}
+
+	got := GetStatus[*agentgateway.AgentgatewayModel, agentgateway.AgentgatewayModelStatus](model)
+	if len(got.Parents) != 1 || got.Parents[0].ParentRef.Name != "gateway" {
+		t.Fatalf("status = %#v, want live AgentgatewayModel status", got)
+	}
+}
+
 func TestModelLLMProvider(t *testing.T) {
 	t.Run("default provider", func(t *testing.T) {
 		providerType := agentgateway.ModelProviderOpenAI

--- a/controller/pkg/controller/start.go
+++ b/controller/pkg/controller/start.go
@@ -151,6 +151,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		agwSyncer.CacheSyncs(),
 		cfg.ExtraAgwResourceStatusHandlers,
 		cfg.AgwCollections.Settings.EnableInferExt,
+		cfg.AgwCollections.Settings.EnableAgentgatewayModels,
 	)
 	if err := cfg.Manager.Add(agwStatusSyncer); err != nil {
 		setupLog.Error(err, "unable to add agentgateway StatusSyncer runnable")

--- a/controller/pkg/syncer/status/collection.go
+++ b/controller/pkg/syncer/status/collection.go
@@ -124,6 +124,8 @@ func enqueueStatus[T any](sw WorkerQueue, obj controllers.Object, ws T, extraGVK
 		res.GroupVersionKind = wellknown.AgentgatewayPolicyGVK
 	case *agentgateway.AgentgatewayBackend:
 		res.GroupVersionKind = wellknown.AgentgatewayBackendGVK
+	case *agentgateway.AgentgatewayModel:
+		res.GroupVersionKind = wellknown.AgentgatewayModelGVK
 	case *gwv1.ListenerSet:
 		res.GroupVersionKind = wellknown.ListenerSetGVK
 	case *gwv1.BackendTLSPolicy:

--- a/controller/pkg/syncer/status/collection_test.go
+++ b/controller/pkg/syncer/status/collection_test.go
@@ -1,0 +1,47 @@
+package status
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
+)
+
+type captureQueue struct {
+	target Resource
+	data   any
+}
+
+func (c *captureQueue) Push(target Resource, data any) {
+	c.target = target
+	c.data = data
+}
+
+func (*captureQueue) Run(context.Context) {}
+
+func TestEnqueueStatusAgentgatewayModelWithoutTypeMeta(t *testing.T) {
+	queue := &captureQueue{}
+	model := &agentgateway.AgentgatewayModel{}
+	model.Name = "model"
+	model.Namespace = "default"
+	model.ResourceVersion = "123"
+	wantStatus := &agentgateway.AgentgatewayModelStatus{}
+
+	enqueueStatus(queue, model, wantStatus, []schema.GroupVersionKind(nil))
+
+	if queue.target.GroupVersionKind != wellknown.AgentgatewayModelGVK {
+		t.Fatalf("GVK = %v, want %v", queue.target.GroupVersionKind, wellknown.AgentgatewayModelGVK)
+	}
+	if queue.target.Name != model.Name || queue.target.Namespace != model.Namespace {
+		t.Fatalf("namespaced name = %s/%s, want %s/%s", queue.target.Namespace, queue.target.Name, model.Namespace, model.Name)
+	}
+	if queue.target.ResourceVersion != model.ResourceVersion {
+		t.Fatalf("resource version = %q, want %q", queue.target.ResourceVersion, model.ResourceVersion)
+	}
+	if queue.data != wantStatus {
+		t.Fatalf("queued status = %p, want %p", queue.data, wantStatus)
+	}
+}

--- a/controller/pkg/syncer/status_syncer.go
+++ b/controller/pkg/syncer/status_syncer.go
@@ -43,6 +43,7 @@ type AgentGwStatusSyncer struct {
 
 	agentgatewayPolicies StatusSyncer[*agentgateway.AgentgatewayPolicy, gwv1.PolicyStatus]
 	agentgatewayBackends StatusSyncer[*agentgateway.AgentgatewayBackend, agentgateway.AgentgatewayBackendStatus]
+	agentgatewayModels   StatusSyncer[*agentgateway.AgentgatewayModel, *agentgateway.AgentgatewayModelStatus]
 
 	// Configuration
 	controllerName string
@@ -72,6 +73,7 @@ func NewAgwStatusSyncer(
 	cacheSyncs []cache.InformerSynced,
 	extraHandlers map[schema.GroupVersionKind]ResourceStatusSyncer,
 	enableInference bool,
+	enableAgentgatewayModels bool,
 ) *AgentGwStatusSyncer {
 	f := kclient.Filter{ObjectFilter: client.ObjectFilter()}
 	syncer := &AgentGwStatusSyncer{
@@ -195,6 +197,19 @@ func NewAgwStatusSyncer(
 			},
 		}
 	}
+	if enableAgentgatewayModels {
+		syncer.agentgatewayModels = StatusSyncer[*agentgateway.AgentgatewayModel, *agentgateway.AgentgatewayModelStatus]{
+			Name:           "agentgatewayModel",
+			ControllerName: controllerName,
+			Client:         kclient.NewFilteredDelayed[*agentgateway.AgentgatewayModel](client, wellknown.AgentgatewayModelGVR, f),
+			Build: func(om metav1.ObjectMeta, s *agentgateway.AgentgatewayModelStatus) *agentgateway.AgentgatewayModel {
+				return &agentgateway.AgentgatewayModel{
+					ObjectMeta: om,
+					Status:     *s,
+				}
+			},
+		}
+	}
 
 	return syncer
 }
@@ -230,6 +245,13 @@ func (s *AgentGwStatusSyncer) Start(ctx context.Context) error {
 			s.inferencePools.Client.HasSynced,
 		)
 	}
+	if s.agentgatewayModels.Client != nil {
+		s.client.WaitForCacheSync(
+			"agent gateway status clients",
+			ctx.Done(),
+			s.agentgatewayModels.Client.HasSynced,
+		)
+	}
 
 	logger.Info("caches warm!")
 
@@ -260,6 +282,10 @@ func (s *AgentGwStatusSyncer) SyncStatus(ctx context.Context, resource status.Re
 		s.agentgatewayPolicies.ApplyStatus(ctx, resource, statusObj)
 	case wellknown.AgentgatewayBackendGVK:
 		s.agentgatewayBackends.ApplyStatus(ctx, resource, statusObj)
+	case wellknown.AgentgatewayModelGVK:
+		if s.agentgatewayModels.Client != nil {
+			s.agentgatewayModels.ApplyStatus(ctx, resource, statusObj)
+		}
 	case wellknown.BackendTLSPolicyGVK:
 		s.backendTLSPolicies.ApplyStatus(ctx, resource, statusObj)
 	case wellknown.InferencePoolGVK:
@@ -364,6 +390,13 @@ func (s StatusSyncer[O, S]) ApplyStatus(ctx context.Context, obj status.Resource
 			}
 		case *gwv1.TLSRouteStatus:
 			cur, ok := any(current).(*gwv1.TLSRoute)
+			if ok {
+				merged := *desired
+				merged.Parents = mergeRouteParentStatuses(s.ControllerName, cur.Status.Parents, desired.Parents)
+				mergedAny = &merged
+			}
+		case *agentgateway.AgentgatewayModelStatus:
+			cur, ok := any(current).(*agentgateway.AgentgatewayModel)
 			if ok {
 				merged := *desired
 				merged.Parents = mergeRouteParentStatuses(s.ControllerName, cur.Status.Parents, desired.Parents)

--- a/controller/test/e2e/modelrouting_test.go
+++ b/controller/test/e2e/modelrouting_test.go
@@ -7,10 +7,13 @@ import (
 	"testing"
 
 	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/base"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/testutils/assertions"
 	testmatchers "github.com/agentgateway/agentgateway/controller/test/gomega/matchers"
 )
 
@@ -28,6 +31,9 @@ func TestAgentgatewayModelRouting(tt *testing.T) {
 
 	gw := modelRoutingGateway(t)
 
+	t.Run("Status", func(t base.Test) {
+		testAgentgatewayModelStatus(t)
+	})
 	t.Run("Visibility", func(t base.Test) {
 		testAgentgatewayModelVisibility(t, gw)
 	})
@@ -43,6 +49,13 @@ func TestAgentgatewayModelRouting(tt *testing.T) {
 	t.Run("FailoverVirtualModel", func(t base.Test) {
 		testAgentgatewayModelFailoverRouting(t, gw)
 	})
+}
+
+func testAgentgatewayModelStatus(t base.Test) {
+	assertions.EventuallyAgentgatewayModelCondition(t, "public-direct", modelRoutingNamespace, gwv1.RouteConditionAccepted, metav1.ConditionTrue)
+	assertions.EventuallyAgentgatewayModelCondition(t, "public-direct", modelRoutingNamespace, gwv1.RouteConditionResolvedRefs, metav1.ConditionTrue)
+	assertions.EventuallyAgentgatewayModelCondition(t, "invalid-target", modelRoutingNamespace, gwv1.RouteConditionAccepted, metav1.ConditionTrue)
+	assertions.EventuallyAgentgatewayModelCondition(t, "invalid-target", modelRoutingNamespace, gwv1.RouteConditionResolvedRefs, metav1.ConditionFalse)
 }
 
 func testAgentgatewayModelVisibility(t base.Test, gw base.Gateway) {

--- a/controller/test/e2e/testdata/modelrouting/setup.yaml
+++ b/controller/test/e2e/testdata/modelrouting/setup.yaml
@@ -223,3 +223,21 @@ spec:
       - modelRef:
           name: internal-fast
         priority: 1
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: invalid-target
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: model-routing
+    sectionName: llm
+  virtualModel:
+    weighted:
+      targets:
+      - modelRef:
+          name: does-not-exist
+        weight: 1

--- a/controller/test/e2e/testutils/assertions/assertions.go
+++ b/controller/test/e2e/testutils/assertions/assertions.go
@@ -119,6 +119,17 @@ func EventuallyGRPCRouteCondition(t Test, routeName string, routeNamespace strin
 	})
 }
 
+func EventuallyAgentgatewayModelCondition(t Test, modelName string, modelNamespace string, cond gwv1.RouteConditionType, expect metav1.ConditionStatus) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		model := &agentgateway.AgentgatewayModel{}
+		if err := t.E2EClusterContext().ControllerClient.Get(t.E2EContext(), ktypes.NamespacedName{Name: modelName, Namespace: modelNamespace}, model); err != nil {
+			return fmt.Errorf("failed to get AgentgatewayModel %s/%s: %w", modelNamespace, modelName, err)
+		}
+		return expectMatch(extractParentConditions(model.Status.Parents), matchers.HaveAnyParentCondition(string(cond), expect), "AgentgatewayModel %s/%s parent condition %s=%s", modelNamespace, modelName, cond, expect)
+	})
+}
+
 func EventuallyInferencePoolCondition(t Test, poolName string, poolNamespace string, cond inf.InferencePoolConditionType, expect metav1.ConditionStatus) {
 	t.Helper()
 	retry.UntilSuccessOrFail(t, func() error {


### PR DESCRIPTION
## Summary

- Reconcile `AgentgatewayModel` status through the status writer.
- Preserve route parent status owned by other controllers.
- Add unit and end-to-end coverage for accepted and unresolved models.

## Root cause

Model status was generated by translation but the live-status reader, status queue classification, and typed status syncer did not handle `AgentgatewayModel`. As a result, Kubernetes resources never received the computed status.

## Validation

- `go test ./controller/pkg/...`
- `go test -tags=e2e ./controller/test/e2e/... -run '^$'`
- `TestAgentgatewayModelRouting` on a local kind cluster
