### PR TITLE
ci: fully cache go

### DIFF
--- a/.github/actions/controller-build-cache/action.yml
+++ b/.github/actions/controller-build-cache/action.yml
@@ -1,0 +1,178 @@
+name: Controller build cache
+description: Set up Rust and Go toolchains and restore source-aware controller build caches
+
+inputs:
+  rust-version:
+    description: Rust toolchain version
+    required: true
+  go-version:
+    description: Go toolchain version
+    required: true
+  save:
+    description: Save missing caches after a successful job
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+  - name: Check runner info
+    shell: bash
+    run: |
+      cat /sys/fs/cgroup/cpu.stat || true
+      cat /proc/pressure/cpu || true
+      lscpu || true
+      openssl speed -seconds 1 -bytes 256 sha256 || true
+
+  - name: Set tools path
+    shell: bash
+    run: echo "$GITHUB_WORKSPACE/tools" >> "$GITHUB_PATH"
+
+  - name: Install Rust
+    uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+    with:
+      toolchain: ${{ inputs.rust-version }}
+
+  # Cargo primarily uses mtimes for change detection. Stable source mtimes let
+  # restored target artifacts remain valid across fresh CI checkouts.
+  - name: Restore source mtimes
+    shell: bash
+    run: ./tools/git-restore-mtime --commit-time
+
+  # rust-cache includes nested .cargo/config.toml files in its exact key, but
+  # excludes them from its fallback prefix. The crates/ tree therefore rolls the
+  # cache forward after Rust changes without making unrelated changes write it.
+  - name: Set Rust cache generation
+    id: rust-cache-generation
+    shell: bash
+    run: |
+      mkdir -p .github/rust-cache/.cargo .github/rust-cache-state
+
+      crates_generation="$(git rev-parse HEAD:crates)"
+      proto_generation="$(git rev-parse HEAD:crates/protos/proto)-$(git rev-parse HEAD:crates/protos/build.rs)"
+
+      printf '# generation = %s\n' "$crates_generation" > .github/rust-cache/.cargo/config.toml
+      echo "protos=$proto_generation" >> "$GITHUB_OUTPUT"
+
+  - name: Restore Rust cache
+    uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+    with:
+      shared-key: controller-e2e
+      cache-workspace-crates: true
+      # Keep the proto generation that produced cached build-script output. A
+      # fallback can then retain dependencies while safely regenerating changed protos.
+      cache-directories: .github/rust-cache-state
+      save-if: ${{ inputs.save }}
+
+  # A fallback may contain old generated protos whose cached mtime is newer than
+  # the Git-restored source. Cargo would incorrectly skip build.rs in that case.
+  - name: Validate cached Rust proto generation
+    shell: bash
+    env:
+      CURRENT_PROTOS: ${{ steps.rust-cache-generation.outputs.protos }}
+    run: |
+      cached_protos="$(cat .github/rust-cache-state/protos 2>/dev/null || true)"
+
+      echo "Cached proto generation: ${cached_protos:-missing}"
+      echo "Current proto generation: $CURRENT_PROTOS"
+
+      if [[ "$cached_protos" != "$CURRENT_PROTOS" ]]; then
+        echo "Proto inputs changed; forcing crates/protos/build.rs to rerun"
+        touch crates/protos/build.rs
+      fi
+
+      printf '%s\n' "$CURRENT_PROTOS" > .github/rust-cache-state/protos
+
+  - name: Install Go
+    uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+    with:
+      go-version: ${{ inputs.go-version }}
+      # setup-go's immutable dependency-only key can leave GOCACHE stale forever.
+      cache: false
+
+  - name: Set Go cache keys
+    id: go-cache-keys
+    shell: bash
+    run: |
+      # Hash only module metadata so README/source-only changes retain the same
+      # dependency cache generation. Git object hashes are content-based and do
+      # not depend on checkout mtimes.
+      dependency_generation="$(
+        git ls-files --stage -- \
+          ':(glob)**/go.mod' ':(glob)**/go.sum' |
+          git hash-object --stdin
+      )"
+
+      {
+        echo "build=$(go env GOCACHE)"
+        echo "modules=$(go env GOMODCACHE)"
+        echo "dependencies=$dependency_generation"
+        # The controller imports the local api/ module, so both trees are inputs.
+        echo "source=$(git rev-parse HEAD:controller)-$(git rev-parse HEAD:api)"
+      } >> "$GITHUB_OUTPUT"
+
+      echo "Go version: $(go env GOVERSION)"
+      echo "Dependency generation: $dependency_generation"
+      echo "Controller/API trees: $(git rev-parse HEAD:controller)-$(git rev-parse HEAD:api)"
+
+  # These are mutually exclusive access modes for the same caches. actions/cache
+  # has no save-if input: the combined action always registers a post-job save on
+  # a miss. Main uses that form so the cache is saved after the build populates it.
+  # PR and conformance jobs use actions/cache/restore, which can read main's cache
+  # but never writes a branch-specific cache. Only one step in each pair will run.
+  - name: Restore writable Go module cache
+    if: ${{ inputs.save == 'true' }}
+    id: go-module-cache-write
+    uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    with:
+      path: ${{ steps.go-cache-keys.outputs.modules }}
+      key: go-mod-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-${{ steps.go-cache-keys.outputs.dependencies }}
+      restore-keys: |
+        go-mod-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-
+
+  - name: Restore read-only Go module cache
+    if: ${{ inputs.save != 'true' }}
+    id: go-module-cache-read
+    uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    with:
+      path: ${{ steps.go-cache-keys.outputs.modules }}
+      key: go-mod-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-${{ steps.go-cache-keys.outputs.dependencies }}
+      restore-keys: |
+        go-mod-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-
+
+  - name: Restore writable Go build cache
+    if: ${{ inputs.save == 'true' }}
+    id: go-build-cache-write
+    uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    with:
+      path: ${{ steps.go-cache-keys.outputs.build }}
+      key: go-build-controller-e2e-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-${{ steps.go-cache-keys.outputs.dependencies }}-${{ steps.go-cache-keys.outputs.source }}
+      restore-keys: |
+        go-build-controller-e2e-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-${{ steps.go-cache-keys.outputs.dependencies }}-
+        go-build-controller-e2e-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-
+
+  - name: Restore read-only Go build cache
+    if: ${{ inputs.save != 'true' }}
+    id: go-build-cache-read
+    uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    with:
+      path: ${{ steps.go-cache-keys.outputs.build }}
+      key: go-build-controller-e2e-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-${{ steps.go-cache-keys.outputs.dependencies }}-${{ steps.go-cache-keys.outputs.source }}
+      restore-keys: |
+        go-build-controller-e2e-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-${{ steps.go-cache-keys.outputs.dependencies }}-
+        go-build-controller-e2e-v0-${{ runner.os }}-${{ runner.arch }}-${{ inputs.go-version }}-
+
+  - name: Show Go cache results
+    shell: bash
+    env:
+      MODULE_HIT_WRITE: ${{ steps.go-module-cache-write.outputs.cache-hit }}
+      MODULE_HIT_READ: ${{ steps.go-module-cache-read.outputs.cache-hit }}
+      BUILD_HIT_WRITE: ${{ steps.go-build-cache-write.outputs.cache-hit }}
+      BUILD_HIT_READ: ${{ steps.go-build-cache-read.outputs.cache-hit }}
+    run: |
+      module_hit="${MODULE_HIT_WRITE:-$MODULE_HIT_READ}"
+      build_hit="${BUILD_HIT_WRITE:-$BUILD_HIT_READ}"
+
+      echo "Module exact hit: $module_hit"
+      echo "Build exact hit: $build_hit"
+      du -sh "${{ steps.go-cache-keys.outputs.modules }}" "${{ steps.go-cache-keys.outputs.build }}" 2>/dev/null || true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -150,45 +150,13 @@ jobs:
         persist-credentials: false
         # git-restore-mtime needs full history to find each file's latest change.
         fetch-depth: 0
