### PR TITLE
chore(api): convert PolicyConditionType/Reason to string type aliases

### DIFF
--- a/controller/api/v1alpha1/agentgateway/policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/policy_types.go
@@ -2,10 +2,10 @@ package agentgateway
 
 // PolicyConditionType is a type of condition for a policy. This type should be
 // used with a Policy resource `Status.Conditions` field.
-type PolicyConditionType string
+type PolicyConditionType = string
 
 // PolicyConditionReason is a reason for a policy condition.
-type PolicyConditionReason string
+type PolicyConditionReason = string
 
 const (
 	// PolicyConditionAccepted indicates whether the policy has been accepted or rejected, and why.


### PR DESCRIPTION
## Summary

Convert `PolicyConditionType` and `PolicyConditionReason` from distinct `string` types to type aliases (`= string`) to align with the upstream Kubernetes `metav1.Condition` API, where `Type` and `Reason` are plain `string` fields.

## Motivation

In the standard Kubernetes `metav1.Condition`:

- `Type string`
- `Reason string`

Previously `PolicyConditionType` and `PolicyConditionReason` were declared as distinct `string` types:

```go
type PolicyConditionType string
type PolicyConditionReason string
```

This caused two issues:

1. **Kubebuilder validation marker warnings** — markers like `+kubebuilder:validation:Enum` were applied to types that kubebuilder already treats as plain `string`.
2. **API incompatibility** — consumers had to convert between `PolicyConditionType` / `PolicyConditionReason` and `string` when interacting with `metav1.Condition` fields.

Switching to type aliases:

```go
type PolicyConditionType = string
type PolicyConditionReason = string
```

aligns the Go declarations with both the generated CRD schema and the upstream K8s `metav1.Condition` conventions, and silences the kubebuilder warnings.