### PR TITLE
proxy: drop special Istio TLV

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -30,7 +30,6 @@ use crate::transport::BufferLimit;
 use crate::transport::stream::{
 	ConnectHeaders, Extension, LoggingMode, Socket, TCPConnectionInfo, TLSConnectionInfo,
 };
-use crate::transport::tls::TlsInfo;
 use crate::types::agent::{
 	BindKey, BindProtocol, Listener, ListenerProtocol, TransportProtocol, TunnelProtocol,
 };
@@ -1175,24 +1174,6 @@ impl Gateway {
 				raw_peer_addr: Some(raw_peer_addr),
 			});
 		}
-
-		// Insert TLSConnectionInfo with identity from TLV 0xD0
-		// Even though there's no TLS on this connection, we use this struct
-		// to carry the peer identity that ztunnel extracted from mTLS
-		if let Some(identity) = pp_info.peer_identity {
-			raw_stream.ext_mut().insert(TLSConnectionInfo {
-				src_identity: Some(TlsInfo {
-					identity: Some(identity),
-					subject_alt_names: vec![],
-					issuer: crate::strng::EMPTY,
-					subject: crate::strng::EMPTY,
-					subject_cn: None,
-					certificate: None,
-				}),
-				server_name: None,
-				negotiated_alpn: None,
-			});
-		}
 	}
 
 	/// Handle incoming connection with a PROXY protocol header.
@@ -1232,8 +1213,7 @@ impl Gateway {
 			},
 		};
 
-		// Continue with normal protocol handling. Any PROXY-derived identity is now in the socket
-		// extensions and will flow through to CEL authorization via with_source().
+		// Continue with normal protocol handling.
 		Self::proxy_bind(bind_name, bind_protocol, raw_stream, inp, drain).await;
 		Ok(())
 	}

--- a/crates/agentgateway/src/proxy/proxy_protocol.rs
+++ b/crates/agentgateway/src/proxy/proxy_protocol.rs
@@ -5,9 +5,6 @@
 //! PROXY protocol. This module parses the PROXY header to extract:
 //!
 //! - Original source/destination addresses (standard PROXY protocol)
-//! - Peer identity from TLV 0xD0 (SPIFFE URI of the source workload, v2 only)
-//!
-//! The extracted identity flows through to CEL authorization via TLSConnectionInfo.
 
 use std::net::SocketAddr;
 
@@ -16,12 +13,7 @@ use ppp::{HeaderResult, PartialResult, v1, v2};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tracing::trace;
 
-use crate::transport::tls::IstioIdentity;
-use crate::types::discovery::Identity;
 use crate::types::frontend;
-
-/// TLV type for peer identity (SPIFFE URI) - matches ztunnel's PROXY_PROTOCOL_AUTHORITY_TLV
-const PROXY_PROTOCOL_AUTHORITY_TLV: u8 = 0xD0;
 
 /// PROXY protocol v1 prefix
 const PROXY_V1_PREFIX: &[u8] = b"PROXY";
@@ -39,7 +31,7 @@ const PROXY_V2_MIN_HEADER: usize = 16;
 
 /// Maximum allowed address/TLV data size.
 /// IPv6 addresses need 36 bytes, plus TLVs. 512 bytes is plenty for typical use
-/// (ztunnel only sends identity TLV) while preventing allocation attacks.
+/// while preventing allocation attacks.
 const PROXY_V2_MAX_ADDR_LEN: usize = 512;
 const PROXY_V2_MAX_HEADER_LEN: usize = PROXY_V2_MIN_HEADER + PROXY_V2_MAX_ADDR_LEN;
 const READ_CHUNK_LEN: usize = 64;
@@ -51,8 +43,6 @@ pub struct ProxyProtocolInfo {
 	pub src_addr: Option<SocketAddr>,
 	/// Original destination address (the service VIP), when provided.
 	pub dst_addr: Option<SocketAddr>,
-	/// Peer identity extracted from TLV 0xD0, if present
-	pub peer_identity: Option<IstioIdentity>,
 }
 
 #[derive(Debug)]
