### PR TITLE
llm: fix invalid max_token req case

### DIFF
--- a/crates/llm/src/tests/requests/policies/openai_with_inputs.json
+++ b/crates/llm/src/tests/requests/policies/openai_with_inputs.json
@@ -1,6 +1,6 @@
 {
   "model": "gpt-4o",
-  "max_tokens": 1024,
+  "max_output_tokens": 1024,
   "input": [
     {
       "type": "message",

--- a/crates/llm/src/tests/requests/policies/openai_with_inputs.openai.snap
+++ b/crates/llm/src/tests/requests/policies/openai_with_inputs.openai.snap
@@ -3,7 +3,7 @@ source: crates/llm/src/golden_tests.rs
 description: src/tests/requests/policies/openai_with_inputs.json
 info:
   model: gpt-4o
-  max_tokens: 1024
+  max_output_tokens: 1024
   input:
     - type: message
       role: user
@@ -76,7 +76,7 @@ info:
       }
     ],
     "model": "gpt-4o",
-    "max_tokens": 1024
+    "max_output_tokens": 1024
   },
   "parsed": {
     "input_format": "Responses",
@@ -84,7 +84,9 @@ info:
     "request_model": "gpt-4o",
     "provider": "openai",
     "streaming": false,
-    "params": {},
+    "params": {
+      "max_tokens": 1024
+    },
     "prompt": [
       {
         "role": "system",

--- a/crates/llm/src/tests/requests/policies/openai_with_text_input.json
+++ b/crates/llm/src/tests/requests/policies/openai_with_text_input.json
@@ -1,5 +1,5 @@
 {
   "model": "gpt-4o",
-  "max_tokens": 1024,
+  "max_output_tokens": 1024,
   "input": "Hello, world"
 }

--- a/crates/llm/src/tests/requests/policies/openai_with_text_input.openai.snap
+++ b/crates/llm/src/tests/requests/policies/openai_with_text_input.openai.snap
@@ -3,7 +3,7 @@ source: crates/llm/src/golden_tests.rs
 description: src/tests/requests/policies/openai_with_text_input.json
 info:
   model: gpt-4o
-  max_tokens: 1024
+  max_output_tokens: 1024
   input: "Hello, world"
 ---
 {
@@ -71,7 +71,7 @@ info:
       }
     ],
     "model": "gpt-4o",
-    "max_tokens": 1024
+    "max_output_tokens": 1024
   },
   "parsed": {
     "input_format": "Responses",
@@ -79,7 +79,9 @@ info:
     "request_model": "gpt-4o",
     "provider": "openai",
     "streaming": false,
-    "params": {},
+    "params": {
+      "max_tokens": 1024
+    },
     "prompt": [
       {
         "role": "system",


### PR DESCRIPTION
This was an unknown field for responses API. Just update the test to be
valid. No prod code changes.

Signed-off-by: John Howard <john.howard@solo.io>
