### PR TITLE
🤖  Fix :authority mutation no-op for CONNECT requests

### DIFF
--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -3476,8 +3476,6 @@ mod header_mutations {
 	}
 }
 
-// Reproduction for a substrate atenet-router bug report: ext_proc rewriting
-// `:authority` on a CONNECT request against a `dynamic: {}` backend.
 mod connect_authority_mutation {
 	use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -3598,9 +3596,7 @@ mod connect_authority_mutation {
 
 	/// Separate from the authority no-op bug: does a `backendTLS` policy attached
 	/// to a `dynamic: {}` route backend actually get originated for a CONNECT
-	/// tunnel? substrate's atenet-router config attaches `backendTLS` exactly
-	/// this way (inline on the route's dynamic backend reference) because the
-	/// worker it tunnels to only accepts TLS.
+	/// tunnel?
 	#[cfg(feature = "tls-aws-lc")]
 	#[tokio::test]
 	async fn connect_dynamic_backend_honors_inline_backend_tls() {
@@ -3626,9 +3622,10 @@ mod connect_authority_mutation {
 			.write()
 			.insert_backend(dynamic_backend.name(), dynamic_backend.into());
 
+		// No `hostname` override
 		let backend_tls: BackendTLS = ResolvedBackendTLS {
 			root: Some(certs.root_cert.pem().into_bytes()),
-			hostname: Some("localhost".to_string()),
+			insecure_host: true,
 			alpn: Some(vec!["http/1.1".to_string()]),
 			..Default::default()
 		}
@@ -3723,6 +3720,171 @@ mod connect_authority_mutation {
 				 the worker's TLS listener undecrypted (partial: {tunneled_text})"
 			),
 		}
+	}
+
+	/// Design question from the substrate atenet-router bug report: switching
+	/// `frontendPolicies.connect.mode` from `route` to `tunnel` would run
+	/// ext_proc on every request inside the tunnel (not just the CONNECT),
+	/// which would fix the target-port propagation gap Route mode has. But it
+	/// needs the *original* CONNECT authority (which carries both the actor
+	/// identity and the target port) available to ext_proc for each re-entered
+	/// request -- the re-entered request's own Host header is whatever the
+	/// client happens to send inside the tunnel, unrelated to the actor.
+	///
+	/// This reproduces the full topology: an outer bind terminates the CONNECT
+	/// tunnel and re-enters an inner wildcard bind, whose route's ext_proc
+	/// resolves `source.connectHeaders["host"]` (the original CONNECT
+	/// authority) instead of `request.host`, then rewrites `:authority` to the
+	/// worker exactly like the existing (working) Route-mode mutation does.
+	#[tokio::test]
+	async fn tunnel_mode_reentry_carries_connect_authority_to_ext_proc() {
+		use crate::types::agent::{BindMode, TunnelProtocol};
+
+		let worker = body_mock(b"WORKER-MARKER").await;
+		let worker_addr = worker.address().to_string();
+		let seen_authority: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+		let ext_proc = {
+			let seen_authority = seen_authority.clone();
+			ExtProcMock::new(move || TunnelRewriteAuthorityExtProc {
+				target: worker_addr.clone(),
+				seen_authority: seen_authority.clone(),
+			})
+			.spawn()
+			.await
+		};
+
+		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+		let t = setup_proxy_test("{}").unwrap();
+		t.inputs()
+			.stores
+			.binds
+			.write()
+			.insert_backend(dynamic_backend.name(), dynamic_backend.into());
+
+		// Outer bind: terminates the CONNECT tunnel (Tunnel mode).
+		let mut outer = simple_bind();
+		outer.key = strng::literal!("outer");
+		outer.address = "127.0.0.1:15013".parse().unwrap();
+		outer.tunnel_protocol = TunnelProtocol::Connect;
+
+		// Inner: wildcard internal bind, re-entered regardless of the CONNECT's
+		// target port (our router serves an actor's arbitrary exposed port, so
+		// there's no fixed port to bind on ahead of time).
+		let mut inner = simple_bind();
+		inner.key = strng::literal!("bind/wildcard");
+		inner.mode = BindMode::Internal;
+
+		let t = t
+			.with_backend(ext_proc.address)
+			.with_bind(outer)
+			.with_bind(inner)
+			.with_route(basic_named_route("/dynamic".into()));
+		let t = t
+			.attach_route_policy_builder(json!({
+				"extProc": {
+					"host": ext_proc.address,
+					"failureMode": "failClosed",
+					"requestAttributes": {
+						"filter_state['dev.substrate.authority']": "source.connectHeaders[\"host\"]",
+					},
+				}
+			}))
+			.await;
+
+		let mut io = t.serve_tunnel(strng::literal!("outer"));
+		let connect_target = "test1.demo.actors.resources.substrate.ate.dev:9090";
+		io.write_all(
+			format!("CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\n\r\n").as_bytes(),
+		)
+		.await
+		.unwrap();
+
+		let mut response = Vec::new();
+		loop {
+			let mut chunk = [0; 1024];
+			let n = io.read(&mut chunk).await.unwrap();
+			assert!(n > 0, "CONNECT response unexpectedly closed");
+			response.extend_from_slice(&chunk[..n]);
+			if response.windows(4).any(|w| w == b"\r\n\r\n") {
+				break;
+			}
+		}
+		let response_text = String::from_utf8_lossy(&response).to_string();
+		assert!(
+			response_text.starts_with("HTTP/1.1 200 OK\r\n"),
+			"unexpected CONNECT response: {response_text}",
+		);
+
+		// The re-entered request's own Host is deliberately unrelated to the
+		// actor -- proving backend resolution doesn't (and can't) depend on it.
+		io.write_all(b"GET /foo HTTP/1.1\r\nHost: irrelevant.example\r\nConnection: close\r\n\r\n")
+			.await
+			.unwrap();
+		let mut tunneled = Vec::new();
+		tokio::time::timeout(
+			std::time::Duration::from_secs(5),
+			io.read_to_end(&mut tunneled),
+		)
+		.await
+		.expect("timed out waiting for tunneled response")
+		.unwrap();
+		let tunneled_text = String::from_utf8_lossy(&tunneled).to_string();
+		assert!(
+			tunneled_text.contains("WORKER-MARKER"),
+			"expected the re-entered request to reach the ext_proc-rewritten worker, \
+			 got: {tunneled_text}",
+		);
+
+		assert_eq!(
+			seen_authority.lock().unwrap().as_deref(),
+			Some(connect_target),
+			"ext_proc should have resolved the ORIGINAL CONNECT authority via \
+			 source.connectHeaders, not the re-entered request's own (unrelated) Host",
+		);
+	}
+}
+
+#[derive(Clone)]
+struct TunnelRewriteAuthorityExtProc {
+	target: String,
+	seen_authority: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait::async_trait]
+impl Handler for TunnelRewriteAuthorityExtProc {
+	async fn on_request(&mut self, request: &proto::ProcessingRequest) {
+		if let Some(ns) = request.attributes.get("envoy.filters.http.ext_proc")
+			&& let Some(v) = ns.fields.get("filter_state['dev.substrate.authority']")
+			&& let Some(prost_wkt_types::value::Kind::StringValue(s)) = &v.kind
+		{
+			*self.seen_authority.lock().unwrap() = Some(s.clone());
+		}
+	}
+
+	async fn handle_request_headers(
+		&mut self,
+		_headers: &HttpHeaders,
+		sender: &Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender
+			.send(request_header_response(Some(CommonResponse {
+				header_mutation: Some(HeaderMutation {
+					set_headers: vec![HeaderValueOption {
+						header: Some(HeaderValue {
+							key: ":authority".to_string(),
+							value: self.target.clone(),
+							raw_value: self.target.clone().into_bytes(),
+						}),
+						append: None,
+						append_action: HeaderAppendAction::OverwriteIfExistsOrAdd.into(),
+					}],
+					remove_headers: vec![],
+				}),
+				..Default::default()
+			})))
+			.await;
+		Ok(())
 	}
 }
 

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -3476,6 +3476,256 @@ mod header_mutations {
 	}
 }
 
