### PR TITLE
feat: import LiteLLM wildcard models

### DIFF
--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -806,9 +806,7 @@ fn import_litellm_model(
 		});
 		return None;
 	};
-	if upstream_model.contains('*')
-		&& upstream_model != "*"
-		&& upstream_model != public_name.as_str()
+	if upstream_model.contains('*') && upstream_model != "*" && upstream_model != public_name.as_str()
 	{
 		findings.push(ImportFinding {
 			source_path: format!("{source_path}.litellm_params.model"),
@@ -922,7 +920,10 @@ fn split_provider(model: &str) -> (&str, &str) {
 }
 
 fn is_supported_model_pattern(pattern: &str) -> bool {
-	let wildcard_count = pattern.chars().filter(|character| *character == '*').count();
+	let wildcard_count = pattern
+		.chars()
+		.filter(|character| *character == '*')
+		.count();
 	wildcard_count == 0
 		|| (wildcard_count == 1
 			&& (pattern == "*" || pattern.starts_with('*') || pattern.ends_with('*')))

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -780,20 +780,24 @@ fn import_litellm_model(
 			None
 		},
 	};
-	if public_name.contains('*') || model_id.contains('*') {
-		let wildcard_path = if public_name.contains('*') {
-			format!("{source_path}.model_name")
-		} else {
-			format!("{source_path}.litellm_params.model")
-		};
-		findings.push(ImportFinding {
-			source_path: wildcard_path,
-			status: ImportStatus::Unsupported,
-			message: "LiteLLM wildcard models are not yet supported and were not emitted".to_string(),
-		});
-		return None;
-	}
 	let (provider_prefix, upstream_model) = split_provider(&model_id);
+	for (path, pattern) in [
+		(format!("{source_path}.model_name"), public_name.as_str()),
+		(
+			format!("{source_path}.litellm_params.model"),
+			upstream_model,
+		),
+	] {
+		if !is_supported_model_pattern(pattern) {
+			findings.push(ImportFinding {
+				source_path: path,
+				status: ImportStatus::Unsupported,
+				message: "LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted"
+					.to_string(),
+			});
+			return None;
+		}
+	}
 	let Some(provider) = map_provider(provider_prefix) else {
 		findings.push(ImportFinding {
 			source_path: format!("{source_path}.litellm_params.model"),
@@ -802,9 +806,23 @@ fn import_litellm_model(
 		});
 		return None;
 	};
+	if upstream_model.contains('*')
+		&& upstream_model != "*"
+		&& upstream_model != public_name.as_str()
+	{
+		findings.push(ImportFinding {
+			source_path: format!("{source_path}.litellm_params.model"),
+			status: ImportStatus::Unsupported,
+			message: "LiteLLM upstream wildcard rewrites cannot be represented safely and the model was not emitted"
+				.to_string(),
+		});
+		return None;
+	}
 
 	let mut output_params = Map::new();
-	output_params.insert("model".to_string(), json!(upstream_model));
+	if !upstream_model.contains('*') {
+		output_params.insert("model".to_string(), json!(upstream_model));
+	}
 	move_litellm_provider_params(&mut params, &mut output_params);
 
 	let rpm = params.remove("rpm");
@@ -901,6 +919,13 @@ fn split_provider(model: &str) -> (&str, &str) {
 		Some((provider, model)) => (provider, model),
 		None => ("openai", model),
 	}
+}
+
+fn is_supported_model_pattern(pattern: &str) -> bool {
+	let wildcard_count = pattern.chars().filter(|character| *character == '*').count();
+	wildcard_count == 0
+		|| (wildcard_count == 1
+			&& (pattern == "*" || pattern.starts_with('*') || pattern.ends_with('*')))
 }
 
 fn map_provider(provider: &str) -> Option<&'static str> {
@@ -1161,7 +1186,7 @@ mod tests {
 	}
 
 	#[test]
-	fn reports_wildcard_models_without_emitting_malformed_names() {
+	fn imports_safe_wildcard_models_and_reports_unsupported_patterns() {
 		assert_litellm_golden("wildcard-model");
 	}
 

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -781,19 +781,25 @@ fn import_litellm_model(
 		},
 	};
 	let (provider_prefix, upstream_model) = split_provider(&model_id);
-	for (path, pattern) in [
-		(format!("{source_path}.model_name"), public_name.as_str()),
+	for (path, pattern, configured_pattern) in [
+		(
+			format!("{source_path}.model_name"),
+			public_name.as_str(),
+			public_name.as_str(),
+		),
 		(
 			format!("{source_path}.litellm_params.model"),
 			upstream_model,
+			model_id.as_str(),
 		),
 	] {
 		if !is_supported_model_pattern(pattern) {
 			findings.push(ImportFinding {
 				source_path: path,
 				status: ImportStatus::Unsupported,
-				message: "LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted"
-					.to_string(),
+				message: format!(
+					"LiteLLM model wildcard pattern {configured_pattern:?} must contain at most one wildcard, at the beginning or end; the model was not emitted"
+				),
 			});
 			return None;
 		}
@@ -811,8 +817,9 @@ fn import_litellm_model(
 		findings.push(ImportFinding {
 			source_path: format!("{source_path}.litellm_params.model"),
 			status: ImportStatus::Unsupported,
-			message: "LiteLLM upstream wildcard rewrites cannot be represented safely and the model was not emitted"
-				.to_string(),
+			message: format!(
+				"LiteLLM upstream wildcard rewrite from public model pattern {public_name:?} to upstream model pattern {model_id:?} cannot be represented safely and the model was not emitted"
+			),
 		});
 		return None;
 	}

--- a/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
+++ b/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
@@ -36,10 +36,10 @@ findings:
     message: Imported model deployment for *-preview
   - sourcePath: "model_list[3].model_name"
     status: unsupported
-    message: LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted
+    message: "LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted"
   - sourcePath: "model_list[4].litellm_params.model"
     status: unsupported
-    message: LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted
+    message: "LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted"
   - sourcePath: "model_list[5].litellm_params.model"
     status: unsupported
     message: LiteLLM upstream wildcard rewrites cannot be represented safely and the model was not emitted

--- a/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
+++ b/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
@@ -36,10 +36,10 @@ findings:
     message: Imported model deployment for *-preview
   - sourcePath: "model_list[3].model_name"
     status: unsupported
-    message: "LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted"
+    message: "LiteLLM model wildcard pattern \"team*chat\" must contain at most one wildcard, at the beginning or end; the model was not emitted"
   - sourcePath: "model_list[4].litellm_params.model"
     status: unsupported
-    message: "LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted"
+    message: "LiteLLM model wildcard pattern \"openai/gpt-*-*\" must contain at most one wildcard, at the beginning or end; the model was not emitted"
   - sourcePath: "model_list[5].litellm_params.model"
     status: unsupported
-    message: LiteLLM upstream wildcard rewrites cannot be represented safely and the model was not emitted
+    message: "LiteLLM upstream wildcard rewrite from public model pattern \"alias-*\" to upstream model pattern \"openai/model-*\" cannot be represented safely and the model was not emitted"

--- a/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
+++ b/crates/agentgateway/src/tests/import/litellm/wildcard-model.snap
@@ -14,8 +14,32 @@ config:
     gateways: default
   llm:
     gateways: default
-    models: []
+    models:
+      - name: "*"
+        provider: openAI
+        params: {}
+      - name: gpt-*
+        provider: openAI
+        params: {}
+      - name: "*-preview"
+        provider: openAI
+        params: {}
 findings:
-  - sourcePath: "model_list[0].model_name"
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for *
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for gpt-*
+  - sourcePath: "model_list[2]"
+    status: exact
+    message: Imported model deployment for *-preview
+  - sourcePath: "model_list[3].model_name"
     status: unsupported
-    message: LiteLLM wildcard models are not yet supported and were not emitted
+    message: LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted
+  - sourcePath: "model_list[4].litellm_params.model"
+    status: unsupported
+    message: LiteLLM model wildcards must appear at most once, at the beginning or end; the model was not emitted
+  - sourcePath: "model_list[5].litellm_params.model"
+    status: unsupported
+    message: LiteLLM upstream wildcard rewrites cannot be represented safely and the model was not emitted

--- a/crates/agentgateway/src/tests/import/litellm/wildcard-model.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/wildcard-model.yaml
@@ -2,3 +2,18 @@ model_list:
 - model_name: "*"
   litellm_params:
     model: "openai/*"
+- model_name: "gpt-*"
+  litellm_params:
+    model: "openai/gpt-*"
+- model_name: "*-preview"
+  litellm_params:
+    model: "openai/*-preview"
+- model_name: "team*chat"
+  litellm_params:
+    model: "openai/*"
+- model_name: "multi-wildcard"
+  litellm_params:
+    model: "openai/gpt-*-*"
+- model_name: "alias-*"
+  litellm_params:
+    model: "openai/model-*"


### PR DESCRIPTION
## Summary

- convert LiteLLM public wildcard model names that agentgateway can represent, including `*`, prefix wildcards, and suffix wildcards
- preserve the requested model for identity provider wildcards such as `openai/*` by omitting a literal wildcard from `params.model`
- emit explicit unsupported findings for middle/multiple wildcards and wildcard rewrites that agentgateway cannot represent safely
- expand the existing wildcard fixture and golden snapshot

This addresses the wildcard model conversion checkbox in #2607. Model-group aliases and other importer follow-ons remain out of scope.

## Validation

- `git diff --check`
- generated output continues to be validated by the importer's native `LocalConfig` loader in the golden test
- local Rust execution was unavailable because downloading the repository-pinned Rust 1.97 toolchain from `static.rust-lang.org` failed with a TLS handshake error; GitHub Actions will run the Rust test suite
