### PR TITLE
crypto: add symcrypt provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-symcrypt",
  "schemars 1.2.1",
  "secrecy",
  "serde",
@@ -332,6 +333,7 @@ dependencies = [
  "sse-stream",
  "stacker",
  "subtle",
+ "symcrypt",
  "tempfile",
  "thiserror 2.0.19",
  "tiktoken-rs",
@@ -1306,6 +1308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2268,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,7 +2479,7 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
@@ -2483,7 +2501,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
@@ -2492,7 +2510,7 @@ dependencies = [
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4906,12 +4924,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "spki",
 ]
 
@@ -6151,6 +6180,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
+name = "rustls-symcrypt"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a60ef37ac1952a7805f074aa129b63a29332f2292cb9e33af396eb22dc44bf"
+dependencies = [
+ "der 0.8.1",
+ "pkcs1",
+ "pkcs8",
+ "rustls",
+ "rustls-pki-types",
+ "sec1 0.8.1",
+ "symcrypt",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6242,11 +6286,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
  "pkcs8",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "der 0.8.1",
+ "hybrid-array",
  "zeroize",
 ]
 
@@ -6692,7 +6748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -7065,6 +7121,26 @@ dependencies = [
  "cpp_demangle",
  "rustc-demangle",
  "symbolic-common",
+]
+
+[[package]]
+name = "symcrypt"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f6e93e13900bae533f1f347c82d2fcf9d7ad7fffd7e58bc9fbd1b68575ca1c"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "symcrypt-sys",
+]
+
+[[package]]
+name = "symcrypt-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0878df9feb068709a68ccdb5cc3201649201e79e823566863f6ca4db4b9201aa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ aws-types = "1.3"
 aws-smithy-eventstream = "0.61"
 aws-smithy-types = "1.3"
 aws-lc-rs = "1.17"
+# SymCrypt backend: symcrypt 0.5.1 dynamic-links the system libsymcrypt by default (requires libsymcrypt installed).
+symcrypt = "0.5.1"
+rustls-symcrypt = { version = "0.2.3", features = ["chacha", "x25519"] }
 axum = { version = "0.8", features = ["macros"] }
 axum-core = "0.5"
 axum-extra = { version = "0.12", features = ["json-lines", "typed-header"] }

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,12 @@ build: $(UI_PREREQ)
 build-target: $(UI_PREREQ)
 	cargo build $(UI_FEATURE) $(CARGO_BUILD_ARGS) --target $(TARGET) --profile $(PROFILE)
 
+# Build with the SymCrypt provider instead of the default aws-lc-rs. --no-default-features
+# also drops jemalloc/mimalloc, which the Linux allocator requires, so they are re-added.
+.PHONY: build-symcrypt
+build-symcrypt: $(UI_PREREQ)
+	cargo build --release --no-default-features --features jemalloc,mimalloc,crypto-symcrypt $(UI_FEATURE) $(CARGO_BUILD_ARGS)
+
 # lint
 .PHONY: lint
 lint:

--- a/crates/agentgateway-app/Cargo.toml
+++ b/crates/agentgateway-app/Cargo.toml
@@ -20,6 +20,7 @@ mimalloc = ["dep:mimalloc", "agentgateway/mimalloc"]
 # Builds that pass `--no-default-features` (e.g. arm64 musl, which drops jemalloc) MUST re-add one
 # of these, otherwise the agentgateway crypto code will fail to compile.
 crypto-aws-lc = ["agentgateway/crypto-aws-lc"]
+crypto-symcrypt = ["agentgateway/crypto-symcrypt"]
 schema = ["agentgateway/schema"]
 
 [dependencies]

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -12,10 +12,11 @@ path = "src/lib.rs"
 default = ["jemalloc", "mimalloc", "crypto-aws-lc"]
 jemalloc = ["dep:tikv-jemallocator", "dep:jemalloc_pprof"]
 mimalloc = ["pprof-alloc/allocator-mimalloc", "dep:mimalloc"]
-# Crypto provider selection. `crypto-aws-lc` (the default) is currently the only
-# backend; it pulls in aws-lc-rs. Selecting a different backend in the future
-# drops aws-lc-rs entirely.
+# Crypto provider selection. `crypto-aws-lc` (the default) backs all crypto with
+# aws-lc-rs. `crypto-symcrypt` routes TLS/AEAD/hash/RNG through SymCrypt and falls
+# back to aws-lc-rs for JWT and certificate issuance (no SymCrypt hook there).
 crypto-aws-lc = ["dep:aws-lc-rs", "rustls/aws_lc_rs", "tokio-rustls/aws_lc_rs", "jsonwebtoken/aws_lc_rs"]
+crypto-symcrypt = ["dep:symcrypt", "dep:rustls-symcrypt", "dep:aws-lc-rs", "jsonwebtoken/aws_lc_rs"]
 ui = []
 schema = ["schemars", "agent-core/schema", "agent-llm/schema"]
 internal_benches = ["divan"]
@@ -40,6 +41,8 @@ aws-credential-types.workspace = true
 aws-sigv4.workspace = true
 aws-types.workspace = true
 aws-lc-rs = { workspace = true, optional = true }
