### PR TITLE
bug: reasoning effort appears in the request

### DIFF
--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -1028,6 +1028,8 @@ pub mod from_messages {
 			|| model.starts_with("gpt-5.1")
 			|| model.starts_with("gpt-5.2");
 		let reasoning_effort = if !tools.is_empty() && !supports_reasoning_with_tools {
+			// Using Some(completions::ReasoningEffort::None) here results in the reasoning_effort field being sent in the request.
+			// Setting this to None omits the field entirely, which is what we want for models that don't support reasoning with tools.
 			None
 		} else {
 			reasoning_effort

--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -1028,7 +1028,7 @@ pub mod from_messages {
 			|| model.starts_with("gpt-5.1")
 			|| model.starts_with("gpt-5.2");
 		let reasoning_effort = if !tools.is_empty() && !supports_reasoning_with_tools {
-			Some(completions::ReasoningEffort::None)
+			None
 		} else {
 			reasoning_effort
 		};

--- a/crates/llm/src/tests/requests/messages/gpt_adaptive_thinking_with_tools.completions.snap
+++ b/crates/llm/src/tests/requests/messages/gpt_adaptive_thinking_with_tools.completions.snap
@@ -34,7 +34,6 @@ info:
       }
     ],
     "model": "gpt-5.6-terra",
-    "reasoning_effort": "none",
     "max_completion_tokens": 64,
     "stream": false,
     "tools": [


### PR DESCRIPTION
Remove reasoning_effort from the request entirely, previously it was set to none.
By sending reasoning_effort in the request even if it is none, at least for azure foundry, returns this error
{"type":"error","error":{"type":"invalid_request_error","message":"Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. Please use /v1/responses instead."}}.
By omitting reasoning_effort it fixes this situation.
Checked with claude cli and curls to verify the fix works.