### PR TITLE
readd conditional validation for ext services

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2731,6 +2731,7 @@ type ExtProcConditional struct {
 	Policy ExtProc `json:"policy"`
 }
 
+// +kubebuilder:validation:ConditionalPolicy
 // +kubebuilder:validation:XValidation:rule="has(self.conditional) ? (!has(self.backendRef) && !has(self.url)) : [has(self.backendRef),has(self.url)].filter(x,x==true).size() == 1",message="exactly one of backendRef or url must be set unless conditional is set"
 type ExtProcOrConditional struct {
 	// +optional
@@ -2783,6 +2784,7 @@ type ExtAuthConditional struct {
 	Policy ExtAuth `json:"policy"`
 }
 
+// +kubebuilder:validation:ConditionalPolicy
 // +kubebuilder:validation:XValidation:rule="has(self.conditional) ? (!has(self.backendRef) && !has(self.url)) : [has(self.backendRef),has(self.url)].filter(x,x==true).size() == 1",message="exactly one of backendRef or url must be set unless conditional is set"
 // +kubebuilder:validation:XValidation:rule="has(self.conditional) || [has(self.grpc),has(self.http)].filter(x,x==true).size() == 1",message="exactly one of the fields in [grpc http] must be set"
 type ExtAuthOrConditional struct {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -8507,6 +8507,9 @@ spec:
                     - message: http.path may not be set when url includes a path
                       rule: '!has(self.url) || !self.url.matches(''^https?://[^/?#]+/'')
                         || !has(self.http) || !has(self.http.path)'
+                    - message: conditional cannot be set with any other field
+                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.cache),has(self.failureMode),has(self.forwardBody),has(self.grpc),has(self.http),has(self.url)].filter(x,x==true).size()
+                        == 0 : true'
                   extProc:
                     description: External processing configuration for the policy.
                     properties:
@@ -8918,6 +8921,9 @@ spec:
                         == 1'
                     - message: url must not include a path
                       rule: '!has(self.url) || self.url.matches(''^https?://[^/?#]+$'')'
+                    - message: conditional cannot be set with any other field
+                      rule: 'has(self.conditional) ? [has(self.backendRef),has(self.failureMode),has(self.metadataContext),has(self.processingOptions),has(self.requestAttributes),has(self.responseAttributes),has(self.url)].filter(x,x==true).size()
+                        == 0 : true'
                   headerModifiers:
                     description: Request and response header modification policy.
                     properties:


### PR DESCRIPTION
in https://github.com/agentgateway/agentgateway/pull/2125 the refactor dropped the check for conditional.

I think this is still something we want to target as configuring a conditional plus a non-conditional would drop the non-conditional silently still