-    - name: Check Runner Info
-      run: |
-        cat /sys/fs/cgroup/cpu.stat || true
-        cat /proc/pressure/cpu || true
-        lscpu || true
-        openssl speed -seconds 1  -bytes 256 sha256 || rtue
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+    - name: Set up controller build caches
+      uses: ./.github/actions/controller-build-cache
       with:
-        toolchain: "${{ env.RUST_VERSION }}"
-    - name: Restore source mtimes
-      run: ./tools/git-restore-mtime --commit-time
-    # rust-cache includes nested .cargo/config.toml files in its exact cache key,
-    # but not in its fallback restore prefix. Keying this synthetic config by the
-    # crates/ Git tree makes Rust input changes update the cache, while changes
-    # elsewhere can exactly reuse it without another cache write.
-    - name: Set Rust cache generation
-      run: |
-        mkdir -p .github/rust-cache/.cargo
-        printf '# generation = %s\n' "$(git rev-parse HEAD:crates)" > .github/rust-cache/.cargo/config.toml
-    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      with:
-        # Workspace artifacts are cheap to cache and can avoid rebuilding when Rust
-        # inputs have not changed. Fallback restores remain best-effort because their
-        # prefix deliberately excludes the source generation above.
-        cache-workspace-crates: true
-        # Github cache will restore from 'main' OR the current branch.
-        # If we cache PR branches, we may evict the 'main' cache and end up with no cache hits at all.
-        # Ideally, we would have main be 'high priority' and not be evicted but I don't think thats possible.
-        save-if: ${{ github.ref == 'refs/heads/main' }}
-    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
+        rust-version: "${{ env.RUST_VERSION }}"
         go-version: "${{ env.GO_VERSION }}"