+symcrypt = { workspace = true, optional = true }
+rustls-symcrypt = { workspace = true, optional = true }
 aws-smithy-eventstream.workspace = true
 aws-smithy-types.workspace = true
 axum-core.workspace = true

--- a/crates/agentgateway/src/crypto/aead.rs
+++ b/crates/agentgateway/src/crypto/aead.rs
@@ -5,131 +5,136 @@
 //! `crypto-aws-lc` (the default) backs it with `aws-lc-rs`. Additional backends
 //! plug in here behind `#[cfg]` without changing call sites.
 
-#[cfg(feature = "crypto-aws-lc")]
-use aws_lc_rs::aead::{AES_256_GCM, Aad, Nonce, RandomizedNonceKey};
-
 /// Length in bytes of the AES-256-GCM nonce that [`Aes256Gcm::seal`] prepends to
 /// each sealed message.
 const NONCE_LEN: usize = 12;
 
-/// AES-256-GCM authenticated encryption keyed with a caller-provided 32-byte key.
-///
-/// [`seal`](Aes256Gcm::seal) generates a fresh random nonce per message and
-/// returns `nonce || ciphertext || tag`; [`open`](Aes256Gcm::open) expects that
-/// same framing.
-#[cfg(feature = "crypto-aws-lc")]
-#[derive(Debug)]
-pub struct Aes256Gcm {
-	key: RandomizedNonceKey,
-}
+pub use imp::Aes256Gcm;
 
 #[cfg(feature = "crypto-aws-lc")]
