### PR TITLE
fix(ui): support macOS hybrid save override

### DIFF
--- a/ui/src/components/ConfigDiffDrawer.tsx
+++ b/ui/src/components/ConfigDiffDrawer.tsx
@@ -37,7 +37,7 @@ export function ConfigSaveButton(props: {
       aria-disabled={fileWriteDisabled}
       onClick={(event) => {
         if (fileWriteDisabled) {
-          if (!event.ctrlKey || !event.shiftKey) return;
+          if ((!event.ctrlKey && !event.metaKey) || !event.shiftKey) return;
           allowNextHybridFileWrite();
         }
         props.onClick();

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -32,7 +32,7 @@ export function useHybridFileWriteOverrideKeys() {
   const [active, setActive] = useState(false);
   useEffect(() => {
     const update = (event: KeyboardEvent) =>
-      setActive(event.ctrlKey && event.shiftKey);
+      setActive((event.ctrlKey || event.metaKey) && event.shiftKey);
     const clear = () => setActive(false);
     window.addEventListener("keydown", update);
     window.addEventListener("keyup", update);

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -239,14 +239,14 @@ test("hybrid settings shows file diff without applying it", async ({
   ).toBeVisible();
   expect(gateway.postedConfigs).toHaveLength(0);
 
-  await page.keyboard.down("Control");
+  await page.keyboard.down("ControlOrMeta");
   await page.keyboard.down("Shift");
   await expect(
     page.getByRole("tooltip").getByText(/Override active/),
   ).toBeVisible();
   await save.click({ force: true });
   await page.keyboard.up("Shift");
-  await page.keyboard.up("Control");
+  await page.keyboard.up("ControlOrMeta");
   await expect.poll(() => gateway.postedConfigs.length).toBe(1);
   await expect(diff).not.toBeVisible();
 });


### PR DESCRIPTION
## Description

Hybrid mode has a guarded shortcut for writing file-backed configuration: hold Shift with the platform's primary modifier, then click Save. On macOS, the old Control+Shift shortcut could never finish because Control-click opens the context menu and Chrome does not send a click event.

This change uses Command+Shift on macOS and keeps Control+Shift on Windows and Linux. The button accepts either browser modifier, while the Playwright test uses `ControlOrMeta` so it follows the operating system running the suite.

## Root Cause

The E2E test passed in Linux CI because Control-click is a normal click there. Chrome never delivered the click on macOS. It emitted pointer and mouse events followed by `contextmenu`, then stopped without sending the event that would have reached React and posted the configuration request.

## Testing

- `npm run test:e2e -- --grep "hybrid settings shows file diff"` (1 passed)
- `npm run lint`
- `npm run build`
