### PR TITLE
test: cover multiple controller installations

### DIFF
--- a/controller/pkg/controller/gatewayclass_test.go
+++ b/controller/pkg/controller/gatewayclass_test.go
@@ -1,0 +1,32 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/deployer"
+)
+
+func TestGatewayClassReconcilerUsesConfiguredControllerName(t *testing.T) {
+	const (
+		gatewayClassName = "agentgateway-secondary"
+		controllerName   = "test.agentgateway.dev/secondary"
+	)
+
+	reconciler := &gatewayClassReconciler{
+		defaultControllerName: controllerName,
+		classInfo: map[string]*deployer.GatewayClassInfo{
+			gatewayClassName: {},
+		},
+	}
+
+	gatewayClass := reconciler.buildDesiredGatewayClass(gatewayClassName, reconciler.classInfo[gatewayClassName])
+
+	assert.Equal(t, gatewayClassName, gatewayClass.Name)
+	assert.Equal(t, gwv1.GatewayController(controllerName), gatewayClass.Spec.ControllerName)
+	assert.True(t, isOurGatewayClass(gatewayClass, sets.New(controllerName)))
+	assert.False(t, isOurGatewayClass(gatewayClass, sets.New("test.agentgateway.dev/primary")))
+}

--- a/controller/test/e2e/manifests/agent-gateway-secondary.yaml
+++ b/controller/test/e2e/manifests/agent-gateway-secondary.yaml
@@ -1,0 +1,11 @@
+gatewayClassName: agentgateway-secondary
+controllerName: test.agentgateway.dev/secondary
+
+discoveryNamespaceSelectors:
+  - matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values:
+          - agentgateway-secondary
+  - matchLabels:
+      e2e.agentgateway.dev/controller: secondary

