### PR TITLE
proxy: avoid blocking on otel drop

### DIFF
--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1843,6 +1843,11 @@ where
 }
 
 pub struct OtelAccessLogger {
+	inner: super::NonBlockingDrop<OtelAccessLoggerInner>,
+}
+
+#[derive(Debug)]
+struct OtelAccessLoggerInner {
 	provider: SdkLoggerProvider,
 	logger: opentelemetry_sdk::logs::SdkLogger,
 }
@@ -2026,11 +2031,13 @@ impl OtelAccessLogger {
 
 		let logger = provider.logger("agentgateway.access");
 
-		Ok(Self { provider, logger })
+		Ok(Self {
+			inner: super::NonBlockingDrop::new(OtelAccessLoggerInner { provider, logger }),
+		})
 	}
 
 	pub fn shutdown(&self) {
-		let _ = self.provider.shutdown();
+		let _ = self.inner.provider.shutdown();
 	}
 }
 
@@ -2053,7 +2060,7 @@ impl OtelLogSink for OtelAccessLogger {
 			_ => "INFO",
 		};
 
-		let mut record = self.logger.create_log_record();
+		let mut record = self.inner.logger.create_log_record();
 		record.set_severity_number(severity);
 		record.set_severity_text(severity_text);
 		record.set_target(target.to_string());
@@ -2097,11 +2104,11 @@ impl OtelLogSink for OtelAccessLogger {
 			);
 		}
 
-		self.logger.emit(record);
+		self.inner.logger.emit(record);
 	}
 
 	fn shutdown(&self) {
-		let _ = self.provider.shutdown();
+		let _ = self.inner.provider.shutdown();
 	}
 }
 
@@ -2251,7 +2258,7 @@ mod tests {
 			.build();
 		(
 			Arc::new(trc::Tracer {
-				provider,
+				provider: crate::telemetry::NonBlockingDrop::new(provider),
 				processor,
 				fields: Arc::new(LoggingFields::default()),
 				filter: None,

--- a/crates/agentgateway/src/telemetry/mod.rs
+++ b/crates/agentgateway/src/telemetry/mod.rs
@@ -33,9 +33,9 @@ impl<T: Send + 'static> Drop for NonBlockingDrop<T> {
 			return;
 		};
 		if let Ok(runtime) = tokio::runtime::Handle::try_current() {
-			let _ = runtime.spawn_blocking(move || drop(value));
+			let _task = runtime.spawn_blocking(move || drop(value));
 		} else {
-			let _ = std::thread::spawn(move || drop(value));
+			let _thread = std::thread::spawn(move || drop(value));
 		}
 	}
 }

--- a/crates/agentgateway/src/telemetry/mod.rs
+++ b/crates/agentgateway/src/telemetry/mod.rs
@@ -2,3 +2,90 @@ pub mod log;
 pub mod log_store;
 pub mod metrics;
 pub mod trc;
+
+/// Moves potentially blocking destruction off the calling thread.
+#[derive(Debug)]
+pub struct NonBlockingDrop<T: Send + 'static>(Option<T>);
+
+impl<T: Send + 'static> NonBlockingDrop<T> {
+	pub fn new(value: T) -> Self {
+		Self(Some(value))
+	}
+}
+
+impl<T: Clone + Send + 'static> Clone for NonBlockingDrop<T> {
+	fn clone(&self) -> Self {
+		Self(self.0.clone())
+	}
+}
+
+impl<T: Send + 'static> std::ops::Deref for NonBlockingDrop<T> {
+	type Target = T;
+
+	fn deref(&self) -> &Self::Target {
+		self.0.as_ref().expect("value is present until drop")
+	}
+}
+
+impl<T: Send + 'static> Drop for NonBlockingDrop<T> {
+	fn drop(&mut self) {
+		let Some(value) = self.0.take() else {
+			return;
+		};
+		if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+			let _ = runtime.spawn_blocking(move || drop(value));
+		} else {
+			let _ = std::thread::spawn(move || drop(value));
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::mpsc;
+	use std::time::Duration;
+
+	use super::NonBlockingDrop;
+
+	struct BlockingDrop {
+		started: mpsc::Sender<()>,
+		release: mpsc::Receiver<()>,
+	}
+
+	impl Drop for BlockingDrop {
+		fn drop(&mut self) {
+			let _ = self.started.send(());
+			let _ = self.release.recv();
+		}
+	}
+
+	#[test]
+	fn non_blocking_drop_returns_before_inner_drop_completes() {
+		let (started_tx, started_rx) = mpsc::channel();
+		let (release_tx, release_rx) = mpsc::channel();
+		let (returned_tx, returned_rx) = mpsc::channel();
+		let thread = std::thread::spawn(move || {
+			let runtime = tokio::runtime::Builder::new_current_thread()
+				.enable_all()
+				.build()
+				.expect("build runtime");
+			runtime.block_on(async move {
+				drop(NonBlockingDrop::new(BlockingDrop {
+					started: started_tx,
+					release: release_rx,
+				}));
+				let _ = returned_tx.send(());
+			});
+		});
+
+		let returned = returned_rx.recv_timeout(Duration::from_secs(1));
+		let _ = release_tx.send(());
+		thread.join().expect("runtime thread exits");
+
+		assert!(returned.is_ok(), "wrapper drop blocked on its inner value");
+		assert!(
+			started_rx.recv_timeout(Duration::from_secs(1)).is_ok(),
+			"inner value was not dropped"
+		);
+	}
+}

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -22,7 +22,7 @@ use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference, TracingC
 
 #[derive(Clone, Debug)]
 pub struct Tracer {
-	pub provider: SdkTracerProvider,
+	pub provider: super::NonBlockingDrop<SdkTracerProvider>,
 	pub processor: SharedSpanProcessor,
 	pub fields: Arc<LoggingFields>,
 	pub(crate) filter: Option<Arc<cel::Expression>>,
@@ -264,7 +264,7 @@ impl Tracer {
 			(provider, processor)
 		};
 		Ok(Tracer {
-			provider,
+			provider: super::NonBlockingDrop::new(provider),
 			processor,
 			fields,
 			filter: config.filter.clone(),
@@ -824,7 +824,7 @@ mod tests {
 			.build();
 		(
 			Tracer {
-				provider,
+				provider: crate::telemetry::NonBlockingDrop::new(provider),
 				processor,
 				fields: Arc::new(LoggingFields::default()),
 				filter: None,


### PR DESCRIPTION
Dropping the otel object can trigger shutdown() which can block for 5s.
This is NOT an async block, so the main thread gets blocked for 5s. This
blocks stats, xds pushes, etc.

Found via a slow test that took 5s oddly - because the previous test
dropped its otel logger.

Signed-off-by: John Howard <john.howard@solo.io>