-        cache-dependency-path: |
-          **/*.sum
-          .github/workflows/cache-e2e
-    - name: Set Path
-      run: |
-        echo "./tools" >> $GITHUB_PATH
+        # PRs can restore the default branch caches, but only postsubmit rolls them forward.
+        save: ${{ github.ref == 'refs/heads/main' }}
     - name: Setup
       run: TEST_MODE=e2e ./controller/test/setup/setup-kind-ci.sh
     - name: E2E
@@ -220,35 +188,11 @@ jobs:
         persist-credentials: false
         # git-restore-mtime needs full history to find each file's latest change.
         fetch-depth: 0
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+    - name: Set up controller build caches
+      uses: ./.github/actions/controller-build-cache
       with:
-        toolchain: "${{ env.RUST_VERSION }}"
-    - name: Restore source mtimes
-      run: ./tools/git-restore-mtime --commit-time
-    # Match the E2E job's exact and fallback cache keys so this job can share them.
-    - name: Set Rust cache generation
-      run: |
-        mkdir -p .github/rust-cache/.cargo
-        printf '# generation = %s\n' "$(git rev-parse HEAD:crates)" > .github/rust-cache/.cargo/config.toml
-    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      with:
-        # Workspace artifacts are cheap to cache and can avoid rebuilding when Rust
-        # inputs have not changed. Fallback restores remain best-effort because their
-        # prefix deliberately excludes the source generation above.
-        cache-workspace-crates: true
-        # We only read the cache from 'E2E' job, since they should have identical cache.
-        save-if: "false"
-        shared-key: "controller-e2e" # Pull E2E job's cache
-    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
+        rust-version: "${{ env.RUST_VERSION }}"
         go-version: "${{ env.GO_VERSION }}"
-        cache-dependency-path: |
-          **/*.sum
-          .github/workflows/cache-e2e
-    - name: Set Path
-      run: |
-        echo "./tools" >> $GITHUB_PATH
     - name: Setup
       run: TEST_MODE=conformance ./controller/test/setup/setup-kind-ci.sh
     - name: Conformance
@@ -296,35 +240,11 @@ jobs:
         persist-credentials: false
         # git-restore-mtime needs full history to find each file's latest change.
         fetch-depth: 0
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+    - name: Set up controller build caches
+      uses: ./.github/actions/controller-build-cache
       with:
-        toolchain: "${{ env.RUST_VERSION }}"
-    - name: Restore source mtimes
-      run: ./tools/git-restore-mtime --commit-time
-    # Match the E2E job's exact and fallback cache keys so this job can share them.
-    - name: Set Rust cache generation
-      run: |
-        mkdir -p .github/rust-cache/.cargo
-        printf '# generation = %s\n' "$(git rev-parse HEAD:crates)" > .github/rust-cache/.cargo/config.toml
-    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      with:
-        # Workspace artifacts are cheap to cache and can avoid rebuilding when Rust
-        # inputs have not changed. Fallback restores remain best-effort because their
-        # prefix deliberately excludes the source generation above.
-        cache-workspace-crates: true
-        # We only read the cache from 'E2E' job, since they should have identical cache.
-        save-if: "false"
-        shared-key: "controller-e2e" # Pull E2E job's cache
-    - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-      with:
+        rust-version: "${{ env.RUST_VERSION }}"
         go-version: "${{ env.GO_VERSION }}"
-        cache-dependency-path: |
-          **/*.sum
-          .github/workflows/cache-e2e
-    - name: Set Path
-      run: |
-        echo "./tools" >> $GITHUB_PATH
     - name: Setup
       run: TEST_MODE=conformance ./controller/test/setup/setup-kind-ci.sh
     - name: GIE Conformance


### PR DESCRIPTION
Today, we cache once when go.sum changes. The cache gets increasingly
stale as time goes on. Now we write the cache on any source change.
Write happens in postsubmit so its pretty cheap. We can restore without
a full match.

Signed-off-by: John Howard <john.howard@solo.io>
