### PR TITLE
Fix initial model catalog refresh

### DIFF
--- a/crates/agentgateway/src/llm/cost/refresh.rs
+++ b/crates/agentgateway/src/llm/cost/refresh.rs
@@ -19,7 +19,7 @@ pub struct RefreshBaseCatalogResponse {
 
 pub async fn refresh_models_dev_base_catalog(
 	file: &Path,
-	model_catalog: &ModelCatalog,
+	model_catalog: Option<&ModelCatalog>,
 ) -> anyhow::Result<RefreshBaseCatalogResponse> {
 	let refreshed = fetch_models_dev_base_catalog().await?;
 	let catalog = refreshed.catalog.clone();
@@ -28,7 +28,9 @@ pub async fn refresh_models_dev_base_catalog(
 		fs_err::tokio::create_dir_all(parent).await?;
 	}
 	fs_err::tokio::write(file, &json).await?;
-	model_catalog.reload().await?;
+	if let Some(model_catalog) = model_catalog {
+		model_catalog.reload().await?;
+	}
 	Ok(refreshed)
 }
 

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -696,7 +696,7 @@ async fn refresh_base_costs(State(app): State<App>) -> Result<Json<Value>, Error
 
 	let refreshed = crate::llm::cost::refresh::refresh_models_dev_base_catalog(
 		&base_costs_file,
-		app.model_catalog.as_ref(),
+		configured_file.map(|_| app.model_catalog.as_ref()),
 	)
 	.await?;
 


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/2827

after writing base-costs.json, the refresh endpoint tried to reload an in-memory catalog with no configured sources. That failed before returning the file path, so the UI never added config.modelCatalog.