### PR TITLE
chore(ui): enable Biome linting

### DIFF
--- a/ui/biome.jsonc
+++ b/ui/biome.jsonc
@@ -53,6 +53,21 @@
 	},
 	"overrides": [
 		{
+			// Defer CSS and React linting until visual regression baselines can guard behavior-changing fixes.
+			"includes": ["**/*", "!src/**/*.{tsx,css}"],
+			"linter": {
+				"domains": {
+					"playwright": "all",
+					"project": "recommended",
+					"test": "recommended",
+					"types": "recommended"
+				},
+				"rules": {
+					"preset": "recommended"
+				}
+			}
+		},
+		{
 			"includes": ["src/**/*.{ts,tsx}"],
 			"linter": {
 				"rules": {

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -267,9 +267,7 @@ export function fileOwnedMcpSettingFields(
 ): ReadonlySet<string> {
 	if (!hybrid) return new Set();
 	const mcp = config?.mcp;
-	return new Set(
-		mcpSettingsFields.filter(field => Object.prototype.hasOwnProperty.call(mcp ?? {}, field))
-	);
+	return new Set(mcpSettingsFields.filter(field => Object.hasOwn(mcp ?? {}, field)));
 }
 
 type LlmPolicyWithGuardrails = NonNullable<LlmConfig['policies']> & {

--- a/ui/src/configMonaco.ts
+++ b/ui/src/configMonaco.ts
@@ -340,18 +340,17 @@ function resolveSchema(
 	if (Array.isArray(schema.allOf)) {
 		return schema.allOf.reduce<Record<string, unknown>>((merged, candidate) => {
 			const resolved = resolveSchema(candidate as Record<string, unknown>, seenRefs);
-			return {
-				...merged,
-				...resolved,
-				properties: {
-					...(typeof merged.properties === 'object' && !Array.isArray(merged.properties)
-						? merged.properties
-						: {}),
-					...(typeof resolved.properties === 'object' && !Array.isArray(resolved.properties)
-						? resolved.properties
-						: {})
-				}
-			};
+			const mergedProperties =
+				typeof merged.properties === 'object' && !Array.isArray(merged.properties)
+					? merged.properties
+					: {};
+			const resolvedProperties =
+				typeof resolved.properties === 'object' && !Array.isArray(resolved.properties)
+					? resolved.properties
+					: {};
+			return Object.assign(merged, resolved, {
+				properties: { ...mergedProperties, ...resolvedProperties }
+			});
 		}, {});
 	}
 	return schema;

--- a/ui/src/costs.ts
+++ b/ui/src/costs.ts
@@ -16,10 +16,11 @@ export function addBaseCostSource(config: GatewayConfig, file: string) {
 			...existing.filter(source => source.file !== file)
 		] as never;
 	}
+	return config;
 }
 
 export async function refreshBaseCostsAndConfigure(updateConfig: {
-	mutateAsync: (updater: (config: GatewayConfig) => GatewayConfig | void) => Promise<unknown>;
+	mutateAsync: (updater: (config: GatewayConfig) => GatewayConfig | undefined) => Promise<unknown>;
 }) {
 	const refreshed = await refreshBaseCosts();
 	if (refreshed.file) {

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -202,7 +202,7 @@ async function requireWritableRuntime(queryClient: ReturnType<typeof useQueryCli
 	const runtime =
 		queryClient.getQueryData<Awaited<ReturnType<typeof getRuntimeInfo>>>(['runtime']) ??
 		(await getRuntimeInfo());
-	if (runtime.ui.configStoreMode == 'readOnly') {
+	if (runtime.ui.configStoreMode === 'readOnly') {
 		throw new Error('The UI is configured as read-only.');
 	}
 	return runtime;
@@ -220,7 +220,7 @@ function invalidateConfigViews(queryClient: ReturnType<typeof useQueryClient>) {
 export function useUpdateConfig() {
 	const queryClient = useQueryClient();
 	return useMutation({
-		mutationFn: async (updater: (config: GatewayConfig) => GatewayConfig | void) => {
+		mutationFn: async (updater: (config: GatewayConfig) => GatewayConfig | undefined) => {
 			const runtime = await requireWritableRuntime(queryClient);
 			const overrideHybridFileWrite = takeHybridFileWriteOverride();
 			if (runtime.ui.configStoreMode === 'hybrid' && !overrideHybridFileWrite) {

--- a/ui/tests/e2e/fixtures.ts
+++ b/ui/tests/e2e/fixtures.ts
@@ -639,7 +639,7 @@ function upsertFileConfigResource(
 					);
 				})
 			: -1;
-		if (!previousId || !previousId.startsWith('@index:')) {
+		if (!previousId?.startsWith('@index:')) {
 			value.metadata = {
 				...record(value.metadata),
 				'agentgateway.dev/id': previousId ?? `test-key-${keys.length + 1}`,

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -951,8 +951,10 @@ test('hybrid LLM and UI policies are stored as individual resources', async ({ p
 			const kind = String(resource.kind);
 			if (!kind.endsWith('.policy')) continue;
 			const sectionName = kind.split('.')[0];
-			const section = (effective[sectionName] ??= {}) as Record<string, unknown>;
-			const policies = (section.policies ??= {}) as Record<string, unknown>;
+			effective[sectionName] ??= {};
+			const section = effective[sectionName] as Record<string, unknown>;
+			section.policies ??= {};
+			const policies = section.policies as Record<string, unknown>;
 			policies[String(resource.id)] = resource.value;
 		}
 		return route.fulfill({


### PR DESCRIPTION
## Why

PR #2957 moved UI formatting and the existing lint policy to Biome, but it left Biome's recommended TypeScript and test rules disabled, keeping the initial toolchain change separate from a new batch of lint findings.

That left a gap. `pnpm lint` enforced formatting and import policy, but it missed ordinary TypeScript and Playwright problems.

This follow-up turns those rules on for plain TypeScript, scripts, configuration, and E2E tests so local linting and CI catch them before review, including missed awaits, focused tests, forced actions, pause calls, and fixed-time waits.

## What Changed

- Recommended preset.
- `project`, `test`, and `types` domains at recommended.
- Every Playwright rule, since Biome 2.5.6 has no recommended Playwright set.
- Six files fixed. No `biome-ignore` comments.

## Scope

TSX and CSS keep their current lint policy because findings in those files can affect rendered output. Visual regression baselines should come first. This PR covers TypeScript and tests.

## Testing

- `pnpm lint`
- `pnpm test:e2e` (28 passed)
