### PR TITLE
llm: skip encoding model id

### DIFF
--- a/crates/llm/src/tests/requests/completions/basic.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/basic.bedrock.snap
@@ -11,7 +11,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "replaceme",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/completions/full.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/full.bedrock.snap
@@ -75,7 +75,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-4-turbo-preview",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/completions/parallel-tool-call.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/parallel-tool-call.bedrock.snap
@@ -28,7 +28,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-3.5-turbo",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/completions/reasoning.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/reasoning.bedrock.snap
@@ -10,7 +10,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-3.5-turbo",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/completions/reasoning_replay.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/reasoning_replay.bedrock.snap
@@ -15,7 +15,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "anthropic.claude-3-7-sonnet-20250219-v1:0",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/completions/reasoning_replay_unsigned.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/reasoning_replay_unsigned.bedrock.snap
@@ -14,7 +14,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "anthropic.claude-3-7-sonnet-20250219-v1:0",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/completions/tool-call.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/tool-call.bedrock.snap
@@ -21,7 +21,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-3.5-turbo",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/messages/basic.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/basic.bedrock.snap
@@ -10,7 +10,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "claude-sonnet-4-20250514",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/messages/metadata.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/metadata.bedrock.snap
@@ -13,7 +13,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "anthropic.claude-3-sonnet",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/messages/reasoning.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/reasoning.bedrock.snap
@@ -20,7 +20,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "claude-opus-4-6",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/messages/reasoning_replay.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/reasoning_replay.bedrock.snap
@@ -23,7 +23,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "claude-3-7-sonnet-20250219-v1:0",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/messages/server_tools.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/server_tools.bedrock.snap
@@ -18,7 +18,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "claude-opus-4-6",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/messages/structured-output.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/structured-output.bedrock.snap
@@ -25,7 +25,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "anthropic.claude-3-sonnet",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/messages/system_message.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/system_message.bedrock.snap
@@ -18,7 +18,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "claude-opus-4-8",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/messages/tool_history_without_tools.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/tool_history_without_tools.bedrock.snap
@@ -20,7 +20,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "anthropic.claude-sonnet-4-20250514-v1:0",
     "messages": [
       {
         "role": "assistant",

--- a/crates/llm/src/tests/requests/messages/tools.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/tools.bedrock.snap
@@ -21,7 +21,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "claude-opus-4-6",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/responses/basic.bedrock.snap
+++ b/crates/llm/src/tests/requests/responses/basic.bedrock.snap
@@ -8,7 +8,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-4o",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/responses/input-list.bedrock.snap
+++ b/crates/llm/src/tests/requests/responses/input-list.bedrock.snap
@@ -10,7 +10,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-4o",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/responses/input-media.bedrock.snap
+++ b/crates/llm/src/tests/requests/responses/input-media.bedrock.snap
@@ -29,7 +29,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-4o",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/responses/instructions.bedrock.snap
+++ b/crates/llm/src/tests/requests/responses/instructions.bedrock.snap
@@ -9,7 +9,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-4o",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/responses/parallel-tool-call.bedrock.snap
+++ b/crates/llm/src/tests/requests/responses/parallel-tool-call.bedrock.snap
@@ -27,7 +27,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-4o",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/tests/requests/responses/structured-output.bedrock.snap
+++ b/crates/llm/src/tests/requests/responses/structured-output.bedrock.snap
@@ -21,7 +21,6 @@ info:
 ---
 {
   "request": {
-    "modelId": "gpt-4o",
     "messages": [
       {
         "role": "user",

--- a/crates/llm/src/types/bedrock.rs
+++ b/crates/llm/src/types/bedrock.rs
@@ -153,8 +153,8 @@ pub struct InferenceConfiguration {
 
 #[derive(Clone, Serialize, Debug)]
 pub struct ConverseRequest {
-	/// Specifies the model or throughput with which to run inference.
-	#[serde(rename = "modelId")]
+	/// Specifies the model or throughput used in the Converse request URI.
+	#[serde(skip_serializing)]
 	pub model_id: String,
 	/// The messages that you want to send to the model.
 	pub messages: Vec<Message>,


### PR DESCRIPTION
This is a url param; bedrock is permissive but its not correct to send
it in the JSON body

Signed-off-by: John Howard <john.howard@solo.io>
