### PR TITLE
api: remove redundant CEL uniqueness check on MCPBackend.targets

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -550,7 +550,6 @@ type MCPBackend struct {
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=32
-	// +kubebuilder:validation:XValidation:message="target names must be unique",rule="self.all(t1, self.exists_one(t2, t1.name == t2.name))"
 	// +required
 	Targets []McpTargetSelector `json:"targets"`
 

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9183,9 +9183,6 @@ spec:
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
-                    x-kubernetes-validations:
-                    - message: target names must be unique
-                      rule: self.all(t1, self.exists_one(t2, t1.name == t2.name))
                 required:
                 - targets
                 type: object


### PR DESCRIPTION
We recently ran into the same MaxItems=32 limit as #1833

While investigating CEL budget consumption to see if there was room to increase this beyond 32, Claude picked up on what it believed to be a redundant CEL validation.

https://github.com/agentgateway/agentgateway/blob/71b1d86186c2e8a314240a87e2005d825573f643/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go#L553

Claude seemed to think that map types already have built-in unique key enforcements. If this is true and applicable, then I believe a large chunk of CEL budget is redundantly allocated towards this rule. The constraint checks each name against each name, resulting in an N^2 computation cost.

Our hope is that, provided this rule is actually redundant, that it be removed, and that the newly-freed CEL budget would be allocated towards an increase in MaxItems. Claude did some testing, and seemed to think going as high as MaxItems=16384 would be feasible if the redundant rule were removed. I imagine this would be unecessarily high, but internally we're hoping it could be increased to at least 128.

This all seems to check out to me, but given the AI-discovered nature my hope is that you all would confirm this validation can be removed against your own internal testing.

Thanks,
Greg

---

This is Claude's writeup:

## Summary

`spec.mcp.targets` (`MCPBackend.Targets`, `controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go:553`) carries both:

```go
// +listType=map
// +listMapKey=name
// +kubebuilder:validation:MinItems=1
// +kubebuilder:validation:MaxItems=32
// +kubebuilder:validation:XValidation:message="target names must be unique",rule="self.all(t1, self.exists_one(t2, t1.name == t2.name))"
// +required
Targets []McpTargetSelector `json:"targets"`
```

`x-kubernetes-list-type: map` + `x-kubernetes-list-map-keys: [name]` is not just a Server-Side-Apply merge hint — it's a **structural schema constraint** the apiextensions-apiserver enforces on every create/update of the custom resource, independent of CEL. It already rejects any `targets` list whose `name` values aren't unique. The `x-kubernetes-validations` rule re-checks the identical constraint.

## Supporting documentation

1. **[kubernetes/kubernetes#84920 — "apiextensions: validate list-type map+set uniqueness in CRs"](https://github.com/kubernetes/kubernetes/pull/84920)** (merged 2020-02-26, shipped in Kubernetes 1.18). Release note:
   > Fixed missing validation of uniqueness of list items in lists with `x-kubernetes-list-type: map` or `x-kubernetes-list-type: set` in CustomResources.

   Fixes [kubernetes/kubernetes#84724](https://github.com/kubernetes/kubernetes/issues/84724). This enforcement predates `x-kubernetes-validations`/CEL entirely (CEL for CRDs shipped as alpha in 1.25, GA in 1.29), so it doesn't depend on CEL being present or evaluated.

2. **[Kubernetes CRD docs — Custom resource definitions](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/)** — structural schemas / `x-kubernetes-list-type` reference.

3. **[controller-tools marker docs](https://pkg.go.dev/sigs.k8s.io/controller-tools/pkg/crd/markers)** — the exact markers this repo uses (`+listType`, `+listMapKey`). `ListType`'s doc comment:
   > `"map"`: it needs to have a key field, which will be used to build an **associative list**. A typical example is a the pod container list, which is indexed by the container name.

4. **This repo's own generated CRD** (`controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml`, pre-change) rendered both constraints on the same field:
   ```yaml
   x-kubernetes-list-map-keys:
   - name
   x-kubernetes-list-type: map
   x-kubernetes-validations:
   - message: target names must be unique
     rule: self.all(t1, self.exists_one(t2, t1.name == t2.name))
   ```
   The first two lines already make the CEL block unreachable in practice.

## This repo already relies on `listMapKey` alone everywhere else

Every other `+listType=map` field in the codebase omits the extra CEL rule — including one 200 lines away in the same file:

```go
// agentgateway_backend_types.go:330-336
// Provider-native API formats this provider supports.
// +kubebuilder:validation:MinItems=1
// +kubebuilder:validation:MaxItems=6
// +listType=map
// +listMapKey=type
// +required
Formats []ProviderFormatConfig `json:"formats"`
```

```go
// agentgateway_policy_types.go:2489-2509
// Headers to set and the values to use.
// +listType=map
// +listMapKey=name
// +kubebuilder:validation:MinItems=1
// +kubebuilder:validation:MaxItems=16
// +optional
Set []HeaderTransformation `json:"set,omitempty"`
// ...
// +listType=map
// +listMapKey=name
// +kubebuilder:validation:MinItems=1
// +kubebuilder:validation:MaxItems=16
// +optional
Add []HeaderTransformation `json:"add,omitempty"`
```

```go
// shared_types.go:102-108
// +listType=map
// +listMapKey=type
// +kubebuilder:validation:MaxItems=8
Conditions []metav1.Condition `json:"conditions,omitempty"`
```

`Targets` was the only `listMapKey`-annotated field in the codebase also carrying a CEL uniqueness rule.

## Verified empirically against a real apiserver

I didn't want to leave the MaxItems feasibility number as an unverified guess, so I actually tested it: spun up `envtest` (real `kube-apiserver` + `etcd`, **v1.36.2**, matching this repo's own `k8s.io/apiextensions-apiserver v0.36.3` dependency exactly) and applied the *actual* generated `targets` schema (extracted verbatim from this repo's rendered CRD) as a standalone test CRD, sweeping `maxItems` to find exactly where CRD establishment starts failing on estimated CEL cost.

**With the rule in place** (today's schema, only `maxItems` varied):

```
maxItems=304  -> applies successfully
maxItems=305  -> rejected:
  x-kubernetes-validations[0].rule: Forbidden: estimated rule cost
  exceeds budget by factor of 1.004853x
```

So even without any other change, this rule caps `targets` at **304** — already a hard ceiling, and the error message names this exact rule.

**With the rule removed:**

```
maxItems=18382  -> applies successfully
maxItems=18383  -> rejected:
  targets.items.properties[static].properties[policies].properties[auth]
  .properties[credentials].items.properties[location]
  .x-kubernetes-validations[0].rule: Forbidden: estimated rule cost
  exceeds budget by factor of 1.000035x
```

Removing the rule raises the ceiling **from 304 to 18382 (~60x)**. The new ceiling is no longer governed by anything in `targets` itself — it's set by an unrelated, pre-existing CEL rule nested under `targets[].static.policies.auth.credentials[].location`. Both boundaries reproduced identically on K8s 1.34.0 and 1.36.2.

This closely matches (and now confirms) the ballpark figure from our earlier investigation — freeing this budget doesn't just clear the requested 128, it clears it by two orders of magnitude, with plenty of margin for future schema growth elsewhere (per @howardjohn's comment on #1833 about not wanting to paint into a corner as new fields get added).

## Confirmed the constraint still holds with the rule gone

To make sure "structural schema enforces this independently" wasn't just theory, I created the CRD with the rule *removed* and tried to create an actual custom resource with two `targets` entries sharing the same `name`:

```
$ kubectl apply -f dup_cr.yaml
The CelBudgetProbe "dup-test" is invalid: spec.targets[1]: Duplicate value: {"name":"duplicate-name"}
```

Rejected — via a generic structural-schema `Duplicate value` error, not the CEL rule's custom message (because the rule isn't there). A control case with unique names applied cleanly. So removing the CEL rule doesn't weaken the guarantee at all; it just removes a second check for a condition the apiserver already refuses to allow.

## Change

- Removed the `x-kubernetes-validations` rule from `MCPBackend.Targets` (`controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go`).
- Regenerated `controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml` via the repo's own `hack/crdgen`.
- `maxItems` is left at 32 in this PR — happy to follow up with an increase once you've confirmed the headroom analysis mentioned in #1833, or to fold it into this PR if you'd rather do both at once.

## Test plan

- [x] Regenerated CRDs; confirmed the `x-kubernetes-validations` block for `targets` is gone while `x-kubernetes-list-type: map` / `x-kubernetes-list-map-keys: [name]` remain untouched.
- [x] Verified via envtest (real kube-apiserver 1.34.0 and 1.36.2) that the map-key uniqueness constraint is still enforced through the structural schema alone.
- [ ] Would appreciate maintainer confirmation against your own CEL-budget analysis from #1833 before merge.