--- a/controller/test/e2e/multicontroller_test.go
+++ b/controller/test/e2e/multicontroller_test.go
@@ -1,0 +1,176 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/test/util/retry"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
+	e2e "github.com/agentgateway/agentgateway/controller/test/e2e"
+	"github.com/agentgateway/agentgateway/controller/test/e2e/base"
+)
+
+const (
+	secondaryControllerName      = "test.agentgateway.dev/secondary"
+	secondaryGatewayClass        = "agentgateway-secondary"
+	secondaryControllerNamespace = "agentgateway-secondary"
+	secondaryWorkloadNamespace   = "agentgateway-secondary-workload"
+)
+
+func TestMultipleControllers(tt *testing.T) {
+	t := New(tt)
+
+	assertGatewayClassController(t, "agentgateway", base.AgentgatewayControllerName)
+
+	secondary := e2e.CreateSharedTestInstallation(
+		secondaryControllerNamespace,
+		e2e.ManifestPath("agent-gateway-secondary.yaml"),
+	)
+	t.Cleanup(func() {
+		secondary.UninstallAgentgatewayCore(t.Ctx, tt)
+		secondary.Finalize()
+	})
+	secondary.InstallAgentgatewayCoreFromLocalChart(t.Ctx, tt)
+
+	assertGatewayClassController(t, secondaryGatewayClass, secondaryControllerName)
+	assertGatewayClassController(t, "agentgateway", base.AgentgatewayControllerName)
+
+	t.Apply(manifest("multicontroller", "setup.yaml"))
+	t.GatewayReady("secondary-gateway", secondaryWorkloadNamespace)
+	t.HTTPRouteAccepted("secondary-route", secondaryWorkloadNamespace)
+	t.HTTPRouteAccepted("primary-route", base.Namespace)
+
+	assertRouteController(t, "secondary-route", secondaryWorkloadNamespace, secondaryControllerName)
+	assertRouteController(t, "primary-route", base.Namespace, base.AgentgatewayControllerName)
+	assertGatewayUsesControlPlane(t, "secondary-gateway", secondaryWorkloadNamespace, secondaryControllerNamespace)
+	applyWithoutResourceWait(t, manifest("multicontroller", "unselected.yaml"))
+	assertGatewayNotProvisioned(t, "unselected-gateway", "agentgateway-unselected")
+
+	secondaryName := types.NamespacedName{Name: "secondary-gateway", Namespace: secondaryWorkloadNamespace}
+	secondaryGateway := base.Gateway{
+		NamespacedName: secondaryName,
+		Address:        base.ResolveGatewayAddress(t, t.Ctx, secondary, secondaryName),
+	}
+	secondaryGateway.Send(
+		t,
+		base.ExpectOK(),
+		curl.WithHostHeader("secondary.multicontroller.example"),
+		curl.WithPath("/status/200"),
+	)
+
+	base.BaseGateway.Send(
+		t,
+		base.ExpectOK(),
+		curl.WithHostHeader("primary.multicontroller.example"),
+		curl.WithPath("/status/200"),
+	)
+
+	assertGatewayClassController(t, "agentgateway", base.AgentgatewayControllerName)
+}
+
+func applyWithoutResourceWait(t base.Test, manifest string) {
+	t.Helper()
+	err := t.TestInstallation.ClusterContext.Client.ApplyYAMLFiles("", manifest)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		err := t.TestInstallation.ClusterContext.Client.DeleteYAMLFiles("", manifest)
+		assert.NoError(t, err)
+	})
+}
+
+func assertGatewayClassController(t base.Test, name, controllerName string) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		gatewayClass := &gwv1.GatewayClass{}
+		if err := t.TestInstallation.ClusterContext.ControllerClient.Get(
+			t.Ctx,
+			types.NamespacedName{Name: name},
+			gatewayClass,
+		); err != nil {
+			return err
+		}
+		if string(gatewayClass.Spec.ControllerName) != controllerName {
+			return fmt.Errorf(
+				"GatewayClass %s controllerName=%q, want %q",
+				name,
+				gatewayClass.Spec.ControllerName,
+				controllerName,
+			)
+		}
+		return nil
+	})
+}
+
+func assertRouteController(t base.Test, name, namespace, controllerName string) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		route := &gwv1.HTTPRoute{}
+		if err := t.TestInstallation.ClusterContext.ControllerClient.Get(
+			t.Ctx,
+			types.NamespacedName{Name: name, Namespace: namespace},
+			route,
+		); err != nil {
+			return err
+		}
+		for _, parent := range route.Status.Parents {
+			if string(parent.ControllerName) != controllerName {
+				continue
+			}
+			for _, condition := range parent.Conditions {
+				if condition.Type == string(gwv1.RouteConditionAccepted) && condition.Status == metav1.ConditionTrue {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("HTTPRoute %s/%s has no Accepted status from controller %q", namespace, name, controllerName)
+	})
+}
+
+func assertGatewayUsesControlPlane(t base.Test, name, namespace, controllerNamespace string) {
+	t.Helper()
+	retry.UntilSuccessOrFail(t, func() error {
+		deployment, err := t.TestInstallation.ClusterContext.Client.Kube().AppsV1().Deployments(namespace).Get(
+			t.Ctx,
+			name,
+			metav1.GetOptions{},
+		)
+		if err != nil {
+			return err
+		}
+		if len(deployment.Spec.Template.Spec.Containers) == 0 {
+			return fmt.Errorf("Gateway %s/%s deployment has no containers", namespace, name)
+		}
+		for _, env := range deployment.Spec.Template.Spec.Containers[0].Env {
+			if env.Name != "XDS_ADDRESS" {
+				continue
+			}
+			if strings.Contains(env.Value, "."+controllerNamespace+".svc.") {
+				return nil
+			}
+			return fmt.Errorf("Gateway %s/%s XDS_ADDRESS=%q does not target namespace %q", namespace, name, env.Value, controllerNamespace)
+		}
+		return fmt.Errorf("Gateway %s/%s deployment has no XDS_ADDRESS", namespace, name)
+	})
+}
+
+func assertGatewayNotProvisioned(t base.Test, name, namespace string) {
+	t.Helper()
+	assert.Never(t, func() bool {
+		_, err := t.TestInstallation.ClusterContext.Client.Kube().AppsV1().Deployments(namespace).Get(
+			t.Ctx,
+			name,
+			metav1.GetOptions{},
+		)
+		return !apierrors.IsNotFound(err)
+	}, 5*time.Second, 100*time.Millisecond, "unselected Gateway %s/%s was provisioned", namespace, name)
+}

--- a/controller/test/e2e/multicontroller_test.go
+++ b/controller/test/e2e/multicontroller_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
 	e2e "github.com/agentgateway/agentgateway/controller/test/e2e"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/base"
