### PR TITLE
fix(llm): extract Gemini usage from Cloud Code's `response` envelope

### DIFF
--- a/crates/llm/src/types/detect.rs
+++ b/crates/llm/src/types/detect.rs
@@ -315,6 +315,37 @@ mod tests {
 		assert_eq!(llm_response.output_tokens, Some(14));
 		assert_eq!(llm_response.total_tokens, Some(22));
 	}
+
+	#[test]
+	fn to_llm_response_extracts_gemini_cloud_code_usage() {
+		// Cloud Code (cloudcode-pa.googleapis.com) serves generateContent with the
+		// whole Gemini payload nested under a `response` key, so the unwrapped
+		// `usageMetadata` paths miss and usage is silently dropped.
+		let resp = Response::Json(serde_json::json!({
+			"response": {
+				"candidates": [{
+					"content": {
+						"role": "model",
+						"parts": [{"text": "Hello!"}]
+					}
+				}],
+				"usageMetadata": {
+					"promptTokenCount": 30460,
+					"candidatesTokenCount": 3,
+					"totalTokenCount": 30550,
+					"thoughtsTokenCount": 87
+				},
+				"modelVersion": "gemini-3.6-flash"
+			},
+			"traceId": "fb9dce3e019159b5"
+		}));
+
+		let llm_response = resp.to_llm_response(crate::LogContentFields::default());
+
+		assert_eq!(llm_response.input_tokens, Some(30460));
+		assert_eq!(llm_response.output_tokens, Some(3));
+		assert_eq!(llm_response.total_tokens, Some(30550));
+	}
 }
 
 #[derive(Debug, Clone)]
@@ -349,7 +380,7 @@ mod lookups {
 	pub const MAX_TOKENS: [&[&str]; 2] = [&["max_completion_tokens"], &["max_tokens"]];
 	pub const ENCODING_FORMAT: [&[&str]; 1] = [&["encoding_format"]];
 	pub const DIMENSIONS: [&[&str]; 1] = [&["dimensions"]];
-	pub const USAGE_INPUT_TOKENS: [&[&str]; 6] = [
+	pub const USAGE_INPUT_TOKENS: [&[&str]; 7] = [
 		&["usage", "input_tokens"],
 		// Responses streaming
 		&["response", "usage", "input_tokens"],
@@ -360,8 +391,11 @@ mod lookups {
 		&["metadata", "usage", "inputTokens"],
 		// Gemini generateContent
 		&["usageMetadata", "promptTokenCount"],
+		// Gemini generateContent via Cloud Code, which wraps the payload in a
+		// `response` envelope
+		&["response", "usageMetadata", "promptTokenCount"],
 	];
-	pub const USAGE_OUTPUT_TOKENS: [&[&str]; 6] = [
+	pub const USAGE_OUTPUT_TOKENS: [&[&str]; 7] = [
 		&["usage", "output_tokens"],
 		// Responses streaming
 		&["response", "usage", "output_tokens"],
@@ -372,13 +406,17 @@ mod lookups {
 		&["metadata", "usage", "outputTokens"],
 		// Gemini generateContent
 		&["usageMetadata", "candidatesTokenCount"],
+		// Gemini generateContent via Cloud Code
+		&["response", "usageMetadata", "candidatesTokenCount"],
 	];
-	pub const USAGE_TOTAL_TOKENS: [&[&str]; 3] = [
+	pub const USAGE_TOTAL_TOKENS: [&[&str]; 4] = [
 		&["usage", "total_tokens"],
 		// Bedrock converse
 		&["usage", "totalTokens"],
 		// Gemini generateContent
 		&["usageMetadata", "totalTokenCount"],
+		// Gemini generateContent via Cloud Code
+		&["response", "usageMetadata", "totalTokenCount"],
 	];
 	pub const INPUT_IMAGE_TOKENS: [&[&str]; 1] = [&["usage", "input_tokens_details", "image_tokens"]];
 	pub const INPUT_TEXT_TOKENS: [&[&str]; 1] = [&["usage", "input_tokens_details", "text_tokens"]];


### PR DESCRIPTION
## Summary

Detect mode reads Gemini usage from `usageMetadata.*`, which matches Vertex and AI Studio. **Cloud Code** (`cloudcode-pa.googleapis.com`) serves the same `generateContent` API but nests the entire payload under a `response` key, so the lookups miss.

The failure is quiet: `gen_ai.request.model` and `gen_ai.provider.name` still populate, so telemetry looks healthy — it just reports no tokens, and therefore no cost. This is the same class of gap as #2571, one envelope further out.

## Evidence

Observed on a live `:streamGenerateContent` call — Google Antigravity routed through a gateway in detect mode. The SSE events carry:

```json
data: {"response": {"candidates": [...],
                    "usageMetadata": {"promptTokenCount": 30460,
                                      "candidatesTokenCount": 3,
                                      "totalTokenCount": 30550,
                                      "thoughtsTokenCount": 87},
                    "modelVersion": "gemini-3.6-flash"},
       "traceId": "..."}
```

Warehouse rows for that request: `provider=gcp.gemini`, `request_model=gemini-3.6-flash-high`, `http_status=200`, `input_tokens=NULL`, `output_tokens=NULL`.

## Change

Adds the `response`-wrapped paths alongside the existing ones for input, output and total tokens — mirroring how the Responses-streaming variants are already handled in the same tables:

```rust
// Gemini generateContent
&["usageMetadata", "promptTokenCount"],
// Gemini generateContent via Cloud Code, which wraps the payload in a
// `response` envelope
&["response", "usageMetadata", "promptTokenCount"],
```

Lookup order is unchanged, so the existing unwrapped shape still wins where present.

## Test

`to_llm_response_extracts_gemini_cloud_code_usage`, using the payload shape above. `cargo test -p agent-llm --lib types::detect` passes (9 tests); `cargo fmt --check` clean.

## Not included

Two adjacent gaps I noticed but left out to keep this focused — happy to add here or in a follow-up if you'd prefer:

- `thoughtsTokenCount` has no mapping, so reasoning tokens are uncounted for Gemini in both shapes (87 of them in the example above).
- `cachedContentTokenCount` has no mapping in `CACHED_INPUT_TOKENS`.