### PR TITLE
cel-fork: static checking for function names, argument counts, function-vs-method usage

### DIFF
--- a/crates/cel-fork/cel/src/check.rs
+++ b/crates/cel-fork/cel/src/check.rs
@@ -1,0 +1,492 @@
+//! Static call-site checking against a [`Context`]'s declared metadata.
+//!
+//! [`Program::check`](crate::Program::check) validates every function call in
+//! an expression against the [`FunctionMeta`] declared at registration,
+//! reporting calls that cannot succeed (or almost certainly misbehave) without
+//! executing anything. This is arity and name-resolution checking only — no
+//! type checking of any kind.
+//!
+//! Checking is deliberately conservative: a call is only diagnosed when the
+//! environment has declared enough for the diagnosis to be trustworthy.
+//! Method-style calls are unchecked unless the environment has declared its
+//! opaque method surface ([`Context::declare_opaque_methods`]), functions
+//! registered without metadata are unchecked, and qualified functions
+//! (`optional.of`, `math.ceil`, ...) are unchecked. Consequently an empty
+//! result means "nothing provably wrong", not "valid".
+
+use std::fmt;
+
+use crate::common::ast::IdedExpr;
+use crate::context::{Context, FunctionMeta, ReceiverStyle};
+use crate::parser::CallSignature;
+
+/// How the checker resolved the name at a diagnosed call site.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CallOrigin {
+	/// A parser-level comprehension macro (`has`, `all`, `exists`,
+	/// `exists_one`/`existsOne`, `map`, `filter`). These expand at parse time
+	/// only when receiver style and arity already match; a mismatched use
+	/// falls through to an ordinary call of a name that is never registered,
+	/// so it fails at runtime even in cases (like surplus arguments) where a
+	/// registered function would tolerate the call.
+	Macro,
+	/// A function registered in the [`Context`].
+	Function,
+}
+
+/// What is wrong with a diagnosed call site.
+///
+/// Argument counts here are expressed as the user wrote them: for a
+/// method-style call `x.f(a, b)` the count is 2, and declared arity ranges
+/// are translated into the same terms before comparison.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DiagnosticKind {
+	/// The name resolves to nothing callable in this environment.
+	UnknownFunction,
+	/// Fewer arguments than the declared minimum; the call fails at runtime.
+	TooFewArguments { min: usize },
+	/// More arguments than the declared maximum.
+	TooManyArguments { max: usize },
+	/// The function must be called method-style (`x.f(...)`) but was called
+	/// bare.
+	ReceiverMissing,
+	/// The function never reads a receiver, but was called method-style.
+	ReceiverForbidden,
+}
+
+/// One statically-detected problem with a call site.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Diagnostic {
+	/// The function name as written in the expression.
+	pub function: String,
+	/// The number of arguments as written (a method-style receiver is not
+	/// counted).
+	pub args: usize,
+	/// Whether the call was written method-style (`x.f(...)`).
+	pub method_style: bool,
+	pub origin: CallOrigin,
+	pub kind: DiagnosticKind,
+}
+
+impl fmt::Display for Diagnostic {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let name = &self.function;
+		let described = match self.origin {
+			CallOrigin::Macro => format!("the '{name}' macro"),
+			CallOrigin::Function => format!("'{name}'"),
+		};
+		match &self.kind {
+			DiagnosticKind::UnknownFunction if self.method_style => {
+				write!(f, "unknown method '{name}'")
+			},
+			DiagnosticKind::UnknownFunction => write!(f, "unknown function '{name}'"),
+			DiagnosticKind::TooFewArguments { min } => write!(
+				f,
+				"{described} requires at least {} but {} provided",
+				plural(*min, "argument"),
+				count_were(self.args),
+			),
+			DiagnosticKind::TooManyArguments { max: 0 } => write!(
+				f,
+				"{described} accepts no arguments but {} provided",
+				count_were(self.args),
+			),
+			DiagnosticKind::TooManyArguments { max } => write!(
+				f,
+				"{described} accepts at most {} but {} provided",
+				plural(*max, "argument"),
+				count_were(self.args),
+			),
+			DiagnosticKind::ReceiverMissing => {
+				write!(f, "{described} must be called as a method: `x.{name}(...)`")
+			},
+			DiagnosticKind::ReceiverForbidden => {
+				write!(f, "{described} cannot be called as a method: `{name}(...)`")
+			},
+		}
+	}
+}
+
+fn plural(n: usize, noun: &str) -> String {
+	if n == 1 {
+		format!("{n} {noun}")
+	} else {
+		format!("{n} {noun}s")
+	}
+}
+
+fn count_were(n: usize) -> String {
+	if n == 1 {
+		"1 was".to_string()
+	} else {
+		format!("{n} were")
+	}
+}
+
+/// Operators are represented as call nodes (`a == b` is `_==_(a, b)`) but are
+/// dispatched inline by the interpreter and never registered in a [`Context`],
+/// so the checker must ignore them. Their synthesized names (`_==_`, `!_`,
+/// `@in`, ...) are never valid CEL identifiers, unlike every registrable
+/// function name, so that property rather than a name list identifies them.
+fn is_operator(name: &str) -> bool {
+	name.starts_with('@') || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+impl IdedExpr {
+	/// Checks every call site against the context's declared metadata. See
+	/// [`Program::check`](crate::Program::check).
+	pub fn check(&self, ctx: &Context) -> Vec<Diagnostic> {
+		let mut diagnostics = Vec::new();
+		for sig in self.call_signatures() {
+			check_call(&sig, ctx, &mut diagnostics);
+		}
+		diagnostics
+	}
+}
+
+fn check_call(sig: &CallSignature, ctx: &Context, out: &mut Vec<Diagnostic>) {
+	if is_operator(sig.name) {
+		return;
+	}
+
+	if sig.method_style {
+		// At runtime, opaque/dynamic values get first refusal on method-style
+		// calls before dispatch falls back to the global function table. An
+		// intercepted call obeys the opaque method's shape, not the global
+		// function's, so checking is only sound once the environment has
+		// declared which names can be intercepted — and never for those names.
+		let Some(declared) = ctx.opaque_methods() else {
+			return;
+		};
+		if declared.contains(sig.name) {
+			return;
+		}
+	}
+
+	// Mirror runtime dispatch: the global function table governs any call that
+	// reaches it, including mismatched macro uses that fell through the parser,
+	// so a registered name wins over the macro table.
+	if ctx.functions.contains_key(sig.name) {
+		if let Some(meta) = ctx.function_meta(sig.name) {
+			check_against(sig, meta, CallOrigin::Function, out);
+		}
+		return;
+	}
+
+	if let Some((_, shape, _)) = crate::parser::macros::MACROS
+		.iter()
+		.find(|(name, _, _)| *name == sig.name)
+	{
+		check_against(sig, *shape, CallOrigin::Macro, out);
+		return;
+	}
+
+	// A call whose target is a bare identifier may be a qualified function
+	// (`optional.of(x)`, `math.ceil(x)`). The call signature does not carry
+	// the target's identity, so any name that exists as a qualified function
+	// is left unchecked rather than misreported.
+	if sig.method_style
+		&& ctx
+			.qualified_functions
+			.keys()
+			.any(|(_, name)| name == sig.name)
+	{
+		return;
+	}
+
+	// A bare call has no opaque fallback, so an unknown name always fails at
+	// runtime. A method-style call only reaches this point when the declared
+	// opaque surface ruled out interception.
+	out.push(diagnostic(
+		sig,
+		CallOrigin::Function,
+		DiagnosticKind::UnknownFunction,
+	));
+}
+
+fn check_against(
+	sig: &CallSignature,
+	meta: FunctionMeta,
+	origin: CallOrigin,
+	out: &mut Vec<Diagnostic>,
+) {
+	match meta.receiver {
+		ReceiverStyle::Required if !sig.method_style => {
+			out.push(diagnostic(sig, origin, DiagnosticKind::ReceiverMissing));
+			return;
+		},
+		ReceiverStyle::Forbidden if sig.method_style => {
+			out.push(diagnostic(sig, origin, DiagnosticKind::ReceiverForbidden));
+		},
+		_ => {},
+	}
+
+	// A Forbidden function's declared range already excludes the receiver.
+	let written = written_args(sig);
+	let (min, max) = if sig.method_style && meta.receiver != ReceiverStyle::Forbidden {
+		(
+			meta.min_args.saturating_sub(1),
+			meta.max_args.map(|m| m.saturating_sub(1)),
+		)
+	} else {
+		(meta.min_args, meta.max_args)
+	};
+	if written < min {
+		out.push(diagnostic(
+			sig,
+			origin,
+			DiagnosticKind::TooFewArguments { min },
+		));
+	} else if let Some(max) = max
+		&& written > max
+	{
+		out.push(diagnostic(
+			sig,
+			origin,
+			DiagnosticKind::TooManyArguments { max },
+		));
+	}
+}
+
+/// The argument count as the user wrote it: a method-style receiver is not
+/// counted.
+fn written_args(sig: &CallSignature) -> usize {
+	sig.arity - usize::from(sig.method_style)
+}
+
+fn diagnostic(sig: &CallSignature, origin: CallOrigin, kind: DiagnosticKind) -> Diagnostic {
+	Diagnostic {
+		function: sig.name.to_string(),
+		args: written_args(sig),
+		method_style: sig.method_style,
+		origin,
+		kind,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::Program;
+
+	fn check(expr: &str, ctx: &Context) -> Vec<Diagnostic> {
+		Program::compile_unoptimized(expr).unwrap().check(ctx)
+	}
+
+	/// A context whose opaque surface is declared complete-and-empty, enabling
+	/// full checking of method-style calls.
+	fn checked_ctx() -> Context {
+		let mut ctx = Context::default();
+		ctx.declare_opaque_methods(std::iter::empty::<String>());
+		ctx
+	}
+
+	#[test]
+	fn operator_dense_expression_is_clean() {
+		let ctx = checked_ctx();
+		assert_eq!(check("a == b && c > d || e in f ? g : h", &ctx), vec![]);
+		assert_eq!(check("!a && -b < c && d[0] != e % f", &ctx), vec![]);
+	}
+
+	#[test]
+	fn well_formed_macros_are_clean() {
+		let ctx = checked_ctx();
+		assert_eq!(check("has(a.b)", &ctx), vec![]);
+		assert_eq!(check("list.map(x, x * 2)", &ctx), vec![]);
+		assert_eq!(check("list.map(x, x > 1, x * 2)", &ctx), vec![]);
+		assert_eq!(check("list.filter(x, x > 1)", &ctx), vec![]);
+		assert_eq!(check("list.exists(x, x > 1)", &ctx), vec![]);
+		assert_eq!(check("list.exists_one(x, x > 1)", &ctx), vec![]);
+		assert_eq!(check("list.existsOne(x, x > 1)", &ctx), vec![]);
+		assert_eq!(check("list.all(x, x > 1)", &ctx), vec![]);
+	}
+
+	#[test]
+	fn wrong_arity_macro_uses_are_diagnosed() {
+		let ctx = checked_ctx();
+
+		let diags = check("list.map(x)", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].origin, CallOrigin::Macro);
+		assert_eq!(diags[0].kind, DiagnosticKind::TooFewArguments { min: 2 });
+		assert_eq!(
+			diags[0].to_string(),
+			"the 'map' macro requires at least 2 arguments but 1 was provided"
+		);
+
+		let diags = check("has(a.b, c)", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::TooManyArguments { max: 1 });
+		assert_eq!(
+			diags[0].to_string(),
+			"the 'has' macro accepts at most 1 argument but 2 were provided"
+		);
+
+		let diags = check("list.filter(x)", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::TooFewArguments { min: 2 });
+
+		let diags = check("map(a, b)", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::ReceiverMissing);
+		assert_eq!(
+			diags[0].to_string(),
+			"the 'map' macro must be called as a method: `x.map(...)`"
+		);
+
+		let diags = check("x.has(y)", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::ReceiverForbidden);
+		assert_eq!(
+			diags[0].to_string(),
+			"the 'has' macro cannot be called as a method: `has(...)`"
+		);
+	}
+
+	#[test]
+	fn unknown_bare_call_is_diagnosed_even_without_opaque_surface() {
+		let ctx = Context::default();
+		let diags = check("contians('a', 'b')", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::UnknownFunction);
+		assert_eq!(diags[0].to_string(), "unknown function 'contians'");
+	}
+
+	#[test]
+	fn method_calls_are_unchecked_until_surface_is_declared() {
+		let ctx = Context::default();
+		assert_eq!(check("secret.unredacted()", &ctx), vec![]);
+		assert_eq!(check("x.contians('a')", &ctx), vec![]);
+		// Even a mismatched macro: its fallen-through call could be intercepted.
+		assert_eq!(check("list.map(x)", &ctx), vec![]);
+	}
+
+	#[test]
+	fn declared_opaque_methods_suppress_only_their_names() {
+		let mut ctx = Context::default();
+		ctx.declare_opaque_methods(["unredacted"]);
+		assert_eq!(check("secret.unredacted()", &ctx), vec![]);
+		let diags = check("secret.unredactd()", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::UnknownFunction);
+		assert_eq!(diags[0].to_string(), "unknown method 'unredactd'");
+	}
+
+	#[test]
+	fn opaque_methods_shadow_global_functions() {
+		let mut ctx = checked_ctx();
+		assert_eq!(
+			check("x.size(y)", &ctx),
+			vec![Diagnostic {
+				function: "size".to_string(),
+				args: 1,
+				method_style: true,
+				origin: CallOrigin::Function,
+				kind: DiagnosticKind::TooManyArguments { max: 0 },
+			}]
+		);
+		assert_eq!(
+			check("x.size(y)", &ctx)[0].to_string(),
+			"'size' accepts no arguments but 1 was provided"
+		);
+		ctx.declare_opaque_methods(["size"]);
+		assert_eq!(check("x.size(y)", &ctx), vec![]);
+	}
+
+	#[test]
+	fn either_style_arity_is_checked_in_both_styles() {
+		let ctx = checked_ctx();
+		assert_eq!(check("size(a)", &ctx), vec![]);
+		assert_eq!(check("a.size()", &ctx), vec![]);
+
+		let diags = check("size(a, b)", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::TooManyArguments { max: 1 });
+		assert_eq!(
+			diags[0].to_string(),
+			"'size' accepts at most 1 argument but 2 were provided"
+		);
+
+		let diags = check("size()", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::TooFewArguments { min: 1 });
+
+		let diags = check("a.contains()", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::TooFewArguments { min: 1 });
+		assert_eq!(
+			diags[0].to_string(),
+			"'contains' requires at least 1 argument but 0 were provided"
+		);
+	}
+
+	#[test]
+	fn forbidden_receiver_is_diagnosed_but_arity_still_checked() {
+		let ctx = checked_ctx();
+		let diags = check("x.duration('1h')", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::ReceiverForbidden);
+		assert_eq!(
+			diags[0].to_string(),
+			"'duration' cannot be called as a method: `duration(...)`"
+		);
+
+		let diags = check("duration('1h', '2h')", &ctx);
+		assert_eq!(diags.len(), 1);
+		assert_eq!(diags[0].kind, DiagnosticKind::TooManyArguments { max: 1 });
+
+		assert_eq!(check("max(a, b, c, d, e)", &ctx), vec![]);
+		assert_eq!(check("max()", &ctx), vec![]);
+	}
+
+	#[test]
+	fn qualified_functions_are_unchecked() {
+		let ctx = checked_ctx();
+		assert_eq!(check("optional.of(x)", &ctx), vec![]);
+		assert_eq!(check("optional.none()", &ctx), vec![]);
+		// Even at arities it would reject: name alone cannot tell the two apart.
+		assert_eq!(check("optional.of(x, y)", &ctx), vec![]);
+	}
+
+	#[test]
+	fn functions_without_metadata_are_unchecked() {
+		let mut ctx = checked_ctx();
+		ctx.add_function("mystery", crate::functions::size);
+		assert_eq!(check("mystery()", &ctx), vec![]);
+		assert_eq!(check("mystery(a, b, c)", &ctx), vec![]);
+	}
+
+	/// Drift guard: metadata that declares a minimum arity must agree with the
+	/// implementation. Every default function whose declared shape rules out a
+	/// bare zero-argument call must actually fail one at runtime, and the two
+	/// variadic ones that declare min 0 must not.
+	#[test]
+	fn declared_minimums_match_runtime_behavior() {
+		let ctx = Context::default();
+		let names: Vec<String> = ctx.functions.keys().cloned().collect();
+		for name in names {
+			let Some(meta) = ctx.function_meta(&name) else {
+				continue;
+			};
+			if meta.receiver == ReceiverStyle::Required {
+				continue;
+			}
+			let Ok(program) = Program::compile(&format!("{name}()")) else {
+				continue;
+			};
+			let result = program.execute(&ctx);
+			if meta.min_args > 0 {
+				assert!(
+					result.is_err(),
+					"{name}() succeeded at runtime but metadata declares min_args {}",
+					meta.min_args
+				);
+			} else {
+				assert!(
+					result.is_ok(),
+					"{name}() failed at runtime ({result:?}) but metadata declares min_args 0",
+				);
+			}
+		}
+	}
+}

--- a/crates/cel-fork/cel/src/context.rs
+++ b/crates/cel-fork/cel/src/context.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use hashbrown::Equivalent;
 
@@ -6,6 +6,84 @@ use crate::common::ast::OptimizedExpr;
 use crate::functions;
 use crate::magic::{Function, IntoFunction};
 use crate::objects::{KeyRef, MapValue, TryIntoValue, Value};
+
+/// Declares how a registered function consumes a method-style receiver.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReceiverStyle {
+	/// Must be called method-style (`x.f(...)`); a bare call fails at runtime.
+	Required,
+	/// Never reads a receiver; `x.f(...)` silently discards `x`.
+	Forbidden,
+	/// Callable either way: the implementation falls back from the receiver to
+	/// the first argument (`FunctionContext::this_or_arg`).
+	Either,
+}
+
+/// Static call-shape metadata for a registered function, consumed by
+/// `Program::check` to validate call sites without
+/// executing them.
+///
+/// Arity counts match [`CallSignature`](crate::parser::CallSignature): a
+/// method-style receiver counts as one argument, so `x.contains(y)` and
+/// `contains(x, y)` are both arity 2. For [`ReceiverStyle::Forbidden`]
+/// functions the receiver never substitutes for an argument, and the range
+/// describes the bare-call form only.
+///
+/// Metadata describes what the implementation accepts *today*, not what a
+/// specification says it should.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FunctionMeta {
+	/// Minimum accepted arity. Calls below this fail at runtime.
+	pub min_args: usize,
+	/// Highest accepted arity, or `None` if variadic.
+	pub max_args: Option<usize>,
+	pub receiver: ReceiverStyle,
+}
+
+impl FunctionMeta {
+	/// A function of exactly `arity` arguments, callable both method-style
+	/// and bare.
+	pub const fn either(arity: usize) -> Self {
+		FunctionMeta {
+			min_args: arity,
+			max_args: Some(arity),
+			receiver: ReceiverStyle::Either,
+		}
+	}
+
+	/// A function of exactly `arity` arguments that never reads a receiver.
+	pub const fn global(arity: usize) -> Self {
+		FunctionMeta {
+			min_args: arity,
+			max_args: Some(arity),
+			receiver: ReceiverStyle::Forbidden,
+		}
+	}
+
+	/// A function of exactly `arity` arguments that must be called
+	/// method-style. The receiver counts toward the arity.
+	pub const fn method(arity: usize) -> Self {
+		FunctionMeta {
+			min_args: arity,
+			max_args: Some(arity),
+			receiver: ReceiverStyle::Required,
+		}
+	}
+
+	/// Accepts up to `max_args`, for functions with optional trailing
+	/// arguments. The arity already given becomes the minimum.
+	pub const fn up_to(mut self, max_args: usize) -> Self {
+		self.max_args = Some(max_args);
+		self
+	}
+
+	/// Accepts any number of trailing arguments beyond the arity already
+	/// given, which becomes the minimum.
+	pub const fn variadic(mut self) -> Self {
+		self.max_args = None;
+		self
+	}
+}
 
 /// Context is a collection of variables and functions that can be used
 /// by the interpreter to resolve expressions.