-impl Aes256Gcm {
-	/// Creates an AES-256-GCM key from 32 bytes of key material.
-	pub fn new(key: &[u8]) -> Result<Self, AeadError> {
-		let key = RandomizedNonceKey::new(&AES_256_GCM, key).map_err(|_| AeadError::InvalidKey)?;
-		Ok(Self { key })
+mod imp {
+	use aws_lc_rs::aead::{AES_256_GCM, Aad, Nonce, RandomizedNonceKey};
+
+	use super::{AeadError, NONCE_LEN};
+
+	/// AES-256-GCM authenticated encryption keyed with a caller-provided 32-byte key.
+	///
+	/// [`seal`](Aes256Gcm::seal) generates a fresh random nonce per message and
+	/// returns `nonce || ciphertext || tag`; [`open`](Aes256Gcm::open) expects that
+	/// same framing.
+	#[derive(Debug)]
+	pub struct Aes256Gcm {
+		key: RandomizedNonceKey,
 	}
 
-	/// Seals `plaintext`, returning `nonce || ciphertext || tag`.
-	pub fn seal(&self, plaintext: &[u8]) -> Result<Vec<u8>, AeadError> {
-		let mut in_out = plaintext.to_vec();
-		// Generates a random nonce and appends the authentication tag in place.
-		let nonce = self
-			.key
-			.seal_in_place_append_tag(Aad::empty(), &mut in_out)
-			.map_err(|_| AeadError::EncryptionFailed)?;
-
-		let mut result = nonce.as_ref().to_vec();
-		result.extend_from_slice(&in_out);
-		Ok(result)
-	}
-
-	/// Opens data framed as `nonce || ciphertext || tag`, returning the plaintext.
-	pub fn open(&self, data: &[u8]) -> Result<Vec<u8>, AeadError> {
-		if data.len() < NONCE_LEN {
-			return Err(AeadError::InvalidFormat);
+	impl Aes256Gcm {
+		/// Creates an AES-256-GCM key from 32 bytes of key material.
+		pub fn new(key: &[u8]) -> Result<Self, AeadError> {
+			let key = RandomizedNonceKey::new(&AES_256_GCM, key).map_err(|_| AeadError::InvalidKey)?;
+			Ok(Self { key })
 		}
 
-		let (nonce_bytes, ciphertext) = data.split_at(NONCE_LEN);
-		let nonce =
-			Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| AeadError::InvalidFormat)?;
-		let mut in_out = ciphertext.to_vec();
-		let plaintext = self
-			.key
-			.open_in_place(nonce, Aad::empty(), &mut in_out)
-			.map_err(|_| AeadError::DecryptionFailed)?;
-		Ok(plaintext.to_vec())
+		/// Seals `plaintext`, returning `nonce || ciphertext || tag`.
+		pub fn seal(&self, plaintext: &[u8]) -> Result<Vec<u8>, AeadError> {
+			let mut in_out = plaintext.to_vec();
+			// Generates a random nonce and appends the authentication tag in place.
+			let nonce = self
+				.key
+				.seal_in_place_append_tag(Aad::empty(), &mut in_out)
+				.map_err(|_| AeadError::EncryptionFailed)?;
+
+			let mut result = nonce.as_ref().to_vec();
+			result.extend_from_slice(&in_out);
+			Ok(result)
+		}
+
+		/// Opens data framed as `nonce || ciphertext || tag`, returning the plaintext.
+		pub fn open(&self, data: &[u8]) -> Result<Vec<u8>, AeadError> {
+			if data.len() < NONCE_LEN {
+				return Err(AeadError::InvalidFormat);
+			}
+
+			let (nonce_bytes, ciphertext) = data.split_at(NONCE_LEN);
+			let nonce =
+				Nonce::try_assume_unique_for_key(nonce_bytes).map_err(|_| AeadError::InvalidFormat)?;
+			let mut in_out = ciphertext.to_vec();
+			let plaintext = self
+				.key
+				.open_in_place(nonce, Aad::empty(), &mut in_out)
+				.map_err(|_| AeadError::DecryptionFailed)?;
+			Ok(plaintext.to_vec())
+		}
 	}
 }
 
-/// AES-256-GCM authentication tag length in bytes.
 #[cfg(feature = "crypto-symcrypt")]
-const TAG_LEN: usize = 16;
-/// AES-256 key length in bytes.
-#[cfg(feature = "crypto-symcrypt")]
-const KEY_LEN: usize = 32;
+mod imp {
+	use super::{AeadError, NONCE_LEN};
 
-/// AES-256-GCM authenticated encryption backed by SymCrypt. The wire format
-/// (`nonce || ciphertext || tag`) matches the aws-lc-rs backend.
-#[cfg(feature = "crypto-symcrypt")]
-pub struct Aes256Gcm {
-	key: symcrypt::gcm::GcmExpandedKey,
-}
+	/// AES-256-GCM authentication tag length in bytes.
+	const TAG_LEN: usize = 16;
+	/// AES-256 key length in bytes.
+	const KEY_LEN: usize = 32;
 
-#[cfg(feature = "crypto-symcrypt")]
-impl Aes256Gcm {
-	/// Creates an AES-256-GCM key from 32 bytes of key material.
-	pub fn new(key: &[u8]) -> Result<Self, AeadError> {
-		if key.len() != KEY_LEN {
-			return Err(AeadError::InvalidKey);
+	/// AES-256-GCM authenticated encryption backed by SymCrypt. The wire format
+	/// (`nonce || ciphertext || tag`) matches the aws-lc-rs backend.
+	pub struct Aes256Gcm {
+		key: symcrypt::gcm::GcmExpandedKey,
+	}
+
+	impl Aes256Gcm {
+		/// Creates an AES-256-GCM key from 32 bytes of key material.
+		pub fn new(key: &[u8]) -> Result<Self, AeadError> {
+			if key.len() != KEY_LEN {
+				return Err(AeadError::InvalidKey);
+			}
+			let key =
+				symcrypt::gcm::GcmExpandedKey::new(key, symcrypt::cipher::BlockCipherType::AesBlock)
+					.map_err(|_| AeadError::InvalidKey)?;
+			Ok(Self { key })
 		}
-		let key = symcrypt::gcm::GcmExpandedKey::new(key, symcrypt::cipher::BlockCipherType::AesBlock)
-			.map_err(|_| AeadError::InvalidKey)?;
-		Ok(Self { key })
-	}
 
-	/// Seals `plaintext`, returning `nonce || ciphertext || tag`.
-	pub fn seal(&self, plaintext: &[u8]) -> Result<Vec<u8>, AeadError> {
-		let mut nonce = [0u8; NONCE_LEN];
-		crate::crypto::rand::fill(&mut nonce).map_err(|_| AeadError::EncryptionFailed)?;
-		let mut buffer = plaintext.to_vec();
-		let mut tag = [0u8; TAG_LEN];
-		self
-			.key
-			.encrypt_in_place(&nonce, &[], &mut buffer, &mut tag);
-		let mut result = Vec::with_capacity(NONCE_LEN + buffer.len() + TAG_LEN);
-		result.extend_from_slice(&nonce);
-		result.extend_from_slice(&buffer);
-		result.extend_from_slice(&tag);
-		Ok(result)
-	}
-
-	/// Opens data framed as `nonce || ciphertext || tag`, returning the plaintext.
-	pub fn open(&self, data: &[u8]) -> Result<Vec<u8>, AeadError> {
-		if data.len() < NONCE_LEN + TAG_LEN {
-			return Err(AeadError::InvalidFormat);
+		/// Seals `plaintext`, returning `nonce || ciphertext || tag`.
+		pub fn seal(&self, plaintext: &[u8]) -> Result<Vec<u8>, AeadError> {
+			let mut nonce = [0u8; NONCE_LEN];
+			crate::crypto::rand::fill(&mut nonce).map_err(|_| AeadError::EncryptionFailed)?;
+			let mut buffer = plaintext.to_vec();
+			let mut tag = [0u8; TAG_LEN];
+			self
+				.key
+				.encrypt_in_place(&nonce, &[], &mut buffer, &mut tag);
+			let mut result = Vec::with_capacity(NONCE_LEN + buffer.len() + TAG_LEN);
+			result.extend_from_slice(&nonce);
+			result.extend_from_slice(&buffer);
+			result.extend_from_slice(&tag);
+			Ok(result)
 		}
-		let (nonce_bytes, rest) = data.split_at(NONCE_LEN);
-		let (ciphertext, tag) = rest.split_at(rest.len() - TAG_LEN);
-		let nonce: &[u8; NONCE_LEN] = nonce_bytes
-			.try_into()
-			.map_err(|_| AeadError::InvalidFormat)?;
-		let mut buffer = ciphertext.to_vec();
-		self
-			.key
-			.decrypt_in_place(nonce, &[], &mut buffer, tag)
-			.map_err(|_| AeadError::DecryptionFailed)?;
-		Ok(buffer)
-	}
-}
 
-// GcmExpandedKey does not implement Debug; provide a redacted impl matching the
-// derived Debug on the aws-lc-rs backend.
-#[cfg(feature = "crypto-symcrypt")]
-impl std::fmt::Debug for Aes256Gcm {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("Aes256Gcm").finish_non_exhaustive()
+		/// Opens data framed as `nonce || ciphertext || tag`, returning the plaintext.
+		pub fn open(&self, data: &[u8]) -> Result<Vec<u8>, AeadError> {
+			if data.len() < NONCE_LEN + TAG_LEN {
+				return Err(AeadError::InvalidFormat);
+			}
+			let (nonce_bytes, rest) = data.split_at(NONCE_LEN);
+			let (ciphertext, tag) = rest.split_at(rest.len() - TAG_LEN);
+			let nonce: &[u8; NONCE_LEN] = nonce_bytes
+				.try_into()
+				.map_err(|_| AeadError::InvalidFormat)?;
+			let mut buffer = ciphertext.to_vec();
+			self
+				.key
+				.decrypt_in_place(nonce, &[], &mut buffer, tag)
+				.map_err(|_| AeadError::DecryptionFailed)?;
+			Ok(buffer)
+		}
+	}
+
+	// GcmExpandedKey does not implement Debug; provide a redacted impl matching the
+	// derived Debug on the aws-lc-rs backend.
+	impl std::fmt::Debug for Aes256Gcm {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			f.debug_struct("Aes256Gcm").finish_non_exhaustive()
+		}
 	}
 }
 

--- a/crates/agentgateway/src/crypto/aead.rs
+++ b/crates/agentgateway/src/crypto/aead.rs
@@ -63,6 +63,76 @@ impl Aes256Gcm {
 	}
 }
 
+/// AES-256-GCM authentication tag length in bytes.
+#[cfg(feature = "crypto-symcrypt")]
+const TAG_LEN: usize = 16;
+/// AES-256 key length in bytes.
+#[cfg(feature = "crypto-symcrypt")]
+const KEY_LEN: usize = 32;
+
+/// AES-256-GCM authenticated encryption backed by SymCrypt. The wire format
+/// (`nonce || ciphertext || tag`) matches the aws-lc-rs backend.
+#[cfg(feature = "crypto-symcrypt")]
+pub struct Aes256Gcm {
+	key: symcrypt::gcm::GcmExpandedKey,
+}
+
+#[cfg(feature = "crypto-symcrypt")]
+impl Aes256Gcm {
+	/// Creates an AES-256-GCM key from 32 bytes of key material.
+	pub fn new(key: &[u8]) -> Result<Self, AeadError> {
+		if key.len() != KEY_LEN {
+			return Err(AeadError::InvalidKey);
+		}
+		let key = symcrypt::gcm::GcmExpandedKey::new(key, symcrypt::cipher::BlockCipherType::AesBlock)
+			.map_err(|_| AeadError::InvalidKey)?;
+		Ok(Self { key })
+	}
+
+	/// Seals `plaintext`, returning `nonce || ciphertext || tag`.
+	pub fn seal(&self, plaintext: &[u8]) -> Result<Vec<u8>, AeadError> {
+		let mut nonce = [0u8; NONCE_LEN];
+		crate::crypto::rand::fill(&mut nonce).map_err(|_| AeadError::EncryptionFailed)?;
+		let mut buffer = plaintext.to_vec();
+		let mut tag = [0u8; TAG_LEN];
+		self
+			.key
+			.encrypt_in_place(&nonce, &[], &mut buffer, &mut tag);
+		let mut result = Vec::with_capacity(NONCE_LEN + buffer.len() + TAG_LEN);
+		result.extend_from_slice(&nonce);
+		result.extend_from_slice(&buffer);
+		result.extend_from_slice(&tag);
+		Ok(result)
+	}
+
+	/// Opens data framed as `nonce || ciphertext || tag`, returning the plaintext.
+	pub fn open(&self, data: &[u8]) -> Result<Vec<u8>, AeadError> {
+		if data.len() < NONCE_LEN + TAG_LEN {
+			return Err(AeadError::InvalidFormat);
+		}
+		let (nonce_bytes, rest) = data.split_at(NONCE_LEN);
+		let (ciphertext, tag) = rest.split_at(rest.len() - TAG_LEN);
+		let nonce: &[u8; NONCE_LEN] = nonce_bytes
+			.try_into()
+			.map_err(|_| AeadError::InvalidFormat)?;
+		let mut buffer = ciphertext.to_vec();
+		self
+			.key
+			.decrypt_in_place(nonce, &[], &mut buffer, tag)
+			.map_err(|_| AeadError::DecryptionFailed)?;
+		Ok(buffer)
+	}
+}
+
+// GcmExpandedKey does not implement Debug; provide a redacted impl matching the
+// derived Debug on the aws-lc-rs backend.
+#[cfg(feature = "crypto-symcrypt")]
+impl std::fmt::Debug for Aes256Gcm {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Aes256Gcm").finish_non_exhaustive()
+	}
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum AeadError {
 	#[error("invalid key")]

--- a/crates/agentgateway/src/crypto/digest.rs
+++ b/crates/agentgateway/src/crypto/digest.rs
@@ -9,88 +9,90 @@
 //! uses the RustCrypto crates directly, as they cannot depend on this crate.
 //! Consolidating those requires a shared crypto crate and is tracked separately.
 
-#[cfg(feature = "crypto-aws-lc")]
-use aws_lc_rs::digest::{self, Context, SHA256};
-
 /// Length in bytes of a SHA-256 digest.
 pub const SHA256_LEN: usize = 32;
 
-/// Computes the SHA-256 digest of `data` in one shot.
-#[cfg(feature = "crypto-aws-lc")]
-pub fn sha256(data: &[u8]) -> [u8; SHA256_LEN] {
-	to_array(digest::digest(&SHA256, data).as_ref())
-}
-
-/// Incremental SHA-256 hasher, for data supplied in multiple pieces.
-#[cfg(feature = "crypto-aws-lc")]
-pub struct Sha256(Context);
+pub use imp::{Sha256, sha256};
 
 #[cfg(feature = "crypto-aws-lc")]
-impl Sha256 {
-	/// Creates a new, empty SHA-256 hasher.
-	pub fn new() -> Self {
-		Self(Context::new(&SHA256))
+mod imp {
+	use aws_lc_rs::digest::{self, Context, SHA256};
+
+	use super::SHA256_LEN;
+
+	/// Computes the SHA-256 digest of `data` in one shot.
+	pub fn sha256(data: &[u8]) -> [u8; SHA256_LEN] {
+		to_array(digest::digest(&SHA256, data).as_ref())
 	}
 
-	/// Adds `data` to the running digest.
-	pub fn update(&mut self, data: impl AsRef<[u8]>) {
-		self.0.update(data.as_ref());
+	/// Incremental SHA-256 hasher, for data supplied in multiple pieces.
+	pub struct Sha256(Context);
+
+	impl Sha256 {
+		/// Creates a new, empty SHA-256 hasher.
+		pub fn new() -> Self {
+			Self(Context::new(&SHA256))
+		}
+
+		/// Adds `data` to the running digest.
+		pub fn update(&mut self, data: impl AsRef<[u8]>) {
+			self.0.update(data.as_ref());
+		}
+
+		/// Consumes the hasher and returns the final digest.
+		pub fn finalize(self) -> [u8; SHA256_LEN] {
+			to_array(self.0.finish().as_ref())
+		}
 	}
 
-	/// Consumes the hasher and returns the final digest.
-	pub fn finalize(self) -> [u8; SHA256_LEN] {
-		to_array(self.0.finish().as_ref())
-	}
-}
-
-#[cfg(feature = "crypto-aws-lc")]
-impl Default for Sha256 {
-	fn default() -> Self {
-		Self::new()
-	}
-}
-
-#[cfg(feature = "crypto-aws-lc")]
-fn to_array(bytes: &[u8]) -> [u8; SHA256_LEN] {
-	let mut out = [0u8; SHA256_LEN];
-	out.copy_from_slice(bytes);
-	out
-}
-
-/// Computes the SHA-256 digest of `data` in one shot (SymCrypt backend).
-#[cfg(feature = "crypto-symcrypt")]
-pub fn sha256(data: &[u8]) -> [u8; SHA256_LEN] {
-	symcrypt::hash::sha256(data)
-}
-
-/// Incremental SHA-256 hasher, for data supplied in multiple pieces.
-#[cfg(feature = "crypto-symcrypt")]
-pub struct Sha256(symcrypt::hash::Sha256State);
-
-#[cfg(feature = "crypto-symcrypt")]
-impl Sha256 {
-	/// Creates a new, empty SHA-256 hasher.
-	pub fn new() -> Self {
-		Self(symcrypt::hash::Sha256State::new())
+	impl Default for Sha256 {
+		fn default() -> Self {
+			Self::new()
+		}
 	}
 
-	/// Adds `data` to the running digest.
-	pub fn update(&mut self, data: impl AsRef<[u8]>) {
-		use symcrypt::hash::HashState;
-		self.0.append(data.as_ref());
-	}
-
-	/// Consumes the hasher and returns the final digest.
-	pub fn finalize(mut self) -> [u8; SHA256_LEN] {
-		use symcrypt::hash::HashState;
-		self.0.result()
+	fn to_array(bytes: &[u8]) -> [u8; SHA256_LEN] {
+		let mut out = [0u8; SHA256_LEN];
+		out.copy_from_slice(bytes);
+		out
 	}
 }
 
 #[cfg(feature = "crypto-symcrypt")]
-impl Default for Sha256 {
-	fn default() -> Self {
-		Self::new()
+mod imp {
+	use super::SHA256_LEN;
+
+	/// Computes the SHA-256 digest of `data` in one shot (SymCrypt backend).
+	pub fn sha256(data: &[u8]) -> [u8; SHA256_LEN] {
+		symcrypt::hash::sha256(data)
+	}
+
+	/// Incremental SHA-256 hasher, for data supplied in multiple pieces.
+	pub struct Sha256(symcrypt::hash::Sha256State);
+
+	impl Sha256 {
+		/// Creates a new, empty SHA-256 hasher.
+		pub fn new() -> Self {
+			Self(symcrypt::hash::Sha256State::new())
+		}
+
+		/// Adds `data` to the running digest.
+		pub fn update(&mut self, data: impl AsRef<[u8]>) {
+			use symcrypt::hash::HashState;
+			self.0.append(data.as_ref());
+		}
+
+		/// Consumes the hasher and returns the final digest.
+		pub fn finalize(mut self) -> [u8; SHA256_LEN] {
+			use symcrypt::hash::HashState;
+			self.0.result()
+		}
+	}
+
+	impl Default for Sha256 {
+		fn default() -> Self {
+			Self::new()
+		}
 	}
 }
 

--- a/crates/agentgateway/src/crypto/digest.rs
+++ b/crates/agentgateway/src/crypto/digest.rs
@@ -57,6 +57,43 @@ fn to_array(bytes: &[u8]) -> [u8; SHA256_LEN] {
 	out
 }
 
+/// Computes the SHA-256 digest of `data` in one shot (SymCrypt backend).
+#[cfg(feature = "crypto-symcrypt")]
+pub fn sha256(data: &[u8]) -> [u8; SHA256_LEN] {
+	symcrypt::hash::sha256(data)
+}
+
+/// Incremental SHA-256 hasher, for data supplied in multiple pieces.
+#[cfg(feature = "crypto-symcrypt")]
+pub struct Sha256(symcrypt::hash::Sha256State);
+
+#[cfg(feature = "crypto-symcrypt")]
+impl Sha256 {
+	/// Creates a new, empty SHA-256 hasher.
+	pub fn new() -> Self {
+		Self(symcrypt::hash::Sha256State::new())
+	}
+
+	/// Adds `data` to the running digest.
+	pub fn update(&mut self, data: impl AsRef<[u8]>) {
+		use symcrypt::hash::HashState;
+		self.0.append(data.as_ref());
+	}
+
+	/// Consumes the hasher and returns the final digest.
+	pub fn finalize(mut self) -> [u8; SHA256_LEN] {
+		use symcrypt::hash::HashState;
+		self.0.result()
+	}
+}
+
+#[cfg(feature = "crypto-symcrypt")]
+impl Default for Sha256 {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::{Sha256, sha256};

--- a/crates/agentgateway/src/crypto/jwt.rs
+++ b/crates/agentgateway/src/crypto/jwt.rs
@@ -9,11 +9,10 @@
 ///
 /// Call once at startup, before any JWT signing or verification. Idempotent.
 pub fn init() {
-	#[cfg(feature = "crypto-aws-lc")]
+	// JWT always uses aws-lc-rs: SymCrypt has no jsonwebtoken provider, so
+	// `crypto-symcrypt` falls back to aws-lc-rs here.
+	#[cfg(any(feature = "crypto-aws-lc", feature = "crypto-symcrypt"))]
 	{
-		// aws-lc-rs is already jsonwebtoken's default; installing explicitly keeps
-		// the choice in this seam. A backend with no built-in provider (e.g.
-		// SymCrypt) would install a custom one here instead.
 		let _ = jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER.install_default();
 	}
 }

--- a/crates/agentgateway/src/crypto/mod.rs
+++ b/crates/agentgateway/src/crypto/mod.rs
@@ -10,11 +10,16 @@
 //! Such documented exceptions must be guarded with the appropriate
 //! `#[cfg(feature = ...)]` so the backend in use stays explicit.
 
-// A crypto backend must be selected at compile time. `crypto-aws-lc` is currently
-// the only backend; as additional providers are added this becomes an
-// exactly-one-of guard.
-#[cfg(not(feature = "crypto-aws-lc"))]
-compile_error!("no crypto backend selected: enable the `crypto-aws-lc` feature");
+// Exactly one crypto backend must be selected at compile time.
+#[cfg(not(any(feature = "crypto-aws-lc", feature = "crypto-symcrypt")))]
+compile_error!(
+	"no crypto backend selected: enable exactly one of `crypto-aws-lc` or `crypto-symcrypt`"
+);
+
+#[cfg(all(feature = "crypto-aws-lc", feature = "crypto-symcrypt"))]
+compile_error!(
+	"multiple crypto backends selected: enable exactly one of `crypto-aws-lc` or `crypto-symcrypt` (pass --no-default-features for a non-default backend)"
+);
 
 pub mod aead;
 pub mod digest;
@@ -36,3 +41,6 @@ pub fn init() {
 /// for startup logging and diagnostics.
 #[cfg(feature = "crypto-aws-lc")]
 pub const CRYPTO_BACKEND: &str = "aws-lc-rs";
+
+#[cfg(feature = "crypto-symcrypt")]
+pub const CRYPTO_BACKEND: &str = "symcrypt";

--- a/crates/agentgateway/src/crypto/rand.rs
+++ b/crates/agentgateway/src/crypto/rand.rs
@@ -5,23 +5,32 @@
 //! with `aws-lc-rs`. Additional backends plug in here behind `#[cfg]` without
 //! changing call sites.
 
-#[cfg(feature = "crypto-aws-lc")]
-use aws_lc_rs::rand::{SecureRandom, SystemRandom};
+pub use imp::fill;
 
-/// Fills `dest` with cryptographically-secure random bytes.
-///
-/// Returns [`RandError`] only if the system CSPRNG fails, which callers should
-/// treat as unrecoverable.
 #[cfg(feature = "crypto-aws-lc")]
-pub fn fill(dest: &mut [u8]) -> Result<(), RandError> {
-	SystemRandom::new().fill(dest).map_err(|_| RandError)
+mod imp {
+	use aws_lc_rs::rand::{SecureRandom, SystemRandom};
+
+	use super::RandError;
+
+	/// Fills `dest` with cryptographically-secure random bytes.
+	///
+	/// Returns [`RandError`] only if the system CSPRNG fails, which callers should
+	/// treat as unrecoverable.
+	pub fn fill(dest: &mut [u8]) -> Result<(), RandError> {
+		SystemRandom::new().fill(dest).map_err(|_| RandError)
+	}
 }
 
-/// Fills `dest` with cryptographically-secure random bytes (SymCrypt backend).
 #[cfg(feature = "crypto-symcrypt")]
-pub fn fill(dest: &mut [u8]) -> Result<(), RandError> {
-	symcrypt::symcrypt_random(dest);
-	Ok(())
+mod imp {
+	use super::RandError;
+
+	/// Fills `dest` with cryptographically-secure random bytes (SymCrypt backend).
+	pub fn fill(dest: &mut [u8]) -> Result<(), RandError> {
+		symcrypt::symcrypt_random(dest);
+		Ok(())
+	}
 }
 
 /// Returns `len` cryptographically-secure random bytes.

--- a/crates/agentgateway/src/crypto/rand.rs
+++ b/crates/agentgateway/src/crypto/rand.rs
@@ -17,8 +17,14 @@ pub fn fill(dest: &mut [u8]) -> Result<(), RandError> {
 	SystemRandom::new().fill(dest).map_err(|_| RandError)
 }
 
+/// Fills `dest` with cryptographically-secure random bytes (SymCrypt backend).
+#[cfg(feature = "crypto-symcrypt")]
+pub fn fill(dest: &mut [u8]) -> Result<(), RandError> {
+	symcrypt::symcrypt_random(dest);
+	Ok(())
+}
+
 /// Returns `len` cryptographically-secure random bytes.
-#[cfg(feature = "crypto-aws-lc")]
 pub fn bytes(len: usize) -> Result<Vec<u8>, RandError> {
 	let mut out = vec![0u8; len];
 	fill(&mut out)?;

--- a/crates/agentgateway/src/crypto/tls.rs
+++ b/crates/agentgateway/src/crypto/tls.rs
@@ -59,3 +59,38 @@ pub fn provider_with_cipher_suites(cipher_suites: &[CipherSuite]) -> Arc<CryptoP
 fn default_crypto_provider() -> CryptoProvider {
 	rustls::crypto::aws_lc_rs::default_provider()
 }
+
+#[cfg(feature = "crypto-symcrypt")]
+fn default_crypto_provider() -> CryptoProvider {
+	rustls_symcrypt::default_symcrypt_provider()
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::transport::tls::{CipherSuite, KeyExchangeGroup};
+
+	// Exercises the compiled-in backend's provider construction and the
+	// cipher-suite / kx-group mappings (aws-lc-rs or SymCrypt).
+	#[test]
+	fn provider_has_default_suites_and_kx() {
+		let p = super::provider();
+		assert!(
+			!p.cipher_suites.is_empty(),
+			"default cipher suites must not be empty"
+		);
+		assert!(
+			!p.kx_groups.is_empty(),
+			"default kx groups must not be empty"
+		);
+	}
+
+	#[test]
+	fn provider_with_options_applies_selection() {
+		let p = super::provider_with_options(
+			&[CipherSuite::TLS_AES_256_GCM_SHA384],
+			&[KeyExchangeGroup::P256],
+		);
+		assert_eq!(p.cipher_suites.len(), 1);
+		assert_eq!(p.kx_groups.len(), 1);
+	}
+}

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -21,6 +21,7 @@ use serde_json::Value;
 use tokio::io::DuplexStream;
 use tokio_rustls::TlsConnector;
 use tracing::{info, trace};
+#[cfg(feature = "crypto-aws-lc")]
 use wiremock::tls_certs::MockTlsCertificates;
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -32,6 +33,7 @@ use crate::proxy::Gateway;
 use crate::proxy::request_builder::RequestBuilder;
 use crate::store::Stores;
 use crate::transport::stream::{Socket, TCPConnectionInfo};
+#[cfg(feature = "crypto-aws-lc")]
 use crate::transport::tls;
 use crate::types::agent::{
 	Backend, BackendReference, BackendTarget, BackendTrafficPolicy, BackendWithPolicies, Bind,

--- a/crates/agentgateway/src/transport/tls.rs
+++ b/crates/agentgateway/src/transport/tls.rs
@@ -41,6 +41,22 @@ pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
 ];
 
+/// All currently supported cipher suites (SymCrypt provider).
+#[cfg(feature = "crypto-symcrypt")]
+pub static ALL_CIPHER_SUITES: &[SupportedCipherSuite] = &[
+	// TLS 1.3 cipher suites
+	rustls_symcrypt::TLS13_AES_256_GCM_SHA384,
+	rustls_symcrypt::TLS13_AES_128_GCM_SHA256,
+	rustls_symcrypt::TLS13_CHACHA20_POLY1305_SHA256,
+	// TLS 1.2 cipher suites
+	rustls_symcrypt::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	rustls_symcrypt::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	rustls_symcrypt::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	rustls_symcrypt::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	rustls_symcrypt::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	rustls_symcrypt::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+];
+
 // Default cipher suites to use if user does not specify cipher suites
 #[cfg(feature = "crypto-aws-lc")]
 pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
@@ -52,12 +68,30 @@ pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
 	rustls::crypto::aws_lc_rs::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 ];
 
+#[cfg(feature = "crypto-symcrypt")]
+pub static DEFAULT_CIPHER_SUITES: &[SupportedCipherSuite] = &[
+	rustls_symcrypt::TLS13_AES_256_GCM_SHA384,
+	rustls_symcrypt::TLS13_AES_128_GCM_SHA256,
+	rustls_symcrypt::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	rustls_symcrypt::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	rustls_symcrypt::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	rustls_symcrypt::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+];
+
 #[cfg(feature = "crypto-aws-lc")]
 pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
 	KeyExchangeGroup::X25519.to_supported_kx_group(),
 	KeyExchangeGroup::P256.to_supported_kx_group(),
 	KeyExchangeGroup::P384.to_supported_kx_group(),
 	KeyExchangeGroup::X25519_MLKEM768.to_supported_kx_group(),
+];
+
+// SymCrypt has no MLKEM/PQC group; offer the classical groups only.
+#[cfg(feature = "crypto-symcrypt")]
+pub static DEFAULT_KEY_EXCHANGE_GROUPS: &[&'static dyn SupportedKxGroup] = &[
+	rustls_symcrypt::X25519,
+	rustls_symcrypt::SECP256R1,
+	rustls_symcrypt::SECP384R1,
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -148,6 +182,36 @@ impl CipherSuite {
 			},
 		}
 	}
+
+	#[cfg(feature = "crypto-symcrypt")]
+	pub fn to_supported_cipher_suite(&self) -> SupportedCipherSuite {
+		match self {
+			// TLS 1.3 cipher suites
+			CipherSuite::TLS_AES_256_GCM_SHA384 => rustls_symcrypt::TLS13_AES_256_GCM_SHA384,
+			CipherSuite::TLS_AES_128_GCM_SHA256 => rustls_symcrypt::TLS13_AES_128_GCM_SHA256,
+			CipherSuite::TLS_CHACHA20_POLY1305_SHA256 => rustls_symcrypt::TLS13_CHACHA20_POLY1305_SHA256,
+
+			// TLS 1.2 cipher suites
+			CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 => {
+				rustls_symcrypt::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+			},
+			CipherSuite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 => {
+				rustls_symcrypt::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+			},
+			CipherSuite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 => {
+				rustls_symcrypt::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+			},
+			CipherSuite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 => {
+				rustls_symcrypt::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+			},
+			CipherSuite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 => {
+				rustls_symcrypt::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+			},
+			CipherSuite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 => {
+				rustls_symcrypt::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+			},
+		}
+	}
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -179,6 +243,17 @@ impl KeyExchangeGroup {
 			KeyExchangeGroup::P256 => rustls::crypto::aws_lc_rs::kx_group::SECP256R1,
 			KeyExchangeGroup::P384 => rustls::crypto::aws_lc_rs::kx_group::SECP384R1,
 			KeyExchangeGroup::X25519_MLKEM768 => rustls::crypto::aws_lc_rs::kx_group::X25519MLKEM768,
+		}
+	}
+
+	#[cfg(feature = "crypto-symcrypt")]
+	pub fn to_supported_kx_group(&self) -> &'static dyn SupportedKxGroup {
+		match self {
+			KeyExchangeGroup::X25519 => rustls_symcrypt::X25519,
+			KeyExchangeGroup::P256 => rustls_symcrypt::SECP256R1,
+			KeyExchangeGroup::P384 => rustls_symcrypt::SECP384R1,
+			// SymCrypt has no MLKEM; fall back to X25519.
+			KeyExchangeGroup::X25519_MLKEM768 => rustls_symcrypt::X25519,
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the `crypto-symcrypt` feature flag to enable symcrypt as a cryptography backend for agentgateway.

These crypto features are now backed by symcrypt when the flag is enabled:

- CSPRNG (random bytes)
- AEAD - AES-256-GCM (seal/open)
- Digest - SHA-256 (one-shot + incremental)
- rustls TLS provider (whole rustls handshake: record AEAD, KDF, signature verify)

Enabling this flag does not disable AWS-LC (yet), we still use it as the backend for these features:

- JWT sign/verify (jwt.rs:11) - jsonwebtoken has no SymCrypt provider installs `jsonwebtoken::crypto::aws_lc::DEFAULT_PROVIDER`
- Certificate generation - `rcgen`, not routed through the crypto module (documented exception in `mod.rs`)
- ML-KEM (post-quantum) kx - rust symcrypt wrappers don't expose ML-KEM yet

We also add a makefile target `build-symcrypt` as shorthand since you have to list other required default features when building.

Note that building with this flag means the binary is dynamically linked to `libsymcrypt.so`, so symcrypt will have to be installed on the node/machine that is running the binary.

Completes Bucket A and Bucket B of https://github.com/agentgateway/agentgateway/issues/2641