### PR TITLE
Followups to session affinity

### DIFF
--- a/crates/agentgateway/src/http/sessionaffinity.rs
+++ b/crates/agentgateway/src/http/sessionaffinity.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
-use twox_hash::XxHash3_64;
-
 use crate::cel::{Executor, Expression};
+use crate::types::loadbalancer::hash_affinity_key;
 use crate::*;
 
 /// Pins requests that carry the same affinity value to the same healthy service endpoint.
@@ -55,7 +54,7 @@ impl Policy {
 			return None;
 		}
 
-		Some(XxHash3_64::oneshot(bytes))
+		Some(hash_affinity_key(bytes))
 	}
 
 	pub fn register_expressions(&self, ctx: &mut crate::cel::ContextBuilder) {

--- a/crates/agentgateway/src/http/sessionaffinity.rs
+++ b/crates/agentgateway/src/http/sessionaffinity.rs
@@ -4,10 +4,12 @@ use crate::cel::{Executor, Expression};
 use crate::types::loadbalancer::hash_affinity_key;
 use crate::*;
 
-/// Pins requests that carry the same affinity value to the same healthy service endpoint.
+/// Configures best-effort session affinity using an existing request attribute.
 ///
-/// This policy is intentionally stateless. Every gateway replica computes the same rendezvous
-/// hash from the request affinity value and the currently available endpoint set.
+/// The source CEL expression selects the affinity value. Requests with the same value are
+/// consistently load balanced to the same healthy service endpoint or AI provider. Unlike session
+/// persistence, this policy does not identify or track a previously selected backend, so changes to
+/// the available backends may remap a value.
 #[apply(schema!)]
 #[cfg_attr(feature = "schema", schemars(rename = "SessionAffinityPolicy"))]
 pub struct Policy {

--- a/crates/agentgateway/src/http/sessionpersistence.rs
+++ b/crates/agentgateway/src/http/sessionpersistence.rs
@@ -1,5 +1,4 @@
 use crate::*;
-
 #[apply(schema!)]
 #[serde(tag = "t")]
 pub enum SessionState {

--- a/crates/agentgateway/src/http/sessionpersistence.rs
+++ b/crates/agentgateway/src/http/sessionpersistence.rs
@@ -1,4 +1,5 @@
 use crate::*;
+
 #[apply(schema!)]
 #[serde(tag = "t")]
 pub enum SessionState {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -67,11 +67,7 @@ pub struct AIBackend {
 }
 
 impl AIBackend {
-	pub fn select_provider(&self) -> Option<(Arc<NamedAIProvider>, ActiveHandle)> {
-		self.select_provider_with_affinity(None)
-	}
-
-	pub fn select_provider_with_affinity(
+	pub fn select_provider(
 		&self,
 		affinity_key: Option<u64>,
 	) -> Option<(Arc<NamedAIProvider>, ActiveHandle)> {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -68,6 +68,18 @@ pub struct AIBackend {
 
 impl AIBackend {
 	pub fn select_provider(&self) -> Option<(Arc<NamedAIProvider>, ActiveHandle)> {
+		self.select_provider_with_affinity(None)
+	}
+
+	pub fn select_provider_with_affinity(
+		&self,
+		affinity_key: Option<u64>,
+	) -> Option<(Arc<NamedAIProvider>, ActiveHandle)> {
+		if let Some(affinity_key) = affinity_key {
+			let (provider, info) = self.providers.select_by_affinity(affinity_key)?;
+			let handle = self.providers.start_request(provider.name.clone(), &info);
+			return Some((provider, handle));
+		}
 		let iter = self.providers.iter();
 		let index = iter.index();
 		if index.is_empty() {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2040,7 +2040,13 @@ async fn make_backend_call(
 
 	let (mut backend_call, mut maybe_inference) = match backend {
 		Backend::AI(n, ai) => {
-			let (provider, handle) = ai.select_provider().ok_or(ProxyError::NoHealthyEndpoints)?;
+			let affinity_key = policies
+				.session_affinity
+				.as_ref()
+				.and_then(|policy| policy.affinity_key(&req));
+			let (provider, handle) = ai
+				.select_provider_with_affinity(affinity_key)
+				.ok_or(ProxyError::NoHealthyEndpoints)?;
 			log.add(move |l| l.request_handle = Some(handle));
 			let sub_backend_name = BackendTargetRef::Backend {
 				name: n.name.as_ref(),

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2748,7 +2748,7 @@ pub fn build_service_call(
 			svc.as_ref(),
 			port,
 			service_override.destination,
-			service_override.affinity_key.as_ref(),
+			service_override.affinity_key,
 		)
 		.ok_or(ProxyError::NoHealthyEndpoints)?;
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2045,7 +2045,7 @@ async fn make_backend_call(
 				.as_ref()
 				.and_then(|policy| policy.affinity_key(&req));
 			let (provider, handle) = ai
-				.select_provider_with_affinity(affinity_key)
+				.select_provider(affinity_key)
 				.ok_or(ProxyError::NoHealthyEndpoints)?;
 			log.add(move |l| l.request_handle = Some(handle));
 			let sub_backend_name = BackendTargetRef::Backend {
@@ -3146,6 +3146,7 @@ mod tests {
 		PromptGuard, PromptGuardStreamingMode, RegexRule, RegexRules, RequestRejection, ResponseGuard,
 		ResponseGuardKind,
 	};
+	use crate::proxy::request_builder::RequestBuilder;
 	use crate::store::LLMRequestPolicies;
 	use crate::test_helpers::proxymock;
 	use crate::types::agent::{Backend, ResourceName, Target};
@@ -3475,6 +3476,84 @@ mod tests {
 			Some("trailers")
 		);
 		assert!(!req.headers().contains_key("x-original-url"));
+	}
+
+	#[tokio::test]
+	async fn llm_session_affinity_pins_provider() {
+		let first = wiremock::MockServer::start().await;
+		let second = wiremock::MockServer::start().await;
+		for mock in [&first, &second] {
+			Mock::given(wiremock::matchers::any())
+				.respond_with(ResponseTemplate::new(200).set_body_raw(
+					include_bytes!("../../../llm/src/tests/response/completions/basic.json").to_vec(),
+					"application/json",
+				))
+				.mount(mock)
+				.await;
+		}
+
+		let mut bind = proxymock::setup_proxy_test("{}").expect("proxy test harness");
+		bind
+			.attach_route(json!({
+				"name": "route",
+				"backends": [{
+					"ai": {
+						"groups": [{
+							"providers": [
+								{
+									"name": "first",
+									"hostOverride": first.address().to_string(),
+									"provider": { "openAI": {} }
+								},
+								{
+									"name": "second",
+									"hostOverride": second.address().to_string(),
+									"provider": { "openAI": {} }
+								}
+							]
+						}]
+					},
+					"policies": {
+						"sessionAffinity": {
+							"source": "request.headers['codex-session-id']"
+						},
+						"ai": {
+							"routes": { "/v1/chat/completions": "completions" }
+						}
+					}
+				}]
+			}))
+			.await;
+		bind = bind.with_bind(proxymock::simple_bind());
+		let io = bind.serve_http(proxymock::BIND_KEY);
+
+		for _ in 0..8 {
+			let response = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions")
+				.header("codex-session-id", "session-a")
+				.body(http::Body::from(
+					include_bytes!("../../../llm/src/tests/requests/completions/basic.json").to_vec(),
+				))
+				.send(io.clone())
+				.await
+				.expect("request succeeds");
+			assert_eq!(response.status(), 200);
+			proxymock::read_body_raw(response.into_body()).await;
+		}
+
+		let first_requests = first
+			.received_requests()
+			.await
+			.expect("first provider request recording")
+			.len();
+		let second_requests = second
+			.received_requests()
+			.await
+			.expect("second provider request recording")
+			.len();
+		assert!(
+			matches!((first_requests, second_requests), (8, 0) | (0, 8)),
+			"expected one provider to receive every request, got {first_requests} and {second_requests}"
+		);
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/store/discovery.rs
+++ b/crates/agentgateway/src/store/discovery.rs
@@ -296,8 +296,12 @@ impl WorkloadStore {
 }
 
 impl WorkloadStore {
+	pub fn find_uid_ref(&self, uid: &Strng) -> Option<&Arc<Workload>> {
+		self.by_uid.get(uid)
+	}
+
 	pub fn find_uid(&self, uid: &Strng) -> Option<Arc<Workload>> {
-		self.by_uid.get(uid).cloned()
+		self.find_uid_ref(uid).cloned()
 	}
 
 	/// Finds the workload by address, as an arc.

--- a/crates/agentgateway/src/store/discovery.rs
+++ b/crates/agentgateway/src/store/discovery.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use agent_xds::XdsUpdate;
+use hashbrown::HashMap as FastHashMap;
 use itertools::Itertools;
 use tokio::sync::watch::Sender;
 use tracing::{Level, instrument};
@@ -231,7 +232,7 @@ pub struct WorkloadStore {
 	/// by_addr maps workload network addresses to workloads
 	by_addr: HashMap<NetworkAddress, WorkloadByAddr>,
 	/// by_uid maps workload UIDs to workloads
-	pub(super) by_uid: HashMap<Strng, Arc<Workload>>,
+	pub(super) by_uid: FastHashMap<Strng, Arc<Workload>>,
 }
 
 impl WorkloadStore {

--- a/crates/agentgateway/src/store/discovery.rs
+++ b/crates/agentgateway/src/store/discovery.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use agent_xds::XdsUpdate;
-use hashbrown::HashMap as FastHashMap;
+use hashbrown::HashMap as HbHashMap;
 use itertools::Itertools;
 use tokio::sync::watch::Sender;
 use tracing::{Level, instrument};

--- a/crates/agentgateway/src/store/discovery.rs
+++ b/crates/agentgateway/src/store/discovery.rs
@@ -232,7 +232,7 @@ pub struct WorkloadStore {
 	/// by_addr maps workload network addresses to workloads
 	by_addr: HashMap<NetworkAddress, WorkloadByAddr>,
 	/// by_uid maps workload UIDs to workloads
-	pub(super) by_uid: FastHashMap<Strng, Arc<Workload>>,
+	pub(super) by_uid: HbHashMap<Strng, Arc<Workload>>,
 }
 
 impl WorkloadStore {

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -126,12 +126,6 @@ impl<T> EndpointGroup<T> {
 		active: IndexMap<EndpointKey, EndpointWithInfo<T>>,
 		rejected: IndexMap<EndpointKey, EndpointWithInfo<T>>,
 	) -> Self {
-		debug_assert!(
-			active
-				.iter()
-				.chain(&rejected)
-				.all(|(key, endpoint)| endpoint.endpoint_hash == hash_endpoint_key(key.as_bytes()))
-		);
 		let sampler = build_sampler(&active);
 		Self {
 			active,

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -457,11 +457,13 @@ impl RendezvousScore {
 }
 
 /// SplitMix64's finalizer, used as a fast deterministic hash of the two pre-hashed inputs. This is
-/// the per-candidate hot path; XXH3 has already processed both arbitrary-length byte strings. The
-/// multipliers below are SplitMix64's avalanche constants, unlike the arbitrary domain seeds above.
+/// the per-candidate hot path; XXH3 has already processed both arbitrary-length byte strings.
+/// The hashes use separate seeds; with either fixed, XOR is a one-to-one translation of the other
+/// and loses no entropy. SplitMix64 then avalanches the combined value.
 #[inline]
 fn rendezvous_hash(affinity_key: u64, endpoint_hash: u64) -> u64 {
 	let mut value = affinity_key ^ endpoint_hash;
+	// Constants and algorithm from https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64
 	value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
 	value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
 	value ^ (value >> 31)

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -302,10 +302,7 @@ impl EndpointSet<Endpoint> {
 					.filter_map(|(_, ewi)| {
 						let workload = viable(workloads, target_port, svc_port, &ewi.endpoint)?;
 						let score = if unit_weights {
-							RendezvousScore::Unweighted(rendezvous_hash(
-								affinity_key,
-								ewi.endpoint_hash,
-							))
+							RendezvousScore::Unweighted(rendezvous_hash(affinity_key, ewi.endpoint_hash))
 						} else {
 							RendezvousScore::Weighted(weighted_rendezvous_score(
 								affinity_key,
@@ -1263,12 +1260,7 @@ mod benches {
 		let affinity_key = hash_affinity_key(b"affinity-benchmark-client");
 
 		b.bench_local(|| {
-			black_box(endpoints.select_affinity(
-				&discovery.workloads,
-				80,
-				8080,
-				black_box(affinity_key),
-			))
+			black_box(endpoints.select_affinity(&discovery.workloads, 80, 8080, black_box(affinity_key)))
 		});
 	}
 
@@ -1279,12 +1271,7 @@ mod benches {
 		let affinity_key = hash_affinity_key(b"affinity-benchmark-client");
 
 		b.bench_local(|| {
-			black_box(endpoints.select_affinity(
-				&discovery.workloads,
-				80,
-				8080,
-				black_box(affinity_key),
-			))
+			black_box(endpoints.select_affinity(&discovery.workloads, 80, 8080, black_box(affinity_key)))
 		});
 	}
 }

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -313,17 +313,14 @@ impl EndpointSet<Endpoint> {
 								ewi.capacity,
 							))
 						};
-						Some((
-							score,
-							Candidate {
-								endpoint: ewi.endpoint.clone(),
-								info: ewi.info.clone(),
-								workload,
-							},
-						))
+						Some((score, ewi, workload))
 					})
 					.max_by(|a, b| a.0.total_cmp(b.0))
-					.map(|(_, candidate)| candidate);
+					.map(|(_, ewi, workload)| Candidate {
+						endpoint: ewi.endpoint.clone(),
+						info: ewi.info.clone(),
+						workload: workload.clone(),
+					});
 				if selected.is_some() {
 					return selected;
 				}
@@ -389,7 +386,7 @@ impl EndpointSet<Endpoint> {
 				Some(Candidate {
 					endpoint: ewi.endpoint.clone(),
 					info: ewi.info.clone(),
-					workload: wl,
+					workload: wl.clone(),
 				})
 			})
 			.max_by(|a, b| a.info.score().total_cmp(&b.info.score()))
@@ -425,7 +422,7 @@ impl EndpointSet<Endpoint> {
 					Some(Candidate {
 						endpoint: ewi.endpoint.clone(),
 						info: ewi.info.clone(),
-						workload: wl,
+						workload: wl.clone(),
 					})
 				})
 				.max_by(|a, b| a.info.score().total_cmp(&b.info.score()))
@@ -465,13 +462,13 @@ fn weighted_rendezvous_score(affinity_key: u64, endpoint_hash: u64, weight: u32)
 	f64::from(weight) / -uniform.ln()
 }
 
-fn viable(
-	workloads: &store::WorkloadStore,
+fn viable<'a>(
+	workloads: &'a store::WorkloadStore,
 	target_port: u16,
 	svc_port: u16,
 	endpoint: &Arc<Endpoint>,
-) -> Option<Arc<Workload>> {
-	let Some(wl) = workloads.find_uid(&endpoint.workload_uid) else {
+) -> Option<&'a Arc<Workload>> {
+	let Some(wl) = workloads.find_uid_ref(&endpoint.workload_uid) else {
 		debug!("failed to fetch workload for {}", endpoint.workload_uid);
 		return None;
 	};
@@ -1227,14 +1224,17 @@ mod benches {
 
 	use super::*;
 
-	fn affinity_fixture(endpoint_count: usize) -> (EndpointSet<Endpoint>, store::DiscoveryStore) {
+	fn affinity_fixture(
+		endpoint_count: usize,
+		capacity: impl Fn(usize) -> u32,
+	) -> (EndpointSet<Endpoint>, store::DiscoveryStore) {
 		let endpoints = EndpointSet::new_empty(1);
 		let mut discovery = store::DiscoveryStore::new();
 		let ranker = LocalityRanker::new(None, None);
 
 		for i in 0..endpoint_count {
 			let uid: Strng = format!("affinity-bench-{i:04}").into();
-			let capacity = (i % 4 + 1) as u32;
+			let capacity = capacity(i);
 			let workload = Arc::new(Workload {
 				uid: uid.clone(),
 				capacity,
@@ -1255,17 +1255,36 @@ mod benches {
 		(endpoints, discovery)
 	}
 
-	/// Measures the real affinity selection loop while keeping fixture construction out of the
-	/// timed section. This includes the ArcSwap snapshot load, endpoint iteration, capacity and
-	/// port viability checks, WorkloadStore lookups, weighted rendezvous scoring, and Arc clones
-	/// used to construct candidates.
+	/// Measures the common equal-weight path, which uses integer rendezvous scores and avoids
+	/// computing a logarithm for each endpoint.
 	#[divan::bench(args = [1_usize, 4, 16, 64, 256, 1024])]
-	fn select_affinity(b: Bencher, endpoint_count: usize) {
-		let (endpoints, discovery) = affinity_fixture(endpoint_count);
+	fn select_affinity_uniform(b: Bencher, endpoint_count: usize) {
+		let (endpoints, discovery) = affinity_fixture(endpoint_count, |_| 1);
 		let affinity_key = hash_affinity_key(b"affinity-benchmark-client");
 
 		b.bench_local(|| {
-			black_box(endpoints.select_affinity(&discovery.workloads, 80, 8080, black_box(affinity_key)))
+			black_box(endpoints.select_affinity(
+				&discovery.workloads,
+				80,
+				8080,
+				black_box(affinity_key),
+			))
+		});
+	}
+
+	/// Measures weighted affinity selection with capacities cycling through 1, 2, 3, and 4.
+	#[divan::bench(args = [1_usize, 4, 16, 64, 256, 1024])]
+	fn select_affinity_weighted(b: Bencher, endpoint_count: usize) {
+		let (endpoints, discovery) = affinity_fixture(endpoint_count, |i| (i % 4 + 1) as u32);
+		let affinity_key = hash_affinity_key(b"affinity-benchmark-client");
+
+		b.bench_local(|| {
+			black_box(endpoints.select_affinity(
+				&discovery.workloads,
+				80,
+				8080,
+				black_box(affinity_key),
+			))
 		});
 	}
 }

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -21,11 +21,26 @@ use crate::*;
 
 type EndpointKey = Strng;
 
+const AFFINITY_KEY_HASH_SEED: u64 = 0x9e37_79b1_85eb_ca87;
+const ENDPOINT_KEY_HASH_SEED: u64 = 0xc2b2_ae3d_27d4_eb4f;
+
+pub(crate) fn hash_affinity_key(value: &[u8]) -> u64 {
+	XxHash3_64::oneshot_with_seed(AFFINITY_KEY_HASH_SEED, value)
+}
+
+fn hash_endpoint_key(value: &[u8]) -> u64 {
+	XxHash3_64::oneshot_with_seed(ENDPOINT_KEY_HASH_SEED, value)
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct EndpointWithInfo<T> {
 	pub endpoint: Arc<T>,
 	pub info: Arc<EndpointInfo>,
 	pub capacity: u32,
+	/// Hash of the endpoint's stable key, cached when it enters an EndpointGroup so affinity
+	/// selection only needs an integer mix per candidate.
+	#[serde(skip)]
+	endpoint_hash: u64,
 }
 
 impl<T> EndpointWithInfo<T> {
@@ -38,7 +53,12 @@ impl<T> EndpointWithInfo<T> {
 			endpoint: Arc::new(ep),
 			info: Default::default(),
 			capacity,
+			endpoint_hash: 0,
 		}
+	}
+
+	fn cache_endpoint_hash(&mut self, key: &EndpointKey) {
+		self.endpoint_hash = hash_endpoint_key(key.as_bytes());
 	}
 }
 
@@ -97,9 +117,12 @@ pub struct EndpointGroup<T> {
 
 impl<T> EndpointGroup<T> {
 	fn from_pools(
-		active: IndexMap<EndpointKey, EndpointWithInfo<T>>,
-		rejected: IndexMap<EndpointKey, EndpointWithInfo<T>>,
+		mut active: IndexMap<EndpointKey, EndpointWithInfo<T>>,
+		mut rejected: IndexMap<EndpointKey, EndpointWithInfo<T>>,
 	) -> Self {
+		for (key, endpoint) in active.iter_mut().chain(rejected.iter_mut()) {
+			endpoint.cache_endpoint_hash(key);
+		}
 		let sampler = build_sampler(&active);
 		Self {
 			active,
@@ -109,8 +132,9 @@ impl<T> EndpointGroup<T> {
 	}
 
 	/// Promote an endpoint to active, removing any prior rejected entry under the same key.
-	fn add(&mut self, key: EndpointKey, ep: EndpointWithInfo<T>) {
+	fn add(&mut self, key: EndpointKey, mut ep: EndpointWithInfo<T>) {
 		self.rejected.swap_remove(&key);
+		ep.cache_endpoint_hash(&key);
 		let cap = ep.capacity;
 		self.active.insert(key, ep);
 		self.update_sampler(Some(cap));
@@ -223,7 +247,7 @@ impl EndpointSet<Endpoint> {
 		svc: &Service,
 		svc_port: u16,
 		override_dest: Option<SocketAddr>,
-		affinity_key: Option<&u64>,
+		affinity_key: Option<u64>,
 	) -> Option<(Arc<Endpoint>, ActiveHandle, Arc<Workload>)> {
 		let Some(target_port) = svc.ports.get(&svc_port).copied() else {
 			debug!("service {} does not have port {}", svc.hostname, svc_port);
@@ -254,7 +278,7 @@ impl EndpointSet<Endpoint> {
 		workloads: &store::WorkloadStore,
 		svc_port: u16,
 		target_port: u16,
-		affinity_key: &u64,
+		affinity_key: u64,
 	) -> Option<Candidate> {
 		for active_phase in [true, false] {
 			for bucket in &self.buckets {
@@ -267,13 +291,30 @@ impl EndpointSet<Endpoint> {
 				} else {
 					&group.rejected
 				};
+				let unit_weights = if active_phase {
+					matches!(&group.sampler, Sampler::Uniform)
+				} else {
+					endpoints.values().all(|ewi| ewi.capacity == 1)
+				};
 				let selected = endpoints
 					.iter()
 					.filter(|(_, ewi)| ewi.capacity > 0)
-					.filter_map(|(key, ewi)| {
+					.filter_map(|(_, ewi)| {
 						let workload = viable(workloads, target_port, svc_port, &ewi.endpoint)?;
+						let score = if unit_weights {
+							RendezvousScore::Unweighted(rendezvous_hash(
+								affinity_key,
+								ewi.endpoint_hash,
+							))
+						} else {
+							RendezvousScore::Weighted(weighted_rendezvous_score(
+								affinity_key,
+								ewi.endpoint_hash,
+								ewi.capacity,
+							))
+						};
 						Some((
-							weighted_rendezvous_score(affinity_key, key.as_bytes(), ewi.capacity),
+							score,
 							Candidate {
 								endpoint: ewi.endpoint.clone(),
 								info: ewi.info.clone(),
@@ -281,7 +322,7 @@ impl EndpointSet<Endpoint> {
 							},
 						))
 					})
-					.max_by(|a, b| a.0.total_cmp(&b.0))
+					.max_by(|a, b| a.0.total_cmp(b.0))
 					.map(|(_, candidate)| candidate);
 				if selected.is_some() {
 					return selected;
@@ -392,9 +433,34 @@ impl EndpointSet<Endpoint> {
 	}
 }
 
-fn weighted_rendezvous_score(affinity_key: &u64, endpoint: &[u8], weight: u32) -> f64 {
-	let hash = XxHash3_64::oneshot_with_seed(*affinity_key, endpoint);
-	// Map into (0, 1], avoiding ln(0). Weighted HRW chooses max(weight / -ln(u)).
+#[derive(Clone, Copy)]
+enum RendezvousScore {
+	Unweighted(u64),
+	Weighted(f64),
+}
+
+impl RendezvousScore {
+	fn total_cmp(self, other: Self) -> Ordering {
+		match (self, other) {
+			(Self::Unweighted(a), Self::Unweighted(b)) => a.cmp(&b),
+			(Self::Weighted(a), Self::Weighted(b)) => a.total_cmp(&b),
+			_ => unreachable!("all candidates in a group use the same rendezvous score type"),
+		}
+	}
+}
+
+/// SplitMix64's finalizer, used as a fast deterministic hash of the two pre-hashed inputs.
+#[inline]
+fn rendezvous_hash(affinity_key: u64, endpoint_hash: u64) -> u64 {
+	let mut value = affinity_key ^ endpoint_hash;
+	value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+	value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+	value ^ (value >> 31)
+}
+
+fn weighted_rendezvous_score(affinity_key: u64, endpoint_hash: u64, weight: u32) -> f64 {
+	let hash = rendezvous_hash(affinity_key, endpoint_hash);
+	// Map into (0, 1), avoiding both ln(0) and division by -ln(1).
 	let uniform = ((hash >> 11) as f64 + 0.5) / ((1_u64 << 53) as f64);
 	f64::from(weight) / -uniform.ln()
 }
@@ -1155,25 +1221,75 @@ impl<T> ActiveEndpointsIter<T> {
 	}
 }
 
+#[cfg(feature = "internal_benches")]
+mod benches {
+	use divan::{Bencher, black_box};
+
+	use super::*;
+
+	fn affinity_fixture(endpoint_count: usize) -> (EndpointSet<Endpoint>, store::DiscoveryStore) {
+		let endpoints = EndpointSet::new_empty(1);
+		let mut discovery = store::DiscoveryStore::new();
+		let ranker = LocalityRanker::new(None, None);
+
+		for i in 0..endpoint_count {
+			let uid: Strng = format!("affinity-bench-{i:04}").into();
+			let capacity = (i % 4 + 1) as u32;
+			let workload = Arc::new(Workload {
+				uid: uid.clone(),
+				capacity,
+				..Default::default()
+			});
+			discovery.workloads.insert(workload.clone());
+			endpoints.insert(
+				Endpoint {
+					workload_uid: uid,
+					port: HashMap::from([(80, 8080)]),
+					status: crate::types::discovery::HealthStatus::Healthy,
+				},
+				&workload,
+				&ranker,
+			);
+		}
+
+		(endpoints, discovery)
+	}
+
+	/// Measures the real affinity selection loop while keeping fixture construction out of the
+	/// timed section. This includes the ArcSwap snapshot load, endpoint iteration, capacity and
+	/// port viability checks, WorkloadStore lookups, weighted rendezvous scoring, and Arc clones
+	/// used to construct candidates.
+	#[divan::bench(args = [1_usize, 4, 16, 64, 256, 1024])]
+	fn select_affinity(b: Bencher, endpoint_count: usize) {
+		let (endpoints, discovery) = affinity_fixture(endpoint_count);
+		let affinity_key = hash_affinity_key(b"affinity-benchmark-client");
+
+		b.bench_local(|| {
+			black_box(endpoints.select_affinity(&discovery.workloads, 80, 8080, black_box(affinity_key)))
+		});
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
 
 	#[test]
 	fn rendezvous_score_is_stable_and_respects_weight() {
-		let affinity_key = 1234;
-		let first = weighted_rendezvous_score(&affinity_key, b"endpoint-a", 1);
+		let affinity_key = hash_affinity_key(b"client-a");
+		let endpoint_a = hash_endpoint_key(b"endpoint-a");
+		let first = weighted_rendezvous_score(affinity_key, endpoint_a, 1);
 		assert_eq!(
 			first,
-			weighted_rendezvous_score(&affinity_key, b"endpoint-a", 1)
+			weighted_rendezvous_score(affinity_key, endpoint_a, 1)
 		);
 		assert_eq!(
 			first * 4.0,
-			weighted_rendezvous_score(&affinity_key, b"endpoint-a", 4)
+			weighted_rendezvous_score(affinity_key, endpoint_a, 4)
 		);
 		assert_ne!(
 			first,
-			weighted_rendezvous_score(&affinity_key, b"endpoint-b", 1)
+			weighted_rendezvous_score(affinity_key, hash_endpoint_key(b"endpoint-b"), 1)
 		);
 	}
 

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -21,9 +21,17 @@ use crate::*;
 
 type EndpointKey = Strng;
 
+// Fixed, non-secret domain separators for the two roles combined by rendezvous_hash. Using
+// different seeds means identical session and endpoint bytes do not produce identical prehashes
+// before they are XORed together. Any two distinct, fixed values would work; primality has no
+// special significance here. We use XXHash's recognizable PRIME64_1 and PRIME64_2 values, which
+// twox-hash declares inside its private xxhash3 module and therefore cannot be imported by users.
+// Keep these stable across replicas and releases: changing either value remaps affinity assignments.
 const AFFINITY_KEY_HASH_SEED: u64 = 0x9e37_79b1_85eb_ca87;
 const ENDPOINT_KEY_HASH_SEED: u64 = 0xc2b2_ae3d_27d4_eb4f;
 
+// Hash the arbitrary-length affinity value once per request. Endpoint selection then operates only
+// on this u64 and the cached endpoint hashes below.
 pub(crate) fn hash_affinity_key(value: &[u8]) -> u64 {
 	XxHash3_64::oneshot_with_seed(AFFINITY_KEY_HASH_SEED, value)
 }
@@ -37,28 +45,26 @@ pub struct EndpointWithInfo<T> {
 	pub endpoint: Arc<T>,
 	pub info: Arc<EndpointInfo>,
 	pub capacity: u32,
-	/// Hash of the endpoint's stable key, cached when it enters an EndpointGroup so affinity
-	/// selection only needs an integer mix per candidate.
+	/// Hash of the endpoint's stable key, computed with the endpoint so there is no uninitialized
+	/// state. Affinity selection therefore needs only an integer mix per candidate.
 	#[serde(skip)]
 	endpoint_hash: u64,
 }
 
 impl<T> EndpointWithInfo<T> {
-	pub fn new(ep: T) -> Self {
-		Self::with_capacity(ep, 1)
+	fn new(key: &EndpointKey, ep: T) -> Self {
+		Self::with_capacity(key, ep, 1)
 	}
 
-	pub fn with_capacity(ep: T, capacity: u32) -> Self {
+	fn with_capacity(key: &EndpointKey, ep: T, capacity: u32) -> Self {
+		// Endpoint identities change far less often than requests arrive. Pay for XXH3 at creation
+		// so the request hot path never reads and hashes an arbitrary-length endpoint key.
 		Self {
 			endpoint: Arc::new(ep),
 			info: Default::default(),
 			capacity,
-			endpoint_hash: 0,
+			endpoint_hash: hash_endpoint_key(key.as_bytes()),
 		}
-	}
-
-	fn cache_endpoint_hash(&mut self, key: &EndpointKey) {
-		self.endpoint_hash = hash_endpoint_key(key.as_bytes());
 	}
 }
 
@@ -117,12 +123,15 @@ pub struct EndpointGroup<T> {
 
 impl<T> EndpointGroup<T> {
 	fn from_pools(
-		mut active: IndexMap<EndpointKey, EndpointWithInfo<T>>,
-		mut rejected: IndexMap<EndpointKey, EndpointWithInfo<T>>,
+		active: IndexMap<EndpointKey, EndpointWithInfo<T>>,
+		rejected: IndexMap<EndpointKey, EndpointWithInfo<T>>,
 	) -> Self {
-		for (key, endpoint) in active.iter_mut().chain(rejected.iter_mut()) {
-			endpoint.cache_endpoint_hash(key);
-		}
+		debug_assert!(
+			active
+				.iter()
+				.chain(&rejected)
+				.all(|(key, endpoint)| endpoint.endpoint_hash == hash_endpoint_key(key.as_bytes()))
+		);
 		let sampler = build_sampler(&active);
 		Self {
 			active,
@@ -132,9 +141,9 @@ impl<T> EndpointGroup<T> {
 	}
 
 	/// Promote an endpoint to active, removing any prior rejected entry under the same key.
-	fn add(&mut self, key: EndpointKey, mut ep: EndpointWithInfo<T>) {
+	fn add(&mut self, key: EndpointKey, ep: EndpointWithInfo<T>) {
 		self.rejected.swap_remove(&key);
-		ep.cache_endpoint_hash(&key);
+		debug_assert_eq!(ep.endpoint_hash, hash_endpoint_key(key.as_bytes()));
 		let cap = ep.capacity;
 		self.active.insert(key, ep);
 		self.update_sampler(Some(cap));
@@ -227,7 +236,7 @@ impl EndpointSet<Endpoint> {
 			None => return, // Strict mode mismatch — drop
 		};
 		let key = ep.workload_uid.clone();
-		let ewi = EndpointWithInfo::with_capacity(ep, dest_workload.capacity);
+		let ewi = EndpointWithInfo::with_capacity(&key, ep, dest_workload.capacity);
 		self.event(EndpointEvent::Add(key, ewi, bucket))
 	}
 
@@ -281,6 +290,9 @@ impl EndpointSet<Endpoint> {
 		affinity_key: u64,
 	) -> Option<Candidate> {
 		for active_phase in [true, false] {
+			// Preserve normal health and locality behavior: exhaust active endpoints across priority
+			// buckets before considering rejected endpoints, and stop at the first bucket with a
+			// viable winner. The affinity hash never overrides priority or health.
 			for bucket in &self.buckets {
 				let group = bucket.load_full();
 				if group.sampler.is_drained() {
@@ -296,6 +308,9 @@ impl EndpointSet<Endpoint> {
 				} else {
 					endpoints.values().all(|ewi| ewi.capacity == 1)
 				};
+				// For weight=1, weight / -ln(u) is strictly increasing in u, so comparing the raw
+				// hash chooses exactly the same endpoint while avoiding an f64 conversion and ln()
+				// for every candidate. A whole candidate set uses one score representation.
 				let selected = endpoints
 					.iter()
 					.filter(|(_, ewi)| ewi.capacity > 0)
@@ -427,9 +442,13 @@ impl EndpointSet<Endpoint> {
 	}
 }
 
+/// Comparable score representations for the two HRW paths. `select_affinity` chooses one path for
+/// the entire candidate set, so comparing different variants would indicate an implementation bug.
 #[derive(Clone, Copy)]
 enum RendezvousScore {
+	/// Equal-capacity fast path: the largest mixed hash is the rendezvous winner.
 	Unweighted(u64),
+	/// Weighted HRW score; larger weights win a proportionally larger keyspace.
 	Weighted(f64),
 }
 
@@ -443,7 +462,9 @@ impl RendezvousScore {
 	}
 }
 
-/// SplitMix64's finalizer, used as a fast deterministic hash of the two pre-hashed inputs.
+/// SplitMix64's finalizer, used as a fast deterministic hash of the two pre-hashed inputs. This is
+/// the per-candidate hot path; XXH3 has already processed both arbitrary-length byte strings. The
+/// multipliers below are SplitMix64's avalanche constants, unlike the arbitrary domain seeds above.
 #[inline]
 fn rendezvous_hash(affinity_key: u64, endpoint_hash: u64) -> u64 {
 	let mut value = affinity_key ^ endpoint_hash;
@@ -454,8 +475,12 @@ fn rendezvous_hash(affinity_key: u64, endpoint_hash: u64) -> u64 {
 
 fn weighted_rendezvous_score(affinity_key: u64, endpoint_hash: u64, weight: u32) -> f64 {
 	let hash = rendezvous_hash(affinity_key, endpoint_hash);
-	// Map into (0, 1), avoiding both ln(0) and division by -ln(1).
+	// Use the 53 bits exactly representable by f64 and place the value at the center of its bucket.
+	// This maps into the open interval (0, 1), avoiding both ln(0) and division by -ln(1).
 	let uniform = ((hash >> 11) as f64 + 0.5) / ((1_u64 << 53) as f64);
+	// This is weighted rendezvous hashing's exponential-race score. Taking the maximum assigns an
+	// endpoint a fraction of keys proportional to its weight while retaining minimal remapping when
+	// the endpoint set changes.
 	f64::from(weight) / -uniform.ln()
 }
 
@@ -656,11 +681,10 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		let buckets = initial_set
 			.into_iter()
 			.map(|items| {
-				let active = IndexMap::from_iter(
-					items
-						.into_iter()
-						.map(|(k, v)| (k, EndpointWithInfo::new(v))),
-				);
+				let active = IndexMap::from_iter(items.into_iter().map(|(key, endpoint)| {
+					let endpoint = EndpointWithInfo::new(&key, endpoint);
+					(key, endpoint)
+				}));
 				let eg = EndpointGroup::from_pools(active, IndexMap::new());
 				Arc::new(ArcSwap::new(Arc::new(eg)))
 			})
@@ -755,6 +779,9 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		ActiveEndpointsIter(self.best_bucket())
 	}
 
+	/// Selects an unweighted rendezvous winner from the same highest-priority healthy bucket used by
+	/// normal iteration. If no active endpoint exists there, `iter` exposes its rejected fallback.
+	/// This generic form is used for AI providers, whose stable provider names are EndpointKeys.
 	pub(crate) fn select_by_affinity(
 		&self,
 		affinity_key: u64,
@@ -800,7 +827,8 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 	}
 
 	pub fn insert_key(&self, key: EndpointKey, ep: T, bucket: usize) {
-		self.event(EndpointEvent::Add(key, EndpointWithInfo::new(ep), bucket))
+		let endpoint = EndpointWithInfo::new(&key, ep);
+		self.event(EndpointEvent::Add(key, endpoint, bucket))
 	}
 	pub fn remove(&self, key: EndpointKey) {
 		self.event(EndpointEvent::Delete(key))
@@ -1644,11 +1672,19 @@ mod tests {
 	) -> EndpointGroup<&'static str> {
 		let active_map = active
 			.iter()
-			.map(|v| ((*v).into(), EndpointWithInfo::new(*v)))
+			.map(|v| {
+				let key = (*v).into();
+				let endpoint = EndpointWithInfo::new(&key, *v);
+				(key, endpoint)
+			})
 			.collect();
 		let rejected_map = rejected
 			.iter()
-			.map(|v| ((*v).into(), EndpointWithInfo::new(*v)))
+			.map(|v| {
+				let key = (*v).into();
+				let endpoint = EndpointWithInfo::new(&key, *v);
+				(key, endpoint)
+			})
 			.collect();
 		EndpointGroup::from_pools(active_map, rejected_map)
 	}
@@ -1873,9 +1909,16 @@ mod tests {
 		let mut map = IndexMap::new();
 		for (i, &cap) in caps.iter().enumerate() {
 			let key: Strng = format!("ep{i}").into();
-			map.insert(key, EndpointWithInfo::with_capacity((), cap));
+			let endpoint = EndpointWithInfo::with_capacity(&key, (), cap);
+			map.insert(key, endpoint);
 		}
 		map
+	}
+
+	fn add_with_capacity(group: &mut EndpointGroup<()>, key: &'static str, capacity: u32) {
+		let key = key.into();
+		let endpoint = EndpointWithInfo::with_capacity(&key, (), capacity);
+		group.add(key, endpoint);
 	}
 
 	#[test]
@@ -1957,20 +2000,20 @@ mod tests {
 	#[test]
 	fn build_sampler_reflects_active_state() {
 		let mut group = EndpointGroup::<()>::default();
-		group.add("a".into(), EndpointWithInfo::with_capacity((), 1));
-		group.add("b".into(), EndpointWithInfo::with_capacity((), 1));
+		add_with_capacity(&mut group, "a", 1);
+		add_with_capacity(&mut group, "b", 1);
 		assert!(matches!(group.sampler, Sampler::Uniform));
 
 		// Replace "a" with cap=3 — now mixed, should become Weighted.
-		group.add("a".into(), EndpointWithInfo::with_capacity((), 3));
+		add_with_capacity(&mut group, "a", 3);
 		let Sampler::Weighted(dist) = &group.sampler else {
 			panic!("expected Weighted, got {:?}", group.sampler);
 		};
 		assert_eq!(dist.weights().collect::<Vec<_>>(), vec![3u64, 1]);
 
 		// Drain everything — should become Drained.
-		group.add("a".into(), EndpointWithInfo::with_capacity((), 0));
-		group.add("b".into(), EndpointWithInfo::with_capacity((), 0));
+		add_with_capacity(&mut group, "a", 0);
+		add_with_capacity(&mut group, "b", 0);
 		assert!(group.sampler.is_drained());
 	}
 
@@ -1979,10 +2022,10 @@ mod tests {
 		// Common XDS case: all endpoints share the default cap=1. Adds and
 		// deletes should leave the sampler as Uniform.
 		let mut group = EndpointGroup::<()>::default();
-		group.add("a".into(), EndpointWithInfo::with_capacity((), 1));
+		add_with_capacity(&mut group, "a", 1);
 		assert!(matches!(group.sampler, Sampler::Uniform));
 
-		group.add("b".into(), EndpointWithInfo::with_capacity((), 1));
+		add_with_capacity(&mut group, "b", 1);
 		assert!(matches!(group.sampler, Sampler::Uniform));
 
 		group.remove(&Strng::from("b"));
@@ -1993,20 +2036,20 @@ mod tests {
 	fn update_sampler_rebuilds_on_cap_mismatch() {
 		// Adding a cap=2 endpoint to a Uniform group must transition to Weighted.
 		let mut group = EndpointGroup::<()>::default();
-		group.add("a".into(), EndpointWithInfo::with_capacity((), 1));
+		add_with_capacity(&mut group, "a", 1);
 		assert!(matches!(group.sampler, Sampler::Uniform));
 
-		group.add("b".into(), EndpointWithInfo::with_capacity((), 2));
+		add_with_capacity(&mut group, "b", 2);
 		assert!(matches!(group.sampler, Sampler::Weighted(_)));
 	}
 
 	#[test]
 	fn update_sampler_drained_stays_drained_on_zero_cap_add() {
 		let mut group = EndpointGroup::<()>::default();
-		group.add("a".into(), EndpointWithInfo::with_capacity((), 0));
+		add_with_capacity(&mut group, "a", 0);
 		assert!(matches!(group.sampler, Sampler::Drained));
 
-		group.add("b".into(), EndpointWithInfo::with_capacity((), 0));
+		add_with_capacity(&mut group, "b", 0);
 		assert!(matches!(group.sampler, Sampler::Drained));
 	}
 
@@ -2014,7 +2057,7 @@ mod tests {
 	fn update_sampler_remove_last_uniform_stays_uniform() {
 		// Deleting the last active entry leaves the sampler as Uniform
 		let mut group = EndpointGroup::<()>::default();
-		group.add("a".into(), EndpointWithInfo::with_capacity((), 1));
+		add_with_capacity(&mut group, "a", 1);
 
 		group.remove(&Strng::from("a"));
 		assert!(matches!(group.sampler, Sampler::Uniform));
@@ -2029,7 +2072,7 @@ mod tests {
 		// select_fallback to skip the whole bucket, which would also skip
 		// the rejected pool — the wrong behavior when active is empty.
 		let mut group = EndpointGroup::<()>::default();
-		group.add("a".into(), EndpointWithInfo::with_capacity((), 0));
+		add_with_capacity(&mut group, "a", 0);
 		assert!(matches!(group.sampler, Sampler::Drained));
 
 		group.remove(&Strng::from("a"));

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -755,6 +755,18 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		ActiveEndpointsIter(self.best_bucket())
 	}
 
+	pub(crate) fn select_by_affinity(
+		&self,
+		affinity_key: u64,
+	) -> Option<(Arc<T>, Arc<EndpointInfo>)> {
+		let iter = self.iter();
+		let endpoint = iter
+			.index()
+			.values()
+			.max_by_key(|endpoint| rendezvous_hash(affinity_key, endpoint.endpoint_hash))?;
+		Some((endpoint.endpoint.clone(), endpoint.info.clone()))
+	}
+
 	/// Visit every endpoint, returning the first `Some` produced by `f`. Active
 	/// endpoints from all buckets are visited before any rejected endpoint, e.g.:
 	///   active in bucket 0

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1320,7 +1320,7 @@ pub struct LocalRouteBackend {
 	pub backend: LocalBackend,
 	/// Backend-level policies such as TLS, authentication, and transformations.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub policies: Option<LocalRouteBackendPolicies>,
+	pub policies: Option<LocalBackendPolicies>,
 }
 
 fn default_weight() -> usize {
@@ -1552,6 +1552,7 @@ impl LocalBackend {
 					mcp_guardrails: None,
 					a2a: None,
 					inference_routing: None,
+					session_affinity: None,
 					ai: None,
 					response_header_modifier: None,
 					request_redirect: None,
@@ -2517,56 +2518,15 @@ pub struct LocalBackendPolicies {
 	/// Route requests through an endpoint picker before forwarding to this backend.
 	#[serde(default)]
 	pub inference_routing: Option<crate::http::ext_proc::InferenceRouting>,
+	/// Keep requests whose CEL expression produces the same value on one backend endpoint.
+	#[serde(default)]
+	pub session_affinity: Option<http::sessionaffinity::Policy>,
 	/// Mark this as LLM traffic to enable LLM processing.
 	#[serde(default)]
 	pub ai: Option<llm::Policy>,
 }
 
-#[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
-#[cfg_attr(
-	feature = "schema",
-	schemars(rename_all = "camelCase", deny_unknown_fields)
-)]
-pub struct LocalRouteBackendPolicies {
-	#[cfg_attr(feature = "schema", serde(flatten))]
-	backend: LocalBackendPolicies,
-
-	/// Keep requests whose CEL expression produces the same value on one service endpoint.
-	#[cfg_attr(feature = "schema", schemars(default))]
-	pub session_affinity: Option<http::sessionaffinity::Policy>,
-}
-
-impl<'de> Deserialize<'de> for LocalRouteBackendPolicies {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: Deserializer<'de>,
-	{
-		let value = serde_json::Value::deserialize(deserializer)?;
-		let serde_json::Value::Object(mut fields) = value else {
-			return Err(serde::de::Error::custom(
-				"route backend policies must be an object",
-			));
-		};
-
-		// Deserialize the route-only policy separately, then pass every existing field through the
-		// original LocalBackendPolicies deserializer. This avoids nested serde(flatten), which causes
-		// the inner policy fields to be treated as unknown, while preserving its strict unknown-field
-		// validation and all existing wire formats.
-		let session_affinity = match fields.remove("sessionAffinity") {
-			None | Some(serde_json::Value::Null) => None,
-			Some(value) => Some(serde_json::from_value(value).map_err(serde::de::Error::custom)?),
-		};
-		let backend = serde_json::from_value(serde_json::Value::Object(fields))
-			.map_err(serde::de::Error::custom)?;
-
-		Ok(Self {
-			backend,
-			session_affinity,
-		})
-	}
-}
-
+#[derive(Clone, Copy)]
 enum InferenceRoutingScope {
 	ServiceRouteBackend,
 	NonServiceRouteBackend,
@@ -2578,59 +2538,40 @@ fn validate_inference_routing_scope(
 	policies: Option<&LocalBackendPolicies>,
 	scope: InferenceRoutingScope,
 ) -> anyhow::Result<()> {
-	if policies.is_none_or(|p| p.inference_routing.is_none()) {
+	let Some(policies) = policies else {
 		return Ok(());
+	};
+	if policies.inference_routing.is_some() {
+		let name = "inferenceRouting";
+		match scope {
+			InferenceRoutingScope::ServiceRouteBackend => {},
+			InferenceRoutingScope::NonServiceRouteBackend => {
+				bail!("{name} is only supported on service route backends")
+			},
+			InferenceRoutingScope::NamedBackend => {
+				bail!("{name} is only supported on service route backends, not named backends")
+			},
+			InferenceRoutingScope::AIProviderPolicies => {
+				bail!("{name} is only supported on service route backends, not AI provider policies")
+			},
+		}
 	}
-	match scope {
-		InferenceRoutingScope::ServiceRouteBackend => Ok(()),
-		InferenceRoutingScope::NonServiceRouteBackend => {
-			bail!("inferenceRouting is only supported on service route backends")
-		},
-		InferenceRoutingScope::NamedBackend => {
-			bail!("inferenceRouting is only supported on service route backends, not named backends")
-		},
-		InferenceRoutingScope::AIProviderPolicies => {
-			bail!(
-				"inferenceRouting is only supported on service route backends, not AI provider policies"
-			)
-		},
-	}
+	Ok(())
 }
 
 fn validate_route_backend_policy_scope(
 	backend: &LocalBackend,
-	policies: Option<&LocalRouteBackendPolicies>,
+	policies: Option<&LocalBackendPolicies>,
 ) -> anyhow::Result<()> {
 	let is_service = matches!(backend, LocalBackend::Service { .. });
 	validate_inference_routing_scope(
-		policies.map(|p| &p.backend),
+		policies,
 		if is_service {
 			InferenceRoutingScope::ServiceRouteBackend
 		} else {
 			InferenceRoutingScope::NonServiceRouteBackend
 		},
-	)?;
-	if !is_service && policies.is_some_and(|p| p.session_affinity.is_some()) {
-		bail!("sessionAffinity is only supported on service route backends")
-	}
-	Ok(())
-}
-
-impl LocalRouteBackendPolicies {
-	pub async fn translate(
-		self,
-		resources: &crate::resource_manager::ResourceFetcher,
-	) -> anyhow::Result<Vec<BackendTrafficPolicy>> {
-		let LocalRouteBackendPolicies {
-			backend,
-			session_affinity,
-		} = self;
-		let mut policies = backend.translate(resources).await?;
-		if let Some(policy) = session_affinity {
-			policies.push(BackendTrafficPolicy::SessionAffinity(policy));
-		}
-		Ok(policies)
-	}
+	)
 }
 
 impl LocalBackendPolicies {
@@ -2653,6 +2594,7 @@ impl LocalBackendPolicies {
 			mcp_guardrails,
 			a2a,
 			inference_routing,
+			session_affinity,
 			ai,
 			response_header_modifier,
 			request_redirect,
@@ -2696,6 +2638,9 @@ impl LocalBackendPolicies {
 		}
 		if let Some(p) = inference_routing {
 			pols.push(BackendTrafficPolicy::InferenceRouting(p))
+		}
+		if let Some(p) = session_affinity {
+			pols.push(BackendTrafficPolicy::SessionAffinity(p))
 		}
 		if let Some(p) = backend_tls {
 			pols.push(BackendTrafficPolicy::BackendTLS(

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2518,7 +2518,9 @@ pub struct LocalBackendPolicies {
 	/// Route requests through an endpoint picker before forwarding to this backend.
 	#[serde(default)]
 	pub inference_routing: Option<crate::http::ext_proc::InferenceRouting>,
-	/// Keep requests whose CEL expression produces the same value on one backend endpoint.
+	/// Apply best-effort session affinity using a request value selected by a CEL expression.
+	/// Requests with the same value are consistently load balanced to the same healthy service
+	/// endpoint or AI provider, but may be remapped when the available backends change.
 	#[serde(default)]
 	pub session_affinity: Option<http::sessionaffinity::Policy>,
 	/// Mark this as LLM traffic to enable LLM processing.

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -219,7 +219,9 @@ fn selected_ai_provider(normalized: &NormalizedLocalConfig) -> Arc<NamedAIProvid
 	let Backend::AI(_, ai) = &backend.backend else {
 		panic!("expected generated AI backend");
 	};
-	let (provider, _handle) = ai.select_provider().expect("expected selected provider");
+	let (provider, _handle) = ai
+		.select_provider(None)
+		.expect("expected selected provider");
 	provider
 }
 

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -281,15 +281,6 @@ fn test_local_backend_policies_reject_unknown_fields() {
 	assert!(err.to_string().contains("unknown field"), "{err}");
 }
 
-#[test]
-fn test_local_route_backend_policies_reject_unknown_fields() {
-	let err = crate::serdes::yamlviajson::from_str::<super::LocalRouteBackendPolicies>(
-		"mcpAuthorizatoin: {}",
-	)
-	.unwrap_err();
-	assert!(err.to_string().contains("unknown field"), "{err}");
-}
-
 #[tokio::test]
 async fn test_multiple_wildcard_binds_rejected() {
 	let err = normalize_test_yaml(

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -1408,29 +1408,6 @@ binds:
 }
 
 #[tokio::test]
-async fn test_session_affinity_requires_service_backend() {
-	let input = r#"
-binds:
-- port: 3000
-  listeners:
-  - routes:
-    - backends:
-      - host: 127.0.0.1:8000
-        policies:
-          sessionAffinity:
-            source: request.headers["x-session-id"]
-"#;
-
-	let err = normalize_test_config(input).await.unwrap_err();
-	assert!(
-		err
-			.to_string()
-			.contains("sessionAffinity is only supported on service route backends"),
-		"unexpected error: {err}"
-	);
-}
-
-#[tokio::test]
 async fn test_session_affinity_service_backend_config() {
 	let input = r#"
 binds:

--- a/schema/config.json
+++ b/schema/config.json
@@ -8531,7 +8531,7 @@
           "default": null
         },
         "sessionAffinity": {
-          "description": "Keep requests whose CEL expression produces the same value on one backend endpoint.",
+          "description": "Apply best-effort session affinity using a request value selected by a CEL expression.\nRequests with the same value are consistently load balanced to the same healthy service\nendpoint or AI provider, but may be remapped when the available backends change.",
           "anyOf": [
             {
               "$ref": "#/$defs/SessionAffinityPolicy"
@@ -8653,7 +8653,7 @@
       ]
     },
     "SessionAffinityPolicy": {
-      "description": "Pins requests that carry the same affinity value to the same healthy service endpoint.\n\nThis policy is intentionally stateless. Every gateway replica computes the same rendezvous\nhash from the request affinity value and the currently available endpoint set.",
+      "description": "Configures best-effort session affinity using an existing request attribute.\n\nThe source CEL expression selects the affinity value. Requests with the same value are\nconsistently load balanced to the same healthy service endpoint or AI provider. Unlike session\npersistence, this policy does not identify or track a previously selected backend, so changes to\nthe available backends may remap a value.",
       "type": "object",
       "properties": {
         "source": {

--- a/schema/config.json
+++ b/schema/config.json
@@ -7331,7 +7331,7 @@
           "description": "Backend-level policies such as TLS, authentication, and transformations.",
           "anyOf": [
             {
-              "$ref": "#/$defs/LocalRouteBackendPolicies"
+              "$ref": "#/$defs/LocalBackendPolicies"
             },
             {
               "type": "null"
@@ -8530,6 +8530,18 @@
           ],
           "default": null
         },
+        "sessionAffinity": {
+          "description": "Keep requests whose CEL expression produces the same value on one backend endpoint.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SessionAffinityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "ai": {
           "description": "Mark this as LLM traffic to enable LLM processing.",
           "anyOf": [
@@ -8640,6 +8652,20 @@
         }
       ]
     },
+    "SessionAffinityPolicy": {
+      "description": "Pins requests that carry the same affinity value to the same healthy service endpoint.\n\nThis policy is intentionally stateless. Every gateway replica computes the same rendezvous\nhash from the request affinity value and the currently available endpoint set.",
+      "type": "object",
+      "properties": {
+        "source": {
+          "description": "CEL expression evaluated against request state. It must return a string or bytes value.\nExamples: `request.headers[\"x-session-id\"]` or `string(source.address)`.",
+          "$ref": "#/$defs/Expression"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "source"
+      ]
+    },
     "LocalAIProviders": {
       "type": "object",
       "properties": {
@@ -8691,239 +8717,6 @@
       "additionalProperties": false,
       "required": [
         "agentRuntimeArn"
-      ]
-    },
-    "LocalRouteBackendPolicies": {
-      "type": "object",
-      "properties": {
-        "requestHeaderModifier": {
-          "description": "Modify request headers before forwarding to this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HeaderModifier"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "transformations": {
-          "description": "Modify request and response data for this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalTransformationConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "backendTLS": {
-          "description": "TLS settings used when connecting to this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalBackendTLS"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "backendAuth": {
-          "description": "Authentication credentials sent to this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/BackendAuthCompat"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "http": {
-          "description": "HTTP protocol settings for this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HTTP"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "tcp": {
-          "description": "TCP protocol settings for this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TCP"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "backendTunnel": {
-          "description": "Tunnel settings used when connecting to this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Tunnel"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "responseHeaderModifier": {
-          "description": "Modify response headers returned from this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HeaderModifier"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "requestRedirect": {
-          "description": "Return a redirect response instead of forwarding to this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RequestRedirect"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "health": {
-          "description": "Detect unhealthy backend responses and temporarily remove unhealthy endpoints.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LocalHealthPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "extAuthz": {
-          "description": "Authorize incoming requests by calling an external authorization service after this backend is selected.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ExtAuthz"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "authorization": {
-          "description": "Authorize incoming requests after this backend is selected.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Authorization"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "mcpAuthorization": {
-          "description": "Authorization rules for MCP requests.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/McpAuthorization"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "mcpGuardrails": {
-          "description": "External MCP policy processors.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/McpGuardrails"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "a2a": {
-          "description": "Mark this traffic as A2A to enable A2A processing and telemetry.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/A2aPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "inferenceRouting": {
-          "description": "Route requests through an endpoint picker before forwarding to this backend.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InferenceRouting"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "ai": {
-          "description": "Mark this as LLM traffic to enable LLM processing.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Policy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
-        "sessionAffinity": {
-          "description": "Keep requests whose CEL expression produces the same value on one service endpoint.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SessionAffinityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        }
-      },
-      "additionalProperties": false
-    },
-    "SessionAffinityPolicy": {
-      "description": "Pins requests that carry the same affinity value to the same healthy service endpoint.\n\nThis policy is intentionally stateless. Every gateway replica computes the same rendezvous\nhash from the request affinity value and the currently available endpoint set.",
-      "type": "object",
-      "properties": {
-        "source": {
-          "description": "CEL expression evaluated against request state. It must return a string or bytes value.\nExamples: `request.headers[\"x-session-id\"]` or `string(source.address)`.",
-          "$ref": "#/$defs/Expression"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "source"
       ]
     },
     "LocalTCPRoute": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -6070,7 +6070,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`binds[].listeners[].routes[].backends[].ai.policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`binds[].listeners[].routes[].backends[].ai.policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`binds[].listeners[].routes[].backends[].ai.policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -9100,7 +9100,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -12093,7 +12093,7 @@
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`binds[].listeners[].routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`binds[].listeners[].routes[].backends[].policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`binds[].listeners[].routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`binds[].listeners[].routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -22211,7 +22211,7 @@
 |`backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`backends[].ai.policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`backends[].ai.policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`backends[].ai.policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -25241,7 +25241,7 @@
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`backends[].ai.groups[].providers[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -28232,7 +28232,7 @@
 |`backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`backends[].policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -36152,7 +36152,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`routeGroups[].routes[].backends[].ai.policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routeGroups[].routes[].backends[].ai.policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`routeGroups[].routes[].backends[].ai.policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -39182,7 +39182,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -42175,7 +42175,7 @@
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`routeGroups[].routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routeGroups[].routes[].backends[].policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`routeGroups[].routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routeGroups[].routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -52657,7 +52657,7 @@
 |`routes[].backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`routes[].backends[].ai.policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routes[].backends[].ai.policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`routes[].backends[].ai.policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routes[].backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -55687,7 +55687,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`routes[].backends[].ai.groups[].providers[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
@@ -58680,7 +58680,7 @@
 |`routes[].backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routes[].backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
-|`routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routes[].backends[].policies.sessionAffinity`|object|Apply best-effort session affinity using a request value selected by a CEL expression.<br>Requests with the same value are consistently load balanced to the same healthy service<br>endpoint or AI provider, but may be remapped when the available backends change.|
 |`routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routes[].backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -6070,6 +6070,8 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`binds[].listeners[].routes[].backends[].ai.policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -9098,6 +9100,8 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -12089,6 +12093,8 @@
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`binds[].listeners[].routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`binds[].listeners[].routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`binds[].listeners[].routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -14055,8 +14061,6 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.minTokens`|integer|Minimum prompt size required before cache markers are added.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptCaching.cacheMessageOffset`|integer|Message offset used when choosing where to place cache markers.|
 |`binds[].listeners[].routes[].backends[].policies.ai.routes`|object|Route type overrides selected by request path suffix.|
-|`binds[].listeners[].routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one service endpoint.|
-|`binds[].listeners[].routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`binds[].listeners[].tcpRoutes`|[]object|TCP routes attached directly to this listener.|
 |`binds[].listeners[].tcpRoutes[].name`|string|Name identifying this route.|
 |`binds[].listeners[].tcpRoutes[].namespace`|string|Namespace scoping this route.|
@@ -22207,6 +22211,8 @@
 |`backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`backends[].ai.policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`backends[].ai.policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`backends[].ai.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -25235,6 +25241,8 @@
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`backends[].ai.groups[].providers[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -28224,6 +28232,8 @@
 |`backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`backends[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -36142,6 +36152,8 @@
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`routeGroups[].routes[].backends[].ai.policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routeGroups[].routes[].backends[].ai.policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -39170,6 +39182,8 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -42161,6 +42175,8 @@
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`routeGroups[].routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routeGroups[].routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routeGroups[].routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -44127,8 +44143,6 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptCaching.minTokens`|integer|Minimum prompt size required before cache markers are added.|
 |`routeGroups[].routes[].backends[].policies.ai.promptCaching.cacheMessageOffset`|integer|Message offset used when choosing where to place cache markers.|
 |`routeGroups[].routes[].backends[].policies.ai.routes`|object|Route type overrides selected by request path suffix.|
-|`routeGroups[].routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one service endpoint.|
-|`routeGroups[].routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`gateways`|object|gateways defines the entrypoint to the proxy, setting up ports and listeners that features (LLM, MCP, and UI) and routes can attach to.<br>Each gateway defines a port that proxy will listen on, and optionally TLS settings for that port.|
 |`gateways.*.port`|integer|port is the port to listen on for this gateway.|
 |`gateways.*.protocol`|enum|protocol controls whether this gateway accepts HTTP/HTTPS routes or TCP/TLS routes. When omitted, gateways<br>default to HTTP, or HTTPS when tls is set.<br>Possible values: `HTTP`, `HTTPS`, `TCP`, `TLS`, `null`.|
@@ -52643,6 +52657,8 @@
 |`routes[].backends[].ai.policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routes[].backends[].ai.policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`routes[].backends[].ai.policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routes[].backends[].ai.policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routes[].backends[].ai.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routes[].backends[].ai.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`routes[].backends[].ai.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -55671,6 +55687,8 @@
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`routes[].backends[].ai.groups[].providers[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routes[].backends[].ai.groups[].providers[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -58662,6 +58680,8 @@
 |`routes[].backends[].policies.inferenceRouting.endpointPicker.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.inferenceRouting.endpointPicker.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routes[].backends[].policies.inferenceRouting.destinationMode`|enum|How to use the destination returned by the endpoint picker.<br>Possible values: `validated`, `passthrough`.|
+|`routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one backend endpoint.|
+|`routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`routes[].backends[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routes[].backends[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`routes[].backends[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -60628,8 +60648,6 @@
 |`routes[].backends[].policies.ai.promptCaching.minTokens`|integer|Minimum prompt size required before cache markers are added.|
 |`routes[].backends[].policies.ai.promptCaching.cacheMessageOffset`|integer|Message offset used when choosing where to place cache markers.|
 |`routes[].backends[].policies.ai.routes`|object|Route type overrides selected by request path suffix.|
-|`routes[].backends[].policies.sessionAffinity`|object|Keep requests whose CEL expression produces the same value on one service endpoint.|
-|`routes[].backends[].policies.sessionAffinity.source`|string|CEL expression evaluated against request state. It must return a string or bytes value.<br>Examples: `request.headers["x-session-id"]` or `string(source.address)`.|
 |`tcpRoutes`|[]object|tcpRoutes defines TCP routes attached to one or more named TCP/TLS gateways.|
 |`tcpRoutes[].gateways`|string|gateways attaches this route to named TCP/TLS gateways or gateway listeners.<br>This can take the form of `<gateway-name>` or `<gateway-name>/<listener-name>` to attach to a specific listener within a gateway.<br>If unset, the 'default' gateway will be used.|
 |`tcpRoutes[].name`|string|Name identifying this route.|


### PR DESCRIPTION
Changes:
* Do not always clone workloads. Use hashbrown to optimize UID lookup
* Pre-hash endpoint keys. see https://dgryski.medium.com/consistent-hashing-algorithmic-tradeoffs-ef6b8e2fcae8
* Simplify local.rs management
* Add support for AI provider
* Add benchmarks

```
1: 260.1 ns --> 30.44 ns
4: 325.9 ns --> 48.93 ns
16: 1.329 µs --> 113.3 ns
64: 5.134 µs --> 392.5 ns
256: 20.47 µs --> 1.64 µs 
1024: 82.61 µs --> 6.603 µs
```