@@ -34,6 +112,16 @@ use crate::objects::{KeyRef, MapValue, TryIntoValue, Value};
 pub struct Context {
 	pub functions: BTreeMap<String, Function>,
 	pub qualified_functions: hashbrown::HashMap<(String, String), Function>,
+	/// Call-shape metadata for entries in `functions`, kept separate because
+	/// [`Function`] is a public type alias with no room for fields. Registered
+	/// via the `*_with_meta` methods; functions without metadata are simply not
+	/// statically checked.
+	function_metadata: BTreeMap<String, FunctionMeta>,
+	/// The method names the environment's opaque/dynamic values may intercept
+	/// before dispatch falls back to `functions`. See
+	/// [`Context::declare_opaque_methods`]. `None` means the surface is
+	/// unknown, which suppresses all static checking of method-style calls.
+	opaque_methods: Option<BTreeSet<String>>,
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -66,6 +154,56 @@ impl Context {
 		self.functions.insert(name.to_string(), value);
 	}
 
+	/// Like [`Context::add_function`], but also declares call-shape metadata so
+	/// `Program::check` can validate call sites.
+	pub fn add_function_with_meta<T: 'static, F>(&mut self, name: &str, meta: FunctionMeta, value: F)
+	where
+		F: IntoFunction<T> + 'static + Send + Sync,
+	{
+		self.add_function(name, value);
+		self.function_metadata.insert(name.to_string(), meta);
+	}
+
+	/// Like [`Context::add_function_direct`], but also declares call-shape
+	/// metadata so `Program::check` can validate call
+	/// sites.
+	pub fn add_function_direct_with_meta(&mut self, name: &str, meta: FunctionMeta, value: Function) {
+		self.add_function_direct(name, value);
+		self.function_metadata.insert(name.to_string(), meta);
+	}
+
+	pub fn function_meta(&self, name: &str) -> Option<FunctionMeta> {
+		self.function_metadata.get(name).copied()
+	}
+
+	/// Declares method names that this environment's opaque or dynamic values
+	/// may intercept at dispatch (before falling back to the global function
+	/// table). May be called multiple times; the names accumulate.
+	///
+	/// Until this is called, the opaque surface is *unknown* and
+	/// `Program::check` will not diagnose any
+	/// method-style call, since any name might be a valid opaque method.
+	/// Calling this — even with an empty iterator — asserts that the declared
+	/// names are the *complete* set of opaque methods, enabling checking of
+	/// method-style calls. When unsure whether a name belongs in the set,
+	/// include it: an extra name only suppresses a diagnostic, while a missing
+	/// one rejects a working expression.
+	pub fn declare_opaque_methods<I>(&mut self, names: I)
+	where
+		I: IntoIterator,
+		I::Item: Into<String>,
+	{
+		self
+			.opaque_methods
+			.get_or_insert_with(Default::default)
+			.extend(names.into_iter().map(Into::into));
+	}
+
+	/// See [`Context::declare_opaque_methods`].
+	pub fn opaque_methods(&self) -> Option<&BTreeSet<String>> {
+		self.opaque_methods.as_ref()
+	}
+
 	pub fn add_qualified_function<T: 'static, F>(&mut self, base: &str, name: &str, value: F)
 	where
 		F: IntoFunction<T> + 'static + Send + Sync,
@@ -81,20 +219,28 @@ impl Default for Context {
 		let mut ctx = Context {
 			functions: Default::default(),
 			qualified_functions: Default::default(),
+			function_metadata: Default::default(),
+			opaque_methods: None,
 		};
 
-		ctx.add_function("contains", functions::contains);
-		ctx.add_function("size", functions::size);
-		ctx.add_function("max", functions::max);
-		ctx.add_function("min", functions::min);
-		ctx.add_function("startsWith", functions::starts_with);
-		ctx.add_function("endsWith", functions::ends_with);
-		ctx.add_function("string", functions::string);
-		ctx.add_function("bytes", functions::bytes);
-		ctx.add_function("double", functions::double);
-		ctx.add_function("int", functions::int);
-		ctx.add_function("uint", functions::uint);
-		ctx.add_function("type", functions::type_);
+		ctx.add_function_with_meta("contains", FunctionMeta::either(2), functions::contains);
+		ctx.add_function_with_meta("size", FunctionMeta::either(1), functions::size);
+		// A zero-argument call yields null rather than erroring, and any receiver
+		// is dropped; neither is recoverable from the declared shape.
+		ctx.add_function_with_meta("max", FunctionMeta::global(0).variadic(), functions::max);
+		ctx.add_function_with_meta("min", FunctionMeta::global(0).variadic(), functions::min);
+		ctx.add_function_with_meta(
+			"startsWith",
+			FunctionMeta::either(2),
+			functions::starts_with,
+		);
+		ctx.add_function_with_meta("endsWith", FunctionMeta::either(2), functions::ends_with);
+		ctx.add_function_with_meta("string", FunctionMeta::either(1), functions::string);
+		ctx.add_function_with_meta("bytes", FunctionMeta::global(1), functions::bytes);
+		ctx.add_function_with_meta("double", FunctionMeta::either(1), functions::double);
+		ctx.add_function_with_meta("int", FunctionMeta::either(1), functions::int);
+		ctx.add_function_with_meta("uint", FunctionMeta::either(1), functions::uint);
+		ctx.add_function_with_meta("type", FunctionMeta::either(1), functions::type_);
 
 		ctx.add_qualified_function("optional", "none", functions::optional_none);
 		ctx.add_qualified_function("optional", "of", functions::optional_of);
@@ -103,26 +249,55 @@ impl Default for Context {
 			"ofNonZeroValue",
 			functions::optional_of_non_zero_value,
 		);
-		ctx.add_function("value", functions::optional_value);
-		ctx.add_function("hasValue", functions::optional_has_value);
-		ctx.add_function("or", functions::optional_or_optional);
-		ctx.add_function("orValue", functions::optional_or_value);
+		ctx.add_function_with_meta("value", FunctionMeta::either(1), functions::optional_value);
+		ctx.add_function_with_meta(
+			"hasValue",
+			FunctionMeta::either(1),
+			functions::optional_has_value,
+		);
+		ctx.add_function_with_meta(
+			"or",
+			FunctionMeta::either(2),
+			functions::optional_or_optional,
+		);
+		ctx.add_function_with_meta(
+			"orValue",
+			FunctionMeta::either(2),
+			functions::optional_or_value,
+		);
 
-		ctx.add_function("matches", functions::matches);
+		ctx.add_function_with_meta("matches", FunctionMeta::either(2), functions::matches);
 
 		{
-			ctx.add_function("duration", functions::duration);
-			ctx.add_function("timestamp", functions::timestamp);
-			ctx.add_function("getFullYear", functions::time::timestamp_year);
-			ctx.add_function("getMonth", functions::time::timestamp_month);
-			ctx.add_function("getDayOfYear", functions::time::timestamp_year_day);
-			ctx.add_function("getDayOfMonth", functions::time::timestamp_month_day);
-			ctx.add_function("getDate", functions::time::timestamp_date);
-			ctx.add_function("getDayOfWeek", functions::time::timestamp_weekday);
-			ctx.add_function("getHours", functions::time::get_hours);
-			ctx.add_function("getMinutes", functions::time::get_minutes);
-			ctx.add_function("getSeconds", functions::time::get_seconds);
-			ctx.add_function("getMilliseconds", functions::time::get_milliseconds);
+			ctx.add_function_with_meta("duration", FunctionMeta::global(1), functions::duration);
+			ctx.add_function_with_meta("timestamp", FunctionMeta::global(1), functions::timestamp);
+			let time_getter = FunctionMeta::either(1);
+			ctx.add_function_with_meta("getFullYear", time_getter, functions::time::timestamp_year);
+			ctx.add_function_with_meta("getMonth", time_getter, functions::time::timestamp_month);
+			ctx.add_function_with_meta(
+				"getDayOfYear",
+				time_getter,
+				functions::time::timestamp_year_day,
+			);
+			ctx.add_function_with_meta(
+				"getDayOfMonth",
+				time_getter,
+				functions::time::timestamp_month_day,
+			);
+			ctx.add_function_with_meta("getDate", time_getter, functions::time::timestamp_date);
+			ctx.add_function_with_meta(
+				"getDayOfWeek",
+				time_getter,
+				functions::time::timestamp_weekday,
+			);
+			ctx.add_function_with_meta("getHours", time_getter, functions::time::get_hours);
+			ctx.add_function_with_meta("getMinutes", time_getter, functions::time::get_minutes);
+			ctx.add_function_with_meta("getSeconds", time_getter, functions::time::get_seconds);
+			ctx.add_function_with_meta(
+				"getMilliseconds",
+				time_getter,
+				functions::time::get_milliseconds,
+			);
 		}
 
 		ctx
@@ -231,5 +406,40 @@ impl<'a> VariableResolver<'a> for MapResolver<'a> {
 			.map(|(k, v)| (KeyRef::String((*k).into()), v.clone()))
 			.collect();
 		Some(Value::Map(MapValue::Borrow(variables)))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Guard against `Option<FunctionMeta>` silently spreading.
+	#[test]
+	fn every_default_function_has_metadata() {
+		let ctx = Context::default();
+		let missing: Vec<&str> = ctx
+			.functions
+			.keys()
+			.filter(|name| ctx.function_meta(name).is_none())
+			.map(String::as_str)
+			.collect();
+		assert!(
+			missing.is_empty(),
+			"functions registered without metadata: {missing:?}"
+		);
+	}
+
+	#[test]
+	fn opaque_surface_tri_state() {
+		let mut ctx = Context::default();
+		assert!(ctx.opaque_methods().is_none());
+		ctx.declare_opaque_methods(std::iter::empty::<String>());
+		assert_eq!(ctx.opaque_methods().map(BTreeSet::len), Some(0));
+		ctx.declare_opaque_methods(["cookie", "unredacted"]);
+		ctx.declare_opaque_methods(["masked"]);
+		let declared = ctx.opaque_methods().unwrap();
+		assert!(declared.contains("cookie"));
+		assert!(declared.contains("unredacted"));
+		assert!(declared.contains("masked"));
 	}
 }

--- a/crates/cel-fork/cel/src/lib.rs
+++ b/crates/cel-fork/cel/src/lib.rs
@@ -14,7 +14,7 @@ pub mod parser;
 
 pub use common::ast::IdedExpr;
 use common::ast::SelectExpr;
-pub use context::Context;
+pub use context::{Context, FunctionMeta, ReceiverStyle};
 pub use functions::FunctionContext;
 pub use objects::{ResolveResult, Value};
 use parser::{CallSignature, Expression, ExpressionReferences, Parser};

--- a/crates/cel-fork/cel/src/lib.rs
+++ b/crates/cel-fork/cel/src/lib.rs
@@ -30,6 +30,7 @@ pub use ser::{Duration, Timestamp};
 mod ser;
 pub use ser::{SerializationError, to_value};
 
+pub mod check;
 mod json;
 mod optimize;
 #[cfg(test)]
@@ -223,12 +224,16 @@ impl Program {
 			.map(|expression| Program { expression })
 	}
 
-	fn optimized(self) -> Program {
+	/// Applies the built-in optimizer. Combined with
+	/// [`Program::compile_unoptimized`], this lets a caller run
+	/// [`Program::check`] between parsing and optimization.
+	pub fn optimized(self) -> Program {
 		Program {
 			expression: crate::optimize::Optimize::new().optimize(self.expression),
 		}
 	}
-	fn optimized_with<T: Optimizer + 'static>(self, t: T) -> Program {
+	/// Applies a custom optimizer; see [`Program::optimized`].
+	pub fn optimized_with<T: Optimizer + 'static>(self, t: T) -> Program {
 		Program {
 			expression: crate::optimize::Optimize::new_with_optimizer(t).optimize(self.expression),
 		}
@@ -278,6 +283,29 @@ impl Program {
 	/// ```
 	pub fn call_signatures(&self) -> Vec<CallSignature<'_>> {
 		self.expression.call_signatures()
+	}
+
+	/// Statically checks every call site against the metadata the context
+	/// declared at registration, reporting calls that cannot succeed (or
+	/// almost certainly misbehave) without executing anything. See the
+	/// [`check`](crate::check) module for what is and is not covered.
+	///
+	/// Optimizers rewrite calls, so diagnostics from an optimized program can
+	/// name functions and arities the author never wrote. Check the program
+	/// from [`Program::compile_unoptimized`], then optimize afterwards via
+	/// [`Program::optimized`] / [`Program::optimized_with`].
+	///
+	/// # Example
+	/// ```rust
+	/// # use cel::{Context, Program};
+	/// let program = Program::compile_unoptimized("siz(foo) > 0").unwrap();
+	/// let diagnostics = program.check(&Context::default());
+	///
+	/// assert_eq!(diagnostics.len(), 1);
+	/// assert_eq!(diagnostics[0].to_string(), "unknown function 'siz'");
+	/// ```
+	pub fn check(&self, ctx: &Context) -> Vec<check::Diagnostic> {
+		self.expression.check(ctx)
 	}
 
 	/// Returns the contained expression

--- a/crates/cel-fork/cel/src/parser/macros.rs
+++ b/crates/cel-fork/cel/src/parser/macros.rs
@@ -1,5 +1,6 @@
 use crate::common::ast::{CallExpr, ComprehensionExpr, Expr, IdedExpr, ListExpr, operators};
 use crate::common::value::CelVal::{Boolean, Int};
+use crate::context::{FunctionMeta, ReceiverStyle};
 use crate::parser::{MacroExprHelper, ParseError};
 
 pub type MacroExpander = fn(
@@ -8,24 +9,55 @@ pub type MacroExpander = fn(
 	args: Vec<IdedExpr>,
 ) -> Result<IdedExpr, ParseError>;
 
+/// The comprehension macros and the call shapes they expand at. A call
+/// matching a shape is expanded at parse time and never appears as a call
+/// node, so the checker treats a surviving call node with one of these names
+/// as a mismatched use. Arity counts include the receiver, per
+/// [`FunctionMeta`]'s convention.
+pub(crate) const MACROS: &[(&str, FunctionMeta, MacroExpander)] = &[
+	(operators::HAS, FunctionMeta::global(1), has_macro_expander),
+	(
+		operators::EXISTS,
+		FunctionMeta::method(3),
+		exists_macro_expander,
+	),
+	(operators::ALL, FunctionMeta::method(3), all_macro_expander),
+	(
+		operators::EXISTS_ONE,
+		FunctionMeta::method(3),
+		exists_one_macro_expander,
+	),
+	(
+		"existsOne",
+		FunctionMeta::method(3),
+		exists_one_macro_expander,
+	),
+	(
+		operators::MAP,
+		FunctionMeta::method(3).up_to(4),
+		map_macro_expander,
+	),
+	(
+		operators::FILTER,
+		FunctionMeta::method(3),
+		filter_macro_expander,
+	),
+];
+
 pub fn find_expander(
 	func_name: &str,
 	target: Option<&IdedExpr>,
 	args: &[IdedExpr],
 ) -> Option<MacroExpander> {
-	match func_name {
-		operators::HAS if args.len() == 1 && target.is_none() => Some(has_macro_expander),
-		operators::EXISTS if args.len() == 2 && target.is_some() => Some(exists_macro_expander),
-		operators::ALL if args.len() == 2 && target.is_some() => Some(all_macro_expander),
-		operators::EXISTS_ONE | "existsOne" if args.len() == 2 && target.is_some() => {
-			Some(exists_one_macro_expander)
-		},
-		operators::MAP if (args.len() == 2 || args.len() == 3) && target.is_some() => {
-			Some(map_macro_expander)
-		},
-		operators::FILTER if args.len() == 2 && target.is_some() => Some(filter_macro_expander),
-		_ => None,
-	}
+	let (_, shape, expander) = MACROS.iter().find(|(name, _, _)| *name == func_name)?;
+	let receiver_ok = match shape.receiver {
+		ReceiverStyle::Required => target.is_some(),
+		ReceiverStyle::Forbidden => target.is_none(),
+		ReceiverStyle::Either => true,
+	};
+	let arity = args.len() + usize::from(target.is_some());
+	(receiver_ok && arity >= shape.min_args && shape.max_args.is_none_or(|max| arity <= max))
+		.then_some(*expander)
 }
 
 fn has_macro_expander(

--- a/crates/cel-fork/cel/src/parser/mod.rs
+++ b/crates/cel-fork/cel/src/parser/mod.rs
@@ -6,7 +6,7 @@ pub mod references;
 
 pub use crate::common::ast::IdedExpr as Expression;
 
-mod macros;
+pub(crate) mod macros;
 mod parse;
 #[allow(non_snake_case)]
 mod parser;


### PR DESCRIPTION
Add support for static checking of CEL expressions. Deliberately conservative -- avoids diagnostics that may be incorrect, avoids breaking existing Rust API compatibility (though contrary to the original drafting of #2866, this _does_ tighten CEL expression compatibility when the previously-allowed expressions were incoherent); only performs checks where enough information is provided to be confident of correctness (if context is not populated with an exhaustive list of dynamic names, f/e, checking for unrecognized names is not performed).

Performance impact is compile-time only, not execution-time.

---

This is the first PR of a series of three.

Claude Code (Fable 5, Opus 5) was used in creation of this PR. That said, I've spent a significant amount of time iterating on it, and am comfortable standing behind it personally.