### PR TITLE
fix(cel): support dynamic header transformation values

### DIFF
--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -335,11 +335,11 @@ impl HeaderOrPseudoValue {
 	}
 
 	pub fn from_cel_result(k: &HeaderOrPseudo, res: Option<Value>) -> Option<HeaderOrPseudoValue> {
-		match (res?.always_materialize_owned(), k) {
+		match (res?, k) {
 			(v, HeaderOrPseudo::Header(_)) => v
-				.as_bytes_pre_materialized()
+				.as_bytes_owned()
 				.ok()
-				.and_then(|b| HeaderValue::from_bytes(b).ok())
+				.and_then(|b| HeaderValue::from_bytes(&b).ok())
 				.map(HeaderOrPseudoValue::Header),
 			(v, HeaderOrPseudo::Status) => v
 				.as_unsigned()
@@ -348,24 +348,24 @@ impl HeaderOrPseudoValue {
 				.and_then(|v| StatusCode::from_u16(v).ok())
 				.map(HeaderOrPseudoValue::Status),
 			(v, HeaderOrPseudo::Method) => v
-				.as_bytes_pre_materialized()
+				.as_bytes_owned()
 				.ok()
-				.and_then(|b| ::http::Method::from_bytes(b).ok())
+				.and_then(|b| ::http::Method::from_bytes(&b).ok())
 				.map(HeaderOrPseudoValue::Method),
 			(v, HeaderOrPseudo::Scheme) => v
-				.as_bytes_pre_materialized()
+				.as_bytes_owned()
 				.ok()
-				.and_then(|b| ::http::uri::Scheme::try_from(b).ok())
+				.and_then(|b| ::http::uri::Scheme::try_from(&b).ok())
 				.map(HeaderOrPseudoValue::Scheme),
 			(v, HeaderOrPseudo::Authority) => v
-				.as_bytes_pre_materialized()
+				.as_bytes_owned()
 				.ok()
-				.and_then(|b| ::http::uri::Authority::try_from(b).ok())
+				.and_then(|b| ::http::uri::Authority::try_from(&b).ok())
 				.map(HeaderOrPseudoValue::Authority),
 			(v, HeaderOrPseudo::Path) => v
-				.as_bytes_pre_materialized()
+				.as_bytes_owned()
 				.ok()
-				.and_then(|b| ::http::uri::PathAndQuery::try_from(b).ok())
+				.and_then(|b| ::http::uri::PathAndQuery::try_from(&b).ok())
 				.map(HeaderOrPseudoValue::Path),
 		}
 	}

--- a/crates/agentgateway/src/http/transformation_cel_tests.rs
+++ b/crates/agentgateway/src/http/transformation_cel_tests.rs
@@ -30,6 +30,63 @@ fn test_transformation() {
 	assert_eq!(req.headers().get("x-insert").unwrap(), "hello Bar");
 }
 
+#[test]
+fn test_transformation_set_cel_header() {
+	let mut req = ::http::Request::builder()
+		.method("GET")
+		.uri("https://www.rust-lang.org/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	req.extensions_mut().insert(crate::http::apikey::Claims {
+		key: crate::http::apikey::APIKey::new("test-api-key"),
+		metadata: serde_json::json!({"user": "test-user"}),
+	});
+	let c = super::LocalTransformationConfig {
+		request: Some(super::LocalTransform {
+			set: vec![("x-analytics-user".into(), "apiKey.user".into())],
+			..Default::default()
+		}),
+		response: None,
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+	xfm.apply_request(&mut req);
+	assert_eq!(req.headers().get("x-analytics-user").unwrap(), "test-user");
+}
+
+#[test]
+fn test_transformation_set_multiple_cel_headers() {
+	let mut req = ::http::Request::builder()
+		.method("GET")
+		.uri("https://www.rust-lang.org/")
+		.body(crate::http::Body::empty())
+		.unwrap();
+	req.extensions_mut().insert(crate::http::apikey::Claims {
+		key: crate::http::apikey::APIKey::new("test-api-key"),
+		metadata: serde_json::json!({
+			"user": "test-user",
+			"group": "test-group",
+		}),
+	});
+	let c = super::LocalTransformationConfig {
+		request: Some(super::LocalTransform {
+			set: vec![
+				("x-analytics-user".into(), "apiKey.user".into()),
+				("x-analytics-group".into(), "apiKey.group".into()),
+			],
+			..Default::default()
+		}),
+		response: None,
+	};
+	let xfm = Transformation::try_from_local_config(c, true).unwrap();
+	xfm.apply_request(&mut req);
+
+	assert_eq!(req.headers().get("x-analytics-user").unwrap(), "test-user");
+	assert_eq!(
+		req.headers().get("x-analytics-group").unwrap(),
+		"test-group"
+	);
+}
+
 #[tokio::test]
 async fn test_transformation_body() {
 	let mut req = ::http::Request::builder()


### PR DESCRIPTION
Fixes #2944

Update CEL header conversion to preserve dynamically represented values when applying request header transformations. This allows `set` expressions such as `apiKey.user` and `apiKey.group` to populate headers, with regression coverage for one and multiple API key metadata headers.

The Rust test command could not run in this environment because the pinned `async-openai` git dependency was unavailable; formatting and diff checks pass.