+// Reproduction for a substrate atenet-router bug report: ext_proc rewriting
+// `:authority` on a CONNECT request against a `dynamic: {}` backend.
+mod connect_authority_mutation {
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+	use super::*;
+	use crate::types::agent::{Backend, ResourceName};
+
+	#[derive(Clone)]
+	struct RewriteAuthorityExtProc {
+		target: String,
+	}
+
+	#[async_trait::async_trait]
+	impl Handler for RewriteAuthorityExtProc {
+		async fn handle_request_headers(
+			&mut self,
+			_headers: &HttpHeaders,
+			sender: &Sender<Result<ProcessingResponse, Status>>,
+		) -> Result<(), Status> {
+			let _ = sender
+				.send(request_header_response(Some(CommonResponse {
+					header_mutation: Some(HeaderMutation {
+						set_headers: vec![HeaderValueOption {
+							header: Some(HeaderValue {
+								key: ":authority".to_string(),
+								value: self.target.clone(),
+								raw_value: self.target.clone().into_bytes(),
+							}),
+							append: None,
+							append_action: HeaderAppendAction::OverwriteIfExistsOrAdd.into(),
+						}],
+						remove_headers: vec![],
+					}),
+					..Default::default()
+				})))
+				.await;
+			Ok(())
+		}
+	}
+
+	/// A CONNECT request's URI is schemeless authority-form. ext_proc rewrites
+	/// `:authority` to point at a different backend than the client requested --
+	/// the same mutation shape that works fine for a normal GET/POST. Expect the
+	/// tunnel to establish against the rewritten target.
+	#[tokio::test]
+	async fn connect_ext_proc_authority_rewrite_to_dynamic_backend() {
+		let worker = body_mock(b"WORKER-MARKER").await;
+		let worker_addr = worker.address().to_string();
+
+		let ext_proc = ExtProcMock::new(move || RewriteAuthorityExtProc {
+			target: worker_addr.clone(),
+		})
+		.spawn()
+		.await;
+
+		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+		let t = setup_proxy_test("{}").unwrap();
+		t.inputs()
+			.stores
+			.binds
+			.write()
+			.insert_backend(dynamic_backend.name(), dynamic_backend.into());
+		let t = t
+			.with_backend(ext_proc.address)
+			.with_bind(simple_bind())
+			.with_route(basic_named_route("/dynamic".into()))
+			.with_connect_enabled();
+		let t = t
+			.attach_route_policy_builder(json!({
+				"extProc": {
+					"host": ext_proc.address,
+					"failureMode": "failClosed",
+				}
+			}))
+			.await;
+
+		let mut io = t.serve(BIND_KEY);
+		// The "decoy" is a reachable server standing in for the client's original
+		// CONNECT target -- reachable so that if the (broken) authority mutation
+		// really is a no-op, the tunnel establishes against IT rather than merely
+		// failing DNS resolution and masking the bug.
+		let decoy = body_mock(b"DECOY-MARKER").await;
+		let connect_target = decoy.address().to_string();
+		io.write_all(format!("CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\n\r\n").as_bytes())
+		.await
+		.unwrap();
+
+		let mut response = Vec::new();
+		loop {
+			let mut chunk = [0; 1024];
+			let n = io.read(&mut chunk).await.unwrap();
+			assert!(n > 0, "CONNECT response unexpectedly closed");
+			response.extend_from_slice(&chunk[..n]);
+			if response.windows(4).any(|w| w == b"\r\n\r\n") {
+				break;
+			}
+		}
+		let response_text = String::from_utf8_lossy(&response).to_string();
+		assert!(
+			response_text.starts_with("HTTP/1.1 200 OK\r\n"),
+			"unexpected CONNECT response: {response_text}",
+		);
+
+		io.write_all(b"GET /foo HTTP/1.1\r\nHost: lo\r\nConnection: close\r\n\r\n")
+			.await
+			.unwrap();
+		let mut tunneled = Vec::new();
+		tokio::time::timeout(std::time::Duration::from_secs(5), io.read_to_end(&mut tunneled))
+			.await
+			.expect("timed out waiting for tunneled response")
+			.unwrap();
+		let tunneled_text = String::from_utf8_lossy(&tunneled).to_string();
+		assert!(
+			tunneled_text.contains("WORKER-MARKER"),
+			"expected the tunnel to reach the ext_proc-rewritten worker, not the client's \
+			 original CONNECT target (the decoy), got: {tunneled_text}",
+		);
+	}
+
+	/// Separate from the authority no-op bug: does a `backendTLS` policy attached
+	/// to a `dynamic: {}` route backend actually get originated for a CONNECT
+	/// tunnel? substrate's atenet-router config attaches `backendTLS` exactly
+	/// this way (inline on the route's dynamic backend reference) because the
+	/// worker it tunnels to only accepts TLS.
+	#[cfg(feature = "tls-aws-lc")]
+	#[tokio::test]
+	async fn connect_dynamic_backend_honors_inline_backend_tls() {
+		use crate::http::backendtls::{BackendTLS, ResolvedBackendTLS};
+		use crate::types::agent::{
+			BackendReference, PathMatch, Route, RouteBackendReference, RouteMatch, RouteName,
+		};
+
+		let (worker, certs) = tls_mock().await;
+		let worker_addr = worker.address().to_string();
+
+		let ext_proc = ExtProcMock::new(move || RewriteAuthorityExtProc {
+			target: worker_addr.clone(),
+		})
+		.spawn()
+		.await;
+
+		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+		let t = setup_proxy_test("{}").unwrap();
+		t.inputs()
+			.stores
+			.binds
+			.write()
+			.insert_backend(dynamic_backend.name(), dynamic_backend.into());
+
+		let backend_tls: BackendTLS = ResolvedBackendTLS {
+			root: Some(certs.root_cert.pem().into_bytes()),
+			hostname: Some("localhost".to_string()),
+			alpn: Some(vec!["http/1.1".to_string()]),
+			..Default::default()
+		}
+		.try_into()
+		.unwrap();
+		let route = Route {
+			key: "route".into(),
+			service_key: None,
+			service_port: 0,
+			name: RouteName {
+				name: "route".into(),
+				namespace: Default::default(),
+				rule_name: None,
+				kind: None,
+			},
+			hostnames: Default::default(),
+			matches: vec![RouteMatch {
+				headers: vec![],
+				path: PathMatch::PathPrefix("/".into()),
+				method: None,
+				query: vec![],
+			}],
+			llm_router: None,
+			inline_policies: Default::default(),
+			backends: vec![RouteBackendReference {
+				weight: 1,
+				target: BackendReference::Backend("/dynamic".into()).into(),
+				inline_policies: vec![BackendTrafficPolicy::BackendTLS(backend_tls)],
+			}],
+		};
+
+		let t = t
+			.with_backend(ext_proc.address)
+			.with_bind(simple_bind())
+			.with_route(route)
+			.with_connect_enabled();
+		let t = t
+			.attach_route_policy_builder(json!({
+				"extProc": {
+					"host": ext_proc.address,
+					"failureMode": "failClosed",
+				}
+			}))
+			.await;
+
+		let mut io = t.serve(BIND_KEY);
+		let decoy = body_mock(b"DECOY-MARKER").await;
+		let connect_target = decoy.address().to_string();
+		io.write_all(format!("CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\n\r\n").as_bytes())
+		.await
+		.unwrap();
+
+		let mut response = Vec::new();
+		loop {
+			let mut chunk = [0; 1024];
+			let n = io.read(&mut chunk).await.unwrap();
+			assert!(n > 0, "CONNECT response unexpectedly closed");
+			response.extend_from_slice(&chunk[..n]);
+			if response.windows(4).any(|w| w == b"\r\n\r\n") {
+				break;
+			}
+		}
+		let response_text = String::from_utf8_lossy(&response).to_string();
+		assert!(
+			response_text.starts_with("HTTP/1.1 200 OK\r\n"),
+			"unexpected CONNECT response: {response_text}",
+		);
+
+		// Plaintext bytes over the tunnel. If the gateway originates its own TLS
+		// to the worker (as it should, given the inline backendTLS policy), the
+		// TLS-only mock server terminates them and responds normally. If it
+		// doesn't (raw pass-through), the mock's TLS listener chokes on the
+		// unencrypted bytes and the connection fails/hangs.
+		io.write_all(b"GET /foo HTTP/1.1\r\nHost: lo\r\nConnection: close\r\n\r\n")
+			.await
+			.unwrap();
+		let mut tunneled = Vec::new();
+		let result = tokio::time::timeout(
+			std::time::Duration::from_secs(5),
+			io.read_to_end(&mut tunneled),
+		)
+		.await;
+		let tunneled_text = String::from_utf8_lossy(&tunneled).to_string();
+		match result {
+			Ok(Ok(_)) => assert!(
+				tunneled_text.starts_with("HTTP/1.1 200 OK\r\n"),
+				"unexpected tunneled response: {tunneled_text}",
+			),
+			Ok(Err(e)) => panic!("tunneled read failed: {e} (partial: {tunneled_text})"),
+			Err(_) => panic!(
+				"timed out waiting for tunneled response -- the plaintext bytes likely reached \
+				 the worker's TLS listener undecrypted (partial: {tunneled_text})"
+			),
+		}
+	}
+}
+
 #[derive(Debug, Clone)]
 struct HeaderAppendActionExtProc {
 	headers: Vec<(String, Vec<u8>, HeaderAppendAction)>,

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -3558,7 +3558,9 @@ mod connect_authority_mutation {
 		// failing DNS resolution and masking the bug.
 		let decoy = body_mock(b"DECOY-MARKER").await;
 		let connect_target = decoy.address().to_string();
-		io.write_all(format!("CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\n\r\n").as_bytes())
+		io.write_all(
+			format!("CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\n\r\n").as_bytes(),
+		)
 		.await
 		.unwrap();
 
@@ -3582,10 +3584,13 @@ mod connect_authority_mutation {
 			.await
 			.unwrap();
 		let mut tunneled = Vec::new();
-		tokio::time::timeout(std::time::Duration::from_secs(5), io.read_to_end(&mut tunneled))
-			.await
-			.expect("timed out waiting for tunneled response")
-			.unwrap();
+		tokio::time::timeout(
+			std::time::Duration::from_secs(5),
+			io.read_to_end(&mut tunneled),
+		)
+		.await
+		.expect("timed out waiting for tunneled response")
+		.unwrap();
 		let tunneled_text = String::from_utf8_lossy(&tunneled).to_string();
 		assert!(
 			tunneled_text.contains("WORKER-MARKER"),
@@ -3597,7 +3602,7 @@ mod connect_authority_mutation {
 	/// Separate from the authority no-op bug: does a `backendTLS` policy attached
 	/// to a `dynamic: {}` route backend actually get originated for a CONNECT
 	/// tunnel?
-	#[cfg(feature = "tls-aws-lc")]
+	#[cfg(feature = "crypto-aws-lc")]
 	#[tokio::test]
 	async fn connect_dynamic_backend_honors_inline_backend_tls() {
 		use crate::http::backendtls::{BackendTLS, ResolvedBackendTLS};
@@ -3674,7 +3679,9 @@ mod connect_authority_mutation {
 		let mut io = t.serve(BIND_KEY);
 		let decoy = body_mock(b"DECOY-MARKER").await;
 		let connect_target = decoy.address().to_string();
-		io.write_all(format!("CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\n\r\n").as_bytes())
+		io.write_all(
+			format!("CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\n\r\n").as_bytes(),
+		)
 		.await
 		.unwrap();
 

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -196,7 +196,15 @@ impl RequestOrResponse<'_> {
 				if let RequestOrResponse::Request(r) = self {
 					let _ = modify_req_uri(r, |uri| {
 						uri.authority = Some(v);
-						if uri.scheme.is_none() {
+						// http::Uri::from_parts requires scheme+authority+path together,
+						// or authority alone with neither scheme nor path (the CONNECT
+						// request-target shape). Only synthesize a scheme when a path is
+						// also present -- i.e. when we're promoting an origin-form URI to
+						// absolute-form. Unconditionally adding a scheme here used to make
+						// Uri::from_parts reject any CONNECT (schemeless, pathless)
+						// request's authority mutation with PathAndQueryMissing, silently
+						// discarded by the `let _ =` above, so the mutation was a no-op.
+						if uri.scheme.is_none() && uri.path_and_query.is_some() {
 							// When authority is set, scheme must also be set
 							// TODO: do the same for HeaderOrPseudo::Scheme
 							uri.scheme = Some(Scheme::HTTP);


### PR DESCRIPTION
apply_header's Authority arm unconditionally forced scheme=Some(HTTP) whenever the request's URI had no scheme yet, then called Uri::from_parts. For a CONNECT request the URI is authority-form (no scheme, no path), so http::Uri::from_parts requires scheme+ authority+path together; adding the scheme without a path made every CONNECT :authority mutation fail with PathAndQueryMissing. The error was silently discarded (`let _ =`), so the mutation was always a complete no-op: the tunnel proxied to whatever authority the client originally sent, ignoring ext_proc's rewrite entirely.

Only synthesize the default scheme when a path is also present, mirroring Uri::from_parts's actual validation rule. A true authority-form (CONNECT) URI is left alone, matching the request shape it already had.

Adds a regression test reproducing the bug (ext_proc rewrites :authority, dynamic backend, CONNECT) and a companion test confirming backendTLS is honored for a CONNECT + dynamic backend once the mutation actually takes effect.