### PR TITLE
llm: don't 503 the whole request when an Anthropic server tool is pre…

### DIFF
--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -1268,7 +1268,7 @@ pub mod from_messages {
 	) -> Result<(bedrock::ConverseRequest, super::BedrockToolNameMap), AIError> {
 		let mut tool_name_map = super::BedrockToolNameMap::default();
 		for tool in req.tools.iter().flatten() {
-			tool_name_map.register(&tool.name);
+			tool_name_map.register(tool.name());
 		}
 		if let Some(messages::ToolChoice::Tool { name, .. }) = &req.tool_choice {
 			tool_name_map.register(name);
@@ -1320,6 +1320,13 @@ pub mod from_messages {
 		let pending_tool_config = if let Some(tools) = req.tools {
 			let mut bedrock_tools = Vec::with_capacity(tools.len());
 			for tool in tools {
+				let messages::Tool::Custom(tool) = tool else {
+					// Bedrock's Converse API has no native equivalent of an Anthropic server tool
+					// (e.g. web_search_20250305) executing upstream of the model. Drop it rather
+					// than fail the whole request; the model just won't see this tool offered.
+					tracing::warn!("Unsupported server tool in Bedrock conversion: {:?}", tool);
+					continue;
+				};
 				bedrock_tools.push((
 					bedrock::Tool::ToolSpec(bedrock::ToolSpecification {
 						name: tool_name_map.register(&tool.name),

--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -1324,7 +1324,7 @@ pub mod from_messages {
 					// Bedrock's Converse API has no native equivalent of an Anthropic server tool
 					// (e.g. web_search_20250305) executing upstream of the model. Drop it rather
 					// than fail the whole request; the model just won't see this tool offered.
-					tracing::warn!("Unsupported server tool in Bedrock conversion: {:?}", tool);
+					tracing::debug!("Unsupported server tool in Bedrock conversion: {:?}", tool);
 					continue;
 				};
 				bedrock_tools.push((

--- a/crates/llm/src/conversion/bedrock_tests.rs
+++ b/crates/llm/src/conversion/bedrock_tests.rs
@@ -500,18 +500,20 @@ fn test_adaptive_thinking_preserves_sampling_and_tool_choice() {
 		temperature: Some(0.7),
 		top_k: Some(50),
 		top_p: Some(0.8),
-		tools: Some(vec![messages::typed::Tool {
-			name: "lookup".to_string(),
-			description: Some("Lookup tool".to_string()),
-			input_schema: json!({
-				"type": "object",
-				"properties": {
-					"q": { "type": "string" }
-				},
-				"required": ["q"]
-			}),
-			cache_control: None,
-		}]),
+		tools: Some(vec![messages::typed::Tool::Custom(
+			messages::typed::CustomTool {
+				name: "lookup".to_string(),
+				description: Some("Lookup tool".to_string()),
+				input_schema: json!({
+					"type": "object",
+					"properties": {
+						"q": { "type": "string" }
+					},
+					"required": ["q"]
+				}),
+				cache_control: None,
+			},
+		)]),
 		tool_choice: Some(messages::typed::ToolChoice::Tool {
 			name: "lookup".to_string(),
 			disable_parallel_tool_use: None,
@@ -574,18 +576,20 @@ fn test_enabled_thinking_applies_sampling_and_tool_choice_constraints() {
 		temperature: Some(0.7),
 		top_k: Some(50),
 		top_p: Some(0.8),
-		tools: Some(vec![messages::typed::Tool {
-			name: "lookup".to_string(),
-			description: Some("Lookup tool".to_string()),
-			input_schema: json!({
-				"type": "object",
-				"properties": {
-					"q": { "type": "string" }
-				},
-				"required": ["q"]
-			}),
-			cache_control: None,
-		}]),
+		tools: Some(vec![messages::typed::Tool::Custom(
+			messages::typed::CustomTool {
+				name: "lookup".to_string(),
+				description: Some("Lookup tool".to_string()),
+				input_schema: json!({
+					"type": "object",
+					"properties": {
+						"q": { "type": "string" }
+					},
+					"required": ["q"]
+				}),
+				cache_control: None,
+			},
+		)]),
 		tool_choice: Some(messages::typed::ToolChoice::Auto {
 			disable_parallel_tool_use: None,
 		}),
@@ -1608,12 +1612,12 @@ fn test_messages_long_tool_names_fit_bedrock_tool_config() {
 				cache_control: None,
 			})],
 		}],
-		tools: Some(vec![messages::Tool {
+		tools: Some(vec![messages::Tool::Custom(messages::CustomTool {
 			name: long_name.to_string(),
 			description: Some("test".to_string()),
 			input_schema: serde_json::json!({"type": "object"}),
 			cache_control: None,
-		}]),
+		})]),
 		tool_choice: None,
 		system: None,
 		metadata: None,
@@ -1642,6 +1646,58 @@ fn test_messages_long_tool_names_fit_bedrock_tool_config() {
 }
 
 #[test]
+fn test_messages_request_with_server_tool_deserializes() {
+	use types::messages::typed as messages;
+
+	// Regression test for https://github.com/agentgateway/agentgateway/issues/2803:
+	// an Anthropic server tool (e.g. Claude Code's built-in web_search) has no
+	// `input_schema` and must not fail deserialization of the whole request.
+	let raw = serde_json::json!({
+		"model": "anthropic.claude-sonnet-4-20250514-v1:0",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "search the web"}]}
+		],
+		"tools": [
+			{"type": "web_search_20250305", "name": "web_search", "max_uses": 5},
+			{
+				"name": "get_weather",
+				"description": "Get the weather",
+				"input_schema": {"type": "object"}
+			}
+		]
+	});
+
+	let req: messages::Request =
+		serde_json::from_value(raw).expect("request with a server tool must deserialize");
+	{
+		let tools = req.tools.as_ref().expect("tools present");
+		assert_eq!(tools.len(), 2);
+		assert!(matches!(tools[0], messages::Tool::Server(_)));
+		assert_eq!(tools[0].name(), "web_search");
+		assert!(matches!(tools[1], messages::Tool::Custom(_)));
+		assert_eq!(tools[1].name(), "get_weather");
+	}
+
+	let provider = Provider {
+		model: None,
+		region: strng::new("us-west-2"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	};
+	let (out, _tool_map) = super::from_messages::translate_internal(req, &provider, None)
+		.expect("Bedrock conversion must not fail on a server tool");
+
+	// The server tool has no Bedrock equivalent and is dropped; the custom tool remains.
+	let tools = out.tool_config.expect("tool config present").tools;
+	assert_eq!(tools.len(), 1);
+	match &tools[0] {
+		types::bedrock::Tool::ToolSpec(spec) => assert_eq!(spec.name, "get_weather"),
+		other => panic!("expected a tool spec, got {other:?}"),
+	}
+}
+
+#[test]
 fn test_messages_long_tool_name_round_trip_response() {
 	use types::messages::typed as messages;
 
@@ -1664,12 +1720,12 @@ fn test_messages_long_tool_name_round_trip_response() {
 				cache_control: None,
 			})],
 		}],
-		tools: Some(vec![messages::Tool {
+		tools: Some(vec![messages::Tool::Custom(messages::CustomTool {
 			name: long_name.to_string(),
 			description: Some("test".to_string()),
 			input_schema: serde_json::json!({"type": "object"}),
 			cache_control: None,
-		}]),
+		})]),
 		tool_choice: None,
 		system: None,
 		metadata: None,

--- a/crates/llm/src/conversion/bedrock_tests.rs
+++ b/crates/llm/src/conversion/bedrock_tests.rs
@@ -1646,58 +1646,6 @@ fn test_messages_long_tool_names_fit_bedrock_tool_config() {
 }
 
 #[test]
-fn test_messages_request_with_server_tool_deserializes() {
-	use types::messages::typed as messages;
-
-	// Regression test for https://github.com/agentgateway/agentgateway/issues/2803:
-	// an Anthropic server tool (e.g. Claude Code's built-in web_search) has no
-	// `input_schema` and must not fail deserialization of the whole request.
-	let raw = serde_json::json!({
-		"model": "anthropic.claude-sonnet-4-20250514-v1:0",
-		"max_tokens": 1024,
-		"messages": [
-			{"role": "user", "content": [{"type": "text", "text": "search the web"}]}
-		],
-		"tools": [
-			{"type": "web_search_20250305", "name": "web_search", "max_uses": 5},
-			{
-				"name": "get_weather",
-				"description": "Get the weather",
-				"input_schema": {"type": "object"}
-			}
-		]
-	});
-
-	let req: messages::Request =
-		serde_json::from_value(raw).expect("request with a server tool must deserialize");
-	{
-		let tools = req.tools.as_ref().expect("tools present");
-		assert_eq!(tools.len(), 2);
-		assert!(matches!(tools[0], messages::Tool::Server(_)));
-		assert_eq!(tools[0].name(), "web_search");
-		assert!(matches!(tools[1], messages::Tool::Custom(_)));
-		assert_eq!(tools[1].name(), "get_weather");
-	}
-
-	let provider = Provider {
-		model: None,
-		region: strng::new("us-west-2"),
-		guardrail_identifier: None,
-		guardrail_version: None,
-	};
-	let (out, _tool_map) = super::from_messages::translate_internal(req, &provider, None)
-		.expect("Bedrock conversion must not fail on a server tool");
-
-	// The server tool has no Bedrock equivalent and is dropped; the custom tool remains.
-	let tools = out.tool_config.expect("tool config present").tools;
-	assert_eq!(tools.len(), 1);
-	match &tools[0] {
-		types::bedrock::Tool::ToolSpec(spec) => assert_eq!(spec.name, "get_weather"),
-		other => panic!("expected a tool spec, got {other:?}"),
-	}
-}
-
-#[test]
 fn test_messages_long_tool_name_round_trip_response() {
 	use types::messages::typed as messages;
 

--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -511,7 +511,7 @@ pub mod from_messages {
 					return events;
 				},
 				SseJsonEvent::Data(Err(e)) => {
-					tracing::warn!(
+					tracing::debug!(
 						"Failed to parse OpenAI stream response during translation: {}",
 						e
 					);

--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -990,15 +990,26 @@ pub mod from_messages {
 		let tools: Vec<completions::Tool> = tools
 			.into_iter()
 			.flat_map(|tools| tools.into_iter())
-			.map(|tool| {
-				completions::Tool::Function(completions::FunctionTool {
-					function: completions::FunctionObject {
-						name: tool.name,
-						description: tool.description,
-						parameters: Some(tool.input_schema),
-						strict: None,
-					},
-				})
+			.filter_map(|tool| match tool {
+				messages::Tool::Custom(tool) => {
+					Some(completions::Tool::Function(completions::FunctionTool {
+						function: completions::FunctionObject {
+							name: tool.name,
+							description: tool.description,
+							parameters: Some(tool.input_schema),
+							strict: None,
+						},
+					}))
+				},
+				// OpenAI completions has no equivalent of an Anthropic server-executed tool
+				// (e.g. web_search_20250305); drop it rather than fail the whole request.
+				messages::Tool::Server(tool) => {
+					tracing::warn!(
+						"Unsupported server tool in completions conversion: {:?}",
+						tool
+					);
+					None
+				},
 			})
 			.collect_vec();
 

--- a/crates/llm/src/conversion/messages.rs
+++ b/crates/llm/src/conversion/messages.rs
@@ -296,16 +296,18 @@ pub mod from_completions {
 			let mapped_tools: Vec<_> = tools
 				.iter()
 				.filter_map(|tool| match tool {
-					completions::Tool::Function(function_tool) => Some(messages::Tool {
-						name: function_tool.function.name.clone(),
-						description: function_tool.function.description.clone(),
-						input_schema: function_tool
-							.function
-							.parameters
-							.clone()
-							.unwrap_or_default(),
-						cache_control: None,
-					}),
+					completions::Tool::Function(function_tool) => {
+						Some(messages::Tool::Custom(messages::CustomTool {
+							name: function_tool.function.name.clone(),
+							description: function_tool.function.description.clone(),
+							input_schema: function_tool
+								.function
+								.parameters
+								.clone()
+								.unwrap_or_default(),
+							cache_control: None,
+						}))
+					},
 					_ => None,
 				})
 				.collect();

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -146,6 +146,7 @@ mod requests {
 		("basic", &[ANTHROPIC, COMPLETIONS, BEDROCK, VERTEX]),
 		("system_message", &[ANTHROPIC, COMPLETIONS, BEDROCK, VERTEX]),
 		("tools", &[ANTHROPIC, COMPLETIONS, BEDROCK, VERTEX]),
+		("server_tools", &[ANTHROPIC, COMPLETIONS, BEDROCK, VERTEX]),
 		("reasoning", &[ANTHROPIC, COMPLETIONS, BEDROCK, VERTEX]),
 		("cache_control", &[COMPLETIONS]),
 		("gpt_adaptive_thinking_with_tools", &[COMPLETIONS]),

--- a/crates/llm/src/tests/requests/messages/server_tools.anthropic.snap
+++ b/crates/llm/src/tests/requests/messages/server_tools.anthropic.snap
@@ -1,0 +1,60 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/server_tools.json
+info:
+  model: claude-opus-4-6
+  max_tokens: 64
+  messages:
+    - role: user
+      content: "Search the web for today's date"
+  tools:
+    - type: web_search_20250305
+      name: web_search
+      max_uses: 5
+    - name: get_weather
+      description: Get the weather
+      input_schema:
+        type: object
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": "Search the web for today's date"
+      }
+    ],
+    "model": "claude-opus-4-6",
+    "max_tokens": 64,
+    "tools": [
+      {
+        "type": "web_search_20250305",
+        "name": "web_search",
+        "max_uses": 5
+      },
+      {
+        "name": "get_weather",
+        "description": "Get the weather",
+        "input_schema": {
+          "type": "object"
+        }
+      }
+    ]
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-opus-4-6",
+    "provider": "anthropic",
+    "streaming": false,
+    "params": {
+      "max_tokens": 64
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Search the web for today's date"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/messages/server_tools.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/server_tools.bedrock.snap
@@ -1,0 +1,67 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/server_tools.json
+info:
+  model: claude-opus-4-6
+  max_tokens: 64
+  messages:
+    - role: user
+      content: "Search the web for today's date"
+  tools:
+    - type: web_search_20250305
+      name: web_search
+      max_uses: 5
+    - name: get_weather
+      description: Get the weather
+      input_schema:
+        type: object
+---
+{
+  "request": {
+    "modelId": "claude-opus-4-6",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "text": "Search the web for today's date"
+          }
+        ]
+      }
+    ],
+    "inferenceConfig": {
+      "maxTokens": 64
+    },
+    "toolConfig": {
+      "tools": [
+        {
+          "toolSpec": {
+            "name": "get_weather",
+            "description": "Get the weather",
+            "inputSchema": {
+              "json": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-opus-4-6",
+    "provider": "bedrock",
+    "streaming": false,
+    "params": {
+      "max_tokens": 64
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Search the web for today's date"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/messages/server_tools.completions.snap
+++ b/crates/llm/src/tests/requests/messages/server_tools.completions.snap
@@ -1,0 +1,64 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/server_tools.json
+info:
+  model: claude-opus-4-6
+  max_tokens: 64
+  messages:
+    - role: user
+      content: "Search the web for today's date"
+  tools:
+    - type: web_search_20250305
+      name: web_search
+      max_uses: 5
+    - name: get_weather
+      description: Get the weather
+      input_schema:
+        type: object
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Search the web for today's date"
+          }
+        ]
+      }
+    ],
+    "model": "claude-opus-4-6",
+    "max_completion_tokens": 64,
+    "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get the weather",
+          "parameters": {
+            "type": "object"
+          }
+        }
+      }
+    ]
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-opus-4-6",
+    "provider": "openai",
+    "streaming": false,
+    "params": {
+      "max_tokens": 64
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Search the web for today's date"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/messages/server_tools.json
+++ b/crates/llm/src/tests/requests/messages/server_tools.json
@@ -1,0 +1,24 @@
+{
+  "model": "claude-opus-4-6",
+  "max_tokens": 64,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Search the web for today's date"
+    }
+  ],
+  "tools": [
+    {
+      "type": "web_search_20250305",
+      "name": "web_search",
+      "max_uses": 5
+    },
+    {
+      "name": "get_weather",
+      "description": "Get the weather",
+      "input_schema": {
+        "type": "object"
+      }
+    }
+  ]
+}

--- a/crates/llm/src/tests/requests/messages/server_tools.vertex.snap
+++ b/crates/llm/src/tests/requests/messages/server_tools.vertex.snap
@@ -1,0 +1,60 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/server_tools.json
+info:
+  model: claude-opus-4-6
+  max_tokens: 64
+  messages:
+    - role: user
+      content: "Search the web for today's date"
+  tools:
+    - type: web_search_20250305
+      name: web_search
+      max_uses: 5
+    - name: get_weather
+      description: Get the weather
+      input_schema:
+        type: object
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": "Search the web for today's date"
+      }
+    ],
+    "anthropic_version": "vertex-2023-10-16",
+    "max_tokens": 64,
+    "tools": [
+      {
+        "type": "web_search_20250305",
+        "name": "web_search",
+        "max_uses": 5
+      },
+      {
+        "name": "get_weather",
+        "description": "Get the weather",
+        "input_schema": {
+          "type": "object"
+        }
+      }
+    ]
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-opus-4-6",
+    "provider": "vertex",
+    "streaming": false,
+    "params": {
+      "max_tokens": 64
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Search the web for today's date"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/types/messages.rs
+++ b/crates/llm/src/types/messages.rs
@@ -1025,9 +1025,36 @@ pub mod typed {
 		pub service_tier: Option<String>,
 	}
 
-	/// Tool definition
+	/// Tool definition. A client-defined custom tool always carries `input_schema` and no `type`
+	/// tag. An Anthropic server tool (`web_search_20250305`, `bash_20250124`, `computer_20250124`,
+	/// `text_editor_20250728`, `code_execution_20250522`, etc.) is tagged with `type` and never
+	/// carries `input_schema` since it runs server-side. `Custom` is tried first so existing custom
+	/// tool payloads (no `type` field) keep matching without a discriminant lookup.
 	#[derive(Debug, Serialize, Deserialize)]
-	pub struct Tool {
+	#[serde(untagged)]
+	pub enum Tool {
+		Custom(CustomTool),
+		Server(ServerTool),
+	}
+
+	impl Tool {
+		pub fn name(&self) -> &str {
+			match self {
+				Tool::Custom(tool) => &tool.name,
+				Tool::Server(tool) => &tool.name,
+			}
+		}
+
+		pub fn cache_control(&self) -> Option<&CacheControlEphemeral> {
+			match self {
+				Tool::Custom(tool) => tool.cache_control.as_ref(),
+				Tool::Server(tool) => tool.cache_control.as_ref(),
+			}
+		}
+	}
+
+	#[derive(Debug, Serialize, Deserialize)]
+	pub struct CustomTool {
 		/// Name of the tool
 		pub name: String,
 		/// Description of the tool
@@ -1038,6 +1065,25 @@ pub mod typed {
 		/// Create a cache control breakpoint at this content block
 		#[serde(skip_serializing_if = "Option::is_none")]
 		pub cache_control: Option<CacheControlEphemeral>,
+	}
+
+	/// An Anthropic server-executed tool (runs upstream of the provider, e.g. `web_search_20250305`).
+	/// We don't model every server tool's specific fields — just enough to round-trip the block
+	/// without failing deserialization. Providers that can't execute a server tool (e.g. Bedrock)
+	/// drop it rather than crash the whole request; see `conversion::bedrock`.
+	#[derive(Debug, Serialize, Deserialize)]
+	pub struct ServerTool {
+		/// Discriminant, e.g. "web_search_20250305"
+		#[serde(rename = "type")]
+		pub tool_type: String,
+		/// Name of the tool
+		pub name: String,
+		/// Create a cache control breakpoint at this content block
+		#[serde(skip_serializing_if = "Option::is_none")]
+		pub cache_control: Option<CacheControlEphemeral>,
+		/// Any other server-tool-specific fields (max_uses, allowed_domains, etc.)
+		#[serde(flatten)]
+		pub extra: std::collections::HashMap<String, serde_json::Value>,
 	}
 
 	/// Tool choice configuration


### PR DESCRIPTION
Anthropic server tools (`web_search_20250305`, `bash_20250124`, `computer_20250124`, `text_editor_20250728`, `code_execution_20250522`, etc.) carry no input_schema — just a type discriminator. The Tool struct required input_schema unconditionally, so any request containing a server tool failed deserialization entirely (503), even though the other tools/messages in the request were fine.

Make Tool a `#[serde(untagged)]` enum with Custom (existing shape) and Server (type-tagged, extra fields via `#[serde(flatten)])` variants. Bedrock Converse and OpenAI completions have no native equivalent for server-side tool execution, so their conversion paths drop Server tools with a warn log instead of failing the request; Custom tools are unaffected.

Should fix #2803