### PR TITLE
refactor(oidc): add browser session store boundary

### DIFF
--- a/crates/agentgateway/src/http/oidc/callback.rs
+++ b/crates/agentgateway/src/http/oidc/callback.rs
@@ -146,7 +146,7 @@ pub(super) async fn handle_callback(
 	}
 
 	// TODO: Revisit whether browser sessions should persist access_token / refresh_token.
-	// The current stateless cookie only stores the validated id_token because that is what
+	// The default cookie store only persists the validated id_token because that is what
 	// the runtime uses today, and larger token payloads can exceed browser cookie limits.
 	let session = BrowserSession {
 		policy_id: policy.policy_id.clone(),
@@ -157,10 +157,10 @@ pub(super) async fn handle_callback(
 			&claims.inner,
 		)),
 	};
-	let encoded = policy.session.encode_browser_session(&session)?;
+	let session_value = policy.browser_session_store.save(&session).await?;
 	let session_cookie = policy.session.set_cookie(
 		&policy.session.cookie_name,
-		&encoded,
+		&session_value,
 		policy.redirect_uri.https,
 		policy.session.ttl,
 	);

--- a/crates/agentgateway/src/http/oidc/local.rs
+++ b/crates/agentgateway/src/http/oidc/local.rs
@@ -346,6 +346,7 @@ impl PreparedOidcPolicy {
 				transaction_ttl: session::default_transaction_ttl(),
 				encoder: oidc_cookie_encoder.clone(),
 			},
+			browser_session_store: Arc::new(oidc_cookie_encoder.clone()),
 			scopes,
 		})
 	}

--- a/crates/agentgateway/src/http/oidc/mod.rs
+++ b/crates/agentgateway/src/http/oidc/mod.rs
@@ -130,6 +130,8 @@ pub struct OidcPolicy {
 	pub client: ClientConfig,
 	pub redirect_uri: RedirectUri,
 	pub session: SessionConfig,
+	#[serde(skip_serializing)]
+	browser_session_store: Arc<dyn session::BrowserSessionStore>,
 	pub scopes: Vec<String>,
 }
 
@@ -209,7 +211,7 @@ impl OidcPolicy {
 		}
 
 		if let Some(cookie) = crate::http::read_request_cookie(req, &self.session.cookie_name) {
-			match self.session.decode_browser_session(&cookie) {
+			match self.browser_session_store.load(&cookie).await {
 				Ok(browser_session) => {
 					if browser_session.policy_id == self.policy_id
 						&& let Ok(claims) = self
@@ -225,7 +227,7 @@ impl OidcPolicy {
 					}
 				},
 				Err(err) => {
-					debug!(error=%err, "failed to decode oidc browser session cookie");
+					debug!(error=%err, "failed to load oidc browser session");
 				},
 			}
 		}

--- a/crates/agentgateway/src/http/oidc/session.rs
+++ b/crates/agentgateway/src/http/oidc/session.rs
@@ -111,6 +111,34 @@ impl BrowserSession {
 	}
 }
 
