### PR TITLE
mcp: set upstream MCP-Protocol-Version from request _meta

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -15,7 +15,7 @@ use rmcp::model::{
 	ClientNotification, ClientRequest, ExtensionCapabilities, GetMeta, JsonObject, JsonRpcRequest,
 };
 use rmcp::transport::TokioChildProcess;
-use rmcp::transport::common::http_header::HEADER_SESSION_ID;
+use rmcp::transport::common::http_header::{HEADER_MCP_PROTOCOL_VERSION, HEADER_SESSION_ID};
 use thiserror::Error;
 use tokio::process::Command;
 
@@ -88,6 +88,7 @@ impl IncomingRequestContext {
 			if k == http::header::CONTENT_ENCODING
 				|| k == http::header::CONTENT_LENGTH
 				|| k.as_str().eq_ignore_ascii_case(HEADER_SESSION_ID)
+				|| k.as_str().eq_ignore_ascii_case(HEADER_MCP_PROTOCOL_VERSION)
 			{
 				continue;
 			}
@@ -658,6 +659,14 @@ mod tests {
 			req.headers().get(HEADER_SESSION_ID).unwrap(),
 			"upstream-sid"
 		);
+	}
+
+	#[test]
+	fn apply_strips_inbound_mcp_protocol_version() {
+		let ctx = ctx_with_headers(&[(HEADER_MCP_PROTOCOL_VERSION, "2025-11-25")]);
+		let mut req = empty_upstream_req();
+		ctx.apply(&mut req).unwrap();
+		assert!(req.headers().get(HEADER_MCP_PROTOCOL_VERSION).is_none());
 	}
 
 	#[test]

--- a/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/upstream/streamablehttp.rs
@@ -4,10 +4,11 @@ use anyhow::anyhow;
 use futures::StreamExt;
 use headers::HeaderMapExt;
 use rmcp::model::{
-	ClientJsonRpcMessage, ClientNotification, ClientRequest, JsonRpcRequest, ServerJsonRpcMessage,
+	ClientJsonRpcMessage, ClientNotification, ClientRequest, GetMeta, JsonRpcRequest,
+	ServerJsonRpcMessage,
 };
 use rmcp::transport::common::http_header::{
-	EVENT_STREAM_MIME_TYPE, HEADER_SESSION_ID, JSON_MIME_TYPE,
+	EVENT_STREAM_MIME_TYPE, HEADER_MCP_PROTOCOL_VERSION, HEADER_SESSION_ID, JSON_MIME_TYPE,
 };
 use sse_stream::SseStream;
 
@@ -94,6 +95,13 @@ impl Client {
 
 		ctx.apply(&mut req).map_err(ClientError::new)?;
 		emit_standard_headers(req.headers_mut(), &message);
+		// Header mirrors the request's own _meta version, not the relayed client value.
+		if let ClientJsonRpcMessage::Request(r) = &message
+			&& let Some(version) = r.request.get_meta().protocol_version()
+			&& let Ok(value) = ::http::HeaderValue::from_str(version.as_str())
+		{
+			req.headers_mut().insert(HEADER_MCP_PROTOCOL_VERSION, value);
+		}
 
 		let resp = self.http_client.call(req).await?;
 


### PR DESCRIPTION
## Problem

The gateway relays downstream request headers to each backend, including `MCP-Protocol-Version`. But that header is the **client↔gateway** version; on the gateway↔upstream leg it must reflect the version the gateway is actually sending in the request body's `_meta`.

This gateway's upstream client never sets the header itself (`emit_standard_headers` only emits `Mcp-Method`/`Mcp-Name`), so relaying the client's value was the *only* source of `mcp-protocol-version` on upstream requests. Two problems follow:

- **Classic backends** (initialize-based): a backend whose SDK predates the client's version rejects the relayed too-new header with `400` (per 2025-06-18, an *unsupported* `MCP-Protocol-Version` MUST 400). The version should instead be negotiated via the `initialize` body.
- **Modern backends** (`server/discover`, 2026-07-28): the [Streamable HTTP spec](https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#protocol-version-header) requires the header to **match** the body's `io.modelcontextprotocol/protocolVersion`, and blindly relaying the client's value can violate that (mismatch ⇒ `400 HeaderMismatch`).

This is the same class of issue as forwarding `Mcp-Session-Id`, fixed in #1985: a client/gateway-leg header leaking onto the gateway/upstream leg.

## Fix

Stop relaying the client's `MCP-Protocol-Version` (stripped in `IncomingRequestContext::apply`, alongside `Content-Encoding`/`Content-Length`/`Mcp-Session-Id`), and instead **derive the header from the outgoing request's `_meta`** in the upstream Streamable HTTP client — mirroring what rmcp's own client does:

- **Modern** requests carry the version in `_meta` → the upstream gets a header that matches the body. ✅
- **Classic** requests have no `_meta` version → the header is omitted, so the backend relies on the version negotiated at `initialize` (an explicit fallback the spec calls out), and the original too-new-header `400` is gone. ✅

## Tests

- New unit test in `mcp/upstream/mod.rs`: `apply` strips an inbound `MCP-Protocol-Version`.
- The existing `modern_stateful_streamable_http_does_not_use_sessions` integration test exercises the modern `server/discover` path end-to-end and covers the derive-and-set behavior.

The existing `apply_*` tests still pass, and `make lint` is clean.
