### PR TITLE
vertex: operator-configured billing labels for cost attribution

### DIFF
--- a/crates/agentgateway/src/http/auth/aws.rs
+++ b/crates/agentgateway/src/http/auth/aws.rs
@@ -455,7 +455,7 @@ fn validate_session_tag_value(key: &str, value: &str) -> anyhow::Result<()> {
 /// numbers, and booleans (common JWT claim types) stringify via
 /// [`cel::Value::as_string`]; anything else (null, lists, maps) is an error so
 /// misattribution fails closed.
-fn cel_value_to_string(v: cel::Value) -> anyhow::Result<String> {
+pub(crate) fn cel_value_to_string(v: cel::Value) -> anyhow::Result<String> {
 	// Materialize Dynamic so nested lookups (e.g. JWT claims) are concrete values.
 	v.always_materialize_owned()
 		.as_string()

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1,5 +1,6 @@
+use std::collections::HashSet;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use ::http::request::Parts;
 use ::http::uri::{Authority, PathAndQuery};
@@ -122,7 +123,7 @@ pub struct NamedAIProvider {
 pub enum AIProvider {
 	OpenAI(openai::Provider),
 	Gemini(gemini::Provider),
-	Vertex(vertex::Provider),
+	Vertex(VertexProvider),
 	Anthropic(anthropic::Provider),
 	Bedrock(BedrockProvider),
 	Azure(AzureProvider),
@@ -219,6 +220,241 @@ impl std::ops::DerefMut for AzureProvider {
 	}
 }
 
+// Wraps `vertex::Provider` (like `BedrockProvider`/`AzureProvider`) to add operator
+// config the wire provider does not carry. Intentionally NOT `deny_unknown_fields`
+// since we use `flatten` (serde cannot enforce it through a flattened field).
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schema", schemars(rename = "VertexProvider"))]
+pub struct VertexProvider {
+	#[serde(flatten)]
+	pub provider: vertex::Provider,
+	/// Billing labels attached to native Gemini `generateContent` requests for cost
+	/// attribution. Labels sent by the client are preserved unless a key conflicts,
+	/// in which case the operator-configured value wins. A label value is either
+	/// static (`value`) or a CEL expression evaluated against each request
+	/// (`expression`).
+	#[serde(
+		default,
+		skip_serializing_if = "VertexLabels::is_empty",
+		deserialize_with = "de_vertex_labels",
+		serialize_with = "ser_vertex_labels"
+	)]
+	#[cfg_attr(feature = "schema", schemars(with = "Vec<VertexLabel>"))]
+	pub labels: VertexLabels,
+}
+
+impl VertexProvider {
+	pub fn new(provider: vertex::Provider) -> Self {
+		Self {
+			provider,
+			labels: Default::default(),
+		}
+	}
+
+	pub fn cel_expressions(&self) -> impl Iterator<Item = &cel::Expression> {
+		self.labels.expressions()
+	}
+
+	/// Resolves the operator-configured labels against the request. Returns `None`
+	/// when no labels are configured.
+	pub fn resolve_labels(
+		&self,
+		req: Option<&RequestSnapshot>,
+	) -> anyhow::Result<Option<serde_json::Map<String, serde_json::Value>>> {
+		if self.labels.is_empty() {
+			return Ok(None);
+		}
+		let exec = Executor::new_request_snapshot(req);
+		self.labels.resolve(&exec).map(Some)
+	}
+}
+
+impl std::ops::Deref for VertexProvider {
+	type Target = vertex::Provider;
+
+	fn deref(&self) -> &Self::Target {
+		&self.provider
+	}
+}
+
+impl std::ops::DerefMut for VertexProvider {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.provider
+	}
+}
+
+/// A billing label attached to native Vertex Gemini `generateContent` requests for
+/// cost attribution. Exactly one of `value` and `expression` must be set.
+#[apply(schema!)]
+pub struct VertexLabel {
+	/// Label key.
+	pub key: String,
+	/// Static label value.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub value: Option<String>,
+	/// CEL expression evaluated against each request to produce the label value, for
+	/// example `jwt.sub` or `request.headers["x-team"]`. If the expression does not
+	/// produce a valid label value at request time, the request is rejected.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub expression: Option<Arc<cel::Expression>>,
+}
+
+// Cloud label limits: https://cloud.google.com/resource-manager/docs/labels-overview#requirements
+const MAX_VERTEX_LABELS: usize = 64;
+const MAX_VERTEX_LABEL_KEY_LEN: usize = 63;
+const MAX_VERTEX_LABEL_VALUE_LEN: usize = 63;
+
+/// The characters Google Cloud accepts in label keys: lowercase letters, numbers,
+/// underscores, and dashes; the first character must be a lowercase letter.
+static VERTEX_LABEL_KEY_CHARSET: LazyLock<regex::Regex> = LazyLock::new(|| {
+	regex::Regex::new(r"^[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]*$").expect("static regex compiles")
+});
+
+/// The characters Google Cloud accepts in label values.
+static VERTEX_LABEL_VALUE_CHARSET: LazyLock<regex::Regex> =
+	LazyLock::new(|| regex::Regex::new(r"^[\p{Ll}\p{Lo}\p{N}_-]*$").expect("static regex compiles"));
+
+fn validate_vertex_label_key(key: &str) -> anyhow::Result<()> {
+	let len = key.chars().count();
+	if !(1..=MAX_VERTEX_LABEL_KEY_LEN).contains(&len) {
+		anyhow::bail!("label key must be 1-{MAX_VERTEX_LABEL_KEY_LEN} characters, got {len}");
+	}
+	if !VERTEX_LABEL_KEY_CHARSET.is_match(key) {
+		anyhow::bail!("label key {key:?} contains characters Google Cloud does not accept");
+	}
+	Ok(())
+}
+
+fn validate_vertex_label_value(key: &str, value: &str) -> anyhow::Result<()> {
+	let len = value.chars().count();
+	if len > MAX_VERTEX_LABEL_VALUE_LEN {
+		anyhow::bail!(
+			"label {key:?} value must be at most {MAX_VERTEX_LABEL_VALUE_LEN} characters, got {len}"
+		);
+	}
+	if !VERTEX_LABEL_VALUE_CHARSET.is_match(value) {
+		anyhow::bail!("label {key:?} value {value:?} contains characters Google Cloud does not accept");
+	}
+	Ok(())
+}
+
+/// Operator-configured Vertex billing labels in their runtime form: static values
+/// pre-resolved, dynamic (CEL) values compiled and evaluated per request.
+#[derive(Debug, Clone, Default)]
+pub struct VertexLabels {
+	// (key, value) pairs, sorted by key.
+	static_labels: Arc<[(String, String)]>,
+	// (key, expression) pairs, sorted by key.
+	dynamic_labels: Arc<[(String, Arc<cel::Expression>)]>,
+}
+
+impl VertexLabels {
+	/// Validates and splits configured labels into static and dynamic sets. All
+	/// constraints that can be checked without a request are checked here, so config
+	/// errors surface at load time rather than per request.
+	pub fn try_new(labels: Vec<VertexLabel>) -> anyhow::Result<Self> {
+		if labels.len() > MAX_VERTEX_LABELS {
+			anyhow::bail!(
+				"at most {MAX_VERTEX_LABELS} labels are allowed, got {}",
+				labels.len()
+			);
+		}
+		let mut keys = HashSet::with_capacity(labels.len());
+		let mut static_labels = Vec::new();
+		let mut dynamic_labels = Vec::new();
+		for label in labels {
+			validate_vertex_label_key(&label.key)?;
+			if !keys.insert(label.key.clone()) {
+				anyhow::bail!("duplicate label key {:?}", label.key);
+			}
+			match (label.value, label.expression) {
+				(Some(value), None) => {
+					validate_vertex_label_value(&label.key, &value)?;
+					static_labels.push((label.key, value));
+				},
+				(None, Some(expression)) => dynamic_labels.push((label.key, expression)),
+				_ => anyhow::bail!(
+					"label {:?} must set exactly one of 'value' or 'expression'",
+					label.key
+				),
+			}
+		}
+		static_labels.sort();
+		dynamic_labels.sort_by(|(a, _), (b, _)| a.cmp(b));
+		Ok(Self {
+			static_labels: static_labels.into(),
+			dynamic_labels: dynamic_labels.into(),
+		})
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.static_labels.is_empty() && self.dynamic_labels.is_empty()
+	}
+
+	pub fn expressions(&self) -> impl Iterator<Item = &cel::Expression> {
+		self.dynamic_labels.iter().map(|(_, e)| e.as_ref())
+	}
+
+	/// Evaluates dynamic labels against the request and merges them with the static
+	/// labels. Fails closed: an expression that cannot produce a valid label value
+	/// is an error.
+	fn resolve(&self, exec: &Executor) -> anyhow::Result<serde_json::Map<String, serde_json::Value>> {
+		let mut resolved = serde_json::Map::new();
+		for (key, value) in self.static_labels.iter() {
+			resolved.insert(key.clone(), serde_json::Value::String(value.clone()));
+		}
+		for (key, expr) in self.dynamic_labels.iter() {
+			let value = exec
+				.eval(expr)
+				.map_err(anyhow::Error::from)
+				.and_then(crate::http::auth::aws::cel_value_to_string)
+				.and_then(|value| {
+					validate_vertex_label_value(key, &value)?;
+					Ok(value)
+				})
+				.map_err(|e| {
+					anyhow::anyhow!(
+						"label {:?} (expression {:?}): {e}",
+						key,
+						expr.original_expression
+					)
+				})?;
+			resolved.insert(key.clone(), serde_json::Value::String(value));
+		}
+		Ok(resolved)
+	}
+}
+
+fn de_vertex_labels<'de, D>(deserializer: D) -> Result<VertexLabels, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	let labels = Vec::<VertexLabel>::deserialize(deserializer)?;
+	VertexLabels::try_new(labels).map_err(serde::de::Error::custom)
+}
+
+fn ser_vertex_labels<S>(labels: &VertexLabels, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: serde::Serializer,
+{
+	let static_entries = labels.static_labels.iter().map(|(key, value)| VertexLabel {
+		key: key.clone(),
+		value: Some(value.clone()),
+		expression: None,
+	});
+	let dynamic_entries = labels
+		.dynamic_labels
+		.iter()
+		.map(|(key, expression)| VertexLabel {
+			key: key.clone(),
+			value: None,
+			expression: Some(expression.clone()),
+		});
+	serializer.collect_seq(static_entries.chain(dynamic_entries))
+}
+
 impl AIProvider {
 	pub fn bedrock(provider: bedrock::Provider) -> Self {
 		Self::Bedrock(BedrockProvider::new(provider))
@@ -226,6 +462,10 @@ impl AIProvider {
 
 	pub fn azure(provider: azure::Provider) -> Self {
 		Self::Azure(AzureProvider::new(provider))
+	}
+
+	pub fn vertex(provider: vertex::Provider) -> Self {
+		Self::Vertex(VertexProvider::new(provider))
 	}
 }
 
@@ -283,6 +523,7 @@ struct ChatRequestContext<'a> {
 	provider: &'a AIProvider,
 	headers: &'a HeaderMap,
 	prompt_caching: Option<&'a policy::PromptCachingConfig>,
+	request_snapshot: Option<&'a RequestSnapshot>,
 }
 
 // Context provider to each response translation
@@ -407,7 +648,14 @@ fn render_vertex_gemini(
 	};
 	match req {
 		types::ChatRequest::Completions(req) => {
-			conversion::vertex_gemini::from_completions::translate(&req, provider.model.as_deref())
+			let labels = provider
+				.resolve_labels(ctx.request_snapshot)
+				.map_err(|e| AIError::LabelResolution(strng::new(e.to_string())))?;
+			conversion::vertex_gemini::from_completions::translate(
+				&req,
+				provider.model.as_deref(),
+				labels.as_ref(),
+			)
 		},
 		_ => Err(AIError::UnsupportedConversion(strng::literal!(
 			"vertex gemini only supports completions input"
@@ -1808,12 +2056,14 @@ impl AIProvider {
 			},
 		};
 
+		let request_snapshot = log.as_ref().and_then(|l| l.request_snapshot.clone());
 		let rendered = chat_translation.render_request(
 			chat_request(req),
 			&ChatRequestContext {
 				provider: self,
 				headers: &parts.headers,
 				prompt_caching: policies.and_then(|p| p.prompt_caching.as_ref()),
+				request_snapshot: request_snapshot.as_deref(),
 			},
 		)?;
 		llm_info.provider_state = rendered.provider_state;

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -24,7 +24,7 @@ fn llm_request_with_tokens(input_tokens: Option<u64>) -> LLMRequest {
 
 #[test]
 fn vertex_gemini_uses_native_completions_and_compat_fallbacks() {
-	let provider = AIProvider::Vertex(vertex::Provider {
+	let provider = AIProvider::vertex(vertex::Provider {
 		project_id: strng::new("test-project"),
 		model: None,
 		region: None,
@@ -691,7 +691,7 @@ async fn count_tokens_uses_native_endpoint_after_model_alias() {
 	use crate::test_helpers::proxymock::setup_proxy_test;
 	use crate::types::agent::BackendTarget;
 
-	let provider = AIProvider::Vertex(vertex::Provider {
+	let provider = AIProvider::vertex(vertex::Provider {
 		model: None,
 		region: None,
 		project_id: strng::new("test-project"),
@@ -749,7 +749,7 @@ async fn vertex_anthropic_messages_prepares_vertex_body() {
 	use crate::test_helpers::proxymock::setup_proxy_test;
 	use crate::types::agent::BackendTarget;
 
-	let provider = AIProvider::Vertex(vertex::Provider {
+	let provider = AIProvider::vertex(vertex::Provider {
 		model: None,
 		region: Some(strng::new("us-central1")),
 		project_id: strng::new("test-project"),
@@ -1768,7 +1768,7 @@ fn setup_request_gemini_applies_path_prefix_with_host_override() {
 #[test]
 fn setup_request_vertex_applies_path_prefix_with_host_override() {
 	assert_prefixed_host_override_path(
-		AIProvider::Vertex(vertex::Provider {
+		AIProvider::vertex(vertex::Provider {
 			model: None,
 			region: Some(strng::new("us-central1")),
 			project_id: strng::new("example-project"),
@@ -2306,7 +2306,7 @@ async fn responses_passthrough_stream_skips_completion_when_disabled() {
 }
 
 fn vertex_provider(model: &str) -> AIProvider {
-	AIProvider::Vertex(vertex::Provider {
+	AIProvider::vertex(vertex::Provider {
 		model: Some(strng::new(model)),
 		region: None,
 		project_id: strng::new("test-project"),
@@ -2468,4 +2468,164 @@ fn fixed_providers_classify_by_family() {
 		),
 		CacheTokenConvention::InputIncludesCache,
 	);
+}
+
+// ---------- Vertex operator labels ----------
+
+fn vertex_label(key: &str, value: Option<&str>, expression: Option<&str>) -> VertexLabel {
+	VertexLabel {
+		key: key.to_string(),
+		value: value.map(str::to_string),
+		expression: expression
+			.map(|e| Arc::new(crate::cel::Expression::new_strict(e).expect("valid CEL expression"))),
+	}
+}
+
+#[test]
+fn vertex_labels_are_validated_at_config_time() {
+	// A static and a dynamic label together are valid
+	assert!(
+		VertexLabels::try_new(vec![
+			vertex_label("team", Some("ai"), None),
+			vertex_label("tenant", None, Some(r#"request.headers["x-tenant"]"#)),
+		])
+		.is_ok()
+	);
+
+	// Keys must match Google Cloud's label requirements
+	let too_long = "a".repeat(64);
+	for bad_key in ["", "Uppercase", "1starts-with-digit", too_long.as_str()] {
+		assert!(
+			VertexLabels::try_new(vec![vertex_label(bad_key, Some("v"), None)]).is_err(),
+			"key {bad_key:?} must be rejected"
+		);
+	}
+
+	// Static values are validated at config time
+	assert!(VertexLabels::try_new(vec![vertex_label("team", Some("Not Valid"), None)]).is_err());
+
+	// Duplicate keys are rejected
+	assert!(
+		VertexLabels::try_new(vec![
+			vertex_label("team", Some("a"), None),
+			vertex_label("team", Some("b"), None),
+		])
+		.is_err()
+	);
+
+	// Exactly one of value/expression must be set
+	assert!(VertexLabels::try_new(vec![vertex_label("team", Some("a"), Some(r#""b""#))]).is_err());
+	assert!(VertexLabels::try_new(vec![vertex_label("team", None, None)]).is_err());
+}
+
+#[test]
+fn vertex_provider_config_parses_labels() {
+	let yaml = r#"
+projectId: test-project
+labels:
+- key: team
+  value: ai
+- key: tenant
+  expression: request.headers["x-tenant"]
+"#;
+	let p: VertexProvider = serdes::yamlviajson::from_str(yaml).unwrap();
+	assert_eq!(p.project_id.as_str(), "test-project");
+	assert!(!p.labels.is_empty());
+	assert_eq!(p.cel_expressions().count(), 1);
+
+	// Invalid labels are rejected at config load
+	let yaml = r#"
+projectId: test-project
+labels:
+- key: Team
+  value: ai
+"#;
+	assert!(serdes::yamlviajson::from_str::<VertexProvider>(yaml).is_err());
+}
+
+/// Snapshot of an original client request with an x-tenant header.
+fn vertex_label_request_snapshot() -> crate::cel::RequestSnapshot {
+	let mut req = ::http::Request::builder()
+		.method(::http::Method::POST)
+		.uri("http://example.com/v1/chat/completions")
+		.header("x-tenant", "acme")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	crate::cel::snapshot_request(&mut req, false)
+}
+
+#[test]
+fn vertex_operator_labels_merge_into_generate_content_request() {
+	let provider = AIProvider::Vertex(VertexProvider {
+		provider: vertex::Provider {
+			project_id: strng::new("test-project"),
+			model: None,
+			region: None,
+		},
+		labels: VertexLabels::try_new(vec![
+			vertex_label("team", Some("ai"), None),
+			vertex_label("tenant", None, Some(r#"request.headers["x-tenant"]"#)),
+		])
+		.unwrap(),
+	});
+	let snap = vertex_label_request_snapshot();
+
+	let chat_req: types::completions::Request = serde_json::from_value(serde_json::json!({
+		"model": "gemini-2.5-flash",
+		"messages": [{"role": "user", "content": "hi"}],
+		"labels": {"team": "client-spoofed", "env": "client"}
+	}))
+	.unwrap();
+
+	let body = render_vertex_gemini(
+		types::ChatRequest::Completions(chat_req),
+		&ChatRequestContext {
+			provider: &provider,
+			headers: &HeaderMap::new(),
+			prompt_caching: None,
+			request_snapshot: Some(&snap),
+		},
+	)
+	.unwrap();
+	let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	// Operator values win on conflict; other client labels are preserved.
+	assert_eq!(body["labels"]["team"], "ai");
+	assert_eq!(body["labels"]["tenant"], "acme");
+	assert_eq!(body["labels"]["env"], "client");
+}
+
+#[test]
+fn vertex_operator_labels_fail_closed() {
+	let provider = AIProvider::Vertex(VertexProvider {
+		provider: vertex::Provider {
+			project_id: strng::new("test-project"),
+			model: None,
+			region: None,
+		},
+		labels: VertexLabels::try_new(vec![vertex_label(
+			"tenant",
+			None,
+			Some(r#"request.headers["x-missing"]"#),
+		)])
+		.unwrap(),
+	});
+	let snap = vertex_label_request_snapshot();
+
+	let chat_req: types::completions::Request = serde_json::from_value(serde_json::json!({
+		"model": "gemini-2.5-flash",
+		"messages": [{"role": "user", "content": "hi"}]
+	}))
+	.unwrap();
+
+	let err = render_vertex_gemini(
+		types::ChatRequest::Completions(chat_req),
+		&ChatRequestContext {
+			provider: &provider,
+			headers: &HeaderMap::new(),
+			prompt_caching: None,
+			request_snapshot: Some(&snap),
+		},
+	)
+	.expect_err("an expression that cannot be resolved must reject the request");
+	assert!(matches!(err, AIError::LabelResolution(_)), "got {err}");
 }

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -300,7 +300,8 @@ impl ProxyError {
 				| llm::AIError::UnsupportedModel
 				| llm::AIError::UnsupportedContent
 				| llm::AIError::UnsupportedConversion(_)
-				| llm::AIError::RequestParsing(_) => StatusCode::BAD_REQUEST,
+				| llm::AIError::RequestParsing(_)
+				| llm::AIError::LabelResolution(_) => StatusCode::BAD_REQUEST,
 				llm::AIError::ModelNotFound => StatusCode::NOT_FOUND,
 				llm::AIError::RequestTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
 				llm::AIError::UnsupportedEncoding(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -348,6 +348,13 @@ impl BackendPolicies {
 				ctx.register_expression(expr);
 			}
 		}
+		if let Some(provider) = self.llm_provider.as_ref()
+			&& let llm::AIProvider::Vertex(vertex) = &provider.provider
+		{
+			for expr in vertex.cel_expressions() {
+				ctx.register_expression(expr);
+			}
+		}
 		if let Some(health) = self.health.as_ref() {
 			health.register_expressions(ctx);
 		}

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1824,7 +1824,7 @@ pub(crate) fn backend_with_policies_from_proto(
 						Some(provider::Provider::Gemini(gemini)) => AIProvider::Gemini(llm::gemini::Provider {
 							model: gemini.model.as_deref().map(strng::new),
 						}),
-						Some(provider::Provider::Vertex(vertex)) => AIProvider::Vertex(llm::vertex::Provider {
+						Some(provider::Provider::Vertex(vertex)) => AIProvider::vertex(llm::vertex::Provider {
 							model: vertex.model.as_deref().map(strng::new),
 							region: (!vertex.region.is_empty()).then(|| strng::new(&vertex.region)),
 							project_id: strng::new(&vertex.project_id),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -4249,7 +4249,7 @@ async fn convert_llm_config(
 			},
 			LocalModelAIProvider::Preset(preset) => AIProvider::Custom(preset.provider(model.clone())),
 			LocalModelAIProvider::Builtin(LocalBuiltinModelAIProvider::Vertex) => {
-				AIProvider::Vertex(crate::llm::vertex::Provider {
+				AIProvider::vertex(crate::llm::vertex::Provider {
 					model,
 					region: p.vertex_region,
 					project_id: p.vertex_project.context("vertex requires vertex_project")?,

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -366,8 +366,8 @@ backends:
                     provider:
                       vertex:
                         model: claude-haiku-4-5-20251001
-                        region: global
                         projectId: my-vertex-project
+                        region: global
                     hostOverride: ~
                     pathOverride: ~
                     pathPrefix: ~

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -83,14 +83,32 @@ pub mod from_completions {
 	pub fn translate(
 		req: &types::completions::Request,
 		configured_model: Option<&str>,
+		operator_labels: Option<&serde_json::Map<String, Value>>,
 	) -> Result<Vec<u8>, AIError> {
-		let out = build_request(req, configured_model)?;
+		let out = build_request(req, configured_model, operator_labels)?;
 		serde_json::to_vec(&out).map_err(AIError::RequestMarshal)
+	}
+
+	/// Merge operator-configured labels over client-sent labels. On a key conflict the
+	/// operator's value wins, so a caller cannot override the gateway's billing attribution.
+	fn merge_labels(
+		client_labels: Option<serde_json::Map<String, Value>>,
+		operator_labels: Option<&serde_json::Map<String, Value>>,
+	) -> Option<serde_json::Map<String, Value>> {
+		let Some(operator_labels) = operator_labels.filter(|l| !l.is_empty()) else {
+			return client_labels;
+		};
+		let mut merged = client_labels.unwrap_or_default();
+		for (key, value) in operator_labels {
+			merged.insert(key.clone(), value.clone());
+		}
+		Some(merged)
 	}
 
 	pub(super) fn build_request(
 		req: &types::completions::Request,
 		configured_model: Option<&str>,
+		operator_labels: Option<&serde_json::Map<String, Value>>,
 	) -> Result<vg::GenerateContentRequest, AIError> {
 		let model = configured_model
 			.or(req.model.as_deref())
@@ -139,7 +157,10 @@ pub mod from_completions {
 			None => Vec::new(),
 		};
 
-		let labels = req.rest.get("labels").and_then(|v| v.as_object().cloned());
+		let labels = merge_labels(
+			req.rest.get("labels").and_then(|v| v.as_object().cloned()),
+			operator_labels,
+		);
 
 		let (system_instruction, tools, tool_config) = if cached_content.is_some() {
 			let dropped: Vec<&str> = [

--- a/crates/llm/src/conversion/vertex_gemini_tests.rs
+++ b/crates/llm/src/conversion/vertex_gemini_tests.rs
@@ -7,7 +7,7 @@ fn req(v: Value) -> types::completions::Request {
 }
 
 fn to_gemini(v: Value) -> Value {
-	let bytes = from_completions::translate(&req(v), None).expect("translate ok");
+	let bytes = from_completions::translate(&req(v), None, None).expect("translate ok");
 	serde_json::from_slice(&bytes).expect("valid json")
 }
 
@@ -71,6 +71,7 @@ fn gs_url_without_extension_or_hint_is_rejected() {
 			]}]
 		})),
 		None,
+		None,
 	);
 	assert!(
 		err.is_err(),
@@ -113,6 +114,7 @@ fn http_image_url_is_rejected() {
 				{ "type": "image_url", "image_url": { "url": "https://example.com/cat.png" } }
 			]}]
 		})),
+		None,
 		None,
 	);
 	assert!(err.is_err(), "http(s) image_url must be rejected");
@@ -1073,6 +1075,79 @@ fn labels_pass_through_at_top_level() {
 		"labels": { "team": "ai" }
 	}));
 	assert_eq!(g["labels"]["team"], "ai");
+}
+
+/// Translate with operator labels and return the outbound JSON.
+fn to_gemini_with_operator_labels(v: Value, operator_labels: Value) -> Value {
+	let labels = operator_labels
+		.as_object()
+		.expect("operator labels are an object")
+		.clone();
+	let bytes = from_completions::translate(&req(v), None, Some(&labels)).expect("translate ok");
+	serde_json::from_slice(&bytes).expect("valid json")
+}
+
+#[test]
+fn operator_labels_are_added_without_client_labels() {
+	let g = to_gemini_with_operator_labels(
+		json!({
+			"model": "gemini-2.5-flash",
+			"messages": [{ "role": "user", "content": "x" }]
+		}),
+		json!({ "cost-center": "platform" }),
+	);
+	assert_eq!(g["labels"]["cost-center"], "platform");
+}
+
+#[test]
+fn operator_labels_merge_with_client_labels() {
+	let g = to_gemini_with_operator_labels(
+		json!({
+			"model": "gemini-2.5-flash",
+			"messages": [{ "role": "user", "content": "x" }],
+			"labels": { "team": "ai" }
+		}),
+		json!({ "cost-center": "platform" }),
+	);
+	assert_eq!(g["labels"]["team"], "ai");
+	assert_eq!(g["labels"]["cost-center"], "platform");
+}
+
+#[test]
+fn operator_labels_win_over_client_labels() {
+	let g = to_gemini_with_operator_labels(
+		json!({
+			"model": "gemini-2.5-flash",
+			"messages": [{ "role": "user", "content": "x" }],
+			"labels": { "team": "spoofed", "env": "client" }
+		}),
+		json!({ "team": "ai" }),
+	);
+	// The operator's value wins on conflict; other client labels are preserved.
+	assert_eq!(g["labels"]["team"], "ai");
+	assert_eq!(g["labels"]["env"], "client");
+}
+
+#[test]
+fn empty_operator_labels_leave_client_labels_untouched() {
+	let g = to_gemini_with_operator_labels(
+		json!({
+			"model": "gemini-2.5-flash",
+			"messages": [{ "role": "user", "content": "x" }],
+			"labels": { "team": "ai" }
+		}),
+		json!({}),
+	);
+	assert_eq!(g["labels"]["team"], "ai");
+
+	let g = to_gemini_with_operator_labels(
+		json!({
+			"model": "gemini-2.5-flash",
+			"messages": [{ "role": "user", "content": "x" }]
+		}),
+		json!({}),
+	);
+	assert!(g.get("labels").is_none() || g["labels"].is_null());
 }
 
 // ---------- Response: content / reasoning / tool calls ----------

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -204,7 +204,7 @@ mod requests {
 							.map(|r| r.body)
 					}),
 					VERTEX_GEMINI => test_request(VERTEX_GEMINI, &path, |i| {
-						conversion::vertex_gemini::from_completions::translate(i, Some("gemini-2.5-pro"))
+						conversion::vertex_gemini::from_completions::translate(i, Some("gemini-2.5-pro"), None)
 					}),
 					other => panic!("unsupported provider in COMPLETION_REQUESTS: {other}"),
 				}

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -373,6 +373,8 @@ pub enum AIError {
 	ResponseMarshal(serde_json::Error),
 	#[error("unsupported content encoding: {0}")]
 	UnsupportedEncoding(Strng),
+	#[error("failed to resolve labels: {0}")]
+	LabelResolution(Strng),
 	#[error("failed to encode response: {0}")]
 	Encoding(axum_core::Error),
 	#[error("error computing tokens")]

--- a/schema/config.json
+++ b/schema/config.json
@@ -8160,11 +8160,49 @@
         "projectId": {
           "description": "Google Cloud project ID for Vertex AI.",
           "type": "string"
+        },
+        "labels": {
+          "description": "Billing labels attached to native Gemini `generateContent` requests for cost\nattribution. Labels sent by the client are preserved unless a key conflicts,\nin which case the operator-configured value wins. A label value is either\nstatic (`value`) or a CEL expression evaluated against each request\n(`expression`).",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VertexLabel"
+          }
+        }
+      },
+      "required": [
+        "projectId"
+      ]
+    },
+    "VertexLabel": {
+      "description": "A billing label attached to native Vertex Gemini `generateContent` requests for\ncost attribution. Exactly one of `value` and `expression` must be set.",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Label key.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Static label value.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expression": {
+          "description": "CEL expression evaluated against each request to produce the label value, for\nexample `jwt.sub` or `request.headers[\"x-team\"]`. If the expression does not\nproduce a valid label value at request time, the request is rejected.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expression"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
-        "projectId"
+        "key"
       ]
     },
     "AnthropicProvider": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -5304,6 +5304,10 @@
 |`binds[].listeners[].routes[].backends[].ai.provider.vertex.model`|string|Model ID to send to Vertex AI, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`binds[].listeners[].routes[].backends[].ai.provider.vertex.projectId`|string|Google Cloud project ID for Vertex AI.|
+|`binds[].listeners[].routes[].backends[].ai.provider.vertex.labels`|[]object|Billing labels attached to native Gemini `generateContent` requests for cost<br>attribution. Labels sent by the client are preserved unless a key conflicts,<br>in which case the operator-configured value wins. A label value is either<br>static (`value`) or a CEL expression evaluated against each request<br>(`expression`).|
+|`binds[].listeners[].routes[].backends[].ai.provider.vertex.labels[].key`|string|Label key.|
+|`binds[].listeners[].routes[].backends[].ai.provider.vertex.labels[].value`|string|Static label value.|
+|`binds[].listeners[].routes[].backends[].ai.provider.vertex.labels[].expression`|string|CEL expression evaluated against each request to produce the label value, for<br>example `jwt.sub` or `request.headers["x-team"]`. If the expression does not<br>produce a valid label value at request time, the request is rejected.|
 |`binds[].listeners[].routes[].backends[].ai.provider.anthropic`|object||
 |`binds[].listeners[].routes[].backends[].ai.provider.anthropic.model`|string|Model ID to send to Anthropic, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.provider.bedrock`|object||
@@ -8605,6 +8609,10 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.model`|string|Model ID to send to Vertex AI, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.projectId`|string|Google Cloud project ID for Vertex AI.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.labels`|[]object|Billing labels attached to native Gemini `generateContent` requests for cost<br>attribution. Labels sent by the client are preserved unless a key conflicts,<br>in which case the operator-configured value wins. A label value is either<br>static (`value`) or a CEL expression evaluated against each request<br>(`expression`).|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].key`|string|Label key.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].value`|string|Static label value.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].expression`|string|CEL expression evaluated against each request to produce the label value, for<br>example `jwt.sub` or `request.headers["x-team"]`. If the expression does not<br>produce a valid label value at request time, the request is rejected.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.anthropic`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.anthropic.model`|string|Model ID to send to Anthropic, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.bedrock`|object||
@@ -22801,6 +22809,10 @@
 |`backends[].ai.provider.vertex.model`|string|Model ID to send to Vertex AI, overriding the model in the client request.|
 |`backends[].ai.provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`backends[].ai.provider.vertex.projectId`|string|Google Cloud project ID for Vertex AI.|
+|`backends[].ai.provider.vertex.labels`|[]object|Billing labels attached to native Gemini `generateContent` requests for cost<br>attribution. Labels sent by the client are preserved unless a key conflicts,<br>in which case the operator-configured value wins. A label value is either<br>static (`value`) or a CEL expression evaluated against each request<br>(`expression`).|
+|`backends[].ai.provider.vertex.labels[].key`|string|Label key.|
+|`backends[].ai.provider.vertex.labels[].value`|string|Static label value.|
+|`backends[].ai.provider.vertex.labels[].expression`|string|CEL expression evaluated against each request to produce the label value, for<br>example `jwt.sub` or `request.headers["x-team"]`. If the expression does not<br>produce a valid label value at request time, the request is rejected.|
 |`backends[].ai.provider.anthropic`|object||
 |`backends[].ai.provider.anthropic.model`|string|Model ID to send to Anthropic, overriding the model in the client request.|
 |`backends[].ai.provider.bedrock`|object||
@@ -26102,6 +26114,10 @@
 |`backends[].ai.groups[].providers[].provider.vertex.model`|string|Model ID to send to Vertex AI, overriding the model in the client request.|
 |`backends[].ai.groups[].providers[].provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`backends[].ai.groups[].providers[].provider.vertex.projectId`|string|Google Cloud project ID for Vertex AI.|
+|`backends[].ai.groups[].providers[].provider.vertex.labels`|[]object|Billing labels attached to native Gemini `generateContent` requests for cost<br>attribution. Labels sent by the client are preserved unless a key conflicts,<br>in which case the operator-configured value wins. A label value is either<br>static (`value`) or a CEL expression evaluated against each request<br>(`expression`).|
+|`backends[].ai.groups[].providers[].provider.vertex.labels[].key`|string|Label key.|
+|`backends[].ai.groups[].providers[].provider.vertex.labels[].value`|string|Static label value.|
+|`backends[].ai.groups[].providers[].provider.vertex.labels[].expression`|string|CEL expression evaluated against each request to produce the label value, for<br>example `jwt.sub` or `request.headers["x-team"]`. If the expression does not<br>produce a valid label value at request time, the request is rejected.|
 |`backends[].ai.groups[].providers[].provider.anthropic`|object||
 |`backends[].ai.groups[].providers[].provider.anthropic.model`|string|Model ID to send to Anthropic, overriding the model in the client request.|
 |`backends[].ai.groups[].providers[].provider.bedrock`|object||
@@ -37832,6 +37848,10 @@
 |`routeGroups[].routes[].backends[].ai.provider.vertex.model`|string|Model ID to send to Vertex AI, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`routeGroups[].routes[].backends[].ai.provider.vertex.projectId`|string|Google Cloud project ID for Vertex AI.|
+|`routeGroups[].routes[].backends[].ai.provider.vertex.labels`|[]object|Billing labels attached to native Gemini `generateContent` requests for cost<br>attribution. Labels sent by the client are preserved unless a key conflicts,<br>in which case the operator-configured value wins. A label value is either<br>static (`value`) or a CEL expression evaluated against each request<br>(`expression`).|
+|`routeGroups[].routes[].backends[].ai.provider.vertex.labels[].key`|string|Label key.|
+|`routeGroups[].routes[].backends[].ai.provider.vertex.labels[].value`|string|Static label value.|
+|`routeGroups[].routes[].backends[].ai.provider.vertex.labels[].expression`|string|CEL expression evaluated against each request to produce the label value, for<br>example `jwt.sub` or `request.headers["x-team"]`. If the expression does not<br>produce a valid label value at request time, the request is rejected.|
 |`routeGroups[].routes[].backends[].ai.provider.anthropic`|object||
 |`routeGroups[].routes[].backends[].ai.provider.anthropic.model`|string|Model ID to send to Anthropic, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.provider.bedrock`|object||
@@ -41133,6 +41153,10 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.model`|string|Model ID to send to Vertex AI, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.projectId`|string|Google Cloud project ID for Vertex AI.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.labels`|[]object|Billing labels attached to native Gemini `generateContent` requests for cost<br>attribution. Labels sent by the client are preserved unless a key conflicts,<br>in which case the operator-configured value wins. A label value is either<br>static (`value`) or a CEL expression evaluated against each request<br>(`expression`).|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].key`|string|Label key.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].value`|string|Static label value.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].expression`|string|CEL expression evaluated against each request to produce the label value, for<br>example `jwt.sub` or `request.headers["x-team"]`. If the expression does not<br>produce a valid label value at request time, the request is rejected.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.anthropic`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.anthropic.model`|string|Model ID to send to Anthropic, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.bedrock`|object||
@@ -55435,6 +55459,10 @@
 |`routes[].backends[].ai.provider.vertex.model`|string|Model ID to send to Vertex AI, overriding the model in the client request.|
 |`routes[].backends[].ai.provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`routes[].backends[].ai.provider.vertex.projectId`|string|Google Cloud project ID for Vertex AI.|
+|`routes[].backends[].ai.provider.vertex.labels`|[]object|Billing labels attached to native Gemini `generateContent` requests for cost<br>attribution. Labels sent by the client are preserved unless a key conflicts,<br>in which case the operator-configured value wins. A label value is either<br>static (`value`) or a CEL expression evaluated against each request<br>(`expression`).|
+|`routes[].backends[].ai.provider.vertex.labels[].key`|string|Label key.|
+|`routes[].backends[].ai.provider.vertex.labels[].value`|string|Static label value.|
+|`routes[].backends[].ai.provider.vertex.labels[].expression`|string|CEL expression evaluated against each request to produce the label value, for<br>example `jwt.sub` or `request.headers["x-team"]`. If the expression does not<br>produce a valid label value at request time, the request is rejected.|
 |`routes[].backends[].ai.provider.anthropic`|object||
 |`routes[].backends[].ai.provider.anthropic.model`|string|Model ID to send to Anthropic, overriding the model in the client request.|
 |`routes[].backends[].ai.provider.bedrock`|object||
@@ -58736,6 +58764,10 @@
 |`routes[].backends[].ai.groups[].providers[].provider.vertex.model`|string|Model ID to send to Vertex AI, overriding the model in the client request.|
 |`routes[].backends[].ai.groups[].providers[].provider.vertex.region`|string|Vertex AI region. Special values: `global` uses the global endpoint, while `us` and `eu`<br>use restricted multi-region endpoints. Other values are treated as regional locations.|
 |`routes[].backends[].ai.groups[].providers[].provider.vertex.projectId`|string|Google Cloud project ID for Vertex AI.|
+|`routes[].backends[].ai.groups[].providers[].provider.vertex.labels`|[]object|Billing labels attached to native Gemini `generateContent` requests for cost<br>attribution. Labels sent by the client are preserved unless a key conflicts,<br>in which case the operator-configured value wins. A label value is either<br>static (`value`) or a CEL expression evaluated against each request<br>(`expression`).|
+|`routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].key`|string|Label key.|
+|`routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].value`|string|Static label value.|
+|`routes[].backends[].ai.groups[].providers[].provider.vertex.labels[].expression`|string|CEL expression evaluated against each request to produce the label value, for<br>example `jwt.sub` or `request.headers["x-team"]`. If the expression does not<br>produce a valid label value at request time, the request is rejected.|
 |`routes[].backends[].ai.groups[].providers[].provider.anthropic`|object||
 |`routes[].backends[].ai.groups[].providers[].provider.anthropic.model`|string|Model ID to send to Anthropic, overriding the model in the client request.|
 |`routes[].backends[].ai.groups[].providers[].provider.bedrock`|object||


### PR DESCRIPTION

#2023 shipped the native Vertex `generateContent`/`streamGenerateContent`
path and a top-level `labels` field on the request. That field is
caller pass-through: the label values come from the client request
(`crates/llm/src/conversion/vertex_gemini.rs`, `req.rest.get("labels")`),
so the operator cannot decide how Vertex spend is attributed. A caller can
omit labels or send another team's value, and the value that reaches Google
Cloud billing is caller-asserted, not operator-set.

This change makes those labels operator-configurable, so the value reaching
Google Cloud billing on the request is operator-decided. That is what turns
Vertex cost attribution from caller-asserted into invoice-grade: the
operator-chosen App/Team/tenant value reaches billing on the
`generateContent` request labels, and finance can slice the Vertex bill by
those dimensions with the value set by the operator rather than trusted from
the caller.

The gateway already provides invoice-grade attribution on AWS via CEL-valued
STS session tags (#2435/#2447, `AwsSessionTag { key, value, expression }` in
`crates/agentgateway/src/http/auth/aws.rs`), which surface in the AWS Cost &
Usage Report. This applies the same pattern to the second cloud, so operators
get operator-set attribution on both major clouds: Bedrock via session tags,
Vertex via these labels.

### What this does

- Adds an operator-set `labels` field to the Vertex provider config. Each
  label is either a static `value` or a CEL `expression` evaluated against
  the request:

  ```yaml
  backends:
  - ai:
      name: vertex
      provider:
        vertex:
          projectId: my-project
          labels:
          - key: cost_center
            value: platform
          - key: tenant
            expression: jwt.sub
  ```

- Operator labels are merged into the outbound `generateContent` request over
  client-sent labels; on a key conflict the operator's value wins, so callers
  cannot override the gateway's attribution (the merge site is
  `from_completions::merge_labels` in
  `crates/llm/src/conversion/vertex_gemini.rs`). Client labels without
  conflicts pass through unchanged, and configs without `labels` are
  unchanged.
- Label keys and static values are validated against Google Cloud's label
  requirements (charset, 63-char key/value limits, max 64 labels) at config
  load; dynamic values are validated per request and fail closed. An
  expression that cannot produce a valid value rejects the request
  (`AIError::LabelResolution` → `ProxyError::Processing`), so no request is
  forwarded to Vertex unlabeled. This matches the AWS session tag posture.
- Implementation follows existing in-tree shapes:
  - `VertexProvider` wraps `vertex::Provider` the same way `BedrockProvider`
    and `AzureProvider` already wrap theirs in
    `crates/agentgateway/src/llm/mod.rs` (`#[serde(flatten)]` + Deref +
    `AIProvider::vertex()`), keeping the CEL-typed config in the gateway
    crate while `crates/llm` stays CEL-free (its `translate` takes the
    already-resolved label map, `Option<&serde_json::Map<String, Value>>`).
  - `VertexLabels` mirrors `AwsSessionTags`: static/dynamic split with
    config-load validation, the same `try_new`/`is_empty`/`expressions`
    surface, the same custom de/ser helpers, and it reuses
    `aws::cel_value_to_string` for fail-closed CEL coercion.
  - Expressions register in `BackendPolicies::register_cel_expressions`
    (`crates/agentgateway/src/store/binds.rs`) alongside the AWS auth
    expressions, so the request-snapshot capture works the same way it does
    for the session tag expressions. Resolution uses the existing
    `Executor::new_request_snapshot`; no new CEL machinery is added.
- `cargo xtask schema` output is included; the `VertexProvider` schema
  definition now carries `labels` (array of `VertexLabel`).

### Tests

- `crates/llm/src/conversion/vertex_gemini_tests.rs`: merge semantics
  (operator labels added without client labels, merged alongside them,
  operator wins on conflict, empty operator set is a no-op).
- `crates/agentgateway/src/llm/tests.rs`: config-time validation (charset,
  length, duplicates, exactly-one-of value/expression), YAML config parsing
  including rejection of an invalid key, end-to-end `render_vertex_gemini`
  with a request snapshot resolving a CEL label from a request header (the
  test sends a spoofed client `labels.team` and asserts the operator value
  wins), and fail-closed rejection on an unresolvable expression.

`cargo test -p agent-llm` (258 tests, including the golden tests over the
changed translate path) and `cargo test -p agentgateway --lib llm::tests`
(59 tests, 4 new) pass against the patch applied to a pristine base;
`cargo clippy -p agent-llm -p agentgateway --all-targets` and the `make lint`
fmt check are clean.

### Tradeoffs

Stated plainly so they are not hidden:

- XDS-configured Vertex backends are unchanged: the Vertex XDS proto has no
  labels field, so the XDS conversion builds the provider via
  `AIProvider::vertex()`, which yields an empty operator label set. Operator
  labels are file/local-config only for now. This is a deliberate scope
  limit, not a silent behavior shift; XDS-configured vertex backends behave
  exactly as before.
- `deny_unknown_fields` no longer applies to the vertex provider block. serde
  cannot enforce it through `#[serde(flatten)]`, the same tradeoff the
  existing Bedrock/Azure wrappers already carry, and the same one called out
  explicitly for the flattened `Claims` block in
  `crates/agentgateway/src/http/apikey.rs`. `VertexLabel` itself keeps
  `deny_unknown_fields` (it uses the `schema!` alias), so unknown keys inside
  a label are still rejected.
- Dynamic labels cost one CEL evaluation per request. Static labels are
  pre-resolved at config load and cost nothing per request; only labels
  configured with an `expression` evaluate per request, and the lazy
  request-snapshot context only captures what the expressions reference.
- Fail-closed rejects the request on a bad expression rather than dropping
  the label or forwarding unlabeled. A silently-unlabeled request is an
  attribution hole, so rejection is the intended behavior, matching the AWS
  session tag posture. Static-only label configs cannot hit this path.
- One insta snapshot updated (`llm_simple_normalized.snap`): `flatten`
  serializes the provider through a map, which alphabetizes the provider's
  field order in the normalized-config dump. Cosmetic only; the wire format
  (JSON/YAML object) is order-insensitive.
