### PR TITLE
llm: expose normalized input tokens count in CEL

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -1409,10 +1409,16 @@ pub struct LLMContext {
 	pub response_model: Option<Strng>,
 	/// The provider of the LLM.
 	pub provider: Strng,
-	/// The number of tokens in the input/prompt.
+	/// The total number of tokens in the input/prompt, including tokens read from or written to
+	/// cache. This has consistent semantics across providers.
 	#[dynamic(rename = "inputTokens")]
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub input_tokens: Option<u64>,
+	/// The provider-reported number of tokens in the input/prompt. This is inconsistent across
+	/// providers: some include cached tokens while others exclude them.
+	#[dynamic(rename = "providerInputTokens")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub provider_input_tokens: Option<u64>,
 	/// The number of image tokens in the input/prompt.
 	#[dynamic(rename = "inputImageTokens")]
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -1457,10 +1463,16 @@ pub struct LLMContext {
 	#[dynamic(rename = "reasoningTokens")]
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub reasoning_tokens: Option<u64>,
-	/// The total number of tokens for the request.
+	/// The total number of input and output tokens for the request. Input tokens include tokens read
+	/// from or written to cache, giving this field consistent semantics across providers.
 	#[dynamic(rename = "totalTokens")]
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub total_tokens: Option<u64>,
+	/// The provider-reported total number of tokens for the request. This is inconsistent across
+	/// providers because some include cached input tokens while others exclude them.
+	#[dynamic(rename = "providerTotalTokens")]
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub provider_total_tokens: Option<u64>,
 	/// The service tier the provider served the request under.
 	#[dynamic(rename = "serviceTier")]
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -1512,16 +1524,21 @@ pub struct LLMContext {
 
 impl LLMContext {
 	pub fn from_llm_info(value: LLMInfo, model_catalog: Option<&llm::cost::ModelCatalog>) -> Self {
+		let legacy_token_semantics = *LEGACY_LLM_USAGE_TOKEN_SEMANTICS;
 		let projection = model_catalog.map(|catalog| catalog.project(&value));
+		let normalized_input_tokens = value.normalized_input_tokens();
+		let cache_convention = value.request.cache_convention;
 
 		let resp = value.response;
 		let mut base = LLMContext {
+			provider_input_tokens: resp.input_tokens,
 			output_tokens: resp.output_tokens,
 			output_image_tokens: resp.output_image_tokens,
 			output_text_tokens: resp.output_text_tokens,
 			output_audio_tokens: resp.output_audio_tokens,
 			count_tokens: resp.count_tokens,
-			total_tokens: resp.total_tokens,
+			total_tokens: None,
+			provider_total_tokens: resp.total_tokens,
 			first_token: resp.first_token,
 			time_to_first_token: None,
 			time_per_output_token: None,
@@ -1542,9 +1559,23 @@ impl LLMContext {
 			..LLMContext::from(value.request)
 		};
 
-		if let Some(pt) = resp.input_tokens {
-			// Better info, override
-			base.input_tokens = Some(pt);
+		if legacy_token_semantics {
+			base.input_tokens = base.provider_input_tokens.or(base.input_tokens);
+			base.total_tokens = base.provider_total_tokens;
+		} else {
+			base.input_tokens = normalized_input_tokens;
+		}
+		if !legacy_token_semantics {
+			base.total_tokens = match (base.input_tokens, base.output_tokens) {
+				(Some(input), Some(output)) => Some(input.saturating_add(output)),
+				_ => resp.total_tokens.map(|total| {
+					cache_convention.include_cache_tokens(
+						total,
+						resp.cached_input_tokens,
+						resp.cache_creation_input_tokens,
+					)
+				}),
+			};
 		}
 
 		if let Some(projection) = projection {
@@ -1596,6 +1627,7 @@ impl From<llm::LLMRequest> for LLMContext {
 			request_model,
 			provider,
 			input_tokens,
+			provider_input_tokens: None,
 			params,
 			prompt,
 
@@ -1609,6 +1641,7 @@ impl From<llm::LLMRequest> for LLMContext {
 			output_text_tokens: None,
 			output_audio_tokens: None,
 			total_tokens: None,
+			provider_total_tokens: None,
 			completion: None,
 			tool_calls: None,
 			reasoning_tokens: None,
@@ -1624,6 +1657,11 @@ impl From<llm::LLMRequest> for LLMContext {
 		}
 	}
 }
+
+static LEGACY_LLM_USAGE_TOKEN_SEMANTICS: Lazy<bool> = Lazy::new(|| {
+	std::env::var("AGENTGATEWAY_LEGACY_LLM_USAGE_TOKEN_SEMANTICS")
+		.is_ok_and(|value| value.eq_ignore_ascii_case("true"))
+});
 
 fn to_value_str<'a, T: AsRef<str>>(c: &'a &'a T) -> Value<'a> {
 	Value::String(c.as_ref().into())
@@ -2294,6 +2332,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			response_model: Some("gpt-4-turbo".into()),
 			provider: "fake-ai".into(),
 			input_tokens: Some(100),
+			provider_input_tokens: Some(100),
 			input_image_tokens: Some(60),
 			input_text_tokens: Some(40),
 			input_audio_tokens: Some(5),
@@ -2305,6 +2344,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			output_audio_tokens: Some(3),
 			reasoning_tokens: Some(30),
 			total_tokens: Some(150),
+			provider_total_tokens: Some(150),
 			service_tier: Some("default".into()),
 			first_token: None,
 			time_to_first_token: Some(chrono::Duration::milliseconds(123).into()),

--- a/crates/agentgateway/src/cel/types_test.rs
+++ b/crates/agentgateway/src/cel/types_test.rs
@@ -75,6 +75,7 @@ fn build_test_request() -> crate::http::Request {
 		response_model: Some("gpt-4-turbo".into()),
 		provider: "openai".into(),
 		input_tokens: Some(100),
+		provider_input_tokens: Some(100),
 		input_image_tokens: None,
 		input_text_tokens: None,
 		input_audio_tokens: None,
@@ -83,6 +84,7 @@ fn build_test_request() -> crate::http::Request {
 		output_text_tokens: None,
 		output_audio_tokens: None,
 		total_tokens: Some(150),
+		provider_total_tokens: Some(150),
 		service_tier: None,
 		first_token: None,
 		time_to_first_token: Some(chrono::Duration::milliseconds(123).into()),
@@ -104,6 +106,25 @@ fn build_test_request() -> crate::http::Request {
 	req
 }
 
+fn llm_context_with_usage(
+	cache_convention: llm::CacheTokenConvention,
+	request_input_tokens: Option<u64>,
+	response: llm::LLMResponse,
+) -> LLMContext {
+	let request = llm::LLMRequest {
+		input_tokens: request_input_tokens,
+		input_format: llm::InputFormat::Completions,
+		cache_convention,
+		request_model: "model".into(),
+		provider: "provider".into(),
+		streaming: false,
+		params: llm::LLMRequestParams::default(),
+		prompt: None,
+		provider_state: None,
+	};
+	LLMContext::from_llm_info(llm::LLMInfo::new(request, response), None)
+}
+
 #[test]
 fn test_snapshot_matches_ref() {
 	let mut req = build_test_request();
@@ -120,6 +141,136 @@ fn test_snapshot_matches_ref() {
 	let ref_executor = Executor::new_request(&req);
 
 	assert_eq!(exec_to_json(&ref_executor), exec_to_json(&snapshot_exec));
+}
+
+#[test]
+fn token_counts_normalize_provider_cache_conventions() {
+	let response = llm::LLMResponse {
+		input_tokens: Some(100),
+		output_tokens: Some(20),
+		total_tokens: Some(120),
+		cached_input_tokens: Some(40),
+		cache_creation_input_tokens: Some(10),
+		..Default::default()
+	};
+	let inclusive = llm_context_with_usage(
+		llm::CacheTokenConvention::InputIncludesCache,
+		None,
+		response,
+	);
+	assert_eq!(inclusive.input_tokens, Some(100));
+	assert_eq!(inclusive.provider_input_tokens, Some(100));
+	assert_eq!(inclusive.cached_input_tokens, Some(40));
+	assert_eq!(inclusive.cache_creation_input_tokens, Some(10));
+	assert_eq!(inclusive.total_tokens, Some(120));
+	assert_eq!(inclusive.provider_total_tokens, Some(120));
+
+	let response = llm::LLMResponse {
+		input_tokens: Some(50),
+		output_tokens: Some(20),
+		total_tokens: Some(70),
+		cached_input_tokens: Some(40),
+		cache_creation_input_tokens: Some(10),
+		..Default::default()
+	};
+	let exclusive = llm_context_with_usage(
+		llm::CacheTokenConvention::InputExcludesCache,
+		None,
+		response,
+	);
+	assert_eq!(exclusive.input_tokens, Some(100));
+	assert_eq!(exclusive.provider_input_tokens, Some(50));
+	assert_eq!(exclusive.cached_input_tokens, Some(40));
+	assert_eq!(exclusive.cache_creation_input_tokens, Some(10));
+	assert_eq!(exclusive.total_tokens, Some(120));
+	assert_eq!(exclusive.provider_total_tokens, Some(70));
+}
+
+#[test]
+fn token_counts_handle_missing_usage_and_overflow() {
+	let no_cache_counts = llm_context_with_usage(
+		llm::CacheTokenConvention::InputExcludesCache,
+		None,
+		llm::LLMResponse {
+			input_tokens: Some(50),
+			output_tokens: Some(20),
+			..Default::default()
+		},
+	);
+	assert_eq!(no_cache_counts.input_tokens, Some(50));
+	assert_eq!(no_cache_counts.total_tokens, Some(70));
+
+	// The request-side tokenizer count already covers the complete prompt. Do not add response
+	// cache details when the provider did not report its own input count.
+	let request_fallback = llm_context_with_usage(
+		llm::CacheTokenConvention::InputExcludesCache,
+		Some(100),
+		llm::LLMResponse {
+			output_tokens: Some(20),
+			cached_input_tokens: Some(40),
+			cache_creation_input_tokens: Some(10),
+			..Default::default()
+		},
+	);
+	assert_eq!(request_fallback.input_tokens, Some(100));
+	assert_eq!(request_fallback.provider_input_tokens, None);
+	assert_eq!(request_fallback.total_tokens, Some(120));
+	assert_eq!(request_fallback.provider_total_tokens, None);
+
+	let missing_input = llm_context_with_usage(
+		llm::CacheTokenConvention::InputExcludesCache,
+		None,
+		llm::LLMResponse {
+			cached_input_tokens: Some(40),
+			cache_creation_input_tokens: Some(10),
+			..Default::default()
+		},
+	);
+	assert_eq!(missing_input.input_tokens, None);
+	assert_eq!(missing_input.total_tokens, None);
+
+	// A provider total is still useful when the individual input/output counts are missing.
+	let provider_total_fallback = llm_context_with_usage(
+		llm::CacheTokenConvention::InputExcludesCache,
+		None,
+		llm::LLMResponse {
+			total_tokens: Some(70),
+			cached_input_tokens: Some(40),
+			cache_creation_input_tokens: Some(10),
+			..Default::default()
+		},
+	);
+	assert_eq!(provider_total_fallback.total_tokens, Some(120));
+	assert_eq!(provider_total_fallback.provider_total_tokens, Some(70));
+
+	let saturated = llm_context_with_usage(
+		llm::CacheTokenConvention::InputExcludesCache,
+		None,
+		llm::LLMResponse {
+			input_tokens: Some(u64::MAX - 5),
+			output_tokens: Some(10),
+			cached_input_tokens: Some(10),
+			cache_creation_input_tokens: Some(10),
+			..Default::default()
+		},
+	);
+	assert_eq!(saturated.input_tokens, Some(u64::MAX));
+	assert_eq!(saturated.total_tokens, Some(u64::MAX));
+}
+
+#[test]
+fn normalized_and_provider_token_counts_are_exposed_to_cel() {
+	let req = build_test_request();
+	let executor = Executor::new_request(&req);
+	let expr = Expression::new_strict(
+		"llm.inputTokens == uint(100) && \
+		 llm.providerInputTokens == uint(100) && \
+		 llm.totalTokens == uint(150) && \
+		 llm.providerTotalTokens == uint(150)",
+	)
+	.unwrap();
+
+	assert!(executor.eval_bool(&expr));
 }
 
 #[test]

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -2756,7 +2756,8 @@ async fn custom_llm_provider_inference_routing_sees_input_shape_and_amends_token
 	);
 	assert_eq!(
 		amend_request.descriptors.first().unwrap().hits_addend,
-		Some(21015)
+		// 21 output tokens * 1000 + (15 provider input + 13 cache write + 12 cache read).
+		Some(21040)
 	);
 }
 

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -2607,7 +2607,7 @@ fn response_prompt_guard_headers(
 fn amend_tokens(rate_limit: store::LLMResponsePolicies, llm_resp: &LLMInfo, exec: Executor) {
 	let input_mismatch = match (
 		llm_resp.request.input_tokens,
-		llm_resp.response.input_tokens,
+		llm_resp.normalized_input_tokens(),
 	) {
 		// Already counted 'req'
 		(Some(req), Some(resp)) => (resp as i64) - (req as i64),

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -89,6 +89,53 @@ fn streaming_amend_on_drop_updates_local_rate_limit() {
 	);
 }
 
+#[test]
+fn streaming_amend_on_drop_uses_cache_inclusive_input_tokens() {
+	let rate_limit =
+		crate::http::localratelimit::RateLimit::try_from(crate::http::localratelimit::RateLimitSpec {
+			max_tokens: 10,
+			tokens_per_fill: 10,
+			fill_interval: std::time::Duration::from_secs(60),
+			limit_type: crate::http::localratelimit::RateLimitType::Tokens,
+		})
+		.unwrap();
+	let mut request = llm_request_with_tokens(Some(5));
+	request.cache_convention = CacheTokenConvention::InputExcludesCache;
+	let log = AsyncLog::default();
+	log.store(Some(LLMInfo {
+		request,
+		response: LLMResponse {
+			input_tokens: Some(2),
+			cached_input_tokens: Some(2),
+			cache_creation_input_tokens: Some(1),
+			output_tokens: Some(4),
+			..Default::default()
+		},
+	}));
+
+	let mut amend = AmendOnDrop::new(
+		log,
+		LLMResponsePolicies {
+			local_rate_limit: vec![rate_limit.clone()],
+			..Default::default()
+		},
+		None,
+		None,
+	);
+	amend.report_usage();
+
+	assert!(
+		rate_limit
+			.check_llm_request(&llm_request_with_tokens(Some(7)))
+			.is_err()
+	);
+	assert!(
+		rate_limit
+			.check_llm_request(&llm_request_with_tokens(Some(6)))
+			.is_ok()
+	);
+}
+
 fn test_root() -> &'static Path {
 	Path::new("../llm/src/tests")
 }

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1738,7 +1738,7 @@ impl Drop for DropOnLog {
 					let total_tokens = llm_response.as_ref().and_then(|llm| {
 						llm
 							.total_tokens
-							.or_else(|| Some(llm.input_tokens? + llm.output_tokens?))
+							.or_else(|| Some(llm.input_tokens?.saturating_add(llm.output_tokens?)))
 					});
 					log_store::emit(log_store::StoredRequestLog {
 						id: uuid::Uuid::now_v7().to_string(),
@@ -2346,6 +2346,68 @@ mod tests {
 		let _ = tracer.provider.force_flush();
 
 		assert!(exporter.finished_spans().is_empty());
+	}
+
+	#[test]
+	fn llm_span_uses_cache_inclusive_input_tokens() {
+		let request = llm::LLMRequest {
+			input_tokens: None,
+			input_format: InputFormat::Messages,
+			cache_convention: llm::CacheTokenConvention::InputExcludesCache,
+			request_model: strng::literal!("claude"),
+			provider: strng::literal!("anthropic"),
+			streaming: false,
+			params: llm::LLMRequestParams::default(),
+			prompt: None,
+			provider_state: None,
+		};
+		let response = llm::LLMResponse {
+			input_tokens: Some(50),
+			cached_input_tokens: Some(40),
+			cache_creation_input_tokens: Some(10),
+			output_tokens: Some(20),
+			total_tokens: Some(70),
+			..Default::default()
+		};
+
+		let (tracer, exporter) = test_tracer();
+		let mut log = test_request_log();
+		log.tracer = Some(tracer.clone());
+		let mut outgoing = trc::TraceParent::new();
+		outgoing.flags = 1;
+		log.outgoing_span = Some(outgoing);
+		log.llm_request = Some(request.clone());
+		log
+			.llm_response
+			.store(Some(llm::LLMInfo::new(request, response)));
+
+		drop(DropOnLog::from(log));
+		let _ = tracer.provider.force_flush();
+
+		let spans = exporter.finished_spans();
+		let span = spans
+			.iter()
+			.find(|span| span.name.as_ref() == "unknown")
+			.expect("request span should be exported");
+		let value = |key: &str| {
+			span
+				.attributes
+				.iter()
+				.find(|attr| attr.key.as_str() == key)
+				.map(|attr| &attr.value)
+		};
+		assert_eq!(
+			value("gen_ai.usage.input_tokens"),
+			Some(&opentelemetry::Value::I64(100))
+		);
+		assert_eq!(
+			value("gen_ai.usage.cache_read.input_tokens"),
+			Some(&opentelemetry::Value::I64(40))
+		);
+		assert_eq!(
+			value("gen_ai.usage.cache_creation.input_tokens"),
+			Some(&opentelemetry::Value::I64(10))
+		);
 	}
 
 	#[tokio::test]

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -184,6 +184,22 @@ impl CacheTokenConvention {
 	pub fn pending() -> Self {
 		Self::InputIncludesCache
 	}
+
+	/// Normalize a provider-reported input token count so it always includes
+	/// tokens read from and written to cache.
+	pub fn include_cache_tokens(
+		self,
+		input_tokens: u64,
+		cached_input_tokens: Option<u64>,
+		cache_creation_input_tokens: Option<u64>,
+	) -> u64 {
+		match self {
+			Self::InputIncludesCache => input_tokens,
+			Self::InputExcludesCache => input_tokens
+				.saturating_add(cached_input_tokens.unwrap_or_default())
+				.saturating_add(cache_creation_input_tokens.unwrap_or_default()),
+		}
+	}
 }
 
 #[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize, ::cel::DynamicType)]
@@ -232,10 +248,28 @@ impl LLMInfo {
 	pub fn input_tokens(&self) -> Option<u64> {
 		self.response.input_tokens.or(self.request.input_tokens)
 	}
+
+	/// Return a cache-inclusive input token count with consistent semantics across providers.
+	/// Falls back to the request-side tokenizer when the response has no usage count.
+	pub fn normalized_input_tokens(&self) -> Option<u64> {
+		self
+			.response
+			.input_tokens
+			.map(|input_tokens| {
+				self.request.cache_convention.include_cache_tokens(
+					input_tokens,
+					self.response.cached_input_tokens,
+					self.response.cache_creation_input_tokens,
+				)
+			})
+			.or(self.request.input_tokens)
+	}
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct LLMResponse {
+	/// Provider-reported input tokens. Whether this includes cache tokens is described by the
+	/// corresponding request's [`CacheTokenConvention`].
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub input_tokens: Option<u64>,
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -353,7 +353,16 @@
           "type": "string"
         },
         "inputTokens": {
-          "description": "The number of tokens in the input/prompt.",
+          "description": "The total number of tokens in the input/prompt, including tokens read from or written to\ncache. This has consistent semantics across providers.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "providerInputTokens": {
+          "description": "The provider-reported number of tokens in the input/prompt. This is inconsistent across\nproviders: some include cached tokens while others exclude them.",
           "type": [
             "integer",
             "null"
@@ -452,7 +461,16 @@
           "minimum": 0
         },
         "totalTokens": {
-          "description": "The total number of tokens for the request.",
+          "description": "The total number of input and output tokens for the request. Input tokens include tokens read\nfrom or written to cache, giving this field consistent semantics across providers.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "providerTotalTokens": {
+          "description": "The provider-reported total number of tokens for the request. This is inconsistent across\nproviders because some include cached input tokens while others exclude them.",
           "type": [
             "integer",
             "null"

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -51,7 +51,8 @@
 |`llm.requestModel`|string|The model requested for the LLM request. This may differ from the actual model used.|
 |`llm.responseModel`|string|The model that actually served the LLM response.|
 |`llm.provider`|string|The provider of the LLM.|
-|`llm.inputTokens`|integer|The number of tokens in the input/prompt.|
+|`llm.inputTokens`|integer|The total number of tokens in the input/prompt, including tokens read from or written to<br>cache. This has consistent semantics across providers.|
+|`llm.providerInputTokens`|integer|The provider-reported number of tokens in the input/prompt. This is inconsistent across<br>providers: some include cached tokens while others exclude them.|
 |`llm.inputImageTokens`|integer|The number of image tokens in the input/prompt.|
 |`llm.inputTextTokens`|integer|The number of text tokens in the input/prompt.<br>Note: this field is only set in multi-modal calls where the total token count is split out by<br>text/image/audio; for standard all-text calls, this is unset.|
 |`llm.inputAudioTokens`|integer|The number of audio tokens in the input/prompt.|
@@ -62,7 +63,8 @@
 |`llm.outputTextTokens`|integer|The number of text tokens in the output/completion.|
 |`llm.outputAudioTokens`|integer|The number of audio tokens in the output/completion.<br>Note: this field is only set in multi-modal calls where the total token count is split out by<br>text/image/audio; for standard all-text calls, this is unset.|
 |`llm.reasoningTokens`|integer|The number of reasoning tokens in the output/completion.|
-|`llm.totalTokens`|integer|The total number of tokens for the request.|
+|`llm.totalTokens`|integer|The total number of input and output tokens for the request. Input tokens include tokens read<br>from or written to cache, giving this field consistent semantics across providers.|
+|`llm.providerTotalTokens`|integer|The provider-reported total number of tokens for the request. This is inconsistent across<br>providers because some include cached input tokens while others exclude them.|
 |`llm.serviceTier`|string|The service tier the provider served the request under.|
 |`llm.timeToFirstToken`|string|Time from request start until the first response token is received.|
 |`llm.timePerOutputToken`|string|Average time from first response token to response completion per output token.|


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/2837
Replaces https://github.com/agentgateway/agentgateway/pull/2509

## Summary

Normalize LLM token usage so `inputTokens` and `totalTokens` have consistent, cache-inclusive semantics across providers.

Providers disagree on whether their reported input and total counts include cache-read and cache-creation tokens. This previously caused CEL expressions, metrics, logs, traces, and token-based rate limits to behave differently depending on the provider.

## Changes

- `inputTokens` now represents total input, including cache-read and cache-creation tokens.
- `totalTokens` now represents normalized input plus output.
- Added `providerInputTokens` for the provider’s unmodified input value.
- Added `providerTotalTokens` for the provider’s unmodified total value.
- Preserved request-side token estimates when provider usage is unavailable.
- Used saturating arithmetic when combining token counts.
- Updated CEL schema documentation and affected rate-limit expectations.
- Added regression coverage confirming normalized values reach telemetry.

## Example

For a provider reporting:

```text
input:         50
cache read:    40
cache write:   10
output:        20
provider total: 70
```

The normalized context is:

```text
inputTokens:          100
providerInputTokens:   50
totalTokens:          120
providerTotalTokens:   70
```

Providers whose input count already includes cached tokens remain unchanged.

## Compatibility

Existing consumers of `inputTokens` and `totalTokens` will now receive normalized values. Consumers that require the exact provider-reported values should use `providerInputTokens` and `providerTotalTokens`.

AGENTGATEWAY_LEGACY_LLM_USAGE_TOKEN_SEMANTICS temporarily returns the old behavior; this is intended to live only through v1.5
