### PR TITLE
examples: fix mcp-multiplex time target failing to start

### DIFF
--- a/examples/mcp-multiplex/README.md
+++ b/examples/mcp-multiplex/README.md
@@ -18,12 +18,19 @@ targets:
 - name: time
   stdio:
     cmd: uvx
-    args: ["mcp-server-time"]
+    args: ["--with", "mcp<2", "mcp-server-time"]
 - name: everything
   stdio:
     cmd: npx
     args: ["@modelcontextprotocol/server-everything"]
 ```
+
+The `--with mcp<2` constraint is needed because `mcp-server-time` requires
+`mcp>=1.23.0` with no upper bound, so `uvx` resolves the SDK to 2.x, which renamed
+`McpError` to `MCPError`. Without the constraint the `time` server fails to import,
+and because one failing target fails `initialize` for the whole multiplexed backend,
+the example does not start. Drop the constraint once `mcp-server-time` supports
+`mcp` 2.x.
 
 Now when we open the MCP inspector we can see the tools from both `time` and `everything`.
 Because we have multiple tools, each tool is prefixed with the `<name>_` to avoid collisions.

--- a/examples/mcp-multiplex/config.yaml
+++ b/examples/mcp-multiplex/config.yaml
@@ -9,7 +9,12 @@ binds:
           - name: time
             stdio:
               cmd: uvx
-              args: ["mcp-server-time"]
+              # mcp-server-time requires `mcp>=1.23.0` with no upper bound, so uvx
+              # resolves the SDK to 2.x, which renamed McpError to MCPError. The
+              # server then fails to import and this target never starts, which
+              # fails initialize for the whole multiplexed backend. Constrain the
+              # SDK until mcp-server-time supports mcp 2.x.
+              args: ["--with", "mcp<2", "mcp-server-time"]
           - name: everything
             stdio:
               cmd: npx


### PR DESCRIPTION
## Problem

The `mcp-multiplex` example does not start. Its `time` target runs `uvx mcp-server-time`, and `mcp-server-time` requires `mcp>=1.23.0` with **no upper bound**, so `uvx` resolves the MCP Python SDK to 2.x. That release renamed `McpError` to `MCPError`, so the server fails to import:

```
ImportError: cannot import name 'McpError' from 'mcp.shared.exceptions'
(Did you mean: 'MCPError'?)
```

Because one failing target fails `initialize` for the entire multiplexed backend, every request returns `HTTP 500` instead of a federated tool list:

```
http.status=500 protocol=mcp mcp.method.name=initialize
error="mcp: failed to send message: upstream closed on receive"
```

This also affects the docs walkthrough that ships this config ([Virtual MCP](https://agentgateway.dev/docs/standalone/latest/mcp/connect/virtual/)), which tells readers to download it and verify federated `time_*` and `everything_*` tools.

## Fix

Constrain the SDK with `--with mcp<2` so the target starts, with a comment explaining why and when it can be dropped. `README.md` is updated to match so the two stay in sync.

## Verification

Against agentgateway v1.4.1, using the config in this PR:

```
$ tools/list
["time_get_current_time","time_convert_time","everything_echo", ...]

$ tools/call time_get_current_time {"timezone":"America/New_York"}
{"timezone":"America/New_York","datetime":"2026-08-05T14:38:15-04:00",
 "day_of_week":"Wednesday","is_dst":true}
```

No `ImportError` in the gateway log, and `initialize` returns 200.

## Notes

- `crates/agentgateway/src/types/local_tests/mcp_simple_config.yaml` has the same `uvx mcp-server-time` invocation, but it is a parse-only snapshot fixture that never launches the server, so it is left unchanged to avoid churning the snapshot.
- The real upstream issue is the missing upper bound in `mcp-server-time`; this is a workaround until that package supports `mcp` 2.x.