### PR TITLE
backend: support a CEL target expression on dynamic backends

### DIFF
--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -27,7 +27,7 @@ use crate::http::{Body, ext_proc};
 use crate::llm::custom;
 use crate::test_helpers::extprocmock::{
 	ExtProcMock, Handler, immediate_response, request_body_response, request_header_response,
-	response_body_response, response_header_response,
+	request_header_response_with_dynamic_metadata, response_body_response, response_header_response,
 };
 use crate::test_helpers::proxymock::*;
 use crate::test_helpers::{MockInstance, ratelimitmock};
@@ -1870,6 +1870,115 @@ mod dynamic_metadata_flow {
 	}
 }
 
+mod dynamic_backend_target {
+	use super::*;
+	use crate::types::agent::{Backend, ResourceName};
+
+	struct WorkerTargetExtProc {
+		target: String,
+	}
+
+	#[async_trait::async_trait]
+	impl Handler for WorkerTargetExtProc {
+		async fn handle_request_headers(
+			&mut self,
+			_headers: &HttpHeaders,
+			sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+		) -> Result<(), Status> {
+			use prost_wkt_types::value::Kind;
+			use prost_wkt_types::{Struct, Value};
+			let metadata = Struct {
+				fields: HashMap::from([(
+					"workerTarget".to_string(),
+					Value {
+						kind: Some(Kind::StringValue(self.target.clone())),
+					},
+				)]),
+			};
+			let _ = sender
+				.send(request_header_response_with_dynamic_metadata(
+					None, metadata,
+				))
+				.await;
+			Ok(())
+		}
+	}
+
+	/// A `dynamic: { target: ... }` backend should dial wherever the CEL
+	/// expression says, reading dynamic metadata an extProc policy already set
+	/// -- not the request's own :authority. The request below points at an
+	/// unrelated host to prove the dial target came from extProc's metadata,
+	/// not from the request itself.
+	#[tokio::test]
+	async fn reads_extproc_metadata_instead_of_request_authority() {
+		let mock = simple_mock().await;
+		let worker_target = mock.address().to_string();
+
+		let ext_proc = ExtProcMock::new(move || WorkerTargetExtProc {
+			target: worker_target.clone(),
+		})
+		.spawn()
+		.await;
+
+		let target_backend = Backend::Dynamic(
+			ResourceName::new("dyn-target".into(), "".into()),
+			Some(Arc::new(
+				Expression::new_strict("extproc.workerTarget").unwrap(),
+			)),
+		);
+		let route = basic_named_route(target_backend.name());
+
+		let t = setup_proxy_test("{}")
+			.unwrap()
+			.with_raw_backend(target_backend.clone().into())
+			.with_backend(ext_proc.address)
+			.with_bind(simple_bind())
+			.with_route(route)
+			.attach_route_policy_builder(json!({
+				"extProc": {
+					"host": ext_proc.address,
+					"failureMode": "failClosed",
+				},
+			}))
+			.await;
+
+		let io = t.serve_http(strng::new("bind"));
+		let res = crate::proxy::request_builder::RequestBuilder::new(
+			Method::GET,
+			"http://totally-unrelated-host",
+		)
+		.send(io)
+		.await
+		.unwrap();
+		assert_eq!(res.status(), 200);
+	}
+
+	/// Omitting `target` keeps today's behavior: the request's own
+	/// :authority/URI is the dial target.
+	#[tokio::test]
+	async fn falls_back_to_request_authority_when_unset() {
+		let mock = simple_mock().await;
+		let target_backend = Backend::Dynamic(ResourceName::new("dyn-target".into(), "".into()), None);
+		let route = basic_named_route(target_backend.name());
+
+		let t = setup_proxy_test("{}")
+			.unwrap()
+			.with_raw_backend(target_backend.clone().into())
+			.with_bind(simple_bind())
+			.with_route(route);
+
+		let io = t.serve_http(strng::new("bind"));
+		let res = crate::proxy::request_builder::RequestBuilder::new(
+			Method::GET,
+			&format!("http://{}", mock.address()),
+		)
+		.send(io)
+		.await
+		.unwrap();
+		assert_eq!(res.status(), 200);
+	}
+}
+
 // Shared proxy setup helpers used by the test groups below.
 pub async fn setup_ext_proc_mock<T: Handler + Send + Sync + 'static>(
 	mock: MockServer,