+#[async_trait::async_trait]
+pub(super) trait BrowserSessionStore: std::fmt::Debug + Send + Sync {
+	async fn load(&self, value: &str) -> Result<BrowserSession, Error>;
+	async fn save(&self, session: &BrowserSession) -> Result<String, Error>;
+}
+
+#[async_trait::async_trait]
+impl BrowserSessionStore for sessionpersistence::Encoder {
+	async fn load(&self, value: &str) -> Result<BrowserSession, Error> {
+		let decoded = self.decrypt(value).map_err(|_| Error::InvalidSession)?;
+		let session: BrowserSession =
+			serde_json::from_slice(&decoded).map_err(|_| Error::InvalidSession)?;
+		if session.is_expired() {
+			return Err(Error::InvalidSession);
+		}
+		Ok(session)
+	}
+
+	async fn save(&self, session: &BrowserSession) -> Result<String, Error> {
+		let json = serde_json::to_string(session).map_err(anyhow::Error::from)?;
+		let encoded = self.encrypt(&json).map_err(|_| Error::InvalidSession)?;
+		if encoded.len() > MAX_BROWSER_COOKIE_VALUE_SIZE {
+			return Err(Error::SessionCookieTooLarge);
+		}
+		Ok(encoded)
+	}
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionConfig {
@@ -145,31 +173,6 @@ impl SessionConfig {
 			.encoder
 			.encrypt(&json)
 			.map_err(|_| Error::InvalidTransaction)
-	}
-
-	pub fn decode_browser_session(&self, cookie: &str) -> Result<BrowserSession, Error> {
-		let decoded = self
-			.encoder
-			.decrypt(cookie)
-			.map_err(|_| Error::InvalidSession)?;
-		let session: BrowserSession =
-			serde_json::from_slice(&decoded).map_err(|_| Error::InvalidSession)?;
-		if session.is_expired() {
-			return Err(Error::InvalidSession);
-		}
-		Ok(session)
-	}
-
-	pub fn encode_browser_session(&self, session: &BrowserSession) -> Result<String, Error> {
-		let json = serde_json::to_string(session).map_err(anyhow::Error::from)?;
-		let encoded = self
-			.encoder
-			.encrypt(&json)
-			.map_err(|_| Error::InvalidSession)?;
-		if encoded.len() > MAX_BROWSER_COOKIE_VALUE_SIZE {
-			return Err(Error::SessionCookieTooLarge);
-		}
-		Ok(encoded)
 	}
 
 	pub fn set_cookie(&self, name: &str, value: &str, is_https: bool, ttl: Duration) -> String {

--- a/crates/agentgateway/src/http/oidc/tests.rs
+++ b/crates/agentgateway/src/http/oidc/tests.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+use super::session::BrowserSessionStore;
 use super::*;
 use crate::http::jwt;
 use crate::proxy::ProxyError;
@@ -93,7 +94,37 @@ fn provider_endpoint(value: impl AsRef<str>) -> ProviderEndpoint {
 	value.as_ref().parse().expect("provider endpoint")
 }
 
+#[derive(Debug)]
+enum TestBrowserSessionStore {
+	LoadMissing,
+	LoadInvalid,
+	SaveValue(&'static str),
+}
+
+#[async_trait::async_trait]
+impl BrowserSessionStore for TestBrowserSessionStore {
+	async fn load(&self, _value: &str) -> Result<BrowserSession, Error> {
+		match self {
+			TestBrowserSessionStore::LoadMissing => Err(Error::MissingSession),
+			TestBrowserSessionStore::LoadInvalid => Err(Error::InvalidSession),
+			TestBrowserSessionStore::SaveValue(_) => {
+				panic!("unexpected browser session load")
+			},
+		}
+	}
+
+	async fn save(&self, _session: &BrowserSession) -> Result<String, Error> {
+		match self {
+			TestBrowserSessionStore::SaveValue(value) => Ok(value.to_string()),
+			TestBrowserSessionStore::LoadMissing | TestBrowserSessionStore::LoadInvalid => {
+				panic!("unexpected browser session save")
+			},
+		}
+	}
+}
+
 fn test_policy() -> OidcPolicy {
+	let encoder = test_oidc_cookie_encoder();
 	let session = SessionConfig {
 		cookie_name: "agw_oidc_s_test".into(),
 		transaction_cookie_prefix: "agw_oidc_t_test".into(),
@@ -101,7 +132,7 @@ fn test_policy() -> OidcPolicy {
 		secure: CookieSecureMode::Never,
 		ttl: Duration::from_secs(3600),
 		transaction_ttl: Duration::from_secs(300),
-		encoder: test_oidc_cookie_encoder(),
+		encoder: encoder.clone(),
 	};
 
 	OidcPolicy {
@@ -119,6 +150,7 @@ fn test_policy() -> OidcPolicy {
 		},
 		redirect_uri: test_redirect_uri(),
 		session,
+		browser_session_store: Arc::new(encoder),
 		scopes: vec!["openid".into(), "profile".into()],
 	}
 }
@@ -312,16 +344,64 @@ fn explicit_provider_config_rejects_relative_endpoints_during_deserialization() 
 }
 
 #[tokio::test]
+async fn cookie_browser_session_store_round_trips() {
+	let store = test_oidc_cookie_encoder();
+	let expected = BrowserSession {
+		policy_id: PolicyId::policy("policy"),
+		raw_id_token: SecretString::new("raw-id-token".into()),
+		expires_at_unix: Some(now_unix() + 300),
+	};
+
+	let value = store.save(&expected).await.expect("save browser session");
+	let actual = store.load(&value).await.expect("load browser session");
+
+	assert_eq!(actual.policy_id, expected.policy_id);
+	assert_eq!(
+		actual.raw_id_token.expose_secret(),
+		expected.raw_id_token.expose_secret()
+	);
+	assert_eq!(actual.expires_at_unix, expected.expires_at_unix);
+}
+
+#[tokio::test]
+async fn cookie_browser_session_store_rejects_expired_values() {
+	let store = test_oidc_cookie_encoder();
+	let expired = BrowserSession {
+		policy_id: PolicyId::policy("policy"),
+		raw_id_token: SecretString::new("raw-id-token".into()),
+		expires_at_unix: Some(now_unix().saturating_sub(1)),
+	};
+
+	let value = store.save(&expired).await.expect("save browser session");
+	let error = store.load(&value).await.expect_err("expired session");
+	assert!(matches!(error, Error::InvalidSession));
+}
+
+#[tokio::test]
+async fn cookie_browser_session_store_preserves_cookie_size_limit() {
+	let store = test_oidc_cookie_encoder();
+	let oversized = BrowserSession {
+		policy_id: PolicyId::policy("policy"),
+		raw_id_token: SecretString::new("x".repeat(4_000).into()),
+		expires_at_unix: Some(now_unix() + 300),
+	};
+
+	let error = store.save(&oversized).await.expect_err("oversized session");
+	assert!(matches!(error, Error::SessionCookieTooLarge));
+}
+
+#[tokio::test]
 async fn apply_derives_claims_from_stored_id_token() {
 	let policy = test_policy();
 	let id_token = signed_id_token(TEST_NONCE);
 	let encoded = policy
-		.session
-		.encode_browser_session(&BrowserSession {
+		.browser_session_store
+		.save(&BrowserSession {
 			policy_id: policy.policy_id.clone(),
 			raw_id_token: SecretString::new(id_token.clone().into()),
 			expires_at_unix: Some(now_unix() + 300),
 		})
+		.await
 		.expect("encode session");
 	let mut req = request(
 		Method::GET,
@@ -343,6 +423,56 @@ async fn apply_derives_claims_from_stored_id_token() {
 		.expect("claims extension");
 	assert_eq!(claims.inner.get("sub"), Some(&json!("user-1")));
 	assert_eq!(claims.jwt.expose_secret(), id_token);
+}
+
+#[tokio::test]
+async fn apply_treats_missing_or_invalid_stored_session_as_unauthenticated() {
+	let cases = [
+		("missing session", TestBrowserSessionStore::LoadMissing),
+		("invalid session", TestBrowserSessionStore::LoadInvalid),
+	];
+	for (name, store) in cases {
+		let mut policy = test_policy();
+		policy.browser_session_store = Arc::new(store);
+		let mut req = request(
+			Method::GET,
+			"https://app.example.com/protected",
+			Some("text/html"),
+		);
+		add_cookie(
+			&mut req,
+			format!("{}=opaque-ticket", policy.session.cookie_name),
+		);
+		let response = test_helpers::test_policy(&policy, &mut req)
+			.await
+			.expect(name)
+			.direct_response
+			.expect("login redirect");
+		assert_eq!(response.status(), ::http::StatusCode::FOUND, "{name}");
+		assert!(response.headers().contains_key(header::LOCATION), "{name}");
+		assert!(
+			response.headers().contains_key(header::SET_COOKIE),
+			"{name}"
+		);
+	}
+}
+
+#[tokio::test]
+async fn apply_does_not_load_store_without_browser_cookie() {
+	let mut policy = test_policy();
+	policy.browser_session_store = Arc::new(TestBrowserSessionStore::SaveValue("unused"));
+	let mut req = request(
+		Method::GET,
+		"https://app.example.com/protected",
+		Some("text/html"),
+	);
+
+	let response = test_helpers::test_policy(&policy, &mut req)
+		.await
+		.expect("login begins without loading browser session")
+		.direct_response
+		.expect("login redirect");
+	assert_eq!(response.status(), ::http::StatusCode::FOUND);
 }
 
 #[tokio::test]
@@ -680,8 +810,9 @@ async fn callback_success_sets_session_cookie_and_clears_transaction_cookie() {
 		.mount(&mock)
 		.await;
 
-	let policy = test_callback_policy(provider_endpoint(format!("{}/token", mock.uri())));
-	let mut policy = policy;
+	let mut policy = test_callback_policy(provider_endpoint(format!("{}/token", mock.uri())));
+	policy.browser_session_store =
+		Arc::new(TestBrowserSessionStore::SaveValue("opaque-session-ticket"));
 	policy.session.secure = CookieSecureMode::Auto;
 	let transaction_id = "tx-1";
 	let callback_state = encoded_callback_state(transaction_id, "test-state");
@@ -718,11 +849,12 @@ async fn callback_success_sets_session_cookie_and_clears_transaction_cookie() {
 		.iter()
 		.map(|h| h.to_str().unwrap().to_string())
 		.collect();
-	assert!(
-		cookies
-			.iter()
-			.any(|cookie| cookie.starts_with(&policy.session.cookie_name))
-	);
+	let session_cookie = cookies
+		.iter()
+		.map(|value| parse_set_cookie(value))
+		.find(|cookie| cookie.name() == policy.session.cookie_name.as_str())
+		.expect("authenticated session cookie");
+	assert_eq!(session_cookie.value(), "opaque-session-ticket");
 	assert!(cookies.iter().all(|cookie| cookie.contains("Secure")));
 	assert!(cookies.iter().any(|cookie| {
 		cookie.starts_with(&policy.session.transaction_cookie_name(transaction_id))

--- a/crates/agentgateway/src/http/oidc/tests.rs
+++ b/crates/agentgateway/src/http/oidc/tests.rs
@@ -394,7 +394,7 @@ async fn cookie_browser_session_store_preserves_cookie_size_limit() {
 async fn apply_derives_claims_from_stored_id_token() {
 	let policy = test_policy();
 	let id_token = signed_id_token(TEST_NONCE);
-	let encoded = policy
+	let session_cookie = policy
 		.browser_session_store
 		.save(&BrowserSession {
 			policy_id: policy.policy_id.clone(),
@@ -402,7 +402,7 @@ async fn apply_derives_claims_from_stored_id_token() {
 			expires_at_unix: Some(now_unix() + 300),
 		})
 		.await
-		.expect("encode session");
+		.expect("save browser session");
 	let mut req = request(
 		Method::GET,
 		"https://app.example.com/protected",
@@ -410,7 +410,7 @@ async fn apply_derives_claims_from_stored_id_token() {
 	);
 	add_cookie(
 		&mut req,
-		format!("{}={encoded}", policy.session.cookie_name),
+		format!("{}={session_cookie}", policy.session.cookie_name),
 	);
 
 	let response = test_helpers::test_policy(&policy, &mut req)


### PR DESCRIPTION
## Why

OIDC browser sessions live entirely in an encrypted cookie today. This PR pulls that storage behind a private interface so another implementation can keep the session on the server and return an opaque value through the same OIDC browser flow. The encrypted-cookie implementation stays in place for now.

## What Changed

`OidcPolicy` now loads and saves a `BrowserSession` through a private async `BrowserSessionStore`. The implementation in this PR is the existing cookie encoder. Tests cover its round trip, expiration, and 3,800-byte limit, then use a fake store to check that login and callback handle opaque values.

## Scope

No backend is added here. There is no new configuration or error mapping. Valid, missing, malformed, and expired OIDC sessions follow the same paths as before, and the callback still emits the same cookie and redirect response. The cookie implementation performs no I/O.

## Testing

```text
make check-default-members
make lint
RUST_TEST_THREADS=1 make test
git diff --check upstream/main
```
