### PR TITLE
fix(cel): wrong-typed receiver should not be treated like an absent one

### DIFF
--- a/crates/cel-fork/cel/src/functions.rs
+++ b/crates/cel-fork/cel/src/functions.rs
@@ -67,8 +67,8 @@ impl<'a, 'vars: 'a, 'rf> FunctionContext<'vars, 'rf> {
 	}
 	pub fn this_or_arg<T: FromValue<'a>>(&self) -> Result<T> {
 		match self.this() {
-			Ok(val) => Ok(val),
-			Err(_e) => self.arg(0),
+			Err(ExecutionError::MissingArgumentOrTarget) => self.arg(0),
+			other => other,
 		}
 	}
 	pub fn this_value(&self) -> Result<Value<'a>> {
@@ -1110,6 +1110,27 @@ mod tests {
 		for (name, script) in tests {
 			assert_eq!(test_script(script, None), Ok(true.into()), "{name}");
 		}
+	}
+
+	#[test]
+	fn test_wrong_typed_receiver_does_not_fall_back() {
+		for script in [
+			"[1, 2].startsWith('zzz')",
+			"[1, 2].endsWith('zzz')",
+			"[1, 2].matches('zzz')",
+			"{'k': 1}.startsWith('zzz')",
+			"[1, 2].getFullYear()",
+		] {
+			assert!(
+				test_script(script, None).is_err(),
+				"{script} must not substitute its argument for the receiver"
+			);
+		}
+
+		assert_script(&(
+			"bare call still falls back for a typed receiver",
+			"getFullYear(timestamp('2023-05-29T00:00:00Z')) == 2023",
+		));
 	}
 
 	#[test]


### PR DESCRIPTION
Only `MissingArgumentOrTarget` should fall back to initial argument in `this_or_arg`.

Closes #2877