@@ -3599,7 +3708,7 @@ mod connect_authority_mutation {
 		.spawn()
 		.await;
 
-		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), None);
 		let t = setup_proxy_test("{}").unwrap();
 		t.inputs()
 			.stores
@@ -3688,7 +3797,7 @@ mod connect_authority_mutation {
 		.spawn()
 		.await;
 
-		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), None);
 		let t = setup_proxy_test("{}").unwrap();
 		t.inputs()
 			.stores
@@ -3830,7 +3939,7 @@ mod connect_authority_mutation {
 			.await
 		};
 
-		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+		let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), None);
 		let t = setup_proxy_test("{}").unwrap();
 		t.inputs()
 			.stores

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -1977,6 +1977,64 @@ mod dynamic_backend_target {
 		.unwrap();
 		assert_eq!(res.status(), 200);
 	}
+
+	#[tokio::test]
+	async fn rejects_non_string_target_expression_results() {
+		let target_backend = Backend::Dynamic(
+			ResourceName::new("dyn-target".into(), "".into()),
+			Some(Arc::new(Expression::new_strict("42").unwrap())),
+		);
+		let route = basic_named_route(target_backend.name());
+		let t = setup_proxy_test("{}")
+			.unwrap()
+			.with_raw_backend(target_backend.into())
+			.with_bind(simple_bind())
+			.with_route(route);
+
+		let res = crate::proxy::request_builder::RequestBuilder::new(
+			Method::GET,
+			"http://totally-unrelated-host",
+		)
+		.send(t.serve_http(strng::new("bind")))
+		.await
+		.unwrap();
+		assert_eq!(res.status(), 503);
+		let body = read_body_raw(res.into_body()).await;
+		assert!(
+			body
+				.as_ref()
+				.starts_with(b"processing failed: dynamic backend target expression must evaluate")
+		);
+	}
+
+	#[tokio::test]
+	async fn rejects_invalid_target_expression_results() {
+		let target_backend = Backend::Dynamic(
+			ResourceName::new("dyn-target".into(), "".into()),
+			Some(Arc::new(
+				Expression::new_strict("'not-a-hostport'").unwrap(),
+			)),
+		);
+		let route = basic_named_route(target_backend.name());
+		let t = setup_proxy_test("{}")
+			.unwrap()
+			.with_raw_backend(target_backend.into())
+			.with_bind(simple_bind())
+			.with_route(route);
+
+		let res = crate::proxy::request_builder::RequestBuilder::new(
+			Method::GET,
+			"http://totally-unrelated-host",
+		)
+		.send(t.serve_http(strng::new("bind")))
+		.await
+		.unwrap();
+		assert_eq!(res.status(), 503);
+		let body = read_body_raw(res.into_body()).await;
+		assert!(body.as_ref().starts_with(
+			b"processing failed: dynamic backend target \"not-a-hostport\": invalid host:port"
+		));
+	}
 }
 
 // Shared proxy setup helpers used by the test groups below.

--- a/crates/agentgateway/src/llm/policy/azure_content_safety.rs
+++ b/crates/agentgateway/src/llm/policy/azure_content_safety.rs
@@ -242,7 +242,7 @@ async fn send_content_safety_request<Req: Serialize, Resp: serde::de::Deserializ
 			strng::literal!("_azure-content-safety"),
 			strng::literal!(""),
 		),
-		(),
+		None,
 	);
 
 	let resp = client

--- a/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
@@ -224,7 +224,7 @@ async fn send_guardrail_request(
 
 	let mock_be = Backend::Dynamic(
 		ResourceName::new(strng::literal!("_bedrock-guardrails"), strng::literal!("")),
-		(),
+		None,
 	);
 
 	let resp = client

--- a/crates/agentgateway/src/llm/policy/google_model_armor.rs
+++ b/crates/agentgateway/src/llm/policy/google_model_armor.rs
@@ -371,7 +371,7 @@ async fn send_model_armor_request<T: Serialize>(
 
 	let mock_be = Backend::Dynamic(
 		ResourceName::new(strng::literal!("_google-model-armor"), strng::literal!("")),
-		(),
+		None,
 	);
 
 	let resp = client

--- a/crates/agentgateway/src/llm/policy/moderation.rs
+++ b/crates/agentgateway/src/llm/policy/moderation.rs
@@ -44,7 +44,7 @@ pub async fn send_request(
 	)?))?;
 	let mock_be = Backend::Dynamic(
 		ResourceName::new(strng::literal!("_openai-moderation"), strng::literal!("")),
-		(),
+		None,
 	);
 	let resp = client
 		.with_outbound(OutboundCallKind::Policy, OutboundCallSubtype::Guardrail)

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1840,12 +1840,14 @@ fn dynamic_backend_target_override(
 		return Ok(None);
 	};
 	let exec = crate::cel::Executor::new_request(req);
