### PR TITLE
fix(llm): preserve buffered responses metadata

### DIFF
--- a/crates/agentgateway/tests/tests/llm_providers.rs
+++ b/crates/agentgateway/tests/tests/llm_providers.rs
@@ -1,7 +1,7 @@
 use agent_core::telemetry::testing;
 use agentgateway::http::Response;
 use http::StatusCode;
-use serde_json::{Value, json};
+use serde_json::json;
 use tracing::warn;
 
 use crate::common::gateway::AgentGateway;
@@ -570,7 +570,8 @@ mod gemini {
 		"gemini",
 		"GEMINI_API_KEY",
 		"gemini-2.5-flash",
-		send_buffered_responses_with_metadata
+		send_responses,
+		false
 	);
 	provider_model_test!(
 		responses_streaming,
@@ -1330,38 +1331,6 @@ async fn send_responses(gw: &AgentGateway, stream: bool) {
 		String::from_utf8_lossy(&bytes)
 	);
 	assert_log("/v1/responses", stream, &test_id).await;
-}
-
-async fn send_buffered_responses_with_metadata(gw: &AgentGateway) {
-	let resp = gw
-		.send_request_json(
-			"http://localhost/v1/responses",
-			json!({
-				"max_output_tokens": 16,
-				"input": "give me a 1 word answer",
-				"stream": false,
-			}),
-		)
-		.await;
-
-	let test_id = test_id_from_response(&resp);
-	let status = resp.status();
-	let bytes = http_body_util::BodyExt::collect(resp.into_body())
-		.await
-		.unwrap()
-		.to_bytes();
-	assert_eq!(
-		status,
-		StatusCode::OK,
-		"body: {:?}",
-		String::from_utf8_lossy(&bytes)
-	);
-
-	let body: Value = serde_json::from_slice(&bytes).expect("buffered response should be JSON");
-	assert_eq!(body["object"], json!("response"));
-	assert!(body["created_at"].is_number());
-	assert!(body["usage"]["total_tokens"].is_number());
-	assert_log("/v1/responses", false, &test_id).await;
 }
 
 pub async fn send_messages(gw: &AgentGateway, stream: bool) {

--- a/crates/agentgateway/tests/tests/llm_providers.rs
+++ b/crates/agentgateway/tests/tests/llm_providers.rs
@@ -1,7 +1,7 @@
 use agent_core::telemetry::testing;
 use agentgateway::http::Response;
 use http::StatusCode;
-use serde_json::json;
+use serde_json::{Value, json};
 use tracing::warn;
 
 use crate::common::gateway::AgentGateway;
@@ -570,8 +570,7 @@ mod gemini {
 		"gemini",
 		"GEMINI_API_KEY",
 		"gemini-2.5-flash",
-		send_responses,
-		false
+		send_buffered_responses_with_metadata
 	);
 	provider_model_test!(
 		responses_streaming,
@@ -1331,6 +1330,38 @@ async fn send_responses(gw: &AgentGateway, stream: bool) {
 		String::from_utf8_lossy(&bytes)
 	);
 	assert_log("/v1/responses", stream, &test_id).await;
+}
+
+async fn send_buffered_responses_with_metadata(gw: &AgentGateway) {
+	let resp = gw
+		.send_request_json(
+			"http://localhost/v1/responses",
+			json!({
+				"max_output_tokens": 16,
+				"input": "give me a 1 word answer",
+				"stream": false,
+			}),
+		)
+		.await;
+
+	let test_id = test_id_from_response(&resp);
+	let status = resp.status();
+	let bytes = http_body_util::BodyExt::collect(resp.into_body())
+		.await
+		.unwrap()
+		.to_bytes();
+	assert_eq!(
+		status,
+		StatusCode::OK,
+		"body: {:?}",
+		String::from_utf8_lossy(&bytes)
+	);
+
+	let body: Value = serde_json::from_slice(&bytes).expect("buffered response should be JSON");
+	assert_eq!(body["object"], json!("response"));
+	assert!(body["created_at"].is_number());
+	assert!(body["usage"]["total_tokens"].is_number());
+	assert_log("/v1/responses", false, &test_id).await;
 }
 
 pub async fn send_messages(gw: &AgentGateway, stream: bool) {

--- a/crates/llm/src/conversion/openai_compat.rs
+++ b/crates/llm/src/conversion/openai_compat.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[path = "openai_compat_tests.rs"]
+mod tests;
+
 pub mod from_responses {
 	use types::completions::typed as completions;
 	use types::responses::typed as responses;
@@ -472,12 +476,8 @@ pub mod to_responses {
 		let resp = serde_json::from_slice::<completions::Response>(bytes)
 			.map_err(logged_response_parsing(bytes))?;
 		let typed = translate_response_internal(resp, model);
-		let mut passthrough =
+		let passthrough =
 			json::convert::<_, types::responses::Response>(&typed).map_err(AIError::ResponseParsing)?;
-		passthrough.rest = serde_json::Value::Object(serde_json::Map::new());
-		if let Some(usage) = passthrough.usage.as_mut() {
-			usage.rest = serde_json::Value::Object(serde_json::Map::new());
-		}
 		Ok(Box::new(passthrough))
 	}
 

--- a/crates/llm/src/conversion/openai_compat_tests.rs
+++ b/crates/llm/src/conversion/openai_compat_tests.rs
@@ -1,0 +1,27 @@
+use bytes::Bytes;
+use serde_json::{Value, json};
+
+use super::to_responses;
+
+fn translate(input: &[u8]) -> Value {
+	let response = to_responses::translate_response(&Bytes::copy_from_slice(input), "input-model")
+		.expect("Chat Completions response should translate");
+	serde_json::from_slice(&response.serialize().expect("response should serialize"))
+		.expect("translated response should be JSON")
+}
+
+#[test]
+fn buffered_failed_response_preserves_error() {
+	let mut input: Value =
+		serde_json::from_slice(include_bytes!("../tests/response/completions/basic.json")).unwrap();
+	input["choices"][0]["finish_reason"] = json!("content_filter");
+	let input = serde_json::to_vec(&input).unwrap();
+
+	let response = translate(&input);
+
+	assert_eq!(response["status"], json!("failed"));
+	assert_eq!(
+		response["error"],
+		json!({"code": "content_filter", "message": "Content filtered"})
+	);
+}

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -485,11 +485,6 @@ mod responses {
 			"parsed": llm_response,
 		});
 		let (snapshot_path, snapshot_name) = snapshot_path_and_name(relative_path, provider);
-		let created_selector = if provider == COMPLETIONS_TO_RESPONSES {
-			".response.created_at"
-		} else {
-			".response.created"
-		};
 
 		insta::with_settings!({
 			info => &provider_value,
@@ -501,7 +496,8 @@ mod responses {
 			insta::assert_json_snapshot!(snapshot_name, report, {
 				".response.id" => "[id]",
 				".response.output.*.id" => "[id]",
-				created_selector => "[date]",
+				".response.created" => "[date]",
+				".response.created_at" => "[date]",
 			});
 		});
 	}
@@ -634,16 +630,11 @@ mod responses {
 	const ALL_COMPLETIONS: &[&str] = &[
 		COMPLETIONS_TO_COMPLETIONS,
 		COMPLETIONS_TO_MESSAGES,
-		COMPLETIONS_TO_DETECT,
-	];
-	const ALL_COMPLETIONS_WITH_RESPONSES: &[&str] = &[
-		COMPLETIONS_TO_COMPLETIONS,
-		COMPLETIONS_TO_MESSAGES,
 		COMPLETIONS_TO_RESPONSES,
 		COMPLETIONS_TO_DETECT,
 	];
 	const COMPLETIONS_RESPONSES: &[(&str, &[&str])] = &[
-		("basic", ALL_COMPLETIONS_WITH_RESPONSES),
+		("basic", ALL_COMPLETIONS),
 		("audio", ALL_COMPLETIONS),
 		(
 			"cache_write",
@@ -652,7 +643,7 @@ mod responses {
 		("openrouter_reasoning", ALL_COMPLETIONS),
 		("gemini_zero_completion_tokens", ALL_COMPLETIONS),
 		("gemini_with_completion_tokens", ALL_COMPLETIONS),
-		("tool_call", ALL_COMPLETIONS_WITH_RESPONSES),
+		("tool_call", ALL_COMPLETIONS),
 		(
 			"truncated_tool_call",
 			&[COMPLETIONS_TO_COMPLETIONS, COMPLETIONS_TO_RESPONSES],

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -485,6 +485,11 @@ mod responses {
 			"parsed": llm_response,
 		});
 		let (snapshot_path, snapshot_name) = snapshot_path_and_name(relative_path, provider);
+		let created_selector = if provider == COMPLETIONS_TO_RESPONSES {
+			".response.created_at"
+		} else {
+			".response.created"
+		};
 
 		insta::with_settings!({
 			info => &provider_value,
@@ -496,7 +501,7 @@ mod responses {
 			insta::assert_json_snapshot!(snapshot_name, report, {
 				".response.id" => "[id]",
 				".response.output.*.id" => "[id]",
-				".response.created" => "[date]",
+				created_selector => "[date]",
 			});
 		});
 	}
@@ -631,8 +636,14 @@ mod responses {
 		COMPLETIONS_TO_MESSAGES,
 		COMPLETIONS_TO_DETECT,
 	];
+	const ALL_COMPLETIONS_WITH_RESPONSES: &[&str] = &[
+		COMPLETIONS_TO_COMPLETIONS,
+		COMPLETIONS_TO_MESSAGES,
+		COMPLETIONS_TO_RESPONSES,
+		COMPLETIONS_TO_DETECT,
+	];
 	const COMPLETIONS_RESPONSES: &[(&str, &[&str])] = &[
-		("basic", ALL_COMPLETIONS),
+		("basic", ALL_COMPLETIONS_WITH_RESPONSES),
 		("audio", ALL_COMPLETIONS),
 		(
 			"cache_write",
@@ -641,8 +652,11 @@ mod responses {
 		("openrouter_reasoning", ALL_COMPLETIONS),
 		("gemini_zero_completion_tokens", ALL_COMPLETIONS),
 		("gemini_with_completion_tokens", ALL_COMPLETIONS),
-		("tool_call", ALL_COMPLETIONS),
-		("truncated_tool_call", &[COMPLETIONS_TO_COMPLETIONS]),
+		("tool_call", ALL_COMPLETIONS_WITH_RESPONSES),
+		(
+			"truncated_tool_call",
+			&[COMPLETIONS_TO_COMPLETIONS, COMPLETIONS_TO_RESPONSES],
+		),
 	];
 	const RESPONSES_RESPONSES: &[(&str, &[&str])] = &[
 		("basic", &[RESPONSES_TO_RESPONSES, RESPONSES_TO_DETECT]),
@@ -756,6 +770,9 @@ mod responses {
 					}),
 					COMPLETIONS_TO_MESSAGES => test_response(provider, &path, |i| {
 						conversion::completions::from_messages::translate_response(&i)
+					}),
+					COMPLETIONS_TO_RESPONSES => test_response(provider, &path, |i| {
+						conversion::openai_compat::to_responses::translate_response(&i, "input-model")
 					}),
 					COMPLETIONS_TO_DETECT => test_response(provider, &path, |bytes| {
 						Ok(Box::new(

--- a/crates/llm/src/tests/response/completions/audio.completions-responses.snap
+++ b/crates/llm/src/tests/response/completions/audio.completions-responses.snap
@@ -1,0 +1,81 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/audio.json
+info:
+  id: chatcmpl-audioTokens123
+  object: chat.completion
+  created: 1755008546
+  model: gpt-4o-audio-preview
+  choices:
+    - index: 0
+      message:
+        role: assistant
+        content: Here is the transcription and spoken answer.
+        audio:
+          id: audio_junk_123
+          data: ZmFrZS1hdWRpby1ieXRlcw==
+          expires_at: 1755009546
+          transcript: Here is the transcription and spoken answer.
+        refusal: ~
+        annotations: []
+      logprobs: ~
+      finish_reason: stop
+  usage:
+    prompt_tokens: 320
+    completion_tokens: 180
+    total_tokens: 500
+    prompt_tokens_details:
+      cached_tokens: 12
+      audio_tokens: 240
+    completion_tokens_details:
+      reasoning_tokens: 15
+      audio_tokens: 90
+      accepted_prediction_tokens: 0
+      rejected_prediction_tokens: 0
+  service_tier: default
+  system_fingerprint: ~
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "completed",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": null,
+            "text": "Here is the transcription and spoken answer."
+          }
+        ],
+        "id": "[id]",
+        "role": "assistant",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 320,
+      "output_tokens": 180,
+      "input_tokens_details": {
+        "cached_tokens": 12
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 15
+      },
+      "total_tokens": 500
+    },
+    "created_at": "[date]",
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 320,
+    "output_tokens": 180,
+    "total_tokens": 500,
+    "reasoning_tokens": 15,
+    "cached_input_tokens": 12,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/llm/src/tests/response/completions/basic.completions-responses.snap
+++ b/crates/llm/src/tests/response/completions/basic.completions-responses.snap
@@ -1,0 +1,76 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/basic.json
+info:
+  id: chatcmpl-C3kBOLGARFj2WJrm5MRyuTiK4u6eF
+  object: chat.completion
+  created: 1755008546
+  model: gpt-3.5-turbo-0125
+  choices:
+    - index: 0
+      message:
+        role: assistant
+        content: "Sorry, I couldn't find the name of the LLM provider. Could you please provide more information or context?"
+        refusal: ~
+        annotations: []
+      logprobs: ~
+      finish_reason: stop
+  usage:
+    prompt_tokens: 17
+    completion_tokens: 23
+    total_tokens: 40
+    prompt_tokens_details:
+      cached_tokens: 0
+      audio_tokens: 0
+    completion_tokens_details:
+      reasoning_tokens: 0
+      audio_tokens: 0
+      accepted_prediction_tokens: 0
+      rejected_prediction_tokens: 0
+  service_tier: default
+  system_fingerprint: ~
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "completed",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": null,
+            "text": "Sorry, I couldn't find the name of the LLM provider. Could you please provide more information or context?"
+          }
+        ],
+        "id": "[id]",
+        "role": "assistant",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 17,
+      "output_tokens": 23,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 40
+    },
+    "created_at": "[date]",
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 17,
+    "output_tokens": 23,
+    "total_tokens": 40,
+    "reasoning_tokens": 0,
+    "cached_input_tokens": 0,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/llm/src/tests/response/completions/gemini_with_completion_tokens.completions-responses.snap
+++ b/crates/llm/src/tests/response/completions/gemini_with_completion_tokens.completions-responses.snap
@@ -1,0 +1,66 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/gemini_with_completion_tokens.json
+info:
+  model: gemini-2.5-flash
+  usage:
+    prompt_tokens: 7
+    completion_tokens: 12
+    total_tokens: 402
+  choices:
+    - message:
+        content: "Hello! I'm functioning perfectly and ready to assist.\n\n"
+        role: assistant
+      finish_reason: length
+      index: 0
+  created: 1775595257
+  id: 9W7VaabzK7KPjMcPnYGiuAU
+  object: chat.completion
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "incomplete",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": null,
+            "text": "Hello! I'm functioning perfectly and ready to assist.\n\n"
+          }
+        ],
+        "id": "[id]",
+        "role": "assistant",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 7,
+      "output_tokens": 12,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 402
+    },
+    "created_at": "[date]",
+    "incomplete_details": {
+      "reason": "max_tokens"
+    },
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 7,
+    "output_tokens": 12,
+    "total_tokens": 19,
+    "reasoning_tokens": 0,
+    "cached_input_tokens": 0,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/llm/src/tests/response/completions/gemini_zero_completion_tokens.completions-responses.snap
+++ b/crates/llm/src/tests/response/completions/gemini_zero_completion_tokens.completions-responses.snap
@@ -1,0 +1,50 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/gemini_zero_completion_tokens.json
+info:
+  model: gemini-2.5-flash
+  usage:
+    prompt_tokens: 7
+    completion_tokens: 0
+    total_tokens: 8
+  choices:
+    - message:
+        role: assistant
+      finish_reason: length
+      index: 0
+  created: 1775595226
+  id: 2m7Vaca_HdfC1MkP1trPwAM
+  object: chat.completion
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "incomplete",
+    "output": [],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 7,
+      "output_tokens": 1,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 8
+    },
+    "created_at": "[date]",
+    "incomplete_details": {
+      "reason": "max_tokens"
+    },
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 7,
+    "output_tokens": 1,
+    "total_tokens": 8,
+    "reasoning_tokens": 0,
+    "cached_input_tokens": 0,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/llm/src/tests/response/completions/openrouter_reasoning.completions-responses.snap
+++ b/crates/llm/src/tests/response/completions/openrouter_reasoning.completions-responses.snap
@@ -1,0 +1,74 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/openrouter_reasoning.json
+info:
+  id: gen-1758648153-xeB95xIQsxABYYNTJLAj
+  provider: test
+  model: test
+  object: chat.completion
+  created: 1758648153
+  choices:
+    - logprobs: ~
+      finish_reason: stop
+      native_finish_reason: stop
+      index: 0
+      message:
+        role: assistant
+        content: hello world!
+        refusal: ~
+        reasoning: "Okay, the user wants me to write a story"
+        reasoning_details:
+          - type: reasoning.text
+            text: "Okay, the user wants me to write a story"
+            format: unknown
+            index: 0
+  usage:
+    prompt_tokens: 23
+    completion_tokens: 796
+    total_tokens: 819
+    prompt_tokens_details: ~
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "completed",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": null,
+            "text": "hello world!"
+          }
+        ],
+        "id": "[id]",
+        "role": "assistant",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 23,
+      "output_tokens": 796,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 819
+    },
+    "created_at": "[date]",
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 23,
+    "output_tokens": 796,
+    "total_tokens": 819,
+    "reasoning_tokens": 0,
+    "cached_input_tokens": 0,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/llm/src/tests/response/completions/stream.completions-responses-streaming.snap
+++ b/crates/llm/src/tests/response/completions/stream.completions-responses-streaming.snap
@@ -1,0 +1,294 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/stream.json
+---
+event: event
+data: {"type":"response.created","sequence_number":1,"response":{"created_at":123,"id":"","model":"gpt-5-nano-2025-08-07","object":"response","output":[],"status":"in_progress"}}
+
+event: event
+data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"in_progress"}}
+
+event: event
+data: {"type":"response.content_part.added","sequence_number":3,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":null,"text":""}}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"","output_index":0,"content_index":0,"delta":""}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"","output_index":0,"content_index":0,"delta":"Hi"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"","output_index":0,"content_index":0,"delta":" there"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"","output_index":0,"content_index":0,"delta":"!"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"","output_index":0,"content_index":0,"delta":" How"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"","output_index":0,"content_index":0,"delta":" can"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"","output_index":0,"content_index":0,"delta":" I"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"","output_index":0,"content_index":0,"delta":" help"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"","output_index":0,"content_index":0,"delta":" today"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"","output_index":0,"content_index":0,"delta":"?"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"","output_index":0,"content_index":0,"delta":" If"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"","output_index":0,"content_index":0,"delta":" you"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"","output_index":0,"content_index":0,"delta":"’re"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"","output_index":0,"content_index":0,"delta":" not"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"","output_index":0,"content_index":0,"delta":" sure"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"","output_index":0,"content_index":0,"delta":" where"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"","output_index":0,"content_index":0,"delta":" to"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"","output_index":0,"content_index":0,"delta":" start"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"","output_index":0,"content_index":0,"delta":","}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"","output_index":0,"content_index":0,"delta":" I"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"","output_index":0,"content_index":0,"delta":" can"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"","output_index":0,"content_index":0,"delta":":\n\n"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"","output_index":0,"content_index":0,"delta":"-"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"","output_index":0,"content_index":0,"delta":" Answer"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"","output_index":0,"content_index":0,"delta":" questions"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"","output_index":0,"content_index":0,"delta":" or"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"","output_index":0,"content_index":0,"delta":" explain"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"","output_index":0,"content_index":0,"delta":" concepts"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"","output_index":0,"content_index":0,"delta":"\n"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"","output_index":0,"content_index":0,"delta":"-"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"","output_index":0,"content_index":0,"delta":" Help"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"","output_index":0,"content_index":0,"delta":" with"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"","output_index":0,"content_index":0,"delta":" writing"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"","output_index":0,"content_index":0,"delta":","}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"","output_index":0,"content_index":0,"delta":" editing"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"","output_index":0,"content_index":0,"delta":","}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"","output_index":0,"content_index":0,"delta":" or"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"","output_index":0,"content_index":0,"delta":" brainstorming"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"","output_index":0,"content_index":0,"delta":"\n"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"","output_index":0,"content_index":0,"delta":"-"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"","output_index":0,"content_index":0,"delta":" Assist"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"","output_index":0,"content_index":0,"delta":" with"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"","output_index":0,"content_index":0,"delta":" coding"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"","output_index":0,"content_index":0,"delta":","}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"","output_index":0,"content_index":0,"delta":" math"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"","output_index":0,"content_index":0,"delta":","}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"","output_index":0,"content_index":0,"delta":" or"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"","output_index":0,"content_index":0,"delta":" data"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"","output_index":0,"content_index":0,"delta":" tasks"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"","output_index":0,"content_index":0,"delta":"\n"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"","output_index":0,"content_index":0,"delta":"-"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"","output_index":0,"content_index":0,"delta":" Plan"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"","output_index":0,"content_index":0,"delta":" something"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"","output_index":0,"content_index":0,"delta":" ("}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"","output_index":0,"content_index":0,"delta":"a"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"","output_index":0,"content_index":0,"delta":" trip"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"","output_index":0,"content_index":0,"delta":","}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"","output_index":0,"content_index":0,"delta":" a"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"","output_index":0,"content_index":0,"delta":" project"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":63,"item_id":"","output_index":0,"content_index":0,"delta":","}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":64,"item_id":"","output_index":0,"content_index":0,"delta":" a"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":65,"item_id":"","output_index":0,"content_index":0,"delta":" study"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":66,"item_id":"","output_index":0,"content_index":0,"delta":" schedule"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":67,"item_id":"","output_index":0,"content_index":0,"delta":")\n"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":68,"item_id":"","output_index":0,"content_index":0,"delta":"-"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":69,"item_id":"","output_index":0,"content_index":0,"delta":" Translate"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":70,"item_id":"","output_index":0,"content_index":0,"delta":" or"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":71,"item_id":"","output_index":0,"content_index":0,"delta":" practice"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":72,"item_id":"","output_index":0,"content_index":0,"delta":" a"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":73,"item_id":"","output_index":0,"content_index":0,"delta":" language"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":74,"item_id":"","output_index":0,"content_index":0,"delta":"\n\n"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":75,"item_id":"","output_index":0,"content_index":0,"delta":"Tell"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":76,"item_id":"","output_index":0,"content_index":0,"delta":" me"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":77,"item_id":"","output_index":0,"content_index":0,"delta":" what"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":78,"item_id":"","output_index":0,"content_index":0,"delta":" you"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":79,"item_id":"","output_index":0,"content_index":0,"delta":"’re"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":80,"item_id":"","output_index":0,"content_index":0,"delta":" aiming"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":81,"item_id":"","output_index":0,"content_index":0,"delta":" for"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":82,"item_id":"","output_index":0,"content_index":0,"delta":","}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":83,"item_id":"","output_index":0,"content_index":0,"delta":" and"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":84,"item_id":"","output_index":0,"content_index":0,"delta":" I"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":85,"item_id":"","output_index":0,"content_index":0,"delta":"’ll"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":86,"item_id":"","output_index":0,"content_index":0,"delta":" tailor"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":87,"item_id":"","output_index":0,"content_index":0,"delta":" my"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":88,"item_id":"","output_index":0,"content_index":0,"delta":" help"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":89,"item_id":"","output_index":0,"content_index":0,"delta":"."}
+
+event: event
+data: {"type":"response.content_part.done","sequence_number":90,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":null,"text":""}}
+
+event: event
+data: {"type":"response.output_item.done","sequence_number":91,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"completed"}}
+
+event: event
+data: {"type":"response.completed","sequence_number":92,"response":{"created_at":123,"id":"","model":"gpt-5-nano-2025-08-07","object":"response","output":[],"status":"completed","usage":{"input_tokens":18,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":null},"output_tokens":286,"output_tokens_details":{"reasoning_tokens":192},"total_tokens":304}}}
+
+
+
+{
+  "input_tokens": 18,
+  "output_tokens": 286,
+  "total_tokens": 304,
+  "reasoning_tokens": 192,
+  "cached_input_tokens": 0,
+  "service_tier": "default",
+  "provider_model": "gpt-5-nano-2025-08-07",
+  "completion": [
+    "Hi there! How can I help today? If you’re not sure where to start, I can:\n\n- Answer questions or explain concepts\n- Help with writing, editing, or brainstorming\n- Assist with coding, math, or data tasks\n- Plan something (a trip, a project, a study schedule)\n- Translate or practice a language\n\nTell me what you’re aiming for, and I’ll tailor my help."
+  ]
+}

--- a/crates/llm/src/tests/response/completions/tool_call.completions-responses.snap
+++ b/crates/llm/src/tests/response/completions/tool_call.completions-responses.snap
@@ -1,0 +1,109 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/tool_call.json
+info:
+  id: chatcmpl-tool-call-test
+  object: chat.completion
+  created: 1772656915
+  model: gpt-4-turbo
+  choices:
+    - index: 0
+      message:
+        role: assistant
+        content: ~
+        tool_calls:
+          - id: call_abc123
+            type: function
+            function:
+              name: get_weather
+              arguments: "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}"
+          - id: call_xyz789
+            type: function
+            function:
+              name: search_web
+              arguments: "{\"query\": \"Claude AI\"}"
+      finish_reason: tool_calls
+  usage:
+    prompt_tokens: 25
+    completion_tokens: 18
+    total_tokens: 43
+    prompt_tokens_details:
+      cached_tokens: 0
+      audio_tokens: 0
+    completion_tokens_details:
+      reasoning_tokens: 0
+      audio_tokens: 0
+  service_tier: default
+  system_fingerprint: ~
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "completed",
+    "output": [
+      {
+        "type": "function_call",
+        "arguments": "{\"location\": \"San Francisco\", \"unit\": \"celsius\"}",
+        "call_id": "call_abc123",
+        "name": "get_weather",
+        "id": "[id]",
+        "status": "completed"
+      },
+      {
+        "type": "function_call",
+        "arguments": "{\"query\": \"Claude AI\"}",
+        "call_id": "call_xyz789",
+        "name": "search_web",
+        "id": "[id]",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 25,
+      "output_tokens": 18,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 43
+    },
+    "created_at": "[date]",
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 25,
+    "output_tokens": 18,
+    "total_tokens": 43,
+    "reasoning_tokens": 0,
+    "cached_input_tokens": 0,
+    "provider_model": "input-model",
+    "output_messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_call",
+            "id": "call_abc123",
+            "name": "get_weather",
+            "arguments": {
+              "location": "San Francisco",
+              "unit": "celsius"
+            }
+          },
+          {
+            "type": "tool_call",
+            "id": "call_xyz789",
+            "name": "search_web",
+            "arguments": {
+              "query": "Claude AI"
+            }
+          }
+        ],
+        "finish_reason": "completed"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/response/completions/truncated_tool_call.completions-responses.snap
+++ b/crates/llm/src/tests/response/completions/truncated_tool_call.completions-responses.snap
@@ -1,0 +1,80 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/truncated_tool_call.json
+info:
+  id: chatcmpl-truncated-tool-call
+  object: chat.completion
+  created: 1700000000
+  model: gpt-x
+  choices:
+    - index: 0
+      message:
+        role: assistant
+        content: ~
+        tool_calls:
+          - id: call_1
+            type: function
+            function:
+              name: get_weather
+              arguments: "{\"location\": \"Par"
+      finish_reason: length
+  usage:
+    prompt_tokens: 20
+    completion_tokens: 15
+    total_tokens: 35
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "incomplete",
+    "output": [
+      {
+        "type": "function_call",
+        "arguments": "{\"location\": \"Par",
+        "call_id": "call_1",
+        "name": "get_weather",
+        "id": "[id]",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 20,
+      "output_tokens": 15,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 35
+    },
+    "created_at": "[date]",
+    "incomplete_details": {
+      "reason": "max_tokens"
+    },
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 20,
+    "output_tokens": 15,
+    "total_tokens": 35,
+    "reasoning_tokens": 0,
+    "cached_input_tokens": 0,
+    "provider_model": "input-model",
+    "output_messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_call",
+            "id": "call_1",
+            "name": "get_weather",
+            "arguments": "{\"location\": \"Par"
+          }
+        ],
+        "finish_reason": "incomplete"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/response/responses/basic.responses-detect.snap
+++ b/crates/llm/src/tests/response/responses/basic.responses-detect.snap
@@ -63,7 +63,7 @@ info:
   "response": {
     "id": "[id]",
     "object": "response",
-    "created_at": 1772657185,
+    "created_at": "[date]",
     "status": "completed",
     "background": false,
     "billing": {

--- a/crates/llm/src/tests/response/responses/basic.responses-responses.snap
+++ b/crates/llm/src/tests/response/responses/basic.responses-responses.snap
@@ -93,7 +93,7 @@ info:
       "total_tokens": 20
     },
     "object": "response",
-    "created_at": 1772657185,
+    "created_at": "[date]",
     "background": false,
     "billing": {
       "payer": "developer"


### PR DESCRIPTION
## Summary

Buffered Chat Completions responses converted to the Responses API now keep the metadata produced by AgentGateway's `ResponseBuilder`, so clients receive `object`, `created_at`, `incomplete_details`, `error`, and `usage.total_tokens` alongside the existing response content and tool calls.

Two cleanup assignments disappear. The code already built these fields, then `openai_compat::to_responses::translate_response` emptied the generated metadata immediately before serialization.

## Root cause

[PR #790](https://github.com/agentgateway/agentgateway/pull/790) deliberately cleared generated fields from buffered Bedrock responses to preserve their existing minimal payload during an `async-openai` upgrade. [PR #1540](https://github.com/agentgateway/agentgateway/pull/1540) copied that pattern into the new OpenAI-compatible Chat-to-Responses converter, so its buffered Responses payload omitted standard metadata from the day it shipped.

The Bedrock converter still keeps the compatibility behavior introduced by [PR #790](https://github.com/agentgateway/agentgateway/pull/790), while native Responses pass-through, streaming conversion, direct Chat Completions, embeddings, and provider-specific conversion paths stay as they were. Copilot Chat and embeddings stay separate.

## Coverage

Golden tests now run Chat Completions to Responses conversion across the shared completions fixture matrix. Seven buffered snapshots cover basic text, audio, OpenRouter reasoning, two Gemini usage cases, tool calls, and truncated tool calls. One streaming snapshot covers event translation. The failed response keeps its focused unit test.

The live Gemini provider assertion was removed because this conversion is local JSON work and does not need provider traffic. The snapshot harness now applies both `created` and `created_at` rewrites to keep dynamic timestamps stable.

## Test plan

```console
cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true
cargo test -p agent-llm
cargo test -p agentgateway --test integration --no-run
cargo clippy -p agent-llm -p agentgateway --all-targets -- -D warnings
```

Manual validation through Copilot using `gemini-3.6-flash` returned HTTP 200 and confirmed the buffered metadata, usage, and request logging.