@@ -82,11 +72,7 @@ fn parse_v1_header(header: v1::Header<'_>) -> anyhow::Result<ProxyProtocolInfo> 
 
 	trace!(src = ?src_addr, dst = ?dst_addr, "parsed PROXY protocol v1 header");
 
-	Ok(ProxyProtocolInfo {
-		src_addr,
-		dst_addr,
-		peer_identity: None,
-	})
+	Ok(ProxyProtocolInfo { src_addr, dst_addr })
 }
 
 fn parse_v2_header(header: v2::Header<'_>) -> anyhow::Result<ProxyProtocolInfo> {
@@ -95,7 +81,6 @@ fn parse_v2_header(header: v2::Header<'_>) -> anyhow::Result<ProxyProtocolInfo> 
 		return Ok(ProxyProtocolInfo {
 			src_addr: None,
 			dst_addr: None,
-			peer_identity: None,
 		});
 	}
 
@@ -118,24 +103,9 @@ fn parse_v2_header(header: v2::Header<'_>) -> anyhow::Result<ProxyProtocolInfo> 
 		v2::Addresses::Unix(_) => bail!("unsupported PROXY protocol address family"),
 	};
 
-	let peer_identity = header
-		.tlvs()
-		.filter_map(|t| t.ok())
-		.find(|t| t.kind == PROXY_PROTOCOL_AUTHORITY_TLV)
-		.and_then(|t| parse_spiffe_identity(&t.value));
+	trace!(src = ?src_addr, dst = ?dst_addr, "parsed PROXY protocol v2 header");
 
-	trace!(
-		src = ?src_addr,
-		dst = ?dst_addr,
-		identity = ?peer_identity,
-		"parsed PROXY protocol v2 header"
-	);
-
-	Ok(ProxyProtocolInfo {
-		src_addr,
-		dst_addr,
-		peer_identity,
-	})
+	Ok(ProxyProtocolInfo { src_addr, dst_addr })
 }
 
 fn could_be_v1_prefix(buffer: &[u8]) -> bool {
@@ -263,25 +233,6 @@ pub async fn parse_proxy_protocol<S: AsyncRead + Unpin>(
 		.ok_or_else(|| anyhow!("expected PROXY protocol {} header", allowed_version))
 }
 
-/// Parse a SPIFFE URI into IstioIdentity components.
-///
-/// Uses the existing `Identity::FromStr` implementation for parsing,
-/// then converts to `IstioIdentity` for compatibility with `TLSConnectionInfo`.
-///
-/// Expected format: `spiffe://trust-domain/ns/namespace/sa/service-account`
-fn parse_spiffe_identity(data: &[u8]) -> Option<IstioIdentity> {
-	let uri = std::str::from_utf8(data).ok()?;
-	// Use existing Identity::FromStr impl (types/discovery.rs)
-	let identity: Identity = uri.parse().ok()?;
-	// Convert to IstioIdentity (same pattern as tls.rs:577-588)
-	let Identity::Spiffe {
-		trust_domain,
-		namespace,
-		service_account,
-	} = identity;
-	Some(IstioIdentity::new(trust_domain, namespace, service_account))
-}
-
 #[cfg(test)]
 mod tests {
 	use std::net::SocketAddrV4;
@@ -307,7 +258,7 @@ mod tests {
 		b"PROXY UNKNOWN\r\n".to_vec()
 	}
 
-	fn build_v2_proxy_header(src: &str, dst: &str, identity: Option<&[u8]>) -> Vec<u8> {
+	fn build_v2_proxy_header(src: &str, dst: &str) -> Vec<u8> {
 		let src: SocketAddrV4 = src.parse().unwrap();
 		let dst: SocketAddrV4 = dst.parse().unwrap();
 		let addresses = ppp::v2::Addresses::IPv4(ppp::v2::IPv4 {
@@ -316,12 +267,9 @@ mod tests {
 			source_port: src.port(),
 			destination_port: dst.port(),
 		});
-		let mut builder =
-			Builder::with_addresses(Version::Two | Command::Proxy, Protocol::Stream, addresses);
-		if let Some(id) = identity {
-			builder = builder.write_tlv(PROXY_PROTOCOL_AUTHORITY_TLV, id).unwrap();
-		}
-		builder.build().unwrap()
+		Builder::with_addresses(Version::Two | Command::Proxy, Protocol::Stream, addresses)
+			.build()
+			.unwrap()
 	}
 
 	fn build_max_len_v2_proxy_header(src: &str, dst: &str) -> Vec<u8> {
@@ -361,37 +309,13 @@ mod tests {
 			destination_port: dst.port(),
 		});
 		Builder::with_addresses(Version::Two | Command::Local, Protocol::Stream, addresses)
-			.write_tlv(
-				PROXY_PROTOCOL_AUTHORITY_TLV,
-				b"spiffe://cluster.local/ns/default/sa/ignored",
-			)
-			.unwrap()
 			.build()
 			.unwrap()
 	}
 
-	#[test]
-	fn test_parse_spiffe_identity() {
-		let cases = [
-			(b"spiffe://cluster.local/ns/default/sa/svc".as_slice(), true),
-			(b"spiffe://cluster.local/ns/default", false), // missing sa
-			(b"https://example.com", false),               // wrong scheme
-			(&[0xff, 0xfe][..], false),                    // invalid UTF-8
-			(b"spiffe://cluster.local/ns/default/sa/svc/extra", false), // extra segment
-			(b"spiffe://cluster.local/namespace/default/sa/svc", false), // wrong marker
-		];
-		for (input, should_parse) in cases {
-			assert_eq!(
-				parse_spiffe_identity(input).is_some(),
-				should_parse,
-				"{input:?}"
-			);
-		}
-	}
-
 	#[tokio::test]
 	async fn test_parse_proxy_protocol_v2() {
-		let header = build_v2_proxy_header("192.168.1.1:12345", "10.0.0.1:8080", None);
+		let header = build_v2_proxy_header("192.168.1.1:12345", "10.0.0.1:8080");
 		let mut data = header.clone();
 		data.extend_from_slice(b"GET / HTTP/1.1\r\n"); // trailing HTTP
 
@@ -402,7 +326,6 @@ mod tests {
 
 		assert_eq!(info.info.src_addr.unwrap().to_string(), "192.168.1.1:12345");
 		assert_eq!(info.info.dst_addr.unwrap().to_string(), "10.0.0.1:8080");
-		assert!(info.info.peer_identity.is_none());
 		assert_eq!(info.consumed_len, header.len());
 	}
 
@@ -419,7 +342,6 @@ mod tests {
 
 		assert_eq!(info.info.src_addr.unwrap().to_string(), "192.168.1.1:12345");
 		assert_eq!(info.info.dst_addr.unwrap().to_string(), "10.0.0.1:8080");
-		assert!(info.info.peer_identity.is_none());
 		assert_eq!(info.consumed_len, header.len());
 	}
 
@@ -433,29 +355,7 @@ mod tests {
 
 		assert!(info.info.src_addr.is_none());
 		assert!(info.info.dst_addr.is_none());
-		assert!(info.info.peer_identity.is_none());
 		assert_eq!(info.consumed_len, header.len());
-	}
-
-	#[tokio::test]
-	async fn test_parse_proxy_protocol_with_identity() {
-		let header = build_v2_proxy_header(
-			"192.168.1.1:12345",
-			"10.0.0.1:8080",
-			Some(b"spiffe://cluster.local/ns/default/sa/my-service"),
-		);
-
-		let mut cursor = std::io::Cursor::new(header);
-		let info = parse_proxy_protocol(&mut cursor, frontend::ProxyVersion::V2)
-			.await
-			.unwrap();
-
-		assert_eq!(info.info.src_addr.unwrap().to_string(), "192.168.1.1:12345");
-		assert_eq!(info.info.dst_addr.unwrap().to_string(), "10.0.0.1:8080");
-		assert_eq!(
-			info.info.peer_identity.unwrap().to_string(),
-			"spiffe://cluster.local/ns/default/sa/my-service"
-		);
 	}
 
 	#[tokio::test]
@@ -468,7 +368,6 @@ mod tests {
 
 		assert!(info.info.src_addr.is_none());
 		assert!(info.info.dst_addr.is_none());
-		assert!(info.info.peer_identity.is_none());
 		assert_eq!(info.consumed_len, header.len());
 	}
 
@@ -482,7 +381,6 @@ mod tests {
 
 		assert!(info.info.src_addr.is_none());
 		assert!(info.info.dst_addr.is_none());
-		assert!(info.info.peer_identity.is_none());
 		assert_eq!(info.consumed_len, header.len());
 	}
 
@@ -498,7 +396,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_parse_proxy_protocol_rejects_disallowed_version() {
-		let header = build_v2_proxy_header("192.168.1.1:12345", "10.0.0.1:8080", None);
+		let header = build_v2_proxy_header("192.168.1.1:12345", "10.0.0.1:8080");
 		let mut cursor = std::io::Cursor::new(header);
 		let err = parse_proxy_protocol(&mut cursor, frontend::ProxyVersion::V1)
 			.await

--- a/fuzz/fuzz_targets/proxy_protocol.rs
+++ b/fuzz/fuzz_targets/proxy_protocol.rs
@@ -1,10 +1,8 @@
 #![no_main]
 
 use std::io::Cursor;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use agentgateway::proxy::proxy_protocol::{detect_proxy_protocol, parse_proxy_protocol};
-use agentgateway::types::discovery::Identity;
+use agentgateway::proxy::proxy_protocol::detect_proxy_protocol;
 use agentgateway::types::frontend::ProxyVersion;
 use libfuzzer_sys::fuzz_target;
 use once_cell::sync::Lazy;
@@ -14,9 +12,6 @@ const V1_PREFIX: &[u8] = b"PROXY ";
 const V1_MAX_BODY_LEN: usize = 107 - V1_PREFIX.len() - 2;
 const V2_SIGNATURE: &[u8] = b"\r\n\r\n\0\r\nQUIT\n";
 const V2_MAX_SUFFIX_LEN: usize = 528 - V2_SIGNATURE.len();
-const V2_IPV4_ADDR_LEN: usize = 12;
-const V2_TLV_HEADER_LEN: usize = 3;
-const V2_MAX_IDENTITY_LEN: usize = 512 - V2_IPV4_ADDR_LEN - V2_TLV_HEADER_LEN;
 
 static RT: Lazy<Runtime> = Lazy::new(|| {
 	tokio::runtime::Builder::new_current_thread()
@@ -30,21 +25,6 @@ fn trim_line_end(mut data: &[u8]) -> &[u8] {
 		data = &data[..data.len() - 1];
 	}
 	data
-}
-
-fn v2_with_identity(identity: &[u8]) -> Vec<u8> {
-	let payload_len = V2_IPV4_ADDR_LEN + V2_TLV_HEADER_LEN + identity.len();
-	let mut header = Vec::with_capacity(V2_SIGNATURE.len() + 4 + payload_len);
-	header.extend_from_slice(V2_SIGNATURE);
-	header.extend_from_slice(&[0x21, 0x11]); // v2 PROXY, TCP over IPv4
-	header.extend_from_slice(&(payload_len as u16).to_be_bytes());
-	header.extend_from_slice(&[192, 168, 1, 1, 10, 0, 0, 1]);
-	header.extend_from_slice(&12345u16.to_be_bytes());
-	header.extend_from_slice(&8080u16.to_be_bytes());
-	header.push(0xd0); // ztunnel authority/identity TLV
-	header.extend_from_slice(&(identity.len() as u16).to_be_bytes());
-	header.extend_from_slice(identity);
-	header
 }
 
 fuzz_target!(|data: &[u8]| {
@@ -78,48 +58,6 @@ fuzz_target!(|data: &[u8]| {
 			if let Ok(Some(parsed)) = detect_proxy_protocol(&mut input, ProxyVersion::V2).await {
 				assert!(parsed.consumed_len <= v2.len());
 			}
-		}
-
-		// Always reach v2 address/TLV parsing with a valid frame. The fuzz bytes
-		// become the SPIFFE identity value, including malformed UTF-8 and shapes.
-		let identity = trim_line_end(data);
-		if identity.len() <= V2_MAX_IDENTITY_LEN {
-			let v2 = v2_with_identity(identity);
-			let mut input = Cursor::new(&v2);
-			let parsed = parse_proxy_protocol(&mut input, ProxyVersion::V2)
-				.await
-				.expect("constructed v2 frame must parse");
-			assert_eq!(parsed.consumed_len, v2.len());
-			assert_eq!(
-				parsed.info.src_addr,
-				Some(SocketAddr::new(
-					IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)),
-					12345
-				))
-			);
-			assert_eq!(
-				parsed.info.dst_addr,
-				Some(SocketAddr::new(
-					IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-					8080
-				))
-			);
-
-			let expected_identity = std::str::from_utf8(identity)
-				.ok()
-				.and_then(|value| value.parse::<Identity>().ok())
-				.map(|value| value.to_string());
-			assert_eq!(
-				parsed.info.peer_identity.map(|value| value.to_string()),
-				expected_identity
-			);
-
-			let mut input = Cursor::new(&v2);
-			assert!(
-				parse_proxy_protocol(&mut input, ProxyVersion::V1)
-					.await
-					.is_err()
-			);
 		}
 	});
 });


### PR DESCRIPTION
This was originally intended to sandwich with ztunnel. This is not
recommended; users should just directly let agentgateway handle mtls. If
sandwich is required it can be done still just without native identity.

Signed-off-by: John Howard <john.howard@solo.io>