-	let value = exec
-		.eval(expr)
-		.map_err(|e| ProxyError::ProcessingString(format!("dynamic backend target expression: {e}")))?;
-	let json = value
-		.json()
-		.map_err(|e| ProxyError::ProcessingString(format!("dynamic backend target expression: {e}")))?;
+	let value = exec.eval(expr).map_err(|e| {
+		ProxyError::ProcessingString(format!("dynamic backend target expression eval: {e}"))
+	})?;
+	let json = value.json().map_err(|e| {
+		ProxyError::ProcessingString(format!(
+			"dynamic backend target expression JSON conversion: {e}"
+		))
+	})?;
 	let serde_json::Value::String(s) = json else {
 		return Err(ProxyError::ProcessingString(
 			"dynamic backend target expression must evaluate to a host:port string".to_string(),

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1824,6 +1824,38 @@ fn target_from_request(req: &Request) -> Result<Target, ProxyError> {
 	Ok(Target::from((host, port)))
 }
 
+/// Evaluates a `Backend::Dynamic` target expression, if one is configured, in
+/// place of the default of reading the request's own :authority/URI. The CEL
+/// context includes any dynamic metadata a route policy (extProc, extAuthz)
+/// already attached to the request -- e.g. `extproc.workerPodIp` -- so the
+/// destination can come from that instead of requiring the policy to rewrite
+/// the request's authority for `target_from_request`/`connect_authority_target`
+/// to then read back. Returns `Ok(None)` when there's no expression, so the
+/// caller falls back to its own default.
+fn dynamic_backend_target_override(
+	req: &Request,
+	expr: &Option<Arc<crate::cel::Expression>>,
+) -> Result<Option<Target>, ProxyError> {
+	let Some(expr) = expr else {
+		return Ok(None);
+	};
+	let exec = crate::cel::Executor::new_request(req);
+	let value = exec
+		.eval(expr)
+		.map_err(|e| ProxyError::ProcessingString(format!("dynamic backend target expression: {e}")))?;
+	let json = value
+		.json()
+		.map_err(|e| ProxyError::ProcessingString(format!("dynamic backend target expression: {e}")))?;
+	let serde_json::Value::String(s) = json else {
+		return Err(ProxyError::ProcessingString(
+			"dynamic backend target expression must evaluate to a host:port string".to_string(),
+		));
+	};
+	let target = Target::try_from(s.as_str())
+		.map_err(|e| ProxyError::ProcessingString(format!("dynamic backend target {s:?}: {e}")))?;
+	Ok(Some(target))
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn apply_inference_routing(
 	policies: &BackendPolicies,
@@ -2197,8 +2229,12 @@ async fn make_backend_call(
 				.into(),
 			);
 		},
-		Backend::Dynamic(_, _) => {
-			let backend_call = BackendCall::from_shared(target_from_request(&req)?, policies);
+		Backend::Dynamic(_, expr) => {
+			let target = match dynamic_backend_target_override(&req, expr)? {
+				Some(target) => target,
+				None => target_from_request(&req)?,
+			};
+			let backend_call = BackendCall::from_shared(target, policies);
 			(backend_call, None)
 		},
 		Backend::Internal(_, _) => (
@@ -2252,10 +2288,14 @@ async fn make_backend_call(
 	.await?;
 
 	// For Dynamic backends, re-resolve the target from the (now potentially transformed)
-	// request URI. This allows policies like `:authority` overrides (e.g., VPC endpoint
-	// routing) to take effect on the actual upstream connection target.
-	if matches!(backend, Backend::Dynamic(_, _)) {
-		backend_call.target = target_from_request(&req)?;
+	// request URI (or re-evaluate the target expression, if any dynamic metadata it reads
+	// could have been affected). This allows policies like `:authority` overrides (e.g., VPC
+	// endpoint routing) to take effect on the actual upstream connection target.
+	if let Backend::Dynamic(_, expr) = backend {
+		backend_call.target = match dynamic_backend_target_override(&req, expr)? {
+			Some(target) => target,
+			None => target_from_request(&req)?,
+		};
 	}
 
 	log.add(|l| {
@@ -2704,10 +2744,13 @@ fn build_connect_backend_call(
 			)
 		},
 		Backend::Opaque(_, target) => Ok(BackendCall::from_shared(target.clone(), policies)),
-		Backend::Dynamic(_, _) => Ok(BackendCall::from_shared(
-			connect_authority_target(req)?,
-			policies,
-		)),
+		Backend::Dynamic(_, expr) => {
+			let target = match dynamic_backend_target_override(req, expr)? {
+				Some(target) => target,
+				None => connect_authority_target(req)?,
+			};
+			Ok(BackendCall::from_shared(target, policies))
+		},
 		Backend::Invalid => Err(ProxyError::BackendDoesNotExist),
 		Backend::AI(_, _)
 		| Backend::LLMRouter(_, _)

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1280,8 +1280,12 @@ pub enum Backend {
 	LLMRouter(ResourceName, Arc<crate::llm::model_router::ModelRouter>),
 	#[serde(rename = "aws", serialize_with = "serialize_backend_tuple")]
 	Aws(ResourceName, crate::aws::AwsBackendConfig),
+	/// The second field, when set, is a CEL expression evaluated against the
+	/// request (with any ext_proc/extAuthz dynamic metadata already attached)
+	/// to compute the dial target, in place of the default behavior of reading
+	/// the request's current :authority/URI (see target_from_request).
 	#[serde(serialize_with = "serialize_backend_tuple")]
-	Dynamic(ResourceName, ()),
+	Dynamic(ResourceName, Option<Arc<crate::cel::Expression>>),
 	/// In-process admin service backend. This is only valid for HTTP routes.
 	#[serde(serialize_with = "serialize_backend_tuple")]
 	Internal(ResourceName, InternalBackend),

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1282,8 +1282,10 @@ pub enum Backend {
 	Aws(ResourceName, crate::aws::AwsBackendConfig),
 	/// The second field, when set, is a CEL expression evaluated against the
 	/// request (with any ext_proc/extAuthz dynamic metadata already attached)
-	/// to compute the dial target, in place of the default behavior of reading
-	/// the request's current :authority/URI (see target_from_request).
+	/// to compute the dial target. The expression and any policy that supplies
+	/// its dynamic metadata are trusted to select that target. This replaces the
+	/// default behavior of reading the request's current :authority/URI (see
+	/// target_from_request).
 	#[serde(serialize_with = "serialize_backend_tuple")]
 	Dynamic(ResourceName, Option<Arc<crate::cel::Expression>>),
 	/// In-process admin service backend. This is only valid for HTTP routes.

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1770,7 +1770,8 @@ pub(crate) fn backend_with_policies_from_proto(
 			};
 			Backend::Opaque(name.into(), target)
 		},
-		Some(backend::Kind::Dynamic(_)) => Backend::Dynamic(name.into(), ()),
+		// xDS-driven dynamic backends don't support a CEL target expression yet.
+		Some(backend::Kind::Dynamic(_)) => Backend::Dynamic(name.into(), None),
 		Some(backend::Kind::Aws(a)) => {
 			let aws_config = match &a.service {
 				Some(proto::agent::aws_backend::Service::AgentCore(ac)) => {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1417,7 +1417,15 @@ pub enum LocalBackend {
 	Opaque(Target),
 	/// Route to the in-process admin service instead of a network upstream.
 	Internal(InternalBackend),
-	Dynamic {},
+	Dynamic {
+		/// CEL expression evaluated against the request to compute the dial
+		/// target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`
+		/// to read dynamic metadata an extProc policy already set). Must
+		/// evaluate to a `host:port` string. If unset, the target is read from
+		/// the request's own :authority/URI, as today.
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		target: Option<Arc<crate::cel::Expression>>,
+	},
 	#[serde(rename = "mcp")]
 	MCP(LocalMcpBackend),
 	#[serde(rename = "ai")]
@@ -1613,7 +1621,7 @@ impl LocalBackend {
 			LocalBackend::Backend(_) => vec![],     // These stay as references
 			LocalBackend::Opaque(tgt) => vec![Backend::Opaque(name, tgt.clone()).into()],
 			LocalBackend::Internal(tgt) => vec![Backend::Internal(name, tgt.clone()).into()],
-			LocalBackend::Dynamic { .. } => vec![Backend::Dynamic(name, ()).into()],
+			LocalBackend::Dynamic { target } => vec![Backend::Dynamic(name, target.clone()).into()],
 			LocalBackend::MCP(tgt) => {
 				let mut targets = vec![];
 				let mut backends = vec![];

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1421,8 +1421,10 @@ pub enum LocalBackend {
 		/// CEL expression evaluated against the request to compute the dial
 		/// target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`
 		/// to read dynamic metadata an extProc policy already set). Must
-		/// evaluate to a `host:port` string. If unset, the target is read from
-		/// the request's own :authority/URI, as today.
+		/// evaluate to a `host:port` string. The expression and any policy that
+		/// supplies its dynamic metadata are trusted to select the dial target.
+		/// If unset, the target is read from the request's own :authority/URI, as
+		/// today.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		target: Option<Arc<crate::cel::Expression>>,
 	},

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -263,7 +263,7 @@ binds:
 		.backends
 		.iter()
 		.find_map(|backend| match &backend.backend {
-			Backend::Dynamic(name, ()) => Some(name),
+			Backend::Dynamic(name, _) => Some(name),
 			_ => None,
 		})
 		.expect("normalized dynamic backend");
@@ -271,6 +271,34 @@ binds:
 		backend.to_string(),
 		"/ns/name/bind/1080/listener0/default/route0/backend0"
 	);
+}
+
+#[tokio::test]
+async fn test_local_dynamic_backend_target_expression_normalizes() {
+	let normalized = normalize_test_yaml(
+		r#"
+binds:
+- port: 1080
+  listeners:
+  - routes:
+    - backends:
+      - dynamic:
+          target: extproc.workerTarget
+"#,
+	)
+	.await
+	.expect("dynamic backend with a target expression should normalize");
+
+	let expr = normalized
+		.backends
+		.iter()
+		.find_map(|backend| match &backend.backend {
+			Backend::Dynamic(_, expr) => Some(expr.clone()),
+			_ => None,
+		})
+		.expect("normalized dynamic backend")
+		.expect("target expression should be set");
+	assert_eq!(expr.original_expression, "extproc.workerTarget");
 }
 
 #[test]

--- a/crates/agentgateway/tests/tests/connect.rs
+++ b/crates/agentgateway/tests/tests/connect.rs
@@ -1024,7 +1024,7 @@ async fn connect_tunnel_dynamic_ca_obo_dynamic_backend() {
 
 	// `dynamic: {}` backend: the upstream is resolved from the decrypted request's
 	// Host/authority (DFP), proven on direct requests by `dfp_uses_host_port`.
-	let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), ());
+	let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), None);
 	let t = setup_proxy_test("{}").unwrap();
 	t.inputs()
 		.stores

--- a/crates/agentgateway/tests/tests/dfp.rs
+++ b/crates/agentgateway/tests/tests/dfp.rs
@@ -11,7 +11,7 @@ pub(in crate::tests) fn setup_dfp_bind() -> TestBind {
 
 pub(in crate::tests) fn setup_dfp_bind_with_config(config: &str) -> TestBind {
 	let backend_name = ResourceName::new("dynamic".into(), "".into());
-	let dynamic_backend = Backend::Dynamic(backend_name, ());
+	let dynamic_backend = Backend::Dynamic(backend_name, None);
 
 	let route = basic_named_route("/dynamic".into());
 
@@ -33,7 +33,7 @@ fn setup_dfp() -> (TestBind, MemoryClient) {
 /// Helper to set up a DFP test behind an HTTPS listener.
 fn setup_dfp_https() -> (TestBind, MemoryClient) {
 	let backend_name = ResourceName::new("dynamic".into(), "".into());
-	let dynamic_backend = Backend::Dynamic(backend_name, ());
+	let dynamic_backend = Backend::Dynamic(backend_name, None);
 
 	let route = basic_named_route("/dynamic".into());
 
@@ -69,7 +69,7 @@ fn setup_dfp_https() -> (TestBind, MemoryClient) {
 async fn dfp_rejects_inference_routing() {
 	let backend_name = ResourceName::new("dynamic".into(), "".into());
 	let dynamic_backend = BackendWithPolicies {
-		backend: Backend::Dynamic(backend_name, ()),
+		backend: Backend::Dynamic(backend_name, None),
 		inline_policies: vec![BackendTrafficPolicy::InferenceRouting(
 			ext_proc::InferenceRouting {
 				target: Arc::new(

--- a/schema/config.json
+++ b/schema/config.json
@@ -7422,6 +7422,19 @@
           "properties": {
             "dynamic": {
               "type": "object",
+              "properties": {
+                "target": {
+                  "description": "CEL expression evaluated against the request to compute the dial\ntarget (e.g. `extproc.workerPodIp + \":\" + string(extproc.workerPodPort)`\nto read dynamic metadata an extProc policy already set). Must\nevaluate to a `host:port` string. If unset, the target is read from\nthe request's own :authority/URI, as today.",
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Expression"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
               "additionalProperties": false
             }
           },

--- a/schema/config.json
+++ b/schema/config.json
@@ -7424,7 +7424,7 @@
               "type": "object",
               "properties": {
                 "target": {
-                  "description": "CEL expression evaluated against the request to compute the dial\ntarget (e.g. `extproc.workerPodIp + \":\" + string(extproc.workerPodPort)`\nto read dynamic metadata an extProc policy already set). Must\nevaluate to a `host:port` string. If unset, the target is read from\nthe request's own :authority/URI, as today.",
+                  "description": "CEL expression evaluated against the request to compute the dial\ntarget (e.g. `extproc.workerPodIp + \":\" + string(extproc.workerPodPort)`\nto read dynamic metadata an extProc policy already set). Must\nevaluate to a `host:port` string. The expression and any policy that\nsupplies its dynamic metadata are trusted to select the dial target.\nIf unset, the target is read from the request's own :authority/URI, as\ntoday.",
                   "anyOf": [
                     {
                       "$ref": "#/$defs/Expression"

--- a/schema/config.md
+++ b/schema/config.md
@@ -4985,6 +4985,7 @@
 |`binds[].listeners[].routes[].backends[].host`|string|Hostname or IP address of the upstream to route to.|
 |`binds[].listeners[].routes[].backends[].internal`|string|Route to the in-process admin service instead of a network upstream.<br>Selects how an internal backend maps proxy requests to the admin API.|
 |`binds[].listeners[].routes[].backends[].dynamic`|object||
+|`binds[].listeners[].routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. If unset, the target is read from<br>the request's own :authority/URI, as today.|
 |`binds[].listeners[].routes[].backends[].mcp`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets`|[]object|MCP server targets to multiplex together.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].sse`|object|Connect to a remote MCP server over HTTP with Server-Sent Events (SSE) streaming.|
@@ -37515,6 +37516,7 @@
 |`routeGroups[].routes[].backends[].host`|string|Hostname or IP address of the upstream to route to.|
 |`routeGroups[].routes[].backends[].internal`|string|Route to the in-process admin service instead of a network upstream.<br>Selects how an internal backend maps proxy requests to the admin API.|
 |`routeGroups[].routes[].backends[].dynamic`|object||
+|`routeGroups[].routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. If unset, the target is read from<br>the request's own :authority/URI, as today.|
 |`routeGroups[].routes[].backends[].mcp`|object||
 |`routeGroups[].routes[].backends[].mcp.targets`|[]object|MCP server targets to multiplex together.|
 |`routeGroups[].routes[].backends[].mcp.targets[].sse`|object|Connect to a remote MCP server over HTTP with Server-Sent Events (SSE) streaming.|
@@ -55118,6 +55120,7 @@
 |`routes[].backends[].host`|string|Hostname or IP address of the upstream to route to.|
 |`routes[].backends[].internal`|string|Route to the in-process admin service instead of a network upstream.<br>Selects how an internal backend maps proxy requests to the admin API.|
 |`routes[].backends[].dynamic`|object||
+|`routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. If unset, the target is read from<br>the request's own :authority/URI, as today.|
 |`routes[].backends[].mcp`|object||
 |`routes[].backends[].mcp.targets`|[]object|MCP server targets to multiplex together.|
 |`routes[].backends[].mcp.targets[].sse`|object|Connect to a remote MCP server over HTTP with Server-Sent Events (SSE) streaming.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -4985,7 +4985,7 @@
 |`binds[].listeners[].routes[].backends[].host`|string|Hostname or IP address of the upstream to route to.|
 |`binds[].listeners[].routes[].backends[].internal`|string|Route to the in-process admin service instead of a network upstream.<br>Selects how an internal backend maps proxy requests to the admin API.|
 |`binds[].listeners[].routes[].backends[].dynamic`|object||
-|`binds[].listeners[].routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. If unset, the target is read from<br>the request's own :authority/URI, as today.|
+|`binds[].listeners[].routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. The expression and any policy that<br>supplies its dynamic metadata are trusted to select the dial target.<br>If unset, the target is read from the request's own :authority/URI, as<br>today.|
 |`binds[].listeners[].routes[].backends[].mcp`|object||
 |`binds[].listeners[].routes[].backends[].mcp.targets`|[]object|MCP server targets to multiplex together.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].sse`|object|Connect to a remote MCP server over HTTP with Server-Sent Events (SSE) streaming.|
@@ -37516,7 +37516,7 @@
 |`routeGroups[].routes[].backends[].host`|string|Hostname or IP address of the upstream to route to.|
 |`routeGroups[].routes[].backends[].internal`|string|Route to the in-process admin service instead of a network upstream.<br>Selects how an internal backend maps proxy requests to the admin API.|
 |`routeGroups[].routes[].backends[].dynamic`|object||
-|`routeGroups[].routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. If unset, the target is read from<br>the request's own :authority/URI, as today.|
+|`routeGroups[].routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. The expression and any policy that<br>supplies its dynamic metadata are trusted to select the dial target.<br>If unset, the target is read from the request's own :authority/URI, as<br>today.|
 |`routeGroups[].routes[].backends[].mcp`|object||
 |`routeGroups[].routes[].backends[].mcp.targets`|[]object|MCP server targets to multiplex together.|
 |`routeGroups[].routes[].backends[].mcp.targets[].sse`|object|Connect to a remote MCP server over HTTP with Server-Sent Events (SSE) streaming.|
@@ -55120,7 +55120,7 @@
 |`routes[].backends[].host`|string|Hostname or IP address of the upstream to route to.|
 |`routes[].backends[].internal`|string|Route to the in-process admin service instead of a network upstream.<br>Selects how an internal backend maps proxy requests to the admin API.|
 |`routes[].backends[].dynamic`|object||
-|`routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. If unset, the target is read from<br>the request's own :authority/URI, as today.|
+|`routes[].backends[].dynamic.target`|string|CEL expression evaluated against the request to compute the dial<br>target (e.g. `extproc.workerPodIp + ":" + string(extproc.workerPodPort)`<br>to read dynamic metadata an extProc policy already set). Must<br>evaluate to a `host:port` string. The expression and any policy that<br>supplies its dynamic metadata are trusted to select the dial target.<br>If unset, the target is read from the request's own :authority/URI, as<br>today.|
 |`routes[].backends[].mcp`|object||
 |`routes[].backends[].mcp.targets`|[]object|MCP server targets to multiplex together.|
 |`routes[].backends[].mcp.targets[].sse`|object|Connect to a remote MCP server over HTTP with Server-Sent Events (SSE) streaming.|


### PR DESCRIPTION
Backend::Dynamic previously always dialed target_from_request -- whatever the request's own :authority/URI said -- so resolving a dynamic destination (e.g. via extProc calling out to a control plane) required extProc to rewrite the request's authority header for that lookup to be picked up.

extProc responses can already carry Envoy's standard dynamic_metadata field, which agentgateway already surfaces to CEL as `extproc.*` (ExtProcDynamicMetadata). Adding an optional CEL target expression on `dynamic: {}` lets a backend read that metadata directly -- `dynamic: { target: "extproc.workerIp + \":\" + string(extproc.workerPort)" }` -- instead of requiring extProc to mutate the request to communicate the destination. Omitting `target` keeps today's target_from_request behavior unchanged.