### PR TITLE
bedrock: correct top_k translation

### DIFF
--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -700,10 +700,9 @@ pub mod from_completions {
 			max_tokens: req.max_tokens(),
 			temperature: req.temperature,
 			top_p: req.top_p,
-			// Map Anthropic-style vendor extension to Bedrock topK when provided
-			top_k: req.vendor_extensions.top_k,
 			stop_sequences: req.stop_sequence(),
 		};
+		let top_k = req.vendor_extensions.top_k;
 
 		let tool_choice = match req.tool_choice {
 			Some(completions::ToolChoiceOption::Function(completions::NamedToolChoice { function })) => {
@@ -814,7 +813,7 @@ pub mod from_completions {
 				.and_then(crate::types::thinking_budget_for_reasoning_effort)
 		});
 
-		let additional_model_request_fields = enabled_thinking_budget.map(|budget| {
+		let mut additional_model_request_fields = enabled_thinking_budget.map(|budget| {
 			serde_json::json!({
 				"thinking": {
 					"type": "enabled",
@@ -822,6 +821,16 @@ pub mod from_completions {
 				}
 			})
 		});
+		// Anthropic manual thinking is incompatible with custom sampling parameters.
+		if enabled_thinking_budget.is_none()
+			&& let Some(top_k) = top_k
+		{
+			additional_model_request_fields
+				.get_or_insert_with(|| serde_json::json!({}))
+				.as_object_mut()
+				.expect("additional model request fields must be a JSON object")
+				.insert("top_k".to_string(), top_k.into());
+		}
 		let output_config = req
 			.response_format
 			.as_ref()
@@ -1556,9 +1565,9 @@ pub mod from_messages {
 				req.temperature
 			},
 			top_p: if thinking_enabled { None } else { req.top_p },
-			top_k: if thinking_enabled { None } else { req.top_k },
 			stop_sequences: req.stop_sequences,
 		};
+		let top_k = if thinking_enabled { None } else { req.top_k };
 
 		let tool_config = pending_tool_config.map(|(tools, tool_choice)| {
 			let mut bedrock_tools = Vec::with_capacity(tools.len() * 2);
@@ -1599,6 +1608,10 @@ pub mod from_messages {
 				.expect("additional model request fields must be a JSON object")
 				.insert(key.to_string(), value);
 		};
+
+		if let Some(top_k) = top_k {
+			upsert_additional_field("top_k", top_k.into());
+		}
 
 		// Preserve explicit output_config in Anthropic's model-specific envelope.
 		if let Some(output_config) = requested_output_config_json {
@@ -2566,7 +2579,6 @@ pub mod from_responses {
 			max_tokens: req.max_output_tokens.unwrap_or(4096) as usize,
 			temperature: req.temperature,
 			top_p: req.top_p,
-			top_k: None,
 			stop_sequences: vec![],
 		};
 		let output_config = req

--- a/crates/llm/src/conversion/bedrock_tests.rs
+++ b/crates/llm/src/conversion/bedrock_tests.rs
@@ -226,6 +226,7 @@ fn test_output_config_effort_without_thinking_is_passed_through() {
 	assert_eq!(
 		out.additional_model_request_fields,
 		Some(json!({
+			"top_k": 50,
 			"output_config": {
 				"effort": "high"
 			}
@@ -234,7 +235,6 @@ fn test_output_config_effort_without_thinking_is_passed_through() {
 	let inference = out.inference_config.unwrap();
 	assert_eq!(inference.temperature, Some(0.7));
 	assert_eq!(inference.top_p, Some(0.8));
-	assert_eq!(inference.top_k, Some(50));
 }
 
 #[test]
@@ -282,6 +282,7 @@ fn test_explicit_empty_output_config_is_preserved() {
 			"thinking": {
 				"type": "adaptive"
 			},
+			"top_k": 50,
 			"output_config": {}
 		}))
 	);
@@ -289,7 +290,6 @@ fn test_explicit_empty_output_config_is_preserved() {
 	let inference = out.inference_config.unwrap();
 	assert_eq!(inference.temperature, Some(0.7));
 	assert_eq!(inference.top_p, Some(0.8));
-	assert_eq!(inference.top_k, Some(50));
 }
 
 #[test]
@@ -402,7 +402,6 @@ fn test_adaptive_thinking_preserves_sampling_and_tool_choice() {
 	let inference = out.inference_config.unwrap();
 	assert_eq!(inference.temperature, Some(0.7));
 	assert_eq!(inference.top_p, Some(0.8));
-	assert_eq!(inference.top_k, Some(50));
 
 	let tool_choice = out
 		.tool_config
@@ -418,7 +417,8 @@ fn test_adaptive_thinking_preserves_sampling_and_tool_choice() {
 		Some(json!({
 			"thinking": {
 				"type": "adaptive"
-			}
+			},
+			"top_k": 50
 		}))
 	);
 }
@@ -479,7 +479,6 @@ fn test_enabled_thinking_applies_sampling_and_tool_choice_constraints() {
 	let inference = out.inference_config.unwrap();
 	assert_eq!(inference.temperature, None);
 	assert_eq!(inference.top_p, None);
-	assert_eq!(inference.top_k, None);
 
 	let tool_choice = out
 		.tool_config

--- a/crates/llm/src/tests/requests/completions/full.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/full.bedrock.snap
@@ -117,7 +117,7 @@ info:
     "inferenceConfig": {
       "maxTokens": 1000,
       "temperature": 0.7,
-      "top_p": 0.9,
+      "topP": 0.9,
       "stopSequences": [
         "\n\n",
         "END"

--- a/crates/llm/src/tests/requests/messages/structured-output.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/structured-output.bedrock.snap
@@ -38,7 +38,7 @@ info:
     "inferenceConfig": {
       "maxTokens": 100,
       "temperature": 0.7,
-      "top_p": 0.8
+      "topP": 0.8
     },
     "outputConfig": {
       "textFormat": {

--- a/crates/llm/src/tests/requests/messages/structured-output.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/structured-output.bedrock.snap
@@ -38,8 +38,7 @@ info:
     "inferenceConfig": {
       "maxTokens": 100,
       "temperature": 0.7,
-      "top_p": 0.8,
-      "topK": 50
+      "top_p": 0.8
     },
     "outputConfig": {
       "textFormat": {
@@ -52,6 +51,7 @@ info:
       }
     },
     "additionalModelRequestFields": {
+      "top_k": 50,
       "output_config": {
         "effort": "high"
       }

--- a/crates/llm/src/types/bedrock.rs
+++ b/crates/llm/src/types/bedrock.rs
@@ -141,7 +141,7 @@ pub struct InferenceConfiguration {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub temperature: Option<f32>,
 	/// Use nucleus sampling.
-	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(rename = "topP", skip_serializing_if = "Option::is_none")]
 	pub top_p: Option<f32>,
 	/// The stop sequences to use.
 	#[serde(rename = "stopSequences", skip_serializing_if = "Vec::is_empty")]

--- a/crates/llm/src/types/bedrock.rs
+++ b/crates/llm/src/types/bedrock.rs
@@ -143,9 +143,6 @@ pub struct InferenceConfiguration {
 	/// Use nucleus sampling.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub top_p: Option<f32>,
-	/// Only sample from the top K options for each subsequent token (if supported by model).
-	#[serde(rename = "topK", skip_serializing_if = "Option::is_none")]
-	pub top_k: Option<usize>,
 	/// The stop sequences to use.
 	#[serde(rename = "stopSequences", skip_serializing_if = "Vec::is_empty")]
 	pub stop_sequences: Vec<String>,


### PR DESCRIPTION
This was sent in the wrong field, where it was silently ignored

Signed-off-by: John Howard <john.howard@solo.io>
