### PR TITLE
Move off deprecated fetch_update

### DIFF
--- a/crates/agentgateway/src/http/localratelimit.rs
+++ b/crates/agentgateway/src/http/localratelimit.rs
@@ -334,7 +334,7 @@ mod ratelimit {
 
 			let _ = self
 				.available
-				.fetch_update(Ordering::AcqRel, Ordering::Acquire, |v| {
+				.try_update(Ordering::AcqRel, Ordering::Acquire, |v| {
 					if tokens_to_remove < 0 {
 						Some(v.saturating_add(tokens_to_remove.unsigned_abs()))
 					} else {

--- a/crates/pool/src/pool.rs
+++ b/crates/pool/src/pool.rs
@@ -434,7 +434,7 @@ impl H2Load {
 		let max = self.max_streams.load(Ordering::Acquire);
 		let prev = self
 			.active_streams
-			.fetch_update(Ordering::AcqRel, Ordering::Acquire, |active| {
+			.try_update(Ordering::AcqRel, Ordering::Acquire, |active| {
 				if active < max { Some(active + 1) } else { None }
 			});
 


### PR DESCRIPTION
This is deprecated on nightly, nbd, just field renamed

Signed-off-by: John Howard <john.howard@solo.io>