+	"github.com/agentgateway/agentgateway/controller/test/testutils"
 )
 
 const (
@@ -36,7 +37,8 @@ func TestMultipleControllers(tt *testing.T) {
 		secondaryControllerNamespace,
 		e2e.ManifestPath("agent-gateway-secondary.yaml"),
 	)
-	t.Cleanup(func() {
+	secondary.ExtraHelmArgs = primaryImageHelmArgs(t)
+	testutils.Cleanup(t, func() {
 		secondary.UninstallAgentgatewayCore(t.Ctx, tt)
 		secondary.Finalize()
 	})
@@ -82,10 +84,35 @@ func applyWithoutResourceWait(t base.Test, manifest string) {
 	t.Helper()
 	err := t.TestInstallation.ClusterContext.Client.ApplyYAMLFiles("", manifest)
 	assert.NoError(t, err)
-	t.Cleanup(func() {
+	testutils.Cleanup(t, func() {
 		err := t.TestInstallation.ClusterContext.Client.DeleteYAMLFiles("", manifest)
 		assert.NoError(t, err)
 	})
+}
+
+func primaryImageHelmArgs(t base.Test) []string {
+	t.Helper()
+	deployment, err := t.TestInstallation.ClusterContext.Client.Kube().AppsV1().Deployments(
+		t.TestInstallation.InstallNamespace,
+	).Get(t.Ctx, "agentgateway", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get primary controller deployment: %v", err)
+	}
+	if len(deployment.Spec.Template.Spec.Containers) == 0 {
+		t.Fatal("primary controller deployment has no containers")
+	}
+
+	image := deployment.Spec.Template.Spec.Containers[0].Image
+	lastSlash := strings.LastIndex(image, "/")
+	lastColon := strings.LastIndex(image, ":")
+	if lastSlash < 0 || lastColon <= lastSlash || lastColon == len(image)-1 {
+		t.Fatalf("primary controller image %q does not contain a registry, repository, and tag", image)
+	}
+
+	return []string{
+		"--set-string", "image.registry=" + image[:lastSlash],
+		"--set-string", "image.tag=" + image[lastColon+1:],
+	}
 }
 
 func assertGatewayClassController(t base.Test, name, controllerName string) {

--- a/controller/test/e2e/testdata/multicontroller/setup.yaml
+++ b/controller/test/e2e/testdata/multicontroller/setup.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentgateway-secondary-workload
+  labels:
+    e2e.agentgateway.dev/controller: secondary
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agentgateway-unselected
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secondary-backend
+  namespace: agentgateway-secondary-workload
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: secondary-backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: secondary-backend
+    spec:
+      securityContext:
+        sysctls:
+          - name: net.ipv4.ip_unprivileged_port_start
+            value: "0"
+      containers:
+        - name: testbox
+          image: ghcr.io/agentgateway/testbox:0.0.1
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          env:
+            - name: INSTANCE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 1
+            failureThreshold: 60
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 5
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: secondary-backend
+  namespace: agentgateway-secondary-workload
+spec:
+  selector:
+    app.kubernetes.io/name: secondary-backend
+  ports:
+    - name: http
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: secondary-gateway
+  namespace: agentgateway-secondary-workload
+spec:
+  gatewayClassName: agentgateway-secondary
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: secondary-route
+  namespace: agentgateway-secondary-workload
+spec:
+  parentRefs:
+    - name: secondary-gateway
+  hostnames:
+    - secondary.multicontroller.example
+  rules:
+    - backendRefs:
+        - name: secondary-backend
+          port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: primary-route
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - primary.multicontroller.example
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80

--- a/controller/test/e2e/testdata/multicontroller/unselected.yaml
+++ b/controller/test/e2e/testdata/multicontroller/unselected.yaml
@@ -1,0 +1,11 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: unselected-gateway
+  namespace: agentgateway-unselected
+spec:
+  gatewayClassName: agentgateway-secondary
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80


### PR DESCRIPTION
## Summary

- Add end-to-end coverage for two independent controller installations.
- Verify GatewayClass and route ownership, xDS targeting, traffic, and namespace isolation.
- Add focused unit coverage for a configured controller name.

## Testing

- `go test ./controller/pkg/controller ./controller/pkg/syncer ./controller/test/helm`
- `go test -tags=e2e ./controller/test/e2e -run "^$"`
- `VERSION=v1.4.0 USE_PORTFORWARD=true go test -tags=e2e -v ./controller/test/e2e -run "^TestMultipleControllers$" -count=1`

Fixes: #1281