### PR TITLE
merge ai policy from AI backends with attached policies

### DIFF
--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -275,7 +275,10 @@ impl BackendPolicies {
 			backend_auth: other.backend_auth.or(self.backend_auth),
 			a2a: other.a2a.or(self.a2a),
 			llm_provider: other.llm_provider.or(self.llm_provider),
-			llm: other.llm.or(self.llm),
+			llm: match (self.llm, other.llm) {
+				(Some(base), Some(more)) => Some(LLMRequestPolicies::merge_llm_policies(&more, &base)),
+				(base, more) => more.or(base),
+			},
 			// Authorization composes to avoid erasing a broader deny
 			authorization: match (
 				self.authorization.into_arc(),
@@ -3522,6 +3525,73 @@ mod tests {
 		);
 		assert_eq!(policy.resolve_route("/v1/messages"), RouteType::Messages);
 		assert_eq!(policy.resolve_route("/v1/models"), RouteType::Passthrough);
+	}
+
+	#[test]
+	fn llm_config_merges() {
+		use crate::llm::policy::{
+			PromptEnrichment, PromptGuard, RegexRule, RegexRules, RequestGuard, RequestGuardKind,
+			SortedRoutes,
+		};
+		use crate::llm::{self, RouteType, SimpleChatCompletionMessage};
+
+		// attached policy (e.g. AgentgatewayPolicy.ai) with prompt guard and enrichment
+		let attached = BackendPolicies {
+			llm: Some(Arc::new(llm::Policy {
+				prompt_guard: Some(PromptGuard {
+					streaming: Default::default(),
+					request: vec![RequestGuard {
+						rejection: Default::default(),
+						kind: RequestGuardKind::Regex(RegexRules {
+							action: Default::default(),
+							rules: vec![RegexRule::Regex {
+								pattern: regex::Regex::new("blocked-word").unwrap(),
+							}],
+						}),
+					}],
+					response: vec![],
+				}),
+				prompts: Some(PromptEnrichment {
+					prepend: vec![SimpleChatCompletionMessage {
+						role: strng::new("system"),
+						content: strng::new("You are a helpful assistant."),
+					}],
+					append: vec![],
+				}),
+				..Default::default()
+			})),
+			..Default::default()
+		};
+
+		// provider level policy (e.g. AgentgatewayBackend.ai.groups.providers.policies)
+		let mut routes = SortedRoutes::default();
+		routes.insert(strng::new("/v1/messages"), RouteType::Messages);
+		let provider = BackendPolicies {
+			llm: Some(Arc::new(llm::Policy {
+				model_aliases: std::collections::HashMap::from([(
+					strng::new("fast"),
+					strng::new("gpt-4.1-nano"),
+				)]),
+				routes,
+				..Default::default()
+			})),
+			..Default::default()
+		};
+
+		let effective = attached.merge(provider).llm.expect("expected AI policy");
+		assert!(
+			effective.prompt_guard.is_some(),
+			"provider-level AI config must not disable the attached prompt guard"
+		);
+		assert!(
+			effective.prompts.is_some(),
+			"provider-level AI config must not disable the attached prompt enrichment"
+		);
+		assert_eq!(
+			effective.model_aliases.get(&strng::new("fast")),
+			Some(&strng::new("gpt-4.1-nano"))
+		);
+		assert_eq!(effective.resolve_route("/v1/messages"), RouteType::Messages);
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes the AgentgatewayBackend's `spec.ai.groups[].providers[].policies.ai` block fully overriding AgentgatewayPolicy's `ai` block, rather than doing field by field merging (that we do elsewhere already). 

```yaml
 apiVersion: agentgateway.dev/v1alpha1
  kind: AgentgatewayBackend
  metadata:
    name: mock-openai
  spec:
    ai:
      groups:
      - providers:
        - name: mock-provider
          host: 10.20.0.8
          port: 8080
          openai:
            model: "gpt-4.1-nano"
          policies:
            auth:
              key: "fake-key"
            # if this field is present, it superseded the one from AgentgatewayPolicy CR
            # rather than merging 
            ai: 
              modelAliases:
                fast: "gpt-4.1-nano"
---
apiVersion: agentgateway.dev/v1alpha1
kind: AgentgatewayPolicy
metadata:
  name: ai-policy
spec:
   ...
   # all fields in this block are ignored because the backend's `ai` block is present
   # even if the backend doesn't set any value for that individual field in `ai`.  
   backend: 
     ai:
      promptGuard:
       ...
      prompt:
        prepend:
        ...
      defaults:
        temperature: 0.2
```






This could be considered a slightly breaking change.. 

For policies like prompt guard, its only stricter. For other stuff like `defaults`, `trasformations`, `model_aliases`, `prompt_caching` those were dropped from the attached `AgentgatewayPolicy` and will now be active. 

Users who wanted the `policies.ai` on `AgentgatewayBackend` to be a full replacement would be broken by this change. An alternative is a better warning or error, especially on the k8s side (currently the ineffective policy will report Accepted/Programmed)