### PR TITLE
mcp: bump backend target `MaxItems` 32 -> 128

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -593,7 +593,7 @@ type MCPBackend struct {
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:MaxItems=128
 	// +required
 	Targets []McpTargetSelector `json:"targets"`
 

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9519,7 +9519,7 @@ spec:
                           be set
                         rule: '[has(self.selector),has(self.static)].filter(x,x==true).size()
                           == 1'
-                    maxItems: 32
+                    maxItems: 128
                     minItems: 1
                     type: array
                     x-kubernetes-list-map-keys:


### PR DESCRIPTION
This is the follow up PR to https://github.com/agentgateway/agentgateway/pull/2831

Related: https://github.com/agentgateway/agentgateway/issues/1833

My team has hit the 32 backend MCP target limit, and we're now having to consider some fairly clunky workarounds (maintaining ongoing patches and rearchitecting).

#2831 removed a redundant CEL validation that was consuming a large chunk of the CEL budget. Now that the redundant rule has been removed, I believe MCP backend target `MaxItems` can be reasonably increased from 32 to 128.

Note (as per [comments](https://github.com/agentgateway/agentgateway/pull/2831#issuecomment-5184036621) from @howardjohn) once this change is made, it cannot be safely reverted. A reversion would mean breaking any installations that have since exceeded 32 targets. I believe 128 is modest enough though that a reversion shouldn't be necessary, but I also acknowledge that it's a decision that should be made deliberately (and a decision I ultimately defer to you all on). 