### PR TITLE
feat(llm): native Gemini inbound API (generateContent, streamGenerateContent, countTokens)

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -1675,7 +1675,7 @@ const (
 	// Processes Cohere /v2/rerank format requests
 	BackendPolicySpec_Ai_RERANK BackendPolicySpec_Ai_RouteType = 10
 	// Processes Gemini models/{model}:generateContent and :streamGenerateContent format requests
-	BackendPolicySpec_Ai_GEMINI_GENERATE_CONTENT BackendPolicySpec_Ai_RouteType = 11
+	BackendPolicySpec_Ai_GENERATE_CONTENT BackendPolicySpec_Ai_RouteType = 11
 	// Processes Gemini models/{model}:countTokens format requests
 	BackendPolicySpec_Ai_GEMINI_COUNT_TOKENS BackendPolicySpec_Ai_RouteType = 12
 )
@@ -1694,23 +1694,23 @@ var (
 		7:  "EMBEDDINGS",
 		8:  "REALTIME",
 		10: "RERANK",
-		11: "GEMINI_GENERATE_CONTENT",
+		11: "GENERATE_CONTENT",
 		12: "GEMINI_COUNT_TOKENS",
 	}
 	BackendPolicySpec_Ai_RouteType_value = map[string]int32{
-		"UNSPECIFIED":             0,
-		"COMPLETIONS":             1,
-		"MESSAGES":                2,
-		"MODELS":                  3,
-		"PASSTHROUGH":             4,
-		"DETECT":                  9,
-		"RESPONSES":               5,
-		"ANTHROPIC_TOKEN_COUNT":   6,
-		"EMBEDDINGS":              7,
-		"REALTIME":                8,
-		"RERANK":                  10,
-		"GEMINI_GENERATE_CONTENT": 11,
-		"GEMINI_COUNT_TOKENS":     12,
+		"UNSPECIFIED":           0,
+		"COMPLETIONS":           1,
+		"MESSAGES":              2,
+		"MODELS":                3,
+		"PASSTHROUGH":           4,
+		"DETECT":                9,
+		"RESPONSES":             5,
+		"ANTHROPIC_TOKEN_COUNT": 6,
+		"EMBEDDINGS":            7,
+		"REALTIME":              8,
+		"RERANK":                10,
+		"GENERATE_CONTENT":      11,
+		"GEMINI_COUNT_TOKENS":   12,
 	}
 )
 
@@ -18257,7 +18257,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xde^\n" +
+	"\x04kind\"\xd7^\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -18280,7 +18280,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x0ebackend_tunnel\x18\x10 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.BackendTunnelH\x00R\rbackendTunnel\x12X\n" +
 	"\text_authz\x18\x11 \x01(\v29.agentgateway.dev.resource.TrafficPolicySpec.ExternalAuthH\x00R\bextAuthz\x12c\n" +
 	"\x0emcp_guardrails\x18\x12 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.McpGuardrailsH\x00R\rmcpGuardrails\x12Y\n" +
-	"\rauthorization\x18\x13 \x01(\v21.agentgateway.dev.resource.TrafficPolicySpec.RBACH\x00R\rauthorization\x1a\xdc/\n" +
+	"\rauthorization\x18\x13 \x01(\v21.agentgateway.dev.resource.TrafficPolicySpec.RBACH\x00R\rauthorization\x1a\xd5/\n" +
 	"\x02Ai\x12^\n" +
 	"\fprompt_guard\x18\x01 \x01(\v2;.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuardR\vpromptGuard\x12Y\n" +
 	"\bdefaults\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntryR\bdefaults\x12\\\n" +
@@ -18423,7 +18423,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x12ACTION_UNSPECIFIED\x10\x00\x12\b\n" +
 	"\x04MASK\x10\x01\x12\n" +
 	"\n" +
-	"\x06REJECT\x10\x02\"\xee\x01\n" +
+	"\x06REJECT\x10\x02\"\xe7\x01\n" +
 	"\tRouteType\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vCOMPLETIONS\x10\x01\x12\f\n" +
@@ -18440,8 +18440,8 @@ const file_resource_proto_rawDesc = "" +
 	"\bREALTIME\x10\b\x12\n" +
 	"\n" +
 	"\x06RERANK\x10\n" +
-	"\x12\x1b\n" +
-	"\x17GEMINI_GENERATE_CONTENT\x10\v\x12\x17\n" +
+	"\x12\x14\n" +
+	"\x10GENERATE_CONTENT\x10\v\x12\x17\n" +
 	"\x13GEMINI_COUNT_TOKENS\x10\f\x1a\x05\n" +
 	"\x03A2a\x1a\x92\x02\n" +
 	"\x10InferenceRouting\x12T\n" +

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -1674,6 +1674,10 @@ const (
 	BackendPolicySpec_Ai_REALTIME BackendPolicySpec_Ai_RouteType = 8
 	// Processes Cohere /v2/rerank format requests
 	BackendPolicySpec_Ai_RERANK BackendPolicySpec_Ai_RouteType = 10
+	// Processes Gemini models/{model}:generateContent and :streamGenerateContent format requests
+	BackendPolicySpec_Ai_GEMINI_GENERATE_CONTENT BackendPolicySpec_Ai_RouteType = 11
+	// Processes Gemini models/{model}:countTokens format requests
+	BackendPolicySpec_Ai_GEMINI_COUNT_TOKENS BackendPolicySpec_Ai_RouteType = 12
 )
 
 // Enum value maps for BackendPolicySpec_Ai_RouteType.
@@ -1690,19 +1694,23 @@ var (
 		7:  "EMBEDDINGS",
 		8:  "REALTIME",
 		10: "RERANK",
+		11: "GEMINI_GENERATE_CONTENT",
+		12: "GEMINI_COUNT_TOKENS",
 	}
 	BackendPolicySpec_Ai_RouteType_value = map[string]int32{
-		"UNSPECIFIED":           0,
-		"COMPLETIONS":           1,
-		"MESSAGES":              2,
-		"MODELS":                3,
-		"PASSTHROUGH":           4,
-		"DETECT":                9,
-		"RESPONSES":             5,
-		"ANTHROPIC_TOKEN_COUNT": 6,
-		"EMBEDDINGS":            7,
-		"REALTIME":              8,
-		"RERANK":                10,
+		"UNSPECIFIED":             0,
+		"COMPLETIONS":             1,
+		"MESSAGES":                2,
+		"MODELS":                  3,
+		"PASSTHROUGH":             4,
+		"DETECT":                  9,
+		"RESPONSES":               5,
+		"ANTHROPIC_TOKEN_COUNT":   6,
+		"EMBEDDINGS":              7,
+		"REALTIME":                8,
+		"RERANK":                  10,
+		"GEMINI_GENERATE_CONTENT": 11,
+		"GEMINI_COUNT_TOKENS":     12,
 	}
 )
 
@@ -18249,7 +18257,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xa8^\n" +
+	"\x04kind\"\xde^\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -18272,7 +18280,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x0ebackend_tunnel\x18\x10 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.BackendTunnelH\x00R\rbackendTunnel\x12X\n" +
 	"\text_authz\x18\x11 \x01(\v29.agentgateway.dev.resource.TrafficPolicySpec.ExternalAuthH\x00R\bextAuthz\x12c\n" +
 	"\x0emcp_guardrails\x18\x12 \x01(\v2:.agentgateway.dev.resource.BackendPolicySpec.McpGuardrailsH\x00R\rmcpGuardrails\x12Y\n" +
-	"\rauthorization\x18\x13 \x01(\v21.agentgateway.dev.resource.TrafficPolicySpec.RBACH\x00R\rauthorization\x1a\xa6/\n" +
+	"\rauthorization\x18\x13 \x01(\v21.agentgateway.dev.resource.TrafficPolicySpec.RBACH\x00R\rauthorization\x1a\xdc/\n" +
 	"\x02Ai\x12^\n" +
 	"\fprompt_guard\x18\x01 \x01(\v2;.agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuardR\vpromptGuard\x12Y\n" +
 	"\bdefaults\x18\x02 \x03(\v2=.agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntryR\bdefaults\x12\\\n" +
@@ -18415,7 +18423,7 @@ const file_resource_proto_rawDesc = "" +
 	"\x12ACTION_UNSPECIFIED\x10\x00\x12\b\n" +
 	"\x04MASK\x10\x01\x12\n" +
 	"\n" +
-	"\x06REJECT\x10\x02\"\xb8\x01\n" +
+	"\x06REJECT\x10\x02\"\xee\x01\n" +
 	"\tRouteType\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vCOMPLETIONS\x10\x01\x12\f\n" +
@@ -18432,7 +18440,9 @@ const file_resource_proto_rawDesc = "" +
 	"\bREALTIME\x10\b\x12\n" +
 	"\n" +
 	"\x06RERANK\x10\n" +
-	"\x1a\x05\n" +
+	"\x12\x1b\n" +
+	"\x17GEMINI_GENERATE_CONTENT\x10\v\x12\x17\n" +
+	"\x13GEMINI_COUNT_TOKENS\x10\f\x1a\x05\n" +
 	"\x03A2a\x1a\x92\x02\n" +
 	"\x10InferenceRouting\x12T\n" +
 	"\x0fendpoint_picker\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\x0eendpointPicker\x12l\n" +

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2266,9 +2266,9 @@ const (
 	// RouteTypeRerank processes Cohere `/v2/rerank` format requests.
 	RouteTypeRerank RouteType = "Rerank"
 
-	// RouteTypeGeminiGenerateContent processes Gemini `models/{model}:generateContent`
+	// RouteTypeGenerateContent processes Gemini `models/{model}:generateContent`
 	// and `models/{model}:streamGenerateContent` format requests.
-	RouteTypeGeminiGenerateContent RouteType = "GeminiGenerateContent"
+	RouteTypeGenerateContent RouteType = "GenerateContent"
 
 	// RouteTypeGeminiCountTokens processes Gemini `models/{model}:countTokens`
 	// format requests.

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2265,6 +2265,14 @@ const (
 
 	// RouteTypeRerank processes Cohere `/v2/rerank` format requests.
 	RouteTypeRerank RouteType = "Rerank"
+
+	// RouteTypeGeminiGenerateContent processes Gemini `models/{model}:generateContent`
+	// and `models/{model}:streamGenerateContent` format requests.
+	RouteTypeGeminiGenerateContent RouteType = "GeminiGenerateContent"
+
+	// RouteTypeGeminiCountTokens processes Gemini `models/{model}:countTokens`
+	// format requests.
+	RouteTypeGeminiCountTokens RouteType = "GeminiCountTokens"
 )
 
 // +kubebuilder:validation:AtLeastOneFieldSet

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -4082,7 +4082,7 @@ spec:
                                           - Detect
                                           - Embeddings
                                           - GeminiCountTokens
-                                          - GeminiGenerateContent
+                                          - GenerateContent
                                           - Messages
                                           - Models
                                           - Passthrough
@@ -12784,7 +12784,7 @@ spec:
                           - Detect
                           - Embeddings
                           - GeminiCountTokens
-                          - GeminiGenerateContent
+                          - GenerateContent
                           - Messages
                           - Models
                           - Passthrough

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -4081,6 +4081,8 @@ spec:
                                           - Completions
                                           - Detect
                                           - Embeddings
+                                          - GeminiCountTokens
+                                          - GeminiGenerateContent
                                           - Messages
                                           - Models
                                           - Passthrough
@@ -12781,6 +12783,8 @@ spec:
                           - Completions
                           - Detect
                           - Embeddings
+                          - GeminiCountTokens
+                          - GeminiGenerateContent
                           - Messages
                           - Models
                           - Passthrough

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3226,6 +3226,8 @@ spec:
                           - Completions
                           - Detect
                           - Embeddings
+                          - GeminiCountTokens
+                          - GeminiGenerateContent
                           - Messages
                           - Models
                           - Passthrough

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3227,7 +3227,7 @@ spec:
                           - Detect
                           - Embeddings
                           - GeminiCountTokens
-                          - GeminiGenerateContent
+                          - GenerateContent
                           - Messages
                           - Models
                           - Passthrough

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -1511,6 +1511,10 @@ func translateRouteType(rt agentgateway.RouteType) api.BackendPolicySpec_Ai_Rout
 		return api.BackendPolicySpec_Ai_REALTIME
 	case agentgateway.RouteTypeRerank:
 		return api.BackendPolicySpec_Ai_RERANK
+	case agentgateway.RouteTypeGeminiGenerateContent:
+		return api.BackendPolicySpec_Ai_GEMINI_GENERATE_CONTENT
+	case agentgateway.RouteTypeGeminiCountTokens:
+		return api.BackendPolicySpec_Ai_GEMINI_COUNT_TOKENS
 	default:
 		// Default to completions if unknown type
 		return api.BackendPolicySpec_Ai_COMPLETIONS

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -1511,8 +1511,8 @@ func translateRouteType(rt agentgateway.RouteType) api.BackendPolicySpec_Ai_Rout
 		return api.BackendPolicySpec_Ai_REALTIME
 	case agentgateway.RouteTypeRerank:
 		return api.BackendPolicySpec_Ai_RERANK
-	case agentgateway.RouteTypeGeminiGenerateContent:
-		return api.BackendPolicySpec_Ai_GEMINI_GENERATE_CONTENT
+	case agentgateway.RouteTypeGenerateContent:
+		return api.BackendPolicySpec_Ai_GENERATE_CONTENT
 	case agentgateway.RouteTypeGeminiCountTokens:
 		return api.BackendPolicySpec_Ai_GEMINI_COUNT_TOKENS
 	default:

--- a/crates/agentgateway/src/llm/cost/mod.rs
+++ b/crates/agentgateway/src/llm/cost/mod.rs
@@ -968,6 +968,28 @@ mod tests {
 	}
 
 	#[test]
+	fn gemini_normalized_output_splits_reasoning_back_out() {
+		// Gemini reports thoughts disjointly from candidates; UsageMetadata::counts()
+		// normalizes output_tokens to candidates + thoughts (the convention the split
+		// below assumes), so the split recovers the original buckets and thinking
+		// tokens are billed at the output rate rather than vanishing from `output`.
+		// Figures from a live gemini-2.5-flash response:
+		// promptTokenCount 14, candidatesTokenCount 293, thoughtsTokenCount 203.
+		let resp = LLMResponse {
+			input_tokens: Some(14),
+			output_tokens: Some(496),
+			reasoning_tokens: Some(203),
+			total_tokens: Some(510),
+			..Default::default()
+		};
+		let u = usage_for(CacheTokenConvention::InputIncludesCache, &resp, true, true);
+		assert_eq!(u.input, 14);
+		assert_eq!(u.output, 293, "visible output = candidates");
+		assert_eq!(u.reasoning, 203);
+		assert_eq!(u.output + u.reasoning, 496);
+	}
+
+	#[test]
 	fn prices_a_known_model() {
 		let snap = CatalogSnapshot::parse(&test_catalog("1")).unwrap();
 		let resp = LLMResponse {

--- a/crates/agentgateway/src/llm/gemini_tests.rs
+++ b/crates/agentgateway/src/llm/gemini_tests.rs
@@ -433,6 +433,68 @@ async fn generate_content_keeps_its_route_type_upstream() {
 	}
 }
 
+#[tokio::test]
+async fn completions_inbound_to_the_gemini_provider_renders_native() {
+	// The Gemini provider advertises the native chat format unconditionally, so
+	// OpenAI-compat clients get the gateway's own Completions -> Gemini conversion
+	// instead of Google's compat shim, matching Vertex with a Gemini model.
+	let provider = gemini_provider(None);
+	let req = gemini_request(
+		"https://example.com/v1/chat/completions",
+		r#"{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hello"}]}"#,
+	);
+
+	let RequestResult::Success {
+		request: mut forwarded,
+		llm_request,
+		upstream_route_type,
+	} = provider
+		.process_completions_request(
+			&backend_info(gemini::DEFAULT_HOST_STR),
+			None,
+			req,
+			false,
+			&mut None,
+		)
+		.await
+		.expect("completions request should process")
+	else {
+		panic!("expected a forwarded request");
+	};
+
+	assert_eq!(upstream_route_type, RouteType::GenerateContent);
+	assert!(matches!(
+		llm_request.provider_state,
+		Some(ProviderState::VertexGemini)
+	));
+
+	provider
+		.setup_request(
+			&mut forwarded,
+			upstream_route_type,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+	assert_eq!(
+		forwarded.uri().path(),
+		"/v1beta/models/gemini-2.5-flash:generateContent"
+	);
+
+	let body = forwarded.into_body().collect().await.unwrap().to_bytes();
+	let json: Value = serde_json::from_slice(&body).expect("forwarded body should be JSON");
+	assert!(
+		json.get("contents").is_some(),
+		"native body carries contents: {json}"
+	);
+	assert!(
+		json.get("messages").is_none(),
+		"OpenAI messages field must not survive the conversion: {json}"
+	);
+}
+
 #[test]
 fn gemini_input_formats_gate_the_policy_stack() {
 	assert!(InputFormat::Gemini.is_chat());

--- a/crates/agentgateway/src/llm/gemini_tests.rs
+++ b/crates/agentgateway/src/llm/gemini_tests.rs
@@ -1,0 +1,904 @@
+use std::collections::HashMap;
+
+use agent_core::strng;
+use http_body_util::BodyExt;
+use serde_json::Value;
+
+use crate::http::Body;
+use crate::llm::policy::Policy;
+use crate::llm::{
+	AIError, AIProvider, CacheTokenConvention, InputFormat, LLMRequest, ProviderState, RequestResult,
+	RouteType, anthropic, bedrock, gemini, openai, vertex,
+};
+use crate::types::agent::Target;
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+fn vertex_provider(region: Option<&str>, model: Option<&str>) -> AIProvider {
+	AIProvider::Vertex(vertex::Provider {
+		project_id: strng::new("test-project"),
+		model: model.map(strng::new),
+		region: region.map(strng::new),
+	})
+}
+
+fn gemini_provider(model: Option<&str>) -> AIProvider {
+	AIProvider::Gemini(gemini::Provider {
+		model: model.map(strng::new),
+	})
+}
+
+/// What `process_gemini_request` hands to `setup_request` for a chat route: the upstream route
+/// type is `Completions` (the provider format the native translation renders into) and the native
+/// render is signalled by `ProviderState::VertexGemini`.
+fn native_chat_request(model: &str, streaming: bool) -> LLMRequest {
+	LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Gemini,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: model.into(),
+		provider: Default::default(),
+		streaming,
+		params: Default::default(),
+		prompt: None,
+		provider_state: Some(ProviderState::VertexGemini),
+	}
+}
+
+/// countTokens has no chat translation, so it never carries `provider_state`; its client-facing
+/// route type is what reaches `setup_request`.
+fn count_tokens_request(model: &str) -> LLMRequest {
+	LLMRequest {
+		input_format: InputFormat::GeminiCountTokens,
+		provider_state: None,
+		..native_chat_request(model, false)
+	}
+}
+
+fn backend_info(host: &str) -> crate::http::auth::BackendInfo {
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+	crate::http::auth::BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from((host, 443)),
+		inputs: setup_proxy_test("{}").unwrap().pi,
+	}
+}
+
+fn gemini_request(uri: &str, body: &str) -> crate::http::Request {
+	::http::Request::builder()
+		.uri(uri)
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(body.as_bytes().to_vec()))
+		.unwrap()
+}
+
+fn generate_content_body(uri: &str) -> crate::http::Request {
+	gemini_request(
+		uri,
+		r#"{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}"#,
+	)
+}
+
+// ── set_required_fields ─────────────────────────────────────────────────────
+
+#[test]
+fn set_required_fields_leaves_gemini_routes_untouched() {
+	// Google auth is applied by the backend-auth policy, so the provider must not rewrite the
+	// client's headers the way the Anthropic provider does.
+	for provider in [
+		gemini_provider(None),
+		vertex_provider(Some("us-central1"), None),
+	] {
+		for route_type in [
+			RouteType::GeminiGenerateContent,
+			RouteType::GeminiCountTokens,
+			RouteType::Completions,
+		] {
+			let mut req = crate::http::tests_common::request(
+				"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+				::http::Method::POST,
+				&[
+					("authorization", "Bearer ya29.token"),
+					("x-goog-user-project", "p"),
+				],
+			);
+			let before = req.headers().clone();
+
+			provider
+				.set_required_fields(
+					&mut req,
+					route_type,
+					Some(&native_chat_request("gemini-2.5-flash", false)),
+				)
+				.unwrap();
+
+			assert_eq!(req.headers(), &before, "{provider:?} / {route_type:?}");
+			assert!(!req.headers().contains_key("anthropic-version"));
+		}
+	}
+}
+
+// ── upstream path building ──────────────────────────────────────────────────
+
+fn setup(
+	provider: &AIProvider,
+	uri: &str,
+	route_type: RouteType,
+	llm_request: &LLMRequest,
+) -> crate::http::Request {
+	let mut req = crate::http::tests_common::request(uri, ::http::Method::POST, &[]);
+	provider
+		.setup_request(&mut req, route_type, Some(llm_request), None, None, false)
+		.expect("setup_request should succeed");
+	req
+}
+
+#[rstest::rstest]
+#[case::global(
+	None,
+	false,
+	"/v1/projects/test-project/locations/global/publishers/google/models/gemini-2.5-flash:generateContent",
+	None,
+	"aiplatform.googleapis.com"
+)]
+#[case::global_streaming(
+	None,
+	true,
+	"/v1/projects/test-project/locations/global/publishers/google/models/gemini-2.5-flash:streamGenerateContent",
+	Some("alt=sse"),
+	"aiplatform.googleapis.com"
+)]
+#[case::regional(
+	Some("us-central1"),
+	false,
+	"/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent",
+	None,
+	"us-central1-aiplatform.googleapis.com"
+)]
+#[case::regional_streaming(
+	Some("us-central1"),
+	true,
+	"/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:streamGenerateContent",
+	Some("alt=sse"),
+	"us-central1-aiplatform.googleapis.com"
+)]
+fn vertex_builds_the_native_publisher_path(
+	#[case] region: Option<&str>,
+	#[case] streaming: bool,
+	#[case] expected_path: &str,
+	#[case] expected_query: Option<&str>,
+	#[case] expected_authority: &str,
+) {
+	let provider = vertex_provider(region, None);
+	let client_path = if streaming {
+		"https://example.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+	} else {
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent"
+	};
+	let req = setup(
+		&provider,
+		client_path,
+		RouteType::Completions,
+		&native_chat_request("gemini-2.5-flash", streaming),
+	);
+
+	assert_eq!(req.uri().path(), expected_path);
+	assert_eq!(req.uri().query(), expected_query);
+	assert_eq!(
+		req.uri().authority().map(|a| a.as_str()),
+		Some(expected_authority)
+	);
+}
+
+#[test]
+fn vertex_count_tokens_uses_the_publisher_path() {
+	let provider = vertex_provider(Some("us-central1"), None);
+	let req = setup(
+		&provider,
+		"https://example.com/v1beta/models/gemini-2.5-flash:countTokens",
+		RouteType::GeminiCountTokens,
+		&count_tokens_request("gemini-2.5-flash"),
+	);
+
+	assert_eq!(
+		req.uri().path(),
+		"/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:countTokens"
+	);
+	assert_eq!(req.uri().query(), None);
+	assert_eq!(
+		req.uri().authority().map(|a| a.as_str()),
+		Some("us-central1-aiplatform.googleapis.com")
+	);
+}
+
+#[test]
+fn vertex_native_path_normalizes_resource_style_model_names() {
+	// Vertex quickstarts and SDK configs write the model as a resource name; the publisher path
+	// supplies its own prefix, so only the bare id may reach it.
+	let provider = vertex_provider(None, None);
+	for model in [
+		"models/gemini-2.5-flash",
+		"google/gemini-2.5-flash",
+		"publishers/google/models/gemini-2.5-flash",
+	] {
+		let req = setup(
+			&provider,
+			"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+			RouteType::Completions,
+			&native_chat_request(model, false),
+		);
+		assert_eq!(
+			req.uri().path(),
+			"/v1/projects/test-project/locations/global/publishers/google/models/gemini-2.5-flash:generateContent",
+			"{model}"
+		);
+	}
+}
+
+#[test]
+fn gemini_api_native_paths_cover_all_three_methods() {
+	let provider = gemini_provider(None);
+	let cases = [
+		(
+			RouteType::Completions,
+			native_chat_request("gemini-2.5-flash", false),
+			"/v1beta/models/gemini-2.5-flash:generateContent",
+			None,
+		),
+		(
+			RouteType::Completions,
+			native_chat_request("gemini-2.5-flash", true),
+			"/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+			Some("alt=sse"),
+		),
+		(
+			RouteType::GeminiCountTokens,
+			count_tokens_request("gemini-2.5-flash"),
+			"/v1beta/models/gemini-2.5-flash:countTokens",
+			None,
+		),
+	];
+	for (route_type, llm_request, expected_path, expected_query) in cases {
+		let req = setup(
+			&provider,
+			"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+			route_type,
+			&llm_request,
+		);
+		assert_eq!(req.uri().path(), expected_path);
+		assert_eq!(req.uri().query(), expected_query);
+		assert_eq!(
+			req.uri().authority().map(|a| a.as_str()),
+			Some(gemini::DEFAULT_HOST_STR)
+		);
+	}
+}
+
+// ── end-to-end: model resolution rewrites the upstream path ─────────────────
+
+async fn process_and_setup(
+	provider: &AIProvider,
+	policy: Option<&Policy>,
+	uri: &str,
+	host: &str,
+) -> (LLMRequest, crate::http::Request) {
+	let RequestResult::Success {
+		request: mut req,
+		llm_request,
+		upstream_route_type,
+		..
+	} = provider
+		.process_gemini_request(
+			&backend_info(host),
+			policy,
+			generate_content_body(uri),
+			false,
+			&mut None,
+		)
+		.await
+		.expect("generateContent request should process")
+	else {
+		panic!("expected a forwarded request");
+	};
+	provider
+		.setup_request(
+			&mut req,
+			upstream_route_type,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+	(llm_request, req)
+}
+
+#[tokio::test]
+async fn generate_content_travels_upstream_as_a_completions_route() {
+	// The client-facing RouteType is GeminiGenerateContent, but the native render's provider
+	// format is Completions, and that is what drives upstream path building.
+	for (provider, host) in [
+		(vertex_provider(None, None), "aiplatform.googleapis.com"),
+		(gemini_provider(None), gemini::DEFAULT_HOST_STR),
+	] {
+		let RequestResult::Success {
+			llm_request,
+			upstream_route_type,
+			..
+		} = provider
+			.process_gemini_request(
+				&backend_info(host),
+				None,
+				generate_content_body("https://example.com/v1beta/models/gemini-2.5-flash:generateContent"),
+				false,
+				&mut None,
+			)
+			.await
+			.expect("generateContent request should process")
+		else {
+			panic!("expected a forwarded request");
+		};
+		assert_eq!(upstream_route_type, RouteType::Completions);
+		assert_eq!(llm_request.input_format, InputFormat::Gemini);
+		assert!(matches!(
+			llm_request.provider_state,
+			Some(ProviderState::VertexGemini)
+		));
+	}
+}
+
+#[test]
+fn gemini_input_formats_gate_the_policy_stack() {
+	assert!(InputFormat::Gemini.is_chat());
+	assert!(InputFormat::Gemini.supports_prompt_guard());
+	// countTokens generates no tokens and has no prompt to rewrite, matching the Anthropic
+	// token-count route.
+	assert!(!InputFormat::GeminiCountTokens.is_chat());
+	assert!(!InputFormat::GeminiCountTokens.supports_prompt_guard());
+}
+
+#[tokio::test]
+async fn backend_model_pinning_rewrites_the_path_model() {
+	// The plan's open question: with `ai.provider.vertexai.model` set, the model also rides the
+	// client's path, so the override has to reach the upstream path, not just the log.
+	let provider = vertex_provider(None, Some("gemini-2.5-pro"));
+	let (llm_request, req) = process_and_setup(
+		&provider,
+		None,
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+		"aiplatform.googleapis.com",
+	)
+	.await;
+
+	assert_eq!(llm_request.request_model, "gemini-2.5-pro");
+	assert_eq!(
+		req.uri().path(),
+		"/v1/projects/test-project/locations/global/publishers/google/models/gemini-2.5-pro:generateContent"
+	);
+}
+
+#[tokio::test]
+async fn model_alias_rewrites_the_path_model() {
+	let provider = vertex_provider(None, None);
+	let policy = Policy {
+		model_aliases: HashMap::from([(strng::new("fast"), strng::new("gemini-2.5-flash"))]),
+		..Default::default()
+	};
+	let (llm_request, req) = process_and_setup(
+		&provider,
+		Some(&policy),
+		"https://example.com/v1beta/models/fast:streamGenerateContent?alt=sse",
+		"aiplatform.googleapis.com",
+	)
+	.await;
+
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+	assert!(llm_request.streaming);
+	assert_eq!(
+		req.uri().path(),
+		"/v1/projects/test-project/locations/global/publishers/google/models/gemini-2.5-flash:streamGenerateContent"
+	);
+	assert_eq!(req.uri().query(), Some("alt=sse"));
+}
+
+#[tokio::test]
+async fn vertex_publisher_shaped_client_path_is_accepted() {
+	// LangChain's ChatVertexAI points at the full Vertex resource path rather than the bare
+	// Gemini-API one; the model still has to be read out of it.
+	let provider = vertex_provider(Some("us-central1"), None);
+	let (llm_request, req) = process_and_setup(
+		&provider,
+		None,
+		"https://example.com/v1/projects/other/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent",
+		"us-central1-aiplatform.googleapis.com",
+	)
+	.await;
+
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+	assert_eq!(
+		req.uri().path(),
+		"/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent"
+	);
+}
+
+// ── the model segment cannot choose the upstream path ───────────────────────
+
+/// Both spellings of the same attack. `%2F` is the dangerous one: it is not a `/`, so it passes
+/// the `[^/]+` route regexes in `binds.rs`, and `Uri::path()` hands it over undecoded — the
+/// traversal only exists after `extract_model_from_path` percent-decodes.
+const TRAVERSAL_MODELS: &[&str] = &[
+	"gemini-2.5-flash/../../../../locations/global/endpoints/openapi/chat/completions",
+	"gemini-2.5-flash%2F..%2F..%2F..%2F..%2Flocations%2Fglobal%2Fendpoints%2Fopenapi%2Fchat%2Fcompletions",
+];
+
+#[tokio::test]
+async fn a_traversal_model_in_the_client_path_is_rejected_before_a_path_is_built() {
+	let vertex = vertex_provider(None, None);
+	let gemini = gemini_provider(None);
+	for model in TRAVERSAL_MODELS {
+		let cases = [
+			(
+				&vertex,
+				"aiplatform.googleapis.com",
+				format!(
+					"https://example.com/v1/projects/other/locations/global/publishers/google/models/{model}:generateContent"
+				),
+			),
+			(
+				&gemini,
+				gemini::DEFAULT_HOST_STR,
+				format!("https://example.com/v1beta/models/{model}:generateContent"),
+			),
+		];
+		for (provider, host, uri) in cases {
+			let request = generate_content_body(&uri);
+			assert_eq!(
+				request.uri().path().contains("%2F"),
+				model.contains("%2F"),
+				"the client's percent-encoding reaches model extraction undecoded"
+			);
+			let err = provider
+				.process_gemini_request(&backend_info(host), None, request, false, &mut None)
+				.await
+				.expect_err("a traversal model must not resolve to an upstream request");
+			// The model is dropped at extraction and the Gemini body carries none, so the request
+			// dies here rather than reaching a path builder.
+			assert!(matches!(err, AIError::MissingField(_)), "{uri}: {err:?}");
+		}
+	}
+}
+
+#[tokio::test]
+async fn a_configured_traversal_model_is_escaped_rather_than_interpolated() {
+	// The model can also come from config (`ai.provider.model`, a model alias), which never went
+	// through path extraction, so the path builders have to hold the line themselves.
+	let (_, req) = process_and_setup(
+		&gemini_provider(Some(TRAVERSAL_MODELS[0])),
+		None,
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+		gemini::DEFAULT_HOST_STR,
+	)
+	.await;
+	assert_eq!(
+		req.uri().path(),
+		"/v1beta/models/gemini-2.5-flash%2F..%2F..%2F..%2F..%2Flocations%2Fglobal%2Fendpoints%2Fopenapi%2Fchat%2Fcompletions:generateContent"
+	);
+
+	// Vertex has a fixed fallback path to land on, so it uses that rather than escaping.
+	let req = setup(
+		&vertex_provider(None, None),
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+		RouteType::Completions,
+		&native_chat_request(TRAVERSAL_MODELS[0], false),
+	);
+	assert_eq!(
+		req.uri().path(),
+		"/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions"
+	);
+}
+
+#[tokio::test]
+async fn tuned_model_resource_names_round_trip_to_their_own_collection() {
+	// `rewrite_path_model` percent-encodes a virtual-model target's `/` so it stays one segment;
+	// decoding it back gives a resource name, and the Gemini API serves those under
+	// `/v1beta/tunedModels/{id}`, not under `/v1beta/models/`.
+	let provider = gemini_provider(None);
+	let uri = "https://example.com/v1beta/models/tunedModels%2Fabc:generateContent";
+	let request = generate_content_body(uri);
+	assert!(
+		request.uri().path().contains("%2F"),
+		"the client's percent-encoding must still be intact when the model is extracted"
+	);
+
+	let (llm_request, req) = process_and_setup(&provider, None, uri, gemini::DEFAULT_HOST_STR).await;
+	assert_eq!(llm_request.request_model, "tunedModels/abc");
+	assert_eq!(req.uri().path(), "/v1beta/tunedModels/abc:generateContent");
+}
+
+#[tokio::test]
+async fn native_request_body_reaches_the_upstream_unchanged() {
+	let provider = vertex_provider(None, None);
+	let (_, req) = process_and_setup(
+		&provider,
+		None,
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+		"aiplatform.googleapis.com",
+	)
+	.await;
+
+	let body: Value = serde_json::from_slice(&req.into_body().collect().await.unwrap().to_bytes())
+		.expect("forwarded body should be JSON");
+	assert_eq!(
+		body,
+		serde_json::json!({"contents":[{"role":"user","parts":[{"text":"hello"}]}]})
+	);
+}
+
+// ── who owns the model ──────────────────────────────────────────────────────
+
+fn model_transformation(expression: &str) -> Policy {
+	Policy {
+		transformations: Some(HashMap::from([(
+			"model".to_string(),
+			std::sync::Arc::new(crate::cel::Expression::new_strict(expression).unwrap()),
+		)])),
+		..Default::default()
+	}
+}
+
+async fn process_and_setup_count_tokens(
+	provider: &AIProvider,
+	policy: Option<&Policy>,
+	uri: &str,
+	body: &str,
+) -> (LLMRequest, crate::http::Request) {
+	let RequestResult::Success {
+		request: mut req,
+		llm_request,
+		upstream_route_type,
+		..
+	} = provider
+		.process_gemini_count_tokens_request(
+			&backend_info("aiplatform.googleapis.com"),
+			policy,
+			gemini_request(uri, body),
+			&mut None,
+		)
+		.await
+		.expect("countTokens request should process")
+	else {
+		panic!("expected a forwarded request");
+	};
+	provider
+		.setup_request(
+			&mut req,
+			upstream_route_type,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+	(llm_request, req)
+}
+
+#[tokio::test]
+async fn a_model_transformation_rewrites_the_upstream_path_model() {
+	// The virtual-model pattern from the local_tests configs: the client asks for `foo/<model>`,
+	// `rewrite_path_model` percent-encodes it into the path, and the operator's transformation
+	// strips the prefix before it reaches Google. `provider_model_is_set_before_llm_transformations`
+	// pins the same precedence on /v1/chat/completions — the gateway injects its model, then the
+	// mutation gets the last word — and the Gemini path is rebuilt from the result.
+	let policy = model_transformation(r#"llmRequest.model.stripPrefix("foo/")"#);
+	let (llm_request, req) = process_and_setup(
+		&vertex_provider(None, None),
+		Some(&policy),
+		"https://example.com/v1beta/models/foo%2Fgemini-2.5-flash:generateContent",
+		"aiplatform.googleapis.com",
+	)
+	.await;
+
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+	assert_eq!(
+		req.uri().path(),
+		"/v1/projects/test-project/locations/global/publishers/google/models/gemini-2.5-flash:generateContent"
+	);
+	// The injected model is gateway bookkeeping; the wire body must not grow a `model` field.
+	let body: Value = serde_json::from_slice(&req.into_body().collect().await.unwrap().to_bytes())
+		.expect("forwarded body should be JSON");
+	assert_eq!(
+		body,
+		serde_json::json!({"contents":[{"role":"user","parts":[{"text":"hello"}]}]})
+	);
+}
+
+#[tokio::test]
+async fn a_model_override_rewrites_the_upstream_path_model() {
+	let policy = Policy {
+		overrides: Some(HashMap::from([(
+			"model".to_string(),
+			serde_json::json!("gemini-2.5-pro"),
+		)])),
+		..Default::default()
+	};
+	let (llm_request, req) = process_and_setup(
+		&gemini_provider(None),
+		Some(&policy),
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+		gemini::DEFAULT_HOST_STR,
+	)
+	.await;
+
+	assert_eq!(llm_request.request_model, "gemini-2.5-pro");
+	assert_eq!(
+		req.uri().path(),
+		"/v1beta/models/gemini-2.5-pro:generateContent"
+	);
+}
+
+#[tokio::test]
+async fn a_client_body_model_never_outranks_the_path() {
+	// Gemini's wire body has no `model`, so one in the body is not a client-facing knob: honouring
+	// it would let a request pick a different model than the URI it was routed and authorized on.
+	let provider = vertex_provider(None, None);
+	let RequestResult::Success {
+		request: req,
+		llm_request,
+		..
+	} = provider
+		.process_gemini_request(
+			&backend_info("aiplatform.googleapis.com"),
+			None,
+			gemini_request(
+				"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+				r#"{"model":"gemini-2.5-pro","contents":[{"role":"user","parts":[{"text":"hello"}]}]}"#,
+			),
+			false,
+			&mut None,
+		)
+		.await
+		.expect("generateContent request should process")
+	else {
+		panic!("expected a forwarded request");
+	};
+
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+	let body: Value = serde_json::from_slice(&req.into_body().collect().await.unwrap().to_bytes())
+		.expect("forwarded body should be JSON");
+	assert_eq!(
+		body,
+		serde_json::json!({"contents":[{"role":"user","parts":[{"text":"hello"}]}]})
+	);
+}
+
+#[tokio::test]
+async fn a_model_transformation_rewrites_the_count_tokens_path_model() {
+	let policy = model_transformation(r#"llmRequest.model.stripPrefix("foo/")"#);
+	let (llm_request, req) = process_and_setup_count_tokens(
+		&vertex_provider(Some("us-central1"), None),
+		Some(&policy),
+		"https://example.com/v1beta/models/foo%2Fgemini-2.5-flash:countTokens",
+		r#"{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}"#,
+	)
+	.await;
+
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+	assert_eq!(
+		req.uri().path(),
+		"/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:countTokens"
+	);
+	let body: Value = serde_json::from_slice(&req.into_body().collect().await.unwrap().to_bytes())
+		.expect("forwarded body should be JSON");
+	assert_eq!(
+		body,
+		serde_json::json!({"contents":[{"role":"user","parts":[{"text":"hello"}]}]})
+	);
+}
+
+#[tokio::test]
+async fn a_count_tokens_body_model_stands_in_when_the_path_has_none() {
+	// Unlike generateContent, Vertex countTokens does take a body-level model, and endpoint-shaped
+	// paths carry none — so it is the fallback, never an override of the path.
+	let (llm_request, req) = process_and_setup_count_tokens(
+		&vertex_provider(None, None),
+		None,
+		"https://example.com/v1/projects/other/locations/global/endpoints/123:countTokens",
+		r#"{"model":"gemini-2.5-flash","contents":[{"role":"user","parts":[{"text":"hello"}]}]}"#,
+	)
+	.await;
+
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+	let body: Value = serde_json::from_slice(&req.into_body().collect().await.unwrap().to_bytes())
+		.expect("forwarded body should be JSON");
+	assert_eq!(
+		body,
+		serde_json::json!({"contents":[{"role":"user","parts":[{"text":"hello"}]}]})
+	);
+}
+
+// ── query handling ──────────────────────────────────────────────────────────
+
+#[test]
+fn a_client_alt_query_is_stripped_from_count_tokens() {
+	// countTokens is unary, but Google honours `alt=sse` on it and answers with SSE framing that
+	// `CountTokensResponse::translate_response` cannot parse — a Google-valid request would become
+	// a gateway error.
+	for provider in [vertex_provider(None, None), gemini_provider(None)] {
+		let req = setup(
+			&provider,
+			"https://example.com/v1beta/models/gemini-2.5-flash:countTokens?alt=sse&foo=bar",
+			RouteType::GeminiCountTokens,
+			&count_tokens_request("gemini-2.5-flash"),
+		);
+		assert_eq!(req.uri().query(), Some("foo=bar"), "{provider:?}");
+	}
+}
+
+// ── response path selection ─────────────────────────────────────────────────
+
+fn native_translation() -> &'static crate::llm::ChatTranslation {
+	vertex_provider(None, None)
+		.chat_translation(InputFormat::Gemini, Some("gemini-2.5-flash"))
+		.expect("gemini inbound on a gemini upstream")
+}
+
+#[test]
+fn non_streaming_response_is_forwarded_and_usage_extracted() {
+	let body = bytes::Bytes::from_static(
+		br#"{"candidates":[{"content":{"role":"model","parts":[{"text":"hi","someNewPartField":1}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":2,"totalTokenCount":10},"modelVersion":"gemini-2.5-flash-001","someNewTopLevelField":true}"#,
+	);
+	let resp = native_translation()
+		.render_response(
+			&body,
+			&crate::llm::ChatResponseContext {
+				model: "gemini-2.5-flash",
+				tool_name_map: None,
+			},
+		)
+		.expect("response should parse");
+
+	let llm = resp.to_llm_response(Default::default());
+	assert_eq!(llm.input_tokens, Some(8));
+	assert_eq!(llm.total_tokens, Some(10));
+	assert_eq!(llm.provider_model.as_deref(), Some("gemini-2.5-flash-001"));
+
+	let out: Value = serde_json::from_slice(&resp.serialize().expect("serialize")).expect("JSON");
+	let expected: Value = serde_json::from_slice(&body).expect("JSON");
+	assert_eq!(
+		out, expected,
+		"the response body must reach the client as-is"
+	);
+}
+
+#[tokio::test]
+async fn streaming_response_is_forwarded_byte_for_byte() {
+	let sse = concat!(
+		"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"hi\"}]}}]}\n\n",
+		"data: {\"candidates\":[{\"finishReason\":\"STOP\"}],",
+		"\"usageMetadata\":{\"promptTokenCount\":8,\"candidatesTokenCount\":2,\"totalTokenCount\":10}}\n\n",
+	);
+	let out = native_translation()
+		.stream(
+			::http::Response::new(Body::from(sse)),
+			crate::llm::ChatStreamContext {
+				buffer_limit: 1024 * 1024,
+				logger: Default::default(),
+				model: "gemini-2.5-flash".to_string(),
+				log_content: Default::default(),
+				tool_name_map: None,
+			},
+		)
+		.into_body()
+		.collect()
+		.await
+		.expect("collect stream")
+		.to_bytes();
+
+	assert_eq!(out.as_ref(), sse.as_bytes());
+}
+
+#[tokio::test]
+async fn count_tokens_errors_pass_through_unchanged() {
+	use crate::llm::BufferedResponse;
+
+	let provider = gemini_provider(None);
+	let body = bytes::Bytes::from_static(
+		br#"{"error":{"code":404,"message":"model not found","status":"NOT_FOUND"}}"#,
+	);
+	let mut parts = ::http::Response::new(()).into_parts().0;
+	parts.status = ::http::StatusCode::NOT_FOUND;
+	let buffered = BufferedResponse {
+		parts,
+		bytes: body.clone(),
+		encoding: None,
+	};
+
+	let resp = provider
+		.process_gemini_count_tokens_response(
+			count_tokens_request("gemini-2.5-flash"),
+			buffered,
+			None,
+			&Default::default(),
+		)
+		.expect("error response should process");
+	assert_eq!(resp.status(), ::http::StatusCode::NOT_FOUND);
+	// Only Google upstreams serve this route, so the client already speaks the error shape.
+	assert_eq!(resp.into_body().collect().await.unwrap().to_bytes(), body);
+}
+
+// ── unsupported upstreams ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn gemini_inbound_requires_a_gemini_upstream() {
+	let cases = [
+		(
+			AIProvider::Anthropic(anthropic::Provider { model: None }),
+			"api.anthropic.com",
+			"anthropic",
+		),
+		(
+			AIProvider::OpenAI(openai::Provider {
+				model: None,
+				moderation: None,
+			}),
+			"api.openai.com",
+			"openai",
+		),
+		(
+			AIProvider::Bedrock(crate::llm::BedrockProvider::new(bedrock::Provider {
+				model: None,
+				region: strng::new("us-east-1"),
+				guardrail_identifier: None,
+				guardrail_version: None,
+			})),
+			"bedrock-runtime.us-east-1.amazonaws.com",
+			"bedrock",
+		),
+		// Vertex is Gemini-capable, but only for Gemini models.
+		(
+			vertex_provider(None, Some("claude-sonnet-4-5")),
+			"aiplatform.googleapis.com",
+			"vertex",
+		),
+	];
+	for (provider, host, expected) in cases {
+		let err = provider
+			.process_gemini_request(
+				&backend_info(host),
+				None,
+				generate_content_body("https://example.com/v1beta/models/gemini-2.5-flash:generateContent"),
+				false,
+				&mut None,
+			)
+			.await
+			.expect_err("Gemini inbound must not reach a non-Gemini upstream");
+		assert!(matches!(err, AIError::UnsupportedConversion(_)), "{err}");
+		let msg = err.to_string();
+		assert!(msg.contains("Gemini") && msg.contains(expected), "{msg}");
+	}
+}
+
+#[tokio::test]
+async fn gemini_count_tokens_requires_a_gemini_upstream() {
+	let provider = vertex_provider(None, Some("claude-sonnet-4-5"));
+	let req = ::http::Request::builder()
+		.uri("https://example.com/v1beta/models/gemini-2.5-flash:countTokens")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{"contents":[{"role":"user","parts":[{"text":"hello"}]}]}"#.to_vec(),
+		))
+		.unwrap();
+
+	let err = provider
+		.process_gemini_count_tokens_request(
+			&backend_info("aiplatform.googleapis.com"),
+			None,
+			req,
+			&mut None,
+		)
+		.await
+		.expect_err("countTokens must not reach a non-Gemini upstream");
+	assert!(matches!(err, AIError::UnsupportedConversion(_)), "{err}");
+	assert!(err.to_string().contains("GeminiCountTokens"), "{err}");
+}

--- a/crates/agentgateway/src/llm/gemini_tests.rs
+++ b/crates/agentgateway/src/llm/gemini_tests.rs
@@ -91,7 +91,7 @@ fn set_required_fields_leaves_oauth_bearer_tokens_untouched() {
 		vertex_provider(Some("us-central1"), None),
 	] {
 		for route_type in [
-			RouteType::GeminiGenerateContent,
+			RouteType::GenerateContent,
 			RouteType::GeminiCountTokens,
 			RouteType::Completions,
 		] {
@@ -127,7 +127,7 @@ fn set_required_fields_moves_api_keys_to_x_goog_api_key_on_native_routes() {
 	let provider = gemini_provider(None);
 	for (route_type, llm_request) in [
 		(
-			RouteType::GeminiGenerateContent,
+			RouteType::GenerateContent,
 			native_chat_request("gemini-2.5-flash", false),
 		),
 		(
@@ -193,7 +193,7 @@ fn set_required_fields_keeps_api_keys_on_the_compat_shim_and_explicit_locations(
 	provider
 		.set_required_fields(
 			&mut req,
-			RouteType::GeminiGenerateContent,
+			RouteType::GenerateContent,
 			Some(&native_chat_request("gemini-2.5-flash", false)),
 		)
 		.unwrap();
@@ -401,7 +401,7 @@ async fn process_and_setup(
 
 #[tokio::test]
 async fn generate_content_travels_upstream_as_a_completions_route() {
-	// The client-facing RouteType is GeminiGenerateContent, but the native render's provider
+	// The client-facing RouteType is GenerateContent, but the native render's provider
 	// format is Completions, and that is what drives upstream path building.
 	for (provider, host) in [
 		(vertex_provider(None, None), "aiplatform.googleapis.com"),

--- a/crates/agentgateway/src/llm/gemini_tests.rs
+++ b/crates/agentgateway/src/llm/gemini_tests.rs
@@ -29,8 +29,8 @@ fn gemini_provider(model: Option<&str>) -> AIProvider {
 }
 
 /// What `process_gemini_request` hands to `setup_request` for a chat route: the upstream route
-/// type is `Completions` (the provider format the native translation renders into) and the native
-/// render is signalled by `ProviderState::VertexGemini`.
+/// type is `GenerateContent` (the provider format the native translation renders into) and the
+/// native render is signalled by `ProviderState::VertexGemini`.
 fn native_chat_request(model: &str, streaming: bool) -> LLMRequest {
 	LLMRequest {
 		input_tokens: None,
@@ -264,7 +264,7 @@ fn vertex_builds_the_native_publisher_path(
 	let req = setup(
 		&provider,
 		client_path,
-		RouteType::Completions,
+		RouteType::GenerateContent,
 		&native_chat_request("gemini-2.5-flash", streaming),
 	);
 
@@ -310,7 +310,7 @@ fn vertex_native_path_normalizes_resource_style_model_names() {
 		let req = setup(
 			&provider,
 			"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
-			RouteType::Completions,
+			RouteType::GenerateContent,
 			&native_chat_request(model, false),
 		);
 		assert_eq!(
@@ -326,13 +326,13 @@ fn gemini_api_native_paths_cover_all_three_methods() {
 	let provider = gemini_provider(None);
 	let cases = [
 		(
-			RouteType::Completions,
+			RouteType::GenerateContent,
 			native_chat_request("gemini-2.5-flash", false),
 			"/v1beta/models/gemini-2.5-flash:generateContent",
 			None,
 		),
 		(
-			RouteType::Completions,
+			RouteType::GenerateContent,
 			native_chat_request("gemini-2.5-flash", true),
 			"/v1beta/models/gemini-2.5-flash:streamGenerateContent",
 			Some("alt=sse"),
@@ -400,9 +400,9 @@ async fn process_and_setup(
 }
 
 #[tokio::test]
-async fn generate_content_travels_upstream_as_a_completions_route() {
-	// The client-facing RouteType is GenerateContent, but the native render's provider
-	// format is Completions, and that is what drives upstream path building.
+async fn generate_content_keeps_its_route_type_upstream() {
+	// The native render's provider format is GenerateContent, so the client-facing
+	// route type survives all the way to upstream path building.
 	for (provider, host) in [
 		(vertex_provider(None, None), "aiplatform.googleapis.com"),
 		(gemini_provider(None), gemini::DEFAULT_HOST_STR),
@@ -424,7 +424,7 @@ async fn generate_content_travels_upstream_as_a_completions_route() {
 		else {
 			panic!("expected a forwarded request");
 		};
-		assert_eq!(upstream_route_type, RouteType::Completions);
+		assert_eq!(upstream_route_type, RouteType::GenerateContent);
 		assert_eq!(llm_request.input_format, InputFormat::Gemini);
 		assert!(matches!(
 			llm_request.provider_state,
@@ -574,7 +574,7 @@ async fn a_configured_traversal_model_is_escaped_rather_than_interpolated() {
 	let req = setup(
 		&vertex_provider(None, None),
 		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
-		RouteType::Completions,
+		RouteType::GenerateContent,
 		&native_chat_request(TRAVERSAL_MODELS[0], false),
 	);
 	assert_eq!(

--- a/crates/agentgateway/src/llm/gemini_tests.rs
+++ b/crates/agentgateway/src/llm/gemini_tests.rs
@@ -83,9 +83,9 @@ fn generate_content_body(uri: &str) -> crate::http::Request {
 // ── set_required_fields ─────────────────────────────────────────────────────
 
 #[test]
-fn set_required_fields_leaves_gemini_routes_untouched() {
-	// Google auth is applied by the backend-auth policy, so the provider must not rewrite the
-	// client's headers the way the Anthropic provider does.
+fn set_required_fields_leaves_oauth_bearer_tokens_untouched() {
+	// OAuth access tokens (GCP backend-auth, workload identity, ...) stay in
+	// `Authorization: Bearer`; only API keys are relocated (see the test below).
 	for provider in [
 		gemini_provider(None),
 		vertex_provider(Some("us-central1"), None),
@@ -117,6 +117,91 @@ fn set_required_fields_leaves_gemini_routes_untouched() {
 			assert!(!req.headers().contains_key("anthropic-version"));
 		}
 	}
+}
+
+#[test]
+fn set_required_fields_moves_api_keys_to_x_goog_api_key_on_native_routes() {
+	// The native endpoints authenticate API keys via `x-goog-api-key`; a key left in
+	// `Authorization: Bearer` (the backend-auth default location) would be rejected as an
+	// invalid OAuth token.
+	let provider = gemini_provider(None);
+	for (route_type, llm_request) in [
+		(
+			RouteType::GeminiGenerateContent,
+			native_chat_request("gemini-2.5-flash", false),
+		),
+		(
+			RouteType::GeminiCountTokens,
+			count_tokens_request("gemini-2.5-flash"),
+		),
+	] {
+		let mut req = crate::http::tests_common::request(
+			"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+			::http::Method::POST,
+			&[("authorization", "Bearer AIzaTestKey123")],
+		);
+
+		provider
+			.set_required_fields(&mut req, route_type, Some(&llm_request))
+			.unwrap();
+
+		assert!(
+			!req.headers().contains_key(::http::header::AUTHORIZATION),
+			"{route_type:?}: the API key must not stay in Authorization"
+		);
+		assert_eq!(
+			req.headers().get("x-goog-api-key").unwrap(),
+			"AIzaTestKey123",
+			"{route_type:?}"
+		);
+	}
+}
+
+#[test]
+fn set_required_fields_keeps_api_keys_on_the_compat_shim_and_explicit_locations() {
+	// The OpenAI-compat shim accepts `Authorization: Bearer <api key>`, so a non-native
+	// route keeps the client's header.
+	let provider = gemini_provider(None);
+	let shim_request = LLMRequest {
+		input_format: InputFormat::Completions,
+		provider_state: None,
+		..native_chat_request("gemini-2.5-flash", false)
+	};
+	let mut req = crate::http::tests_common::request(
+		"https://example.com/v1/chat/completions",
+		::http::Method::POST,
+		&[("authorization", "Bearer AIzaTestKey123")],
+	);
+	provider
+		.set_required_fields(&mut req, RouteType::Completions, Some(&shim_request))
+		.unwrap();
+	assert_eq!(
+		req.headers().get(::http::header::AUTHORIZATION).unwrap(),
+		"Bearer AIzaTestKey123"
+	);
+	assert!(!req.headers().contains_key("x-goog-api-key"));
+
+	// An explicitly configured Authorization location must never be rewritten.
+	let mut req = crate::http::tests_common::request(
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+		::http::Method::POST,
+		&[("authorization", "Bearer AIzaTestKey123")],
+	);
+	req
+		.extensions_mut()
+		.insert(crate::http::auth::AppliedBackendAuthLocation { explicit: true });
+	provider
+		.set_required_fields(
+			&mut req,
+			RouteType::GeminiGenerateContent,
+			Some(&native_chat_request("gemini-2.5-flash", false)),
+		)
+		.unwrap();
+	assert_eq!(
+		req.headers().get(::http::header::AUTHORIZATION).unwrap(),
+		"Bearer AIzaTestKey123"
+	);
+	assert!(!req.headers().contains_key("x-goog-api-key"));
 }
 
 // ── upstream path building ──────────────────────────────────────────────────

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -2840,25 +2840,8 @@ fn google_invalid_argument(message: &str) -> ::http::Response<Body> {
 
 /// Remove `alt` from the request query, keeping any other parameters (e.g. `key`).
 fn strip_alt_query(req: &mut Request) {
-	let Some(query) = req.uri().query() else {
-		return;
-	};
-	if !url::form_urlencoded::parse(query.as_bytes()).any(|(k, _)| k == "alt") {
-		return;
-	}
-	let remaining = url::form_urlencoded::Serializer::new(String::new())
-		.extend_pairs(url::form_urlencoded::parse(query.as_bytes()).filter(|(k, _)| k != "alt"))
-		.finish();
-	let pq = if remaining.is_empty() {
-		req.uri().path().to_string()
-	} else {
-		format!("{}?{}", req.uri().path(), remaining)
-	};
-	// The rebuilt path-and-query is a subset of an already-valid URI; failure is unreachable.
-	let _ = http::modify_req_uri(req, |uri| {
-		uri.path_and_query = Some(PathAndQuery::from_str(&pq)?);
-		Ok(())
-	});
+	// Removing a parameter from an already-valid URI cannot fail.
+	let _ = http::modify_query_parameters(req.uri_mut(), std::iter::empty::<(&str, &str)>(), ["alt"]);
 }
 
 fn bedrock_tool_name_map(req: &LLMRequest) -> Option<&conversion::bedrock::BedrockToolNameMap> {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -315,9 +315,10 @@ const CHAT_TRANSLATIONS: &[ChatTranslation] = {
 		// Direct passthrough
 		chat(InputFormat::Responses, ChatFormat::OpenAIResponses),
 		chat(InputFormat::Gemini, ChatFormat::VertexGemini),
-		// Quirk: normally we prefer direct passthrough. However, for Gemini, we can do a better job of
-		// the conversion than Google's OpenAI compatible endpoint, so we put this first. This will
-		// only actually be used for Vertex + Gemini models.
+		// Quirk: normally we prefer direct passthrough. However, our conversion does a better job
+		// than Google's OpenAI compatible endpoint, so any provider that speaks native Gemini
+		// (Vertex or the Gemini API with a Gemini model, custom providers advertising
+		// generateContent) takes it in preference to the compat shim.
 		chat(InputFormat::Completions, ChatFormat::VertexGemini),
 		chat(InputFormat::Completions, ChatFormat::OpenAICompletions),
 		chat(InputFormat::Messages, ChatFormat::AnthropicMessages),
@@ -907,11 +908,7 @@ impl AIProvider {
 		}
 	}
 
-	fn supported_chat_formats(
-		&self,
-		input_format: InputFormat,
-		request_model: Option<&str>,
-	) -> Vec<ChatFormat> {
+	fn supported_chat_formats(&self, request_model: Option<&str>) -> Vec<ChatFormat> {
 		match self {
 			AIProvider::OpenAI(_) => {
 				vec![ChatFormat::OpenAIResponses, ChatFormat::OpenAICompletions]
@@ -929,12 +926,7 @@ impl AIProvider {
 			},
 			AIProvider::Azure(_) => vec![ChatFormat::OpenAIResponses, ChatFormat::OpenAICompletions],
 
-			// The Gemini API serves the native generateContent format too, but only native Gemini
-			// inbound selects it: the Completions --> VertexGemini conversion is Vertex-specific.
-			AIProvider::Gemini(_) if input_format == InputFormat::Gemini => {
-				vec![ChatFormat::VertexGemini]
-			},
-			AIProvider::Gemini(_) => vec![ChatFormat::OpenAICompletions],
+			AIProvider::Gemini(_) => vec![ChatFormat::VertexGemini, ChatFormat::OpenAICompletions],
 			AIProvider::Anthropic(_) => vec![ChatFormat::AnthropicMessages],
 			AIProvider::Bedrock(_) => vec![ChatFormat::BedrockConverse],
 
@@ -984,7 +976,7 @@ impl AIProvider {
 		input_format: InputFormat,
 		request_model: Option<&str>,
 	) -> Result<&'static ChatTranslation, AIError> {
-		let supported = self.supported_chat_formats(input_format, request_model);
+		let supported = self.supported_chat_formats(request_model);
 		CHAT_TRANSLATIONS
 			.iter()
 			.find(|translation| {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1577,7 +1577,7 @@ impl AIProvider {
 				parts,
 				tokenize,
 				log,
-				|req| types::ChatRequest::Gemini(Box::new(req.inner)),
+				|req| types::ChatRequest::Gemini(req.inner),
 			)
 			.await
 	}

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -47,6 +47,8 @@ pub const LOCAL_LISTENER_NAME: &str = "llm";
 
 #[cfg(test)]
 mod anthropic_tests;
+#[cfg(test)]
+mod gemini_tests;
 
 #[cfg(test)]
 mod tests;
@@ -312,6 +314,7 @@ const CHAT_TRANSLATIONS: &[ChatTranslation] = {
 	&[
 		// Direct passthrough
 		chat(InputFormat::Responses, ChatFormat::OpenAIResponses),
+		chat(InputFormat::Gemini, ChatFormat::VertexGemini),
 		// Quirk: normally we prefer direct passthrough. However, for Gemini, we can do a better job of
 		// the conversion than Google's OpenAI compatible endpoint, so we put this first. This will
 		// only actually be used for Vertex + Gemini models.
@@ -354,6 +357,10 @@ fn render_openai_completions(
 			apply_openai_moderation(&mut translated.moderation, ctx)?;
 			serde_json::to_vec(&translated).map_err(AIError::RequestMarshal)
 		},
+		// Missing: Gemini --> Completions (cross-provider translation is out of scope)
+		types::ChatRequest::Gemini(_) => Err(AIError::UnsupportedConversion(strng::literal!(
+			"gemini to completions"
+		))),
 	}
 }
 
@@ -393,6 +400,9 @@ fn render_anthropic_messages(req: types::ChatRequest) -> Result<Vec<u8>, AIError
 		types::ChatRequest::Responses(_) => Err(AIError::UnsupportedConversion(strng::literal!(
 			"responses to messages"
 		))),
+		types::ChatRequest::Gemini(_) => Err(AIError::UnsupportedConversion(strng::literal!(
+			"gemini to messages"
+		))),
 	}
 }
 
@@ -400,17 +410,20 @@ fn render_vertex_gemini(
 	req: types::ChatRequest,
 	ctx: &ChatRequestContext<'_>,
 ) -> Result<Vec<u8>, AIError> {
-	let AIProvider::Vertex(provider) = ctx.provider else {
-		return Err(AIError::UnsupportedConversion(strng::literal!(
-			"expected vertex provider"
-		)));
-	};
 	match req {
+		// Native Gemini inbound is a passthrough, so unlike the completions conversion it does
+		// not depend on Vertex specifics; the Gemini API provider renders through here too.
+		types::ChatRequest::Gemini(req) => serde_json::to_vec(&req).map_err(AIError::RequestMarshal),
 		types::ChatRequest::Completions(req) => {
+			let AIProvider::Vertex(provider) = ctx.provider else {
+				return Err(AIError::UnsupportedConversion(strng::literal!(
+					"expected vertex provider"
+				)));
+			};
 			conversion::vertex_gemini::from_completions::translate(&req, provider.model.as_deref())
 		},
 		_ => Err(AIError::UnsupportedConversion(strng::literal!(
-			"vertex gemini only supports completions input"
+			"vertex gemini only supports completions or native gemini input"
 		))),
 	}
 }
@@ -440,6 +453,9 @@ fn render_bedrock_converse(
 			Some(ctx.headers),
 			ctx.prompt_caching,
 		),
+		types::ChatRequest::Gemini(_) => Err(AIError::UnsupportedConversion(strng::literal!(
+			"gemini to bedrock converse"
+		))),
 	}?;
 	let provider_state = if bedrock.tool_name_map.is_empty() {
 		None
@@ -561,6 +577,7 @@ impl ChatTranslation {
 				))),
 			},
 			ChatFormat::VertexGemini => match self.input {
+				InputFormat::Gemini => AIProvider::parse_response::<types::gemini::Response>(bytes),
 				InputFormat::Completions => {
 					conversion::vertex_gemini::to_completions::translate_response(bytes)
 				},
@@ -675,6 +692,14 @@ impl ChatTranslation {
 			},
 
 			ChatFormat::VertexGemini => match self.input {
+				InputFormat::Gemini => resp.map(|b| {
+					conversion::vertex_gemini::passthrough_stream(
+						b,
+						ctx.buffer_limit,
+						ctx.logger,
+						ctx.log_content,
+					)
+				}),
 				InputFormat::Completions => resp.map(|b| {
 					conversion::vertex_gemini::to_completions::translate_stream(
 						b,
@@ -764,6 +789,8 @@ impl ChatTranslation {
 			},
 
 			ChatFormat::VertexGemini => match format {
+				// Native Gemini clients expect the Google error shape; pass it through unchanged.
+				ChatErrorFormat::Google if self.input == InputFormat::Gemini => Ok(bytes.clone()),
 				ChatErrorFormat::Google => conversion::completions::translate_google_error(bytes),
 				_ => unsupported(),
 			},
@@ -879,7 +906,11 @@ impl AIProvider {
 		}
 	}
 
-	fn supported_chat_formats(&self, request_model: Option<&str>) -> Vec<ChatFormat> {
+	fn supported_chat_formats(
+		&self,
+		input_format: InputFormat,
+		request_model: Option<&str>,
+	) -> Vec<ChatFormat> {
 		match self {
 			AIProvider::OpenAI(_) => {
 				vec![ChatFormat::OpenAIResponses, ChatFormat::OpenAICompletions]
@@ -897,6 +928,11 @@ impl AIProvider {
 			},
 			AIProvider::Azure(_) => vec![ChatFormat::OpenAIResponses, ChatFormat::OpenAICompletions],
 
+			// The Gemini API serves the native generateContent format too, but only native Gemini
+			// inbound selects it: the Completions --> VertexGemini conversion is Vertex-specific.
+			AIProvider::Gemini(_) if input_format == InputFormat::Gemini => {
+				vec![ChatFormat::VertexGemini]
+			},
 			AIProvider::Gemini(_) => vec![ChatFormat::OpenAICompletions],
 			AIProvider::Anthropic(_) => vec![ChatFormat::AnthropicMessages],
 			AIProvider::Bedrock(_) => vec![ChatFormat::BedrockConverse],
@@ -946,7 +982,7 @@ impl AIProvider {
 		input_format: InputFormat,
 		request_model: Option<&str>,
 	) -> Result<&'static ChatTranslation, AIError> {
-		let supported = self.supported_chat_formats(request_model);
+		let supported = self.supported_chat_formats(input_format, request_model);
 		CHAT_TRANSLATIONS
 			.iter()
 			.find(|translation| {
@@ -982,7 +1018,9 @@ impl AIProvider {
 			InputFormat::Detect
 			| InputFormat::Completions
 			| InputFormat::Messages
-			| InputFormat::Responses => return None,
+			| InputFormat::Responses
+			| InputFormat::Gemini
+			| InputFormat::GeminiCountTokens => return None,
 		};
 		self
 			.supports_format(format, request_model)
@@ -1138,6 +1176,19 @@ impl AIProvider {
 			return Ok(());
 		}
 
+		// Native Gemini paths carry their own `?alt=sse` (see `native_gemini_path`) while the
+		// client's query is preserved alongside, so a client-sent `alt` would arrive upstream
+		// duplicated. countTokens is unary and never sets one, but Google honours `alt=sse` there
+		// too and answers with SSE framing that `CountTokensResponse` cannot parse — so drop the
+		// client's `alt` on both native routes (same gate as the render below). Stripping it here
+		// rather than at parse time keeps it intact on the paths above, which forward the client's
+		// URI untouched.
+		if route_type == RouteType::GeminiCountTokens
+			|| llm_request.is_some_and(|l| matches!(l.provider_state, Some(ProviderState::VertexGemini)))
+		{
+			strip_alt_query(req);
+		}
+
 		match self {
 			AIProvider::OpenAI(_) => http::modify_req(req, |req| {
 				http::modify_uri(req, |uri| {
@@ -1179,14 +1230,26 @@ impl AIProvider {
 				})?;
 				Ok(())
 			}),
-			AIProvider::Gemini(_) => http::modify_req(req, |req| {
-				http::modify_uri(req, |uri| {
-					let path = Self::with_path_prefix(gemini::path(route_type), path_prefix);
-					Self::set_path_and_query(uri, &path)?;
+			AIProvider::Gemini(_) => {
+				// Native Gemini renders (provider_state VertexGemini) go to the native
+				// generateContent endpoint, and countTokens is only ever native; everything else
+				// uses the OpenAI-compat shim.
+				let native = llm_request
+					.filter(|l| {
+						route_type == RouteType::GeminiCountTokens
+							|| matches!(l.provider_state, Some(ProviderState::VertexGemini))
+					})
+					.map(|l| gemini::native_gemini_path(route_type, l.request_model.as_str(), l.streaming));
+				http::modify_req(req, |req| {
+					http::modify_uri(req, |uri| {
+						let path = native.as_deref().unwrap_or(gemini::path(route_type));
+						let path = Self::with_path_prefix(path, path_prefix);
+						Self::set_path_and_query(uri, &path)?;
+						Ok(())
+					})?;
 					Ok(())
-				})?;
-				Ok(())
-			}),
+				})
+			},
 			AIProvider::Vertex(provider) => {
 				let request_model = llm_request.map(|l| l.request_model.as_str());
 				let streaming = llm_request.map(|l| l.streaming).unwrap_or(false);
@@ -1448,6 +1511,45 @@ impl AIProvider {
 			.await
 	}
 
+	pub async fn process_gemini_request(
+		&self,
+		backend_info: &crate::http::auth::BackendInfo,
+		policies: Option<&Policy>,
+		req: Request,
+		tokenize: bool,
+		log: &mut Option<&mut RequestLog>,
+	) -> Result<RequestResult, AIError> {
+		// The Gemini wire body carries neither model nor a stream flag; both come from the
+		// URI: models/{model}:generateContent vs models/{model}:streamGenerateContent.
+		let streaming = req.uri().path().ends_with(":streamGenerateContent");
+		if streaming && !query_requests_sse(req.uri()) {
+			// Without alt=sse Google streams a JSON array, which we cannot parse incrementally.
+			// This can never succeed, so answer with a terminal client error rather than an
+			// AIError, which would surface as a retryable 503 and invite SDK retry storms.
+			return Ok(RequestResult::Rejected(google_invalid_argument(
+				"streamGenerateContent requires alt=sse; the JSON-array streaming variant is not supported",
+			)));
+		}
+		let (parts, mut req) = self
+			.read_gemini_body_and_default_model::<types::gemini::Request>(policies, req, log)
+			.await?;
+		req.streaming = streaming;
+		self.apply_model_alias(policies, &mut req);
+
+		self
+			.process_chat_request(
+				backend_info,
+				policies,
+				InputFormat::Gemini,
+				req,
+				parts,
+				tokenize,
+				log,
+				|req| types::ChatRequest::Gemini(Box::new(req.inner)),
+			)
+			.await
+	}
+
 	pub async fn process_embeddings_request(
 		&self,
 		backend_info: &crate::http::auth::BackendInfo,
@@ -1587,6 +1689,37 @@ impl AIProvider {
 			.await
 	}
 
+	pub async fn process_gemini_count_tokens_request(
+		&self,
+		backend_info: &crate::http::auth::BackendInfo,
+		policies: Option<&Policy>,
+		req: Request,
+		log: &mut Option<&mut RequestLog>,
+	) -> Result<RequestResult, AIError> {
+		// Like generateContent, the model comes from the URI, not the body — except that Vertex
+		// countTokens does accept a body-level one, which stands in when the URI has none (an
+		// `endpoints/{id}:countTokens` path, say).
+		let (parts, mut req) = self
+			.read_gemini_body_and_default_model::<types::gemini::CountTokensRequest>(policies, req, log)
+			.await?;
+		self.apply_model_alias(policies, &mut req);
+
+		self
+			.process_non_chat_request(
+				backend_info,
+				policies,
+				InputFormat::GeminiCountTokens,
+				req,
+				parts,
+				false,
+				log,
+				|provider, req, _, request_model| {
+					provider.render_gemini_count_tokens_request(req, request_model)
+				},
+			)
+			.await
+	}
+
 	pub async fn process_detect_request(
 		&self,
 		backend_info: &crate::http::auth::BackendInfo,
@@ -1665,6 +1798,25 @@ impl AIProvider {
 			},
 			_ => Err(AIError::UnsupportedConversion(strng::literal!(
 				"count_tokens not supported for this provider"
+			))),
+		}
+	}
+
+	/// Native Gemini countTokens is passthrough, so the upstream must speak it natively; there is
+	/// no conversion from other providers' count-tokens endpoints.
+	fn render_gemini_count_tokens_request(
+		&self,
+		req: &types::gemini::CountTokensRequest,
+		request_model: &str,
+	) -> Result<Vec<u8>, AIError> {
+		match self {
+			AIProvider::Gemini(_) => serde_json::to_vec(req).map_err(AIError::RequestMarshal),
+			AIProvider::Vertex(p) if p.is_gemini_model(Some(request_model)) => {
+				serde_json::to_vec(req).map_err(AIError::RequestMarshal)
+			},
+			_ => Err(AIError::UnsupportedConversion(strng::format!(
+				"from GeminiCountTokens to provider {}",
+				self.provider()
 			))),
 		}
 	}
@@ -1851,18 +2003,21 @@ impl AIProvider {
 		} else {
 			None
 		};
-		let provider_format = if original_format == InputFormat::Detect {
-			None
-		} else {
-			self
-				.non_chat_provider_format_for(original_format, request_model.as_deref())
-				.ok_or_else(|| {
-					AIError::UnsupportedConversion(strng::format!(
-						"from {original_format:?} to provider {}",
-						self.provider()
-					))
-				})?
-				.into()
+		// Detect is raw passthrough and native Gemini countTokens has no upstream provider format
+		// to translate through (its provider support is checked by the render closure); both keep
+		// their client-facing route type upstream.
+		let provider_format = match original_format {
+			InputFormat::Detect | InputFormat::GeminiCountTokens => None,
+			_ => Some(
+				self
+					.non_chat_provider_format_for(original_format, request_model.as_deref())
+					.ok_or_else(|| {
+						AIError::UnsupportedConversion(strng::format!(
+							"from {original_format:?} to provider {}",
+							self.provider()
+						))
+					})?,
+			),
 		};
 		let prepared = self
 			.prepare_request(
@@ -1904,9 +2059,11 @@ impl AIProvider {
 		Ok(RequestResult::Success {
 			request: req,
 			llm_request: llm_info,
-			upstream_route_type: provider_format
-				.map(custom::ProviderFormat::route_type)
-				.unwrap_or(RouteType::Detect),
+			upstream_route_type: match provider_format {
+				Some(format) => format.route_type(),
+				None if original_format == InputFormat::GeminiCountTokens => RouteType::GeminiCountTokens,
+				None => RouteType::Detect,
+			},
 		})
 	}
 
@@ -1944,6 +2101,9 @@ impl AIProvider {
 		match req.input_format {
 			InputFormat::CountTokens => {
 				self.process_count_tokens_response(req, buffered, model_catalog, &log)
+			},
+			InputFormat::GeminiCountTokens => {
+				self.process_gemini_count_tokens_response(req, buffered, model_catalog, &log)
 			},
 			InputFormat::Embeddings => {
 				self.process_embeddings_buffered_response(req, buffered, model_catalog, &log)
@@ -2125,6 +2285,42 @@ impl AIProvider {
 		};
 
 		parts.headers.remove(header::CONTENT_LENGTH);
+		Ok(Self::finalize_response(
+			parts,
+			bytes.into(),
+			req,
+			LLMResponse {
+				count_tokens: Some(count),
+				..Default::default()
+			},
+			model_catalog,
+			log,
+		))
+	}
+
+	fn process_gemini_count_tokens_response(
+		&self,
+		req: LLMRequest,
+		buffered: BufferedResponse,
+		model_catalog: Option<&cost::ModelCatalog>,
+		log: &AsyncLog<llm::LLMInfo>,
+	) -> Result<Response, AIError> {
+		let BufferedResponse {
+			mut parts, bytes, ..
+		} = buffered;
+		parts.headers.remove(header::CONTENT_LENGTH);
+		if !parts.status.is_success() {
+			let body = self.process_error(&req, parts.status, &bytes)?;
+			return Ok(Self::finalize_response(
+				parts,
+				body.into(),
+				req,
+				LLMResponse::default(),
+				model_catalog,
+				log,
+			));
+		}
+		let (bytes, count) = types::gemini::CountTokensResponse::translate_response(bytes)?;
 		Ok(Self::finalize_response(
 			parts,
 			bytes.into(),
@@ -2440,6 +2636,35 @@ impl AIProvider {
 		hreq: Request,
 		log: &mut Option<&mut RequestLog>,
 	) -> Result<(Parts, T), AIError> {
+		self
+			.read_body_resolving_model(policies, hreq, log, false)
+			.await
+	}
+
+	/// Native Gemini bodies have no `model` of their own — the URI carries it — so the path (or a
+	/// backend pin) outranks anything a client puts in the body, which would otherwise defeat
+	/// virtual-model rewrites and path-based policy. The resolved model is still injected into the
+	/// body JSON before the operator's body mutations run, so a `transformations`/`overrides` entry
+	/// for `model` applies here exactly as it does on `/v1/chat/completions`; the Gemini request
+	/// types keep it off the wire.
+	async fn read_gemini_body_and_default_model<T: RequestType + DeserializeOwned>(
+		&self,
+		policies: Option<&Policy>,
+		hreq: Request,
+		log: &mut Option<&mut RequestLog>,
+	) -> Result<(Parts, T), AIError> {
+		self
+			.read_body_resolving_model(policies, hreq, log, true)
+			.await
+	}
+
+	async fn read_body_resolving_model<T: RequestType + DeserializeOwned>(
+		&self,
+		policies: Option<&Policy>,
+		hreq: Request,
+		log: &mut Option<&mut RequestLog>,
+		path_model_wins: bool,
+	) -> Result<(Parts, T), AIError> {
 		let buffer = http::buffer_limit(&hreq);
 		let (mut parts, body) = hreq.into_parts();
 		// Decode Content-Encoding (gzip/deflate/br/zstd) before parsing the body as
@@ -2476,7 +2701,7 @@ impl AIProvider {
 
 		let mut request: serde_json::Value =
 			serde_json::from_slice(bytes.as_ref()).map_err(AIError::RequestParsing)?;
-		self.set_provider_request_model(&parts, &mut request)?;
+		self.set_provider_request_model(&parts, &mut request, path_model_wins)?;
 		let mut request = if let Some(p) = policies {
 			p.apply_request_body_mutations(request, log)?
 		} else {
@@ -2492,6 +2717,7 @@ impl AIProvider {
 		&self,
 		parts: &Parts,
 		req: &mut serde_json::Value,
+		path_model_wins: bool,
 	) -> Result<(), AIError> {
 		let Some(obj) = req.as_object_mut() else {
 			return Err(AIError::MissingField("request must be an object".into()));
@@ -2501,7 +2727,7 @@ impl AIProvider {
 				"model".to_string(),
 				serde_json::Value::String(provider_model.to_string()),
 			);
-		} else if !matches!(obj.get("model"), Some(serde_json::Value::String(_)))
+		} else if (path_model_wins || !matches!(obj.get("model"), Some(serde_json::Value::String(_))))
 			&& let Some(path_model) = types::detect::extract_model_from_path(parts.uri.path())
 		{
 			obj.insert(
@@ -2561,6 +2787,11 @@ impl AIProvider {
 				// Passthrough; nothing needed
 				Ok(bytes.clone())
 			},
+			(_, InputFormat::GeminiCountTokens) => {
+				// Passthrough; only Google upstreams serve this route, so the error is already
+				// the Google shape the client expects.
+				Ok(bytes.clone())
+			},
 			(AIProvider::Bedrock(_), InputFormat::Embeddings) => {
 				conversion::bedrock::from_embeddings::translate_error(bytes)
 			},
@@ -2583,6 +2814,51 @@ impl AIProvider {
 			))),
 		}
 	}
+}
+
+fn query_requests_sse(uri: &::http::Uri) -> bool {
+	uri.query().is_some_and(|q| {
+		url::form_urlencoded::parse(q.as_bytes()).any(|(k, v)| k == "alt" && v == "sse")
+	})
+}
+
+/// Terminal 400 in the Google error shape, which the Gemini SDKs know how to parse.
+fn google_invalid_argument(message: &str) -> ::http::Response<Body> {
+	let body = serde_json::json!({
+		"error": {
+			"code": 400,
+			"message": message,
+			"status": "INVALID_ARGUMENT",
+		}
+	});
+	::http::Response::builder()
+		.status(::http::StatusCode::BAD_REQUEST)
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(body.to_string()))
+		.expect("failed to build gemini error response")
+}
+
+/// Remove `alt` from the request query, keeping any other parameters (e.g. `key`).
+fn strip_alt_query(req: &mut Request) {
+	let Some(query) = req.uri().query() else {
+		return;
+	};
+	if !url::form_urlencoded::parse(query.as_bytes()).any(|(k, _)| k == "alt") {
+		return;
+	}
+	let remaining = url::form_urlencoded::Serializer::new(String::new())
+		.extend_pairs(url::form_urlencoded::parse(query.as_bytes()).filter(|(k, _)| k != "alt"))
+		.finish();
+	let pq = if remaining.is_empty() {
+		req.uri().path().to_string()
+	} else {
+		format!("{}?{}", req.uri().path(), remaining)
+	};
+	// The rebuilt path-and-query is a subset of an already-valid URI; failure is unreachable.
+	let _ = http::modify_req_uri(req, |uri| {
+		uri.path_and_query = Some(PathAndQuery::from_str(&pq)?);
+		Ok(())
+	});
 }
 
 fn bedrock_tool_name_map(req: &LLMRequest) -> Option<&conversion::bedrock::BedrockToolNameMap> {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1419,7 +1419,7 @@ impl AIProvider {
 			AIProvider::Gemini(_)
 				if matches!(
 					route_type,
-					RouteType::GeminiGenerateContent | RouteType::GeminiCountTokens
+					RouteType::GenerateContent | RouteType::GeminiCountTokens
 				) || llm_request
 					.is_some_and(|l| matches!(l.provider_state, Some(ProviderState::VertexGemini))) =>
 			{

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1413,6 +1413,35 @@ impl AIProvider {
 					Ok(())
 				}
 			},
+			AIProvider::Gemini(_)
+				if matches!(
+					route_type,
+					RouteType::GeminiGenerateContent | RouteType::GeminiCountTokens
+				) || llm_request
+					.is_some_and(|l| matches!(l.provider_state, Some(ProviderState::VertexGemini))) =>
+			{
+				http::modify_req(req, |req| {
+					if let Some(authz) = req.headers.typed_get::<headers::Authorization<Bearer>>() {
+						let explicit_authorization = req
+							.extensions
+							.get::<AppliedBackendAuthLocation>()
+							.is_some_and(|auth| auth.explicit);
+
+						// The native endpoints authenticate API keys via x-goog-api-key;
+						// `Authorization: Bearer` is reserved for OAuth access tokens there.
+						// Google API keys are uniformly "AIza"-prefixed, so relocate exactly
+						// those, keeping OAuth tokens (ya29., JWTs, ...) and explicitly
+						// configured Authorization intact.
+						if !explicit_authorization && authz.token().starts_with(gemini::API_KEY_PREFIX) {
+							req.headers.remove(http::header::AUTHORIZATION);
+							let mut api_key = HeaderValue::from_str(authz.token())?;
+							api_key.set_sensitive(true);
+							req.headers.insert("x-goog-api-key", api_key);
+						}
+					}
+					Ok(())
+				})
+			},
 			_ => Ok(()),
 		}
 	}

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -415,12 +415,10 @@ fn render_vertex_gemini(
 		// not depend on Vertex specifics; the Gemini API provider renders through here too.
 		types::ChatRequest::Gemini(req) => serde_json::to_vec(&req).map_err(AIError::RequestMarshal),
 		types::ChatRequest::Completions(req) => {
-			let AIProvider::Vertex(provider) = ctx.provider else {
-				return Err(AIError::UnsupportedConversion(strng::literal!(
-					"expected vertex provider"
-				)));
-			};
-			conversion::vertex_gemini::from_completions::translate(&req, provider.model.as_deref())
+			// The conversion only needs the backend-pinned model, which every Gemini-speaking
+			// provider (Vertex, the Gemini API, custom) exposes the same way.
+			let override_model = ctx.provider.override_model();
+			conversion::vertex_gemini::from_completions::translate(&req, override_model.as_deref())
 		},
 		_ => Err(AIError::UnsupportedConversion(strng::literal!(
 			"vertex gemini only supports completions or native gemini input"
@@ -485,7 +483,7 @@ impl ChatTranslation {
 				InputFormat::Responses => custom::ProviderFormat::Responses,
 				_ => unreachable!("chat translation selected for non-chat input"),
 			},
-			ChatFormat::VertexGemini => custom::ProviderFormat::Completions,
+			ChatFormat::VertexGemini => custom::ProviderFormat::GenerateContent,
 		}
 	}
 
@@ -955,6 +953,7 @@ impl AIProvider {
 					custom::ProviderFormat::Completions => Some(ChatFormat::OpenAICompletions),
 					custom::ProviderFormat::Messages => Some(ChatFormat::AnthropicMessages),
 					custom::ProviderFormat::Responses => Some(ChatFormat::OpenAIResponses),
+					custom::ProviderFormat::GenerateContent => Some(ChatFormat::VertexGemini),
 					_ => None,
 				})
 				.collect(),
@@ -1293,33 +1292,52 @@ impl AIProvider {
 				})?;
 				Ok(())
 			}),
-			AIProvider::Custom(provider) => http::modify_req(req, |req| {
-				http::modify_uri(req, |uri| {
-					if let Some(path) = provider.path_for_route(route_type) {
-						Self::set_path_and_query(uri, path)?;
-						return Ok(());
-					}
-					let path = match route_type {
-						RouteType::Messages | RouteType::AnthropicTokenCount => format!(
-							"{}{}",
-							path_prefix.map_or(anthropic::DEFAULT_BASE_PATH, |prefix| {
-								prefix.trim_end_matches('/')
-							}),
-							anthropic::path_suffix(route_type)
-						),
-						_ => format!(
-							"{}{}",
-							path_prefix.map_or(openai::DEFAULT_BASE_PATH, |prefix| {
-								prefix.trim_end_matches('/')
-							}),
-							openai::path_suffix(route_type)
-						),
-					};
-					Self::set_path_and_query(uri, &path)?;
+			AIProvider::Custom(provider) => {
+				// The native Gemini formats embed the model in the path and pick the method by
+				// streaming, which a static configured path cannot express, so their default is
+				// the canonical Gemini API shape. A configured path still wins verbatim below,
+				// which only suits single-model unary shims.
+				let native = llm_request
+					.filter(|_| {
+						matches!(
+							route_type,
+							RouteType::GenerateContent | RouteType::GeminiCountTokens
+						)
+					})
+					.map(|l| gemini::native_gemini_path(route_type, l.request_model.as_str(), l.streaming));
+				http::modify_req(req, |req| {
+					http::modify_uri(req, |uri| {
+						if let Some(path) = provider.path_for_route(route_type) {
+							Self::set_path_and_query(uri, path)?;
+							return Ok(());
+						}
+						if let Some(native) = native.as_deref() {
+							let path = Self::with_path_prefix(native, path_prefix);
+							Self::set_path_and_query(uri, &path)?;
+							return Ok(());
+						}
+						let path = match route_type {
+							RouteType::Messages | RouteType::AnthropicTokenCount => format!(
+								"{}{}",
+								path_prefix.map_or(anthropic::DEFAULT_BASE_PATH, |prefix| {
+									prefix.trim_end_matches('/')
+								}),
+								anthropic::path_suffix(route_type)
+							),
+							_ => format!(
+								"{}{}",
+								path_prefix.map_or(openai::DEFAULT_BASE_PATH, |prefix| {
+									prefix.trim_end_matches('/')
+								}),
+								openai::path_suffix(route_type)
+							),
+						};
+						Self::set_path_and_query(uri, &path)?;
+						Ok(())
+					})?;
 					Ok(())
-				})?;
-				Ok(())
-			}),
+				})
+			},
 		}
 	}
 
@@ -1844,6 +1862,9 @@ impl AIProvider {
 		match self {
 			AIProvider::Gemini(_) => serde_json::to_vec(req).map_err(AIError::RequestMarshal),
 			AIProvider::Vertex(p) if p.is_gemini_model(Some(request_model)) => {
+				serde_json::to_vec(req).map_err(AIError::RequestMarshal)
+			},
+			AIProvider::Custom(p) if p.supports(custom::ProviderFormat::GeminiCountTokens) => {
 				serde_json::to_vec(req).map_err(AIError::RequestMarshal)
 			},
 			_ => Err(AIError::UnsupportedConversion(strng::format!(

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -884,7 +884,7 @@ impl AIProvider {
 				}
 				formats
 			},
-			AIProvider::Gemini(_) => vec![Completions, Embeddings],
+			AIProvider::Gemini(_) => vec![Completions, Embeddings, GeminiCountTokens],
 			AIProvider::Anthropic(_) => vec![Messages, AnthropicTokenCount],
 			AIProvider::Bedrock(p) => {
 				let mut formats = vec![Completions, Messages, Responses, Embeddings, Rerank];
@@ -899,6 +899,9 @@ impl AIProvider {
 				} else {
 					vec![Completions]
 				};
+				if p.is_gemini_model(request_model) {
+					formats.push(GeminiCountTokens);
+				}
 				formats.extend([Embeddings, Rerank]);
 				formats
 			},
@@ -1014,13 +1017,13 @@ impl AIProvider {
 			InputFormat::Embeddings => Embeddings,
 			InputFormat::Realtime => Realtime,
 			InputFormat::CountTokens => AnthropicTokenCount,
+			InputFormat::GeminiCountTokens => GeminiCountTokens,
 			InputFormat::Rerank => Rerank,
 			InputFormat::Detect
 			| InputFormat::Completions
 			| InputFormat::Messages
 			| InputFormat::Responses
-			| InputFormat::Gemini
-			| InputFormat::GeminiCountTokens => return None,
+			| InputFormat::Gemini => return None,
 		};
 		self
 			.supports_format(format, request_model)
@@ -2032,11 +2035,9 @@ impl AIProvider {
 		} else {
 			None
 		};
-		// Detect is raw passthrough and native Gemini countTokens has no upstream provider format
-		// to translate through (its provider support is checked by the render closure); both keep
-		// their client-facing route type upstream.
+		// Detect is raw passthrough and keeps its client-facing route type upstream.
 		let provider_format = match original_format {
-			InputFormat::Detect | InputFormat::GeminiCountTokens => None,
+			InputFormat::Detect => None,
 			_ => Some(
 				self
 					.non_chat_provider_format_for(original_format, request_model.as_deref())
@@ -2090,7 +2091,6 @@ impl AIProvider {
 			llm_request: llm_info,
 			upstream_route_type: match provider_format {
 				Some(format) => format.route_type(),
-				None if original_format == InputFormat::GeminiCountTokens => RouteType::GeminiCountTokens,
 				None => RouteType::Detect,
 			},
 		})

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -66,6 +66,18 @@ pub fn default_route_types() -> Arc<llm::Policy> {
 			),
 			(strng::new(":rawPredict"), llm::RouteType::Messages),
 			(strng::new(":streamRawPredict"), llm::RouteType::Messages),
+			(
+				strng::new(":generateContent"),
+				llm::RouteType::GeminiGenerateContent,
+			),
+			(
+				strng::new(":streamGenerateContent"),
+				llm::RouteType::GeminiGenerateContent,
+			),
+			(
+				strng::new(":countTokens"),
+				llm::RouteType::GeminiCountTokens,
+			),
 			(strng::new("/v1/responses"), llm::RouteType::Responses),
 			(strng::new("/v1/images/generations"), llm::RouteType::Detect),
 			(strng::new("/v1/images/edits"), llm::RouteType::Detect),
@@ -546,17 +558,20 @@ fn rewrite_uri_model(req: &mut Request, target: &str) -> RouterResult<()> {
 
 fn rewrite_path_model(path: &str, target: &str) -> Option<String> {
 	if path.ends_with(":streamRawPredict") || path.ends_with(":rawPredict") {
-		// Vertex: .../publishers/{publisher}/models/{model}:{rawPredict|streamRawPredict}
-		// Preserve the publisher from the path; only rewrite the model id. Matching only
-		// `publishers/anthropic` incorrectly dropped virtual-model rewrites for other publishers.
-		let (prefix, rest) = path.split_once("/publishers/")?;
-		let (publisher, after_publisher) = rest.split_once("/models/")?;
-		if publisher.is_empty() {
-			return None;
+		return rewrite_publishers_path_model(path, target);
+	}
+	if path.ends_with(":generateContent")
+		|| path.ends_with(":streamGenerateContent")
+		|| path.ends_with(":countTokens")
+	{
+		if path.contains("/publishers/") {
+			return rewrite_publishers_path_model(path, target);
 		}
-		let (_, suffix) = after_publisher.split_once(':')?;
+		// Gemini API: /v1beta/models/{model}:{suffix}
+		let (prefix, rest) = path.split_once("/models/")?;
+		let (_, suffix) = rest.split_once(':')?;
 		return Some(format!(
-			"{prefix}/publishers/{publisher}/models/{}:{suffix}",
+			"{prefix}/models/{}:{suffix}",
 			encode_model_path_segment(target)
 		));
 	}
@@ -576,6 +591,22 @@ fn rewrite_path_model(path: &str, target: &str) -> Option<String> {
 		}
 	}
 	None
+}
+
+fn rewrite_publishers_path_model(path: &str, target: &str) -> Option<String> {
+	// Vertex: .../publishers/{publisher}/models/{model}:{suffix}
+	// Preserve the publisher from the path; only rewrite the model id. Matching only
+	// `publishers/anthropic` incorrectly dropped virtual-model rewrites for other publishers.
+	let (prefix, rest) = path.split_once("/publishers/")?;
+	let (publisher, after_publisher) = rest.split_once("/models/")?;
+	if publisher.is_empty() {
+		return None;
+	}
+	let (_, suffix) = after_publisher.split_once(':')?;
+	Some(format!(
+		"{prefix}/publishers/{publisher}/models/{}:{suffix}",
+		encode_model_path_segment(target)
+	))
 }
 
 fn encode_model_path_segment(model: &str) -> String {
@@ -854,6 +885,117 @@ mod tests {
 	}
 
 	#[test]
+	fn rewrite_path_model_rewrites_vertex_gemini_paths() {
+		assert_eq!(
+			rewrite_path_model(
+				"/v1/projects/p/locations/global/publishers/google/models/virtual:generateContent",
+				"gemini-2.5-flash",
+			)
+			.as_deref(),
+			Some(
+				"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash:generateContent"
+			)
+		);
+		assert_eq!(
+			rewrite_path_model(
+				"/v1/projects/p/locations/global/publishers/google/models/virtual:streamGenerateContent",
+				"gemini-2.5-flash",
+			)
+			.as_deref(),
+			Some(
+				"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash:streamGenerateContent"
+			)
+		);
+		assert_eq!(
+			rewrite_path_model(
+				"/v1/projects/p/locations/global/publishers/google/models/virtual:countTokens",
+				"gemini-2.5-flash",
+			)
+			.as_deref(),
+			Some("/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash:countTokens")
+		);
+	}
+
+	#[test]
+	fn rewrite_path_model_rewrites_bare_gemini_api_paths() {
+		assert_eq!(
+			rewrite_path_model("/v1beta/models/virtual:generateContent", "gemini-2.5-pro").as_deref(),
+			Some("/v1beta/models/gemini-2.5-pro:generateContent")
+		);
+		assert_eq!(
+			rewrite_path_model(
+				"/v1beta/models/virtual:streamGenerateContent",
+				"gemini-2.5-pro"
+			)
+			.as_deref(),
+			Some("/v1beta/models/gemini-2.5-pro:streamGenerateContent")
+		);
+		assert_eq!(
+			rewrite_path_model("/v1beta/models/virtual:countTokens", "gemini-2.5-pro").as_deref(),
+			Some("/v1beta/models/gemini-2.5-pro:countTokens")
+		);
+	}
+
+	#[test]
+	fn rewrite_path_model_encodes_slashes_in_gemini_targets() {
+		// Vertex tuned/global endpoints are addressed by resource name, which must stay in a single
+		// path segment.
+		assert_eq!(
+			rewrite_path_model("/v1beta/models/virtual:generateContent", "tunedModels/abc").as_deref(),
+			Some("/v1beta/models/tunedModels%2Fabc:generateContent")
+		);
+		assert_eq!(
+			rewrite_path_model(
+				"/v1/projects/p/locations/global/publishers/google/models/virtual:generateContent",
+				"tunedModels/abc",
+			)
+			.as_deref(),
+			Some(
+				"/v1/projects/p/locations/global/publishers/google/models/tunedModels%2Fabc:generateContent"
+			)
+		);
+	}
+
+	#[test]
+	fn rewrite_path_model_ignores_gemini_shaped_paths_it_cannot_parse() {
+		// No `/models/` segment, and a publisher path missing its publisher: rewriting would
+		// fabricate a path, so both must no-op and leave the client's URI alone.
+		assert_eq!(
+			rewrite_path_model(
+				"/v1beta/tunedModels/virtual:generateContent",
+				"gemini-2.5-flash"
+			),
+			None
+		);
+		assert_eq!(
+			rewrite_path_model(
+				"/v1/projects/p/locations/global/publishers//models/virtual:countTokens",
+				"gemini-2.5-flash",
+			),
+			None
+		);
+		assert_eq!(
+			rewrite_path_model("/v1beta/models/virtual:embedContent", "gemini-2.5-flash"),
+			None
+		);
+	}
+
+	#[test]
+	fn rewrite_uri_model_preserves_alt_sse_on_gemini_streams() {
+		// The streaming route is only SSE because of `?alt=sse`; a virtual-model rewrite that
+		// dropped it would flip the upstream to the JSON-array variant.
+		let mut req = ::http::Request::builder()
+			.uri("http://example.com/v1beta/models/virtual:streamGenerateContent?alt=sse&key=abc")
+			.body(http::Body::empty())
+			.unwrap();
+		rewrite_uri_model(&mut req, "gemini-2.5-flash").expect("URI rewrites");
+		assert_eq!(
+			req.uri().to_string(),
+			"http://example.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse&key=abc"
+		);
+	}
+
+	#[test]
 	fn rewrite_uri_model_preserves_query() {
 		let mut req = ::http::Request::builder()
 			.uri("http://example.com/model/virtual/converse?trace=true")
@@ -915,6 +1057,127 @@ mod tests {
 				.await
 				.expect("decompressed request body"),
 			Bytes::from_static(body)
+		);
+	}
+
+	#[tokio::test]
+	async fn requested_model_reads_gemini_paths_without_touching_the_body() {
+		// The Gemini body carries no `model`, so the router has to take it from the path — and must
+		// leave the body untouched, since it is what reaches the upstream verbatim.
+		let body = br#"{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}"#;
+		for uri in [
+			"http://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+			"http://example.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+			"http://example.com/v1beta/models/gemini-2.5-flash:countTokens",
+			"http://example.com/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash:generateContent",
+		] {
+			let mut req = ::http::Request::builder()
+				.uri(uri)
+				.body(http::Body::from(body.as_slice()))
+				.unwrap();
+
+			let requested = requested_model(&mut req)
+				.await
+				.expect("the model rides the Gemini path");
+			assert_eq!(requested.model, "gemini-2.5-flash", "{uri}");
+			assert!(matches!(requested.location, RequestedModelLocation::Path));
+			assert_eq!(
+				http::read_body_with_limit(req.into_body(), 1024)
+					.await
+					.expect("request body"),
+				Bytes::from_static(body),
+				"{uri}"
+			);
+		}
+	}
+
+	#[test]
+	fn default_routes_resolve_gemini_suffixes() {
+		let policy = default_route_types();
+		assert_eq!(
+			policy.resolve_route("/v1beta/models/gemini-2.5-flash:generateContent"),
+			llm::RouteType::GeminiGenerateContent
+		);
+		assert_eq!(
+			policy.resolve_route("/v1beta/models/gemini-2.5-flash:streamGenerateContent"),
+			llm::RouteType::GeminiGenerateContent
+		);
+		assert_eq!(
+			policy.resolve_route("/v1beta/models/gemini-2.5-flash:countTokens"),
+			llm::RouteType::GeminiCountTokens
+		);
+		assert_eq!(
+			policy.resolve_route(
+				"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-pro:generateContent"
+			),
+			llm::RouteType::GeminiGenerateContent
+		);
+	}
+
+	#[test]
+	fn default_routes_resolve_gemini_stream_ignoring_query() {
+		// The dispatcher matches on `uri.path()`, so the `?alt=sse` the Gemini SDKs append to the
+		// streaming endpoint never reaches the suffix matcher.
+		let uri: ::http::Uri = "/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+			.parse()
+			.expect("valid uri");
+		assert_eq!(
+			default_route_types().resolve_route(uri.path()),
+			llm::RouteType::GeminiGenerateContent
+		);
+	}
+
+	#[test]
+	fn stream_generate_content_does_not_match_generate_content() {
+		// `:generateContent` is not a suffix of `:streamGenerateContent`, so the two entries are
+		// independent even before longest-suffix-first ordering applies. Point them at different
+		// route types so a mis-resolution would be visible.
+		let policy = llm::Policy {
+			routes: [
+				(strng::new(":generateContent"), llm::RouteType::Passthrough),
+				(
+					strng::new(":streamGenerateContent"),
+					llm::RouteType::GeminiGenerateContent,
+				),
+			]
+			.into_iter()
+			.collect(),
+			..Default::default()
+		};
+		assert_eq!(
+			policy.resolve_route("/v1beta/models/gemini-2.5-flash:streamGenerateContent"),
+			llm::RouteType::GeminiGenerateContent
+		);
+		assert_eq!(
+			policy.resolve_route("/v1beta/models/gemini-2.5-flash:generateContent"),
+			llm::RouteType::Passthrough
+		);
+	}
+
+	#[test]
+	fn default_routes_preserve_existing_suffixes() {
+		let policy = default_route_types();
+		assert_eq!(
+			policy.resolve_route("/v1/projects/p/locations/us/publishers/anthropic/models/m:rawPredict"),
+			llm::RouteType::Messages
+		);
+		assert_eq!(
+			policy.resolve_route(
+				"/v1/projects/p/locations/us/publishers/anthropic/models/m:streamRawPredict"
+			),
+			llm::RouteType::Messages
+		);
+		assert_eq!(
+			policy.resolve_route("/v1/messages"),
+			llm::RouteType::Messages
+		);
+		assert_eq!(
+			policy.resolve_route("/v1/chat/completions"),
+			llm::RouteType::Completions
+		);
+		assert_eq!(
+			policy.resolve_route("/v1/anything/else"),
+			llm::RouteType::Passthrough
 		);
 	}
 }

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -68,11 +68,11 @@ pub fn default_route_types() -> Arc<llm::Policy> {
 			(strng::new(":streamRawPredict"), llm::RouteType::Messages),
 			(
 				strng::new(":generateContent"),
-				llm::RouteType::GeminiGenerateContent,
+				llm::RouteType::GenerateContent,
 			),
 			(
 				strng::new(":streamGenerateContent"),
-				llm::RouteType::GeminiGenerateContent,
+				llm::RouteType::GenerateContent,
 			),
 			(
 				strng::new(":countTokens"),
@@ -1096,11 +1096,11 @@ mod tests {
 		let policy = default_route_types();
 		assert_eq!(
 			policy.resolve_route("/v1beta/models/gemini-2.5-flash:generateContent"),
-			llm::RouteType::GeminiGenerateContent
+			llm::RouteType::GenerateContent
 		);
 		assert_eq!(
 			policy.resolve_route("/v1beta/models/gemini-2.5-flash:streamGenerateContent"),
-			llm::RouteType::GeminiGenerateContent
+			llm::RouteType::GenerateContent
 		);
 		assert_eq!(
 			policy.resolve_route("/v1beta/models/gemini-2.5-flash:countTokens"),
@@ -1110,7 +1110,7 @@ mod tests {
 			policy.resolve_route(
 				"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-pro:generateContent"
 			),
-			llm::RouteType::GeminiGenerateContent
+			llm::RouteType::GenerateContent
 		);
 	}
 
@@ -1123,7 +1123,7 @@ mod tests {
 			.expect("valid uri");
 		assert_eq!(
 			default_route_types().resolve_route(uri.path()),
-			llm::RouteType::GeminiGenerateContent
+			llm::RouteType::GenerateContent
 		);
 	}
 
@@ -1137,7 +1137,7 @@ mod tests {
 				(strng::new(":generateContent"), llm::RouteType::Passthrough),
 				(
 					strng::new(":streamGenerateContent"),
-					llm::RouteType::GeminiGenerateContent,
+					llm::RouteType::GenerateContent,
 				),
 			]
 			.into_iter()
@@ -1146,7 +1146,7 @@ mod tests {
 		};
 		assert_eq!(
 			policy.resolve_route("/v1beta/models/gemini-2.5-flash:streamGenerateContent"),
-			llm::RouteType::GeminiGenerateContent
+			llm::RouteType::GenerateContent
 		);
 		assert_eq!(
 			policy.resolve_route("/v1beta/models/gemini-2.5-flash:generateContent"),

--- a/crates/agentgateway/src/llm/policy/streaming_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/streaming_guardrails.rs
@@ -271,6 +271,28 @@ impl GuardedSseBody {
 			{
 				return Some(text.to_string());
 			}
+			// Native Gemini: candidates[].content.parts[].text. `candidateCount` is client
+			// controlled, so reading only candidates[0] would let the client hide text from the
+			// guard in a second candidate. Concatenating every candidate is the conservative
+			// choice: the guard evaluates one text stream, and a window that contains all
+			// candidates can only match more than one that contains a subset — every substring of
+			// a single candidate is still contiguous in the concatenation. Thought parts are
+			// excluded, as they are on the non-streaming path (types::gemini::candidate_text).
+			if let Some(candidates) = v.get("candidates").and_then(|c| c.as_array()) {
+				return Some(
+					candidates
+						.iter()
+						.filter_map(|c| {
+							c.get("content")
+								.and_then(|c| c.get("parts"))
+								.and_then(|p| p.as_array())
+						})
+						.flatten()
+						.filter(|p| p.get("thought").and_then(serde_json::Value::as_bool) != Some(true))
+						.filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+						.collect(),
+				);
+			}
 		}
 		None
 	}
@@ -571,6 +593,129 @@ mod tests {
 		let bytes = guarded.collect().await.unwrap().to_bytes();
 		assert!(contains(&bytes, b"guardrail_blocked"));
 		assert!(!contains(&bytes, b"SSN"));
+	}
+
+	fn gemini_delta_bytes(text: &str, thought: &str) -> Bytes {
+		sse_bytes(&format!(
+			"{{\"candidates\":[{{\"content\":{{\"role\":\"model\",\"parts\":[{{\"text\":\"{}\",\"thought\":true}},{{\"text\":\"{}\"}}]}}}}]}}",
+			thought, text
+		))
+	}
+
+	#[tokio::test]
+	async fn test_gemini_sse_text_is_evaluated() {
+		let chunk1 = gemini_delta_bytes("my SSN", "planning the answer");
+		let chunk2 = gemini_delta_bytes(" is 123-45-6789", "still planning");
+		let body = make_body(vec![chunk1, chunk2]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(pattern_evaluator("SSN is"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"123-45-6789"));
+	}
+
+	fn gemini_candidates_bytes(candidates: serde_json::Value) -> Bytes {
+		sse_bytes(&serde_json::json!({ "candidates": candidates }).to_string())
+	}
+
+	#[tokio::test]
+	async fn test_gemini_sse_evaluates_every_candidate() {
+		// candidateCount is client-controlled: the guard-relevant text sits in candidates[1]
+		// behind a candidates[0] that only carries a thought part.
+		let chunk = gemini_candidates_bytes(serde_json::json!([
+			{ "content": { "role": "model", "parts": [{ "text": "planning", "thought": true }] } },
+			{ "content": { "role": "model", "parts": [{ "text": "my SSN is 123-45-6789" }] } }
+		]));
+		let body = make_body(vec![chunk]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(pattern_evaluator("SSN"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"123-45-6789"));
+	}
+
+	#[tokio::test]
+	async fn test_gemini_sse_scans_past_a_candidate_without_content() {
+		// A candidate can carry only a finishReason; that must not end the scan.
+		let chunk = gemini_candidates_bytes(serde_json::json!([
+			{ "finishReason": "STOP" },
+			{ "content": { "role": "model", "parts": [{ "text": "forbidden words" }] } }
+		]));
+		let body = make_body(vec![chunk]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(pattern_evaluator("forbidden"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(contains(&bytes, b"guardrail_blocked"));
+		assert!(!contains(&bytes, b"forbidden"));
+	}
+
+	fn text_delta(chunk: serde_json::Value) -> Option<String> {
+		GuardedSseBody::extract_text_delta(SseFrame::Event(Event {
+			id: None,
+			name: "message".into(),
+			data: Bytes::from(chunk.to_string()),
+		}))
+	}
+
+	#[test]
+	fn test_extract_text_delta_matches_one_arm_per_chunk_shape() {
+		assert_eq!(
+			text_delta(serde_json::json!({ "type": "response.output_text.delta", "delta": "a" })),
+			Some("a".to_string())
+		);
+		assert_eq!(
+			text_delta(serde_json::json!({ "choices": [{ "delta": { "content": "b" } }] })),
+			Some("b".to_string())
+		);
+		assert_eq!(
+			text_delta(serde_json::json!({ "type": "content_block_delta", "delta": { "text": "c" } })),
+			Some("c".to_string())
+		);
+		assert_eq!(
+			text_delta(serde_json::json!({
+				"candidates": [
+					{ "content": { "parts": [{ "text": "d" }] } },
+					{ "content": { "parts": [{ "text": "e" }, { "text": "skip", "thought": true }] } }
+				]
+			})),
+			Some("de".to_string())
+		);
+		assert_eq!(text_delta(serde_json::json!({ "usageMetadata": {} })), None);
+	}
+
+	#[tokio::test]
+	async fn test_gemini_sse_ignores_thought_parts() {
+		let chunk = gemini_delta_bytes("all good", "forbidden");
+		let body = make_body(vec![chunk.clone()]);
+
+		let guarded = GuardedSseBody::new(
+			body,
+			vec![Box::new(pattern_evaluator("forbidden"))],
+			1024 * 1024,
+			None,
+		);
+
+		let bytes = guarded.collect().await.unwrap().to_bytes();
+		assert!(bytes.starts_with(&chunk));
+		assert!(!contains(&bytes, b"guardrail_blocked"));
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -149,11 +149,11 @@ fn gemini_render_is_passthrough_with_unknown_fields() {
 		}],
 		"modelArmorConfig": { "promptTemplateName": "projects/p/locations/l/templates/t" }
 	});
-	let inner: types::vertex_gemini::GenerateContentRequest =
+	let inner: types::gemini::GenerateContentRequest =
 		serde_json::from_value(raw.clone()).expect("valid request");
 	let rendered = translation
 		.render_request(
-			types::ChatRequest::Gemini(Box::new(inner)),
+			types::ChatRequest::Gemini(inner),
 			&ChatRequestContext {
 				provider: &provider,
 				headers: &HeaderMap::new(),

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -75,14 +75,26 @@ fn gemini_inbound_selects_native_translation_only_for_gemini_upstreams() {
 			.output,
 		ChatFormat::VertexGemini
 	);
-	// Completions inbound on the Gemini API provider keeps the OpenAI-compat shim.
+	// Completions inbound on the Gemini API provider prefers our native conversion over the
+	// OpenAI-compat shim, matching Vertex with a Gemini model.
 	assert_eq!(
 		gemini
 			.chat_translation(InputFormat::Completions, Some("gemini-2.5-flash"))
 			.unwrap()
 			.output,
-		ChatFormat::OpenAICompletions
+		ChatFormat::VertexGemini
 	);
+	// Messages and Responses clients still ride the compat shim: there is no conversion from
+	// those formats to native Gemini.
+	for input in [InputFormat::Messages, InputFormat::Responses] {
+		assert_eq!(
+			gemini
+				.chat_translation(input, Some("gemini-2.5-flash"))
+				.unwrap()
+				.output,
+			ChatFormat::OpenAICompletions
+		);
+	}
 }
 
 #[test]

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -108,6 +108,114 @@ fn gemini_inbound_to_non_gemini_upstream_is_unsupported() {
 }
 
 #[test]
+fn custom_provider_generate_content_advertises_the_native_chat_format() {
+	let provider = custom_provider(custom::ProviderFormat::GenerateContent);
+
+	// Native Gemini input takes the direct passthrough.
+	assert_eq!(
+		provider
+			.chat_translation(InputFormat::Gemini, Some("gemini-2.5-flash"))
+			.unwrap()
+			.output,
+		ChatFormat::VertexGemini
+	);
+	// Completions input prefers our native conversion over the compat shim, exactly like
+	// Vertex with a Gemini model (the CHAT_TRANSLATIONS quirk).
+	assert_eq!(
+		provider
+			.chat_translation(InputFormat::Completions, Some("gemini-2.5-flash"))
+			.unwrap()
+			.output,
+		ChatFormat::VertexGemini
+	);
+
+	// A custom provider that does not declare the format has no Gemini-input translation.
+	let undeclared = custom_provider(custom::ProviderFormat::Completions);
+	assert!(
+		undeclared
+			.chat_translation(InputFormat::Gemini, Some("gemini-2.5-flash"))
+			.is_err()
+	);
+}
+
+#[tokio::test]
+async fn custom_provider_completions_inbound_renders_native_gemini() {
+	// With generateContent declared, the CHAT_TRANSLATIONS quirk applies to custom providers
+	// too: OpenAI-compat input converts to the native request, and the conversion must not
+	// assume a Vertex provider.
+	let provider = custom_provider(custom::ProviderFormat::GenerateContent);
+	let req = ::http::Request::builder()
+		.uri("/v1/chat/completions")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{"model": "gemini-2.5-flash", "messages": [{"role": "user", "content": "hello"}]}"#
+				.to_vec(),
+		))
+		.unwrap();
+
+	let RequestResult::Success {
+		request: mut forwarded,
+		llm_request,
+		upstream_route_type,
+	} = provider
+		.process_completions_request(&openai_test_backend_info(), None, req, false, &mut None)
+		.await
+		.expect("completions request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	assert_eq!(upstream_route_type, RouteType::GenerateContent);
+	assert!(matches!(
+		llm_request.provider_state,
+		Some(ProviderState::VertexGemini)
+	));
+
+	provider
+		.setup_request(
+			&mut forwarded,
+			upstream_route_type,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+	assert_eq!(
+		forwarded.uri().path(),
+		"/v1beta/models/gemini-2.5-flash:generateContent"
+	);
+
+	let body = forwarded.into_body().collect().await.unwrap().to_bytes();
+	let json: Value = serde_json::from_slice(&body).expect("forwarded body should be JSON");
+	assert!(json.get("contents").is_some(), "{json}");
+	assert!(json.get("messages").is_none(), "{json}");
+}
+
+#[test]
+fn custom_provider_declaring_gemini_count_tokens_renders_passthrough() {
+	// countTokens has no cross-provider conversion, so the render gate must accept exactly
+	// the providers that speak it natively, including a custom provider declaring it.
+	let req: types::gemini::CountTokensRequest =
+		serde_json::from_value(json!({"contents": [{"role": "user", "parts": [{"text": "hi"}]}]}))
+			.unwrap();
+
+	let provider = custom_provider(custom::ProviderFormat::GeminiCountTokens);
+	let body = provider
+		.render_gemini_count_tokens_request(&req, "gemini-2.5-flash")
+		.expect("declared format renders passthrough");
+	let json: Value = serde_json::from_slice(&body).unwrap();
+	assert!(json.get("contents").is_some(), "{json}");
+
+	let undeclared = custom_provider(custom::ProviderFormat::Completions);
+	assert!(
+		undeclared
+			.render_gemini_count_tokens_request(&req, "gemini-2.5-flash")
+			.is_err()
+	);
+}
+
+#[test]
 fn gemini_render_is_passthrough_with_unknown_fields() {
 	let provider = AIProvider::Vertex(vertex::Provider {
 		project_id: strng::new("test-project"),
@@ -2404,6 +2512,96 @@ fn setup_request_custom_path_override_wins_over_format_path() {
 		.expect("setup_request should succeed");
 
 	assert_eq!(req.uri().path(), "/override/messages");
+	assert_eq!(req.uri().query(), None);
+}
+
+#[test]
+fn setup_request_custom_generate_content_defaults_to_the_native_path() {
+	// A static configured path cannot carry the model or the streaming method, so the
+	// default for the native Gemini chat format is the canonical Gemini API shape.
+	let provider = custom_provider(custom::ProviderFormat::GenerateContent);
+	for (streaming, expected_path, expected_query) in [
+		(
+			false,
+			"/v1beta/models/gemini-2.5-flash:generateContent",
+			None,
+		),
+		(
+			true,
+			"/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+			Some("alt=sse"),
+		),
+	] {
+		let llm_request = LLMRequest {
+			input_tokens: None,
+			input_format: InputFormat::Gemini,
+			cache_convention: CacheTokenConvention::pending(),
+			request_model: "gemini-2.5-flash".into(),
+			provider: Default::default(),
+			streaming,
+			params: Default::default(),
+			prompt: None,
+			provider_state: Some(ProviderState::VertexGemini),
+		};
+		let mut req = crate::http::tests_common::request(
+			"https://gemini.example.com/v1beta/models/gemini-2.5-flash:generateContent",
+			http::Method::POST,
+			&[],
+		);
+
+		provider
+			.setup_request(
+				&mut req,
+				RouteType::GenerateContent,
+				Some(&llm_request),
+				None,
+				None,
+				false,
+			)
+			.expect("setup_request should succeed");
+
+		assert_eq!(req.uri().path(), expected_path, "streaming={streaming}");
+		assert_eq!(req.uri().query(), expected_query, "streaming={streaming}");
+	}
+}
+
+#[test]
+fn setup_request_custom_count_tokens_defaults_to_the_native_path() {
+	// Regression: with no configured path, countTokens used to fall through to the
+	// OpenAI default and land on /v1/chat/completions.
+	let provider = custom_provider(custom::ProviderFormat::GeminiCountTokens);
+	let llm_request = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::GeminiCountTokens,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: "gemini-2.5-flash".into(),
+		provider: Default::default(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+		provider_state: None,
+	};
+	let mut req = crate::http::tests_common::request(
+		"https://gemini.example.com/v1beta/models/gemini-2.5-flash:countTokens",
+		http::Method::POST,
+		&[],
+	);
+
+	provider
+		.setup_request(
+			&mut req,
+			RouteType::GeminiCountTokens,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+
+	assert_eq!(
+		req.uri().path(),
+		"/v1beta/models/gemini-2.5-flash:countTokens"
+	);
 	assert_eq!(req.uri().query(), None);
 }
 

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -47,6 +47,187 @@ fn vertex_gemini_uses_native_completions_and_compat_fallbacks() {
 }
 
 #[test]
+fn gemini_inbound_selects_native_translation_only_for_gemini_upstreams() {
+	let vertex = AIProvider::Vertex(vertex::Provider {
+		project_id: strng::new("test-project"),
+		model: None,
+		region: None,
+	});
+	assert_eq!(
+		vertex
+			.chat_translation(InputFormat::Gemini, Some("gemini-2.5-flash"))
+			.unwrap()
+			.output,
+		ChatFormat::VertexGemini
+	);
+	// Vertex with a non-Gemini model has no Gemini-input translation.
+	assert!(
+		vertex
+			.chat_translation(InputFormat::Gemini, Some("claude-sonnet-4-5"))
+			.is_err()
+	);
+
+	let gemini = AIProvider::Gemini(gemini::Provider { model: None });
+	assert_eq!(
+		gemini
+			.chat_translation(InputFormat::Gemini, Some("gemini-2.5-flash"))
+			.unwrap()
+			.output,
+		ChatFormat::VertexGemini
+	);
+	// Completions inbound on the Gemini API provider keeps the OpenAI-compat shim.
+	assert_eq!(
+		gemini
+			.chat_translation(InputFormat::Completions, Some("gemini-2.5-flash"))
+			.unwrap()
+			.output,
+		ChatFormat::OpenAICompletions
+	);
+}
+
+#[test]
+fn gemini_inbound_to_non_gemini_upstream_is_unsupported() {
+	let anthropic = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let Err(err) = anthropic.chat_translation(InputFormat::Gemini, Some("claude-opus-4")) else {
+		panic!("expected unsupported conversion");
+	};
+	assert!(matches!(err, AIError::UnsupportedConversion(_)));
+	let msg = err.to_string();
+	assert!(msg.contains("Gemini") && msg.contains("anthropic"), "{msg}");
+
+	let vertex = AIProvider::Vertex(vertex::Provider {
+		project_id: strng::new("test-project"),
+		model: None,
+		region: None,
+	});
+	let Err(err) = vertex.chat_translation(InputFormat::Gemini, Some("claude-sonnet-4-5")) else {
+		panic!("expected unsupported conversion");
+	};
+	let msg = err.to_string();
+	assert!(msg.contains("Gemini") && msg.contains("vertex"), "{msg}");
+}
+
+#[test]
+fn gemini_render_is_passthrough_with_unknown_fields() {
+	let provider = AIProvider::Vertex(vertex::Provider {
+		project_id: strng::new("test-project"),
+		model: None,
+		region: None,
+	});
+	let translation = provider
+		.chat_translation(InputFormat::Gemini, Some("gemini-2.5-flash"))
+		.unwrap();
+
+	let raw = json!({
+		"contents": [{
+			"role": "user",
+			"parts": [
+				{ "text": "describe this", "someNewPartField": 1 },
+				{ "inlineData": { "mimeType": "image/png", "data": "AAAA" } }
+			],
+			"someNewContentField": true
+		}],
+		"systemInstruction": { "parts": [{ "text": "be brief" }] },
+		"tools": [
+			{ "functionDeclarations": [{
+				"name": "get_weather",
+				"parameters": { "type": "object" },
+				"behavior": "BLOCKING"
+			}] },
+			{ "googleSearch": {} }
+		],
+		"toolConfig": { "functionCallingConfig": { "mode": "AUTO", "someNewKnob": 1 } },
+		"generationConfig": {
+			"temperature": 0.5,
+			"thinkingConfig": { "thinkingLevel": "high", "someNewField": true },
+			"responseModalities": ["TEXT"]
+		},
+		"safetySettings": [{
+			"category": "HARM_CATEGORY_HATE_SPEECH",
+			"threshold": "BLOCK_NONE",
+			"someNewField": 1
+		}],
+		"modelArmorConfig": { "promptTemplateName": "projects/p/locations/l/templates/t" }
+	});
+	let inner: types::vertex_gemini::GenerateContentRequest =
+		serde_json::from_value(raw.clone()).expect("valid request");
+	let rendered = translation
+		.render_request(
+			types::ChatRequest::Gemini(Box::new(inner)),
+			&ChatRequestContext {
+				provider: &provider,
+				headers: &HeaderMap::new(),
+				prompt_caching: None,
+			},
+		)
+		.expect("render");
+	assert!(matches!(
+		rendered.provider_state,
+		Some(ProviderState::VertexGemini)
+	));
+	let out: Value = serde_json::from_slice(&rendered.body).expect("valid body");
+	assert_eq!(
+		out, raw,
+		"render must pass unknown fields through untouched"
+	);
+}
+
+#[test]
+fn gemini_error_passes_google_shape_through() {
+	let provider = AIProvider::Vertex(vertex::Provider {
+		project_id: strng::new("test-project"),
+		model: None,
+		region: None,
+	});
+	let translation = provider
+		.chat_translation(InputFormat::Gemini, Some("gemini-2.5-flash"))
+		.unwrap();
+	assert!(matches!(
+		provider.chat_error_format(translation, Some("gemini-2.5-flash")),
+		ChatErrorFormat::Google
+	));
+
+	let body = bytes::Bytes::from_static(
+		br#"{"error":{"code":400,"message":"bad request","status":"INVALID_ARGUMENT"}}"#,
+	);
+	let out = translation
+		.error(
+			&body,
+			::http::StatusCode::BAD_REQUEST,
+			ChatErrorFormat::Google,
+		)
+		.expect("error translation");
+	assert_eq!(out, body);
+}
+
+#[test]
+fn strip_alt_query_removes_only_alt() {
+	let mut req = crate::http::tests_common::request(
+		"https://example.com/v1beta/models/m:streamGenerateContent?alt=sse&key=abc",
+		http::Method::POST,
+		&[],
+	);
+	strip_alt_query(&mut req);
+	assert_eq!(req.uri().query(), Some("key=abc"));
+
+	let mut req = crate::http::tests_common::request(
+		"https://example.com/v1beta/models/m:streamGenerateContent?alt=sse",
+		http::Method::POST,
+		&[],
+	);
+	strip_alt_query(&mut req);
+	assert_eq!(req.uri().query(), None);
+
+	let mut req = crate::http::tests_common::request(
+		"https://example.com/v1beta/models/m:generateContent?key=abc",
+		http::Method::POST,
+		&[],
+	);
+	strip_alt_query(&mut req);
+	assert_eq!(req.uri().query(), Some("key=abc"));
+}
+
+#[test]
 fn streaming_amend_on_drop_updates_local_rate_limit() {
 	let rate_limit =
 		crate::http::localratelimit::RateLimit::try_from(crate::http::localratelimit::RateLimitSpec {
@@ -788,6 +969,281 @@ async fn count_tokens_uses_native_endpoint_after_model_alias() {
 	assert_eq!(upstream_route_type, RouteType::AnthropicTokenCount);
 	assert_eq!(forwarded_json["model"], json!("claude-3-5-sonnet"));
 	assert_eq!(llm_request.request_model, "claude-3-5-sonnet");
+}
+
+fn gemini_generate_content_request(uri: &str) -> ::http::Request<Body> {
+	::http::Request::builder()
+		.uri(uri)
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+				"someNewTopLevelField": {"a": true}
+			}"#
+				.to_vec(),
+		))
+		.unwrap()
+}
+
+fn vertex_backend_info() -> crate::http::auth::BackendInfo {
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+	crate::http::auth::BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("aiplatform.googleapis.com", 443)),
+		inputs: setup_proxy_test("{}").unwrap().pi,
+	}
+}
+
+#[tokio::test]
+async fn gemini_generate_content_forwards_unknown_top_level_fields() {
+	let provider = AIProvider::Vertex(vertex::Provider {
+		model: None,
+		region: None,
+		project_id: strng::new("test-project"),
+	});
+	let req = gemini_generate_content_request(
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+	);
+
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		..
+	} = provider
+		.process_gemini_request(&vertex_backend_info(), None, req, false, &mut None)
+		.await
+		.expect("generateContent request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+	assert!(!llm_request.streaming);
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+	assert_eq!(forwarded_json["someNewTopLevelField"], json!({"a": true}));
+	assert_eq!(forwarded_json["contents"][0]["parts"][0]["text"], "hello");
+	assert!(
+		forwarded_json.get("model").is_none(),
+		"the model rides the path, not the body: {forwarded_json}"
+	);
+}
+
+#[tokio::test]
+async fn gemini_stream_without_alt_sse_is_rejected_with_google_shaped_400() {
+	let provider = AIProvider::Vertex(vertex::Provider {
+		model: None,
+		region: None,
+		project_id: strng::new("test-project"),
+	});
+	for uri in [
+		"https://example.com/v1beta/models/gemini-2.5-flash:streamGenerateContent",
+		"https://example.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=json",
+	] {
+		let RequestResult::Rejected(resp) = provider
+			.process_gemini_request(
+				&vertex_backend_info(),
+				None,
+				gemini_generate_content_request(uri),
+				false,
+				&mut None,
+			)
+			.await
+			.expect("the non-SSE streaming variant is a client error, not a gateway failure")
+		else {
+			panic!("expected a direct response for {uri}");
+		};
+
+		assert_eq!(resp.status(), ::http::StatusCode::BAD_REQUEST);
+		let body = resp.into_body().collect().await.unwrap().to_bytes();
+		let body: Value = serde_json::from_slice(&body).expect("error body should be JSON");
+		assert_eq!(body["error"]["code"], json!(400));
+		assert_eq!(body["error"]["status"], json!("INVALID_ARGUMENT"));
+		assert!(
+			body["error"]["message"]
+				.as_str()
+				.is_some_and(|m| m.contains("alt=sse")),
+			"{body}"
+		);
+	}
+}
+
+fn gemini_count_tokens_request(uri: &str) -> ::http::Request<Body> {
+	::http::Request::builder()
+		.uri(uri)
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			br#"{
+				"contents": [{"role": "user", "parts": [{"text": "hello"}]}],
+				"someNewField": {"a": true}
+			}"#
+				.to_vec(),
+		))
+		.unwrap()
+}
+
+#[tokio::test]
+async fn gemini_count_tokens_passes_body_through_on_vertex() {
+	use crate::http::auth::BackendInfo;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::Vertex(vertex::Provider {
+		model: None,
+		region: None,
+		project_id: strng::new("test-project"),
+	});
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("aiplatform.googleapis.com", 443)),
+		inputs,
+	};
+	let req =
+		gemini_count_tokens_request("https://example.com/v1beta/models/gemini-2.5-flash:countTokens");
+
+	let RequestResult::Success {
+		request: forwarded,
+		llm_request,
+		upstream_route_type,
+		..
+	} = provider
+		.process_gemini_count_tokens_request(&backend_info, None, req, &mut None)
+		.await
+		.expect("countTokens request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+
+	assert_eq!(upstream_route_type, RouteType::GeminiCountTokens);
+	assert_eq!(llm_request.input_format, InputFormat::GeminiCountTokens);
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+	assert!(!llm_request.streaming);
+
+	let forwarded_body = forwarded.collect().await.unwrap().to_bytes();
+	let forwarded_json: Value =
+		serde_json::from_slice(&forwarded_body).expect("forwarded request should be JSON");
+	assert_eq!(forwarded_json["someNewField"], json!({"a": true}));
+	assert_eq!(forwarded_json["contents"][0]["parts"][0]["text"], "hello");
+	assert!(
+		forwarded_json.get("model").is_none(),
+		"the model rides the path, not the body: {forwarded_json}"
+	);
+}
+
+#[tokio::test]
+async fn gemini_count_tokens_applies_model_alias_and_rewrites_upstream_path() {
+	use crate::http::auth::BackendInfo;
+	use crate::llm::policy::Policy;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::Gemini(gemini::Provider { model: None });
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from((gemini::DEFAULT_HOST_STR, 443)),
+		inputs,
+	};
+	let policy = Policy {
+		model_aliases: std::collections::HashMap::from([(
+			strng::new("fast"),
+			strng::new("gemini-2.5-flash"),
+		)]),
+		..Default::default()
+	};
+	let req = gemini_count_tokens_request("https://example.com/v1beta/models/fast:countTokens");
+
+	let RequestResult::Success {
+		request: mut forwarded,
+		llm_request,
+		upstream_route_type,
+		..
+	} = provider
+		.process_gemini_count_tokens_request(&backend_info, Some(&policy), req, &mut None)
+		.await
+		.expect("countTokens request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+	assert_eq!(llm_request.request_model, "gemini-2.5-flash");
+
+	provider
+		.setup_request(
+			&mut forwarded,
+			upstream_route_type,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+	assert_eq!(
+		forwarded.uri().path(),
+		"/v1beta/models/gemini-2.5-flash:countTokens"
+	);
+	assert_eq!(forwarded.uri().query(), None);
+	assert_eq!(
+		forwarded.uri().authority().map(|a| a.as_str()),
+		Some(gemini::DEFAULT_HOST_STR)
+	);
+}
+
+#[tokio::test]
+async fn gemini_count_tokens_on_non_gemini_upstream_is_unsupported() {
+	use crate::http::auth::BackendInfo;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let inputs = setup_proxy_test("{}").unwrap().pi;
+	let backend_info = BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("api.anthropic.com", 443)),
+		inputs,
+	};
+	let req =
+		gemini_count_tokens_request("https://example.com/v1beta/models/claude-opus-4:countTokens");
+
+	let err = provider
+		.process_gemini_count_tokens_request(&backend_info, None, req, &mut None)
+		.await
+		.expect_err("countTokens against a non-Gemini upstream must be rejected");
+	assert!(matches!(err, AIError::UnsupportedConversion(_)), "{err}");
+}
+
+#[test]
+fn gemini_count_tokens_response_reports_total_tokens() {
+	let provider = AIProvider::Gemini(gemini::Provider { model: None });
+	let req = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::GeminiCountTokens,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: "gemini-2.5-flash".into(),
+		provider: "gcp.gemini".into(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+		provider_state: None,
+	};
+	let body = br#"{"totalTokens":31,"promptTokensDetails":[{"modality":"TEXT","tokenCount":31}]}"#;
+	let buffered = BufferedResponse {
+		parts: ::http::Response::new(()).into_parts().0,
+		bytes: bytes::Bytes::from_static(body),
+		encoding: None,
+	};
+
+	let log = AsyncLog::<llm::LLMInfo>::default();
+	let resp = provider
+		.process_gemini_count_tokens_response(req, buffered, None, &log)
+		.expect("countTokens response should process");
+	assert_eq!(
+		log.take().expect("llm info").response.count_tokens,
+		Some(31)
+	);
+	assert!(resp.headers().get(header::CONTENT_LENGTH).is_none());
 }
 
 #[tokio::test]
@@ -1993,6 +2449,147 @@ fn assert_prefixed_host_override_path(
 	assert_eq!(req.uri().query(), expected_query);
 }
 
+fn native_gemini_llm_request(request_model: &str, streaming: bool) -> LLMRequest {
+	LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Gemini,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: request_model.into(),
+		provider: Default::default(),
+		streaming,
+		params: Default::default(),
+		prompt: None,
+		provider_state: Some(ProviderState::VertexGemini),
+	}
+}
+
+#[test]
+fn setup_request_gemini_native_builds_generate_content_path() {
+	let provider = AIProvider::Gemini(gemini::Provider { model: None });
+	let llm_request = native_gemini_llm_request("gemini-2.5-flash", false);
+	let mut req = crate::http::tests_common::request(
+		"https://example.com/v1beta/models/gemini-2.5-flash:generateContent",
+		http::Method::POST,
+		&[],
+	);
+
+	provider
+		.setup_request(
+			&mut req,
+			RouteType::Completions,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+
+	assert_eq!(
+		req.uri().authority().map(|a| a.as_str()),
+		Some("generativelanguage.googleapis.com")
+	);
+	assert_eq!(
+		req.uri().path(),
+		"/v1beta/models/gemini-2.5-flash:generateContent"
+	);
+	assert_eq!(req.uri().query(), None);
+}
+
+#[test]
+fn setup_request_gemini_native_streaming_adds_alt_sse_and_keeps_client_query() {
+	let provider = AIProvider::Gemini(gemini::Provider { model: None });
+	// The client's own alt=sse is dropped in favour of the path-provided one, while any other
+	// parameter such as key survives.
+	let llm_request = native_gemini_llm_request("models/gemini-2.5-flash", true);
+	let mut req = crate::http::tests_common::request(
+		"https://example.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse&key=abc",
+		http::Method::POST,
+		&[],
+	);
+
+	provider
+		.setup_request(
+			&mut req,
+			RouteType::Completions,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+
+	assert_eq!(
+		req.uri().path(),
+		"/v1beta/models/gemini-2.5-flash:streamGenerateContent"
+	);
+	assert_eq!(req.uri().query(), Some("alt=sse&key=abc"));
+}
+
+#[test]
+fn setup_request_gemini_native_streaming_keeps_client_alt_with_host_override() {
+	// hostOverride without pathPrefix forwards the client's URI verbatim, so alt=sse must
+	// still be there: the upstream would otherwise answer with the JSON-array variant.
+	for provider in [
+		AIProvider::Gemini(gemini::Provider { model: None }),
+		AIProvider::Vertex(vertex::Provider {
+			model: None,
+			region: None,
+			project_id: strng::new("test-project"),
+		}),
+	] {
+		let llm_request = native_gemini_llm_request("gemini-2.5-flash", true);
+		let mut req = crate::http::tests_common::request(
+			"https://proxy.example.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+			http::Method::POST,
+			&[],
+		);
+
+		provider
+			.setup_request(
+				&mut req,
+				RouteType::Completions,
+				Some(&llm_request),
+				None,
+				None,
+				true,
+			)
+			.expect("setup_request should succeed");
+
+		assert_eq!(
+			req.uri().path(),
+			"/v1beta/models/gemini-2.5-flash:streamGenerateContent"
+		);
+		assert_eq!(req.uri().query(), Some("alt=sse"));
+	}
+}
+
+#[test]
+fn setup_request_gemini_without_native_state_keeps_compat_path() {
+	let provider = AIProvider::Gemini(gemini::Provider { model: None });
+	let llm_request = LLMRequest {
+		provider_state: None,
+		..native_gemini_llm_request("gemini-2.5-flash", false)
+	};
+	let mut req = crate::http::tests_common::request(
+		"https://example.com/v1/chat/completions",
+		http::Method::POST,
+		&[],
+	);
+
+	provider
+		.setup_request(
+			&mut req,
+			RouteType::Completions,
+			Some(&llm_request),
+			None,
+			None,
+			false,
+		)
+		.expect("setup_request should succeed");
+
+	assert_eq!(req.uri().path(), "/v1beta/openai/chat/completions");
+}
+
 #[test]
 fn setup_request_gemini_applies_path_prefix_with_host_override() {
 	assert_prefixed_host_override_path(
@@ -2706,4 +3303,24 @@ fn fixed_providers_classify_by_family() {
 		),
 		CacheTokenConvention::InputIncludesCache,
 	);
+}
+
+#[test]
+fn query_requests_sse_matches_alt_query_parameter() {
+	let uri = |s: &str| s.parse::<::http::Uri>().expect("valid uri");
+	assert!(query_requests_sse(&uri(
+		"/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+	)));
+	assert!(query_requests_sse(&uri(
+		"/v1beta/models/gemini-2.5-flash:streamGenerateContent?key=abc&alt=sse"
+	)));
+	assert!(!query_requests_sse(&uri(
+		"/v1beta/models/gemini-2.5-flash:streamGenerateContent"
+	)));
+	assert!(!query_requests_sse(&uri(
+		"/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=json"
+	)));
+	assert!(!query_requests_sse(&uri(
+		"/v1beta/models/gemini-2.5-flash:streamGenerateContent?halt=sse"
+	)));
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2332,7 +2332,7 @@ async fn make_backend_call(
 				| RouteType::Messages
 				| RouteType::Responses
 				| RouteType::AnthropicTokenCount
-				| RouteType::GeminiGenerateContent
+				| RouteType::GenerateContent
 				| RouteType::GeminiCountTokens
 				| RouteType::Embeddings
 				| RouteType::Rerank
@@ -2395,7 +2395,7 @@ async fn make_backend_call(
 						))
 						.await
 						.map_err(ProxyError::AIRequest)?,
-						RouteType::GeminiGenerateContent => Box::pin(llm.provider.process_gemini_request(
+						RouteType::GenerateContent => Box::pin(llm.provider.process_gemini_request(
 							&backend_info,
 							llm_request_policies.llm.as_deref(),
 							req,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2332,6 +2332,8 @@ async fn make_backend_call(
 				| RouteType::Messages
 				| RouteType::Responses
 				| RouteType::AnthropicTokenCount
+				| RouteType::GeminiGenerateContent
+				| RouteType::GeminiCountTokens
 				| RouteType::Embeddings
 				| RouteType::Rerank
 				| RouteType::Detect => {
@@ -2393,6 +2395,25 @@ async fn make_backend_call(
 						))
 						.await
 						.map_err(ProxyError::AIRequest)?,
+						RouteType::GeminiGenerateContent => Box::pin(llm.provider.process_gemini_request(
+							&backend_info,
+							llm_request_policies.llm.as_deref(),
+							req,
+							llm.tokenize,
+							&mut log,
+						))
+						.await
+						.map_err(ProxyError::AIRequest)?,
+						RouteType::GeminiCountTokens => {
+							Box::pin(llm.provider.process_gemini_count_tokens_request(
+								&backend_info,
+								llm_request_policies.llm.as_deref(),
+								req,
+								&mut log,
+							))
+							.await
+							.map_err(ProxyError::AIRequest)?
+						},
 						RouteType::Detect => Box::pin(llm.provider.process_detect_request(
 							&backend_info,
 							llm_request_policies.llm.as_deref(),
@@ -2451,7 +2472,10 @@ async fn make_backend_call(
 
 					// Apply all policies (rate limits, prompt guards, enrichment)
 					// count_tokens skips policies (no tokens generated, no prompts to manipulate)
-					let response_policies = if route_type == RouteType::AnthropicTokenCount {
+					let response_policies = if matches!(
+						route_type,
+						RouteType::AnthropicTokenCount | RouteType::GeminiCountTokens
+					) {
 						LLMResponsePolicies::default()
 					} else {
 						Box::pin(

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -783,8 +783,19 @@ impl Store {
 		.collect::<Vec<_>>();
 		matches.push(RouteMatch {
 			path: agent::PathMatch::Regex(
-				regex::Regex::new(r"^/v(?:[0-9]+|[0-9]+beta[0-9]+)/projects/[^/]+/locations/[^/]+/publishers/[^/]+/models/[^/]+:(?:rawPredict|streamRawPredict)$")
+				regex::Regex::new(r"^/v(?:[0-9]+|[0-9]+beta[0-9]+)/projects/[^/]+/locations/[^/]+/publishers/[^/]+/models/[^/]+:(?:rawPredict|streamRawPredict|generateContent|streamGenerateContent|countTokens)$")
 					.expect("valid Vertex model route regex"),
+			),
+			method: None,
+			headers: vec![],
+			query: vec![],
+		});
+		matches.push(RouteMatch {
+			path: agent::PathMatch::Regex(
+				// Gemini API shape has no publisher segment and uses versions like v1beta;
+				// v1alpha is what the SDKs emit for preview features.
+				regex::Regex::new(r"^/v[0-9]+(?:(?:alpha|beta)[0-9]*)?/models/[^/]+:(?:generateContent|streamGenerateContent|countTokens)$")
+					.expect("valid Gemini model route regex"),
 			),
 			method: None,
 			headers: vec![],
@@ -2531,17 +2542,39 @@ mod tests {
 				.iter()
 				.all(|route_match| { !matches!(route_match.path, agent::PathMatch::PathPrefix(_)) })
 		);
-		let vertex = matches
+		let regexes = matches
 			.iter()
-			.find_map(|route_match| match &route_match.path {
+			.filter_map(|route_match| match &route_match.path {
 				agent::PathMatch::Regex(regex) => Some(regex),
 				_ => None,
 			})
-			.expect("Vertex raw-predict route match");
-		assert!(vertex.is_match(
+			.collect::<Vec<_>>();
+		let matches_any = |path: &str| regexes.iter().any(|regex| regex.is_match(path));
+		assert!(matches_any(
 			"/v1/projects/project/locations/us-central1/publishers/google/models/gemini:rawPredict"
 		));
-		assert!(!vertex.is_match("/arbitrary/v1/chat/completions"));
+		assert!(matches_any(
+			"/v1/projects/project/locations/global/publishers/google/models/gemini-2.5-flash:generateContent"
+		));
+		assert!(matches_any(
+			"/v1/projects/project/locations/global/publishers/google/models/gemini-2.5-flash:streamGenerateContent"
+		));
+		assert!(matches_any(
+			"/v1/projects/project/locations/global/publishers/google/models/gemini-2.5-flash:countTokens"
+		));
+		assert!(matches_any(
+			"/v1beta/models/gemini-2.5-flash:generateContent"
+		));
+		assert!(matches_any(
+			"/v1beta/models/gemini-2.5-flash:streamGenerateContent"
+		));
+		assert!(matches_any("/v1beta/models/gemini-2.5-flash:countTokens"));
+		assert!(matches_any(
+			"/v1alpha/models/gemini-2.5-flash:generateContent"
+		));
+		assert!(matches_any("/v1/models/gemini-2.5-flash:generateContent"));
+		assert!(!matches_any("/v1beta/models/gemini-2.5-flash:rawPredict"));
+		assert!(!matches_any("/arbitrary/v1/chat/completions"));
 	}
 
 	#[test]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -688,7 +688,7 @@ fn convert_route_type(proto_rt: i32, diagnostics: &mut Diagnostics) -> llm::Rout
 		Ok(ProtoRT::Embeddings) => llm::RouteType::Embeddings,
 		Ok(ProtoRT::Realtime) => llm::RouteType::Realtime,
 		Ok(ProtoRT::Rerank) => llm::RouteType::Rerank,
-		Ok(ProtoRT::GeminiGenerateContent) => llm::RouteType::GeminiGenerateContent,
+		Ok(ProtoRT::GenerateContent) => llm::RouteType::GenerateContent,
 		Ok(ProtoRT::GeminiCountTokens) => llm::RouteType::GeminiCountTokens,
 		Err(_) => {
 			diagnostics.add_warning(format!(
@@ -4741,7 +4741,7 @@ mod tests {
 					("/v1/detect".to_string(), RouteType::Detect as i32),
 					(
 						"/v1beta/models".to_string(),
-						RouteType::GeminiGenerateContent as i32,
+						RouteType::GenerateContent as i32,
 					),
 					(
 						"/v1beta/models:countTokens".to_string(),
@@ -4815,7 +4815,7 @@ mod tests {
 			);
 			assert_eq!(
 				ai_policy.routes.get("/v1beta/models"),
-				Some(&llm::RouteType::GeminiGenerateContent)
+				Some(&llm::RouteType::GenerateContent)
 			);
 			assert_eq!(
 				ai_policy.routes.get("/v1beta/models:countTokens"),

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -688,6 +688,8 @@ fn convert_route_type(proto_rt: i32, diagnostics: &mut Diagnostics) -> llm::Rout
 		Ok(ProtoRT::Embeddings) => llm::RouteType::Embeddings,
 		Ok(ProtoRT::Realtime) => llm::RouteType::Realtime,
 		Ok(ProtoRT::Rerank) => llm::RouteType::Rerank,
+		Ok(ProtoRT::GeminiGenerateContent) => llm::RouteType::GeminiGenerateContent,
+		Ok(ProtoRT::GeminiCountTokens) => llm::RouteType::GeminiCountTokens,
 		Err(_) => {
 			diagnostics.add_warning(format!(
 				"unknown proto RouteType value {}, defaulting to Completions",
@@ -4737,6 +4739,14 @@ mod tests {
 					),
 					("/v1/messages".to_string(), RouteType::Messages as i32),
 					("/v1/detect".to_string(), RouteType::Detect as i32),
+					(
+						"/v1beta/models".to_string(),
+						RouteType::GeminiGenerateContent as i32,
+					),
+					(
+						"/v1beta/models:countTokens".to_string(),
+						RouteType::GeminiCountTokens as i32,
+					),
 				]
 				.into_iter()
 				.collect(),
@@ -4790,7 +4800,7 @@ mod tests {
 			assert!(post_transformation_policy.get("max_tokens").is_some());
 
 			// Verify routes conversion
-			assert_eq!(ai_policy.routes.len(), 3);
+			assert_eq!(ai_policy.routes.len(), 5);
 			assert_eq!(
 				ai_policy.routes.get("/v1/chat/completions"),
 				Some(&llm::RouteType::Completions)
@@ -4802,6 +4812,14 @@ mod tests {
 			assert_eq!(
 				ai_policy.routes.get("/v1/detect"),
 				Some(&llm::RouteType::Detect)
+			);
+			assert_eq!(
+				ai_policy.routes.get("/v1beta/models"),
+				Some(&llm::RouteType::GeminiGenerateContent)
+			);
+			assert_eq!(
+				ai_policy.routes.get("/v1beta/models:countTokens"),
+				Some(&llm::RouteType::GeminiCountTokens)
 			);
 		} else {
 			panic!("Expected AI policy variant");

--- a/crates/agentgateway/src/types/local_tests/llm_provider_reference_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_provider_reference_normalized.snap
@@ -140,9 +140,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -169,9 +169,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []

--- a/crates/agentgateway/src/types/local_tests/llm_provider_reference_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_provider_reference_normalized.snap
@@ -139,7 +139,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -165,7 +168,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -425,7 +425,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -451,7 +454,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -480,7 +486,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -506,7 +515,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -532,7 +544,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -558,7 +573,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []

--- a/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_simple_normalized.snap
@@ -426,9 +426,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -455,9 +455,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -487,9 +487,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -516,9 +516,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -545,9 +545,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -574,9 +574,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
@@ -126,7 +126,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -152,7 +155,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -173,7 +179,10 @@ backends:
                   /v1/responses: responses
                   /v1/responses/compact: detect
                   /v2/rerank: rerank
+                  ":countTokens": geminiCountTokens
+                  ":generateContent": geminiGenerateContent
                   ":rawPredict": messages
+                  ":streamGenerateContent": geminiGenerateContent
                   ":streamRawPredict": messages
               routing:
                 conditional:
@@ -199,7 +208,10 @@ backends:
                   /v1/responses: responses
                   /v1/responses/compact: detect
                   /v2/rerank: rerank
+                  ":countTokens": geminiCountTokens
+                  ":generateContent": geminiGenerateContent
                   ":rawPredict": messages
+                  ":streamGenerateContent": geminiGenerateContent
                   ":streamRawPredict": messages
               routing:
                 conditional:

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_conditional_normalized.snap
@@ -127,9 +127,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -156,9 +156,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -180,9 +180,9 @@ backends:
                   /v1/responses/compact: detect
                   /v2/rerank: rerank
                   ":countTokens": geminiCountTokens
-                  ":generateContent": geminiGenerateContent
+                  ":generateContent": generateContent
                   ":rawPredict": messages
-                  ":streamGenerateContent": geminiGenerateContent
+                  ":streamGenerateContent": generateContent
                   ":streamRawPredict": messages
               routing:
                 conditional:
@@ -209,9 +209,9 @@ backends:
                   /v1/responses/compact: detect
                   /v2/rerank: rerank
                   ":countTokens": geminiCountTokens
-                  ":generateContent": geminiGenerateContent
+                  ":generateContent": generateContent
                   ":rawPredict": messages
-                  ":streamGenerateContent": geminiGenerateContent
+                  ":streamGenerateContent": generateContent
                   ":streamRawPredict": messages
               routing:
                 conditional:

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
@@ -214,9 +214,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -243,9 +243,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -267,9 +267,9 @@ backends:
                   /v1/responses/compact: detect
                   /v2/rerank: rerank
                   ":countTokens": geminiCountTokens
-                  ":generateContent": geminiGenerateContent
+                  ":generateContent": generateContent
                   ":rawPredict": messages
-                  ":streamGenerateContent": geminiGenerateContent
+                  ":streamGenerateContent": generateContent
                   ":streamRawPredict": messages
               routing:
                 failover:

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_failover_normalized.snap
@@ -213,7 +213,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -239,7 +242,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -260,7 +266,10 @@ backends:
                   /v1/responses: responses
                   /v1/responses/compact: detect
                   /v2/rerank: rerank
+                  ":countTokens": geminiCountTokens
+                  ":generateContent": geminiGenerateContent
                   ":rawPredict": messages
+                  ":streamGenerateContent": geminiGenerateContent
                   ":streamRawPredict": messages
               routing:
                 failover:

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
@@ -160,9 +160,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -189,9 +189,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -218,9 +218,9 @@ backends:
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
                     ":countTokens": geminiCountTokens
-                    ":generateContent": geminiGenerateContent
+                    ":generateContent": generateContent
                     ":rawPredict": messages
-                    ":streamGenerateContent": geminiGenerateContent
+                    ":streamGenerateContent": generateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -242,9 +242,9 @@ backends:
                   /v1/responses/compact: detect
                   /v2/rerank: rerank
                   ":countTokens": geminiCountTokens
-                  ":generateContent": geminiGenerateContent
+                  ":generateContent": generateContent
                   ":rawPredict": messages
-                  ":streamGenerateContent": geminiGenerateContent
+                  ":streamGenerateContent": generateContent
                   ":streamRawPredict": messages
               routing:
                 weighted:

--- a/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
+++ b/crates/agentgateway/src/types/local_tests/llm_virtual_model_normalized.snap
@@ -159,7 +159,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -185,7 +188,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -211,7 +217,10 @@ backends:
                     /v1/responses: responses
                     /v1/responses/compact: detect
                     /v2/rerank: rerank
+                    ":countTokens": geminiCountTokens
+                    ":generateContent": geminiGenerateContent
                     ":rawPredict": messages
+                    ":streamGenerateContent": geminiGenerateContent
                     ":streamRawPredict": messages
                 authorization: ~
               backendPolicies: []
@@ -232,7 +241,10 @@ backends:
                   /v1/responses: responses
                   /v1/responses/compact: detect
                   /v2/rerank: rerank
+                  ":countTokens": geminiCountTokens
+                  ":generateContent": geminiGenerateContent
                   ":rawPredict": messages
+                  ":streamGenerateContent": geminiGenerateContent
                   ":streamRawPredict": messages
               routing:
                 weighted:

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -31,6 +31,75 @@ fn join_tool_call_id(base: String, signature: Option<&str>) -> String {
 	}
 }
 
+/// Passthrough for native Gemini inbound: forward the `:streamGenerateContent?alt=sse` SSE
+/// bytes untouched while extracting usage for telemetry. Gemini attaches cumulative
+/// `usageMetadata` to chunks with the full totals on the final event, so updating on every
+/// chunk leaves the last event's counts in the log even on early client disconnect.
+pub fn passthrough_stream(
+	b: axum_core::body::Body,
+	buffer_limit: usize,
+	log: crate::StreamingUsageGuard,
+	log_content: crate::LogContentFields,
+) -> axum_core::body::Body {
+	use std::time::Instant;
+	let mut saw_token = false;
+	crate::parse::sse::json_passthrough::<vg::GenerateContentResponse>(b, buffer_limit, move |f| {
+		// Gemini never sends a [DONE] sentinel, so f(None) does not fire; all bookkeeping
+		// happens per-chunk and the guard flushes on drop.
+		let Some(Ok(chunk)) = f else {
+			return;
+		};
+		if !saw_token {
+			saw_token = true;
+			log.update(|r| r.response.first_token = Some(Instant::now()));
+		}
+		if let Some(m) = &chunk.model_version {
+			log.update(|r| {
+				if r.response.provider_model.is_none() {
+					r.response.provider_model = Some(strng::new(m));
+				}
+			});
+		}
+		if let Some(um) = &chunk.usage_metadata {
+			let (prompt, completion, total) = um.counts();
+			log.update(|r| {
+				r.response.input_tokens = Some(prompt);
+				r.response.output_tokens = Some(completion);
+				r.response.total_tokens = Some(total);
+				r.response.cached_input_tokens = um.cached_content_token_count;
+				r.response.reasoning_tokens = um.thoughts_token_count;
+			});
+		}
+		if log_content.completion {
+			let text: String = chunk
+				.candidates
+				.first()
+				.and_then(|c| c.content.as_ref())
+				.map(|c| {
+					c.parts
+						.iter()
+						.filter_map(|p| match p {
+							vg::Part::Text(t) if t.thought != Some(true) => Some(t.text.as_str()),
+							_ => None,
+						})
+						.collect()
+				})
+				.unwrap_or_default();
+			if !text.is_empty() {
+				log.update(|r| {
+					let completion = r
+						.response
+						.completion
+						.get_or_insert_with(|| vec![String::new()]);
+					if let Some(first) = completion.first_mut() {
+						first.push_str(&text);
+					}
+				});
+			}
+		}
+	})
+}
+
 pub mod from_completions {
 	use serde::Deserialize;
 	use serde_json::{Value, json};
@@ -170,6 +239,7 @@ pub mod from_completions {
 			safety_settings,
 			cached_content,
 			labels,
+			rest: Default::default(),
 		})
 	}
 
@@ -477,6 +547,7 @@ pub mod from_completions {
 					.and_then(Value::as_str)
 					.map(str::to_string),
 				parameters: f.get("parameters").map(normalize_gemini_schema),
+				rest: Default::default(),
 			})
 			.collect();
 		if decls.is_empty() {
@@ -484,6 +555,7 @@ pub mod from_completions {
 		} else {
 			vec![vg::Tool {
 				function_declarations: decls,
+				rest: Default::default(),
 			}]
 		}
 	}
@@ -513,12 +585,14 @@ pub mod from_completions {
 				vg::FunctionCallingConfig {
 					mode: Some("ANY".into()),
 					allowed_function_names: name.map(|n| vec![n.to_string()]).unwrap_or_default(),
+					rest: Default::default(),
 				}
 			},
 			_ => return None,
 		};
 		Some(vg::ToolConfig {
 			function_calling_config: Some(cfg),
+			rest: Default::default(),
 		})
 	}
 
@@ -556,6 +630,7 @@ pub mod from_completions {
 			response_mime_type,
 			response_schema,
 			thinking_config,
+			rest: Default::default(),
 		};
 
 		if cfg == vg::GenerationConfig::default() {
@@ -925,6 +1000,7 @@ pub mod from_completions {
 				thinking_level: Some(level.into()),
 				thinking_budget: None,
 				include_thoughts: Some(true),
+				rest: Default::default(),
 			})
 		} else {
 			// Gemini 2.5 takes the shared conservative budget scale. Some models cap the
@@ -935,6 +1011,7 @@ pub mod from_completions {
 				thinking_level: None,
 				thinking_budget: Some(budget),
 				include_thoughts: Some(true),
+				rest: Default::default(),
 			})
 		}
 	}
@@ -1345,7 +1422,7 @@ pub mod to_completions {
 				});
 			}
 			if let Some(um) = &chunk.usage_metadata {
-				let (prompt, completion, total) = usage_counts(um);
+				let (prompt, completion, total) = um.counts();
 				log.update(|r| {
 					r.response.input_tokens = Some(prompt);
 					r.response.output_tokens = Some(completion);
@@ -1419,17 +1496,8 @@ pub mod to_completions {
 		parse::sse::append_done_on_success(body)
 	}
 
-	/// Prompt, completion, and total token counts from Gemini usage metadata
-	/// (total falls back to prompt + completion when absent).
-	fn usage_counts(um: &vg::UsageMetadata) -> (u64, u64, u64) {
-		let prompt = um.prompt_token_count.unwrap_or(0);
-		let completion = um.candidates_token_count.unwrap_or(0);
-		let total = um.total_token_count.unwrap_or(prompt + completion);
-		(prompt, completion, total)
-	}
-
 	fn build_usage(um: &vg::UsageMetadata) -> completions::Usage {
-		let (prompt, completion, total) = usage_counts(um);
+		let (prompt, completion, total) = um.counts();
 		completions::Usage {
 			prompt_tokens: prompt as u32,
 			completion_tokens: completion as u32,

--- a/crates/llm/src/conversion/vertex_gemini_tests.rs
+++ b/crates/llm/src/conversion/vertex_gemini_tests.rs
@@ -1332,3 +1332,219 @@ fn streaming_usage_suppressed_on_interim_content_chunks() {
 	assert_eq!(c2["usage"]["total_tokens"], 7);
 	assert_eq!(c2["choices"][0]["finish_reason"], "stop");
 }
+
+// ---------- Native Gemini inbound: SSE passthrough with usage extraction ----------
+
+mod passthrough {
+	use std::sync::{Arc, Mutex};
+
+	use http_body_util::BodyExt;
+
+	use super::*;
+	use crate::{
+		CacheTokenConvention, InputFormat, LLMInfo, LLMRequest, LLMResponse, LogContentFields,
+		StreamingUsageGuard, StreamingUsageReporter,
+	};
+
+	struct Capture(Arc<Mutex<LLMInfo>>);
+
+	impl StreamingUsageReporter for Capture {
+		fn update(&self, f: &mut dyn FnMut(&mut LLMInfo)) {
+			f(&mut self.0.lock().unwrap())
+		}
+		fn report_usage(&mut self) {}
+	}
+
+	fn captured_info() -> Arc<Mutex<LLMInfo>> {
+		Arc::new(Mutex::new(LLMInfo {
+			request: LLMRequest {
+				input_tokens: None,
+				input_format: InputFormat::Gemini,
+				cache_convention: CacheTokenConvention::pending(),
+				request_model: "gemini-2.5-flash".into(),
+				provider: "gcp.vertex_ai".into(),
+				streaming: true,
+				params: Default::default(),
+				prompt: None,
+				provider_state: None,
+			},
+			response: LLMResponse::default(),
+		}))
+	}
+
+	#[tokio::test]
+	async fn passthrough_stream_forwards_bytes_and_extracts_final_usage() {
+		// Cumulative usageMetadata on every chunk; the last SSE event carries the totals.
+		let input = concat!(
+			"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"reason\",\"thought\":true},{\"text\":\"Hel\"}]}}],",
+			"\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":1,\"totalTokenCount\":8},",
+			"\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"r1\",\"someNewField\":true}\n\n",
+			"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"lo\"}]},\"finishReason\":\"STOP\"}],",
+			"\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":4,\"totalTokenCount\":13,\"thoughtsTokenCount\":2},",
+			"\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"r1\"}\n\n",
+		);
+		let captured = captured_info();
+		let out = passthrough_stream(
+			axum_core::body::Body::from(input),
+			1024 * 1024,
+			StreamingUsageGuard::new(Box::new(Capture(captured.clone()))),
+			LogContentFields {
+				completion: true,
+				tool_calls: false,
+			},
+		)
+		.collect()
+		.await
+		.expect("collect stream")
+		.to_bytes();
+
+		assert_eq!(
+			out.as_ref(),
+			input.as_bytes(),
+			"stream must pass through byte-for-byte"
+		);
+		let info = captured.lock().unwrap();
+		assert_eq!(info.response.input_tokens, Some(7));
+		assert_eq!(info.response.output_tokens, Some(4), "last event wins");
+		assert_eq!(info.response.total_tokens, Some(13));
+		assert_eq!(info.response.reasoning_tokens, Some(2));
+		assert_eq!(
+			info.response.provider_model.as_deref(),
+			Some("gemini-2.5-flash")
+		);
+		assert!(info.response.first_token.is_some());
+		assert_eq!(
+			info.response.completion,
+			Some(vec!["Hello".to_string()]),
+			"visible text accumulates across chunks, thought text excluded"
+		);
+	}
+
+	#[tokio::test]
+	async fn passthrough_stream_keeps_usage_from_before_disconnect() {
+		// Simulates an early cut: only the first (interim) event arrives.
+		let input = concat!(
+			"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"Hi\"}]}}],",
+			"\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":1,\"totalTokenCount\":8}}\n\n",
+		);
+		let captured = captured_info();
+		let out = passthrough_stream(
+			axum_core::body::Body::from(input),
+			1024 * 1024,
+			StreamingUsageGuard::new(Box::new(Capture(captured.clone()))),
+			LogContentFields::default(),
+		)
+		.collect()
+		.await
+		.expect("collect stream")
+		.to_bytes();
+
+		assert_eq!(out.as_ref(), input.as_bytes());
+		let info = captured.lock().unwrap();
+		assert_eq!(info.response.input_tokens, Some(7));
+		assert_eq!(info.response.output_tokens, Some(1));
+		assert_eq!(info.response.total_tokens, Some(8));
+		assert_eq!(
+			info.response.completion, None,
+			"completion logging disabled"
+		);
+	}
+
+	fn body_from_frames(frames: &[&str]) -> axum_core::body::Body {
+		let frames: Vec<Result<bytes::Bytes, std::convert::Infallible>> = frames
+			.iter()
+			.map(|f| Ok(bytes::Bytes::copy_from_slice(f.as_bytes())))
+			.collect();
+		axum_core::body::Body::from_stream(futures_util::stream::iter(frames))
+	}
+
+	async fn run_passthrough(
+		body: axum_core::body::Body,
+		captured: &Arc<Mutex<LLMInfo>>,
+	) -> bytes::Bytes {
+		passthrough_stream(
+			body,
+			1024 * 1024,
+			StreamingUsageGuard::new(Box::new(Capture(captured.clone()))),
+			LogContentFields {
+				completion: true,
+				tool_calls: false,
+			},
+		)
+		.collect()
+		.await
+		.expect("collect stream")
+		.to_bytes()
+	}
+
+	/// Real Vertex chunking splits SSE events across TCP frames; the passthrough must reassemble
+	/// events for usage extraction without altering what the client receives.
+	#[tokio::test]
+	async fn passthrough_stream_reassembles_events_split_across_frames() {
+		let frames = [
+			"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"Hel\"}]}}],",
+			"\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":1,\"totalTokenCount\":8},",
+			"\"modelVersion\":\"gemini-2.5-flash\"}\n",
+			"\ndata: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[",
+			"{\"functionCall\":{\"name\":\"get_weather\",\"id\":\"fc_1\",\"args\":{\"city\":\"Berlin\"}},",
+			"\"thoughtSignature\":\"sig\"},{\"text\":\"lo\"}]},\"finishReason\":\"STOP\"}],",
+			"\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":5,\"totalTokenCount\":12}}\n\n",
+		];
+		let captured = captured_info();
+		let out = run_passthrough(body_from_frames(&frames), &captured).await;
+
+		assert_eq!(out.as_ref(), frames.concat().as_bytes());
+		let info = captured.lock().unwrap();
+		assert_eq!(info.response.output_tokens, Some(5));
+		assert_eq!(info.response.total_tokens, Some(12));
+		assert_eq!(info.response.completion, Some(vec!["Hello".to_string()]));
+	}
+
+	/// An unparseable event must not poison the stream: the bytes still reach the client and the
+	/// usage from the events around it is still recorded.
+	#[tokio::test]
+	async fn passthrough_stream_tolerates_malformed_events() {
+		let input = concat!(
+			"data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"Hi\"}]}}],",
+			"\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":1,\"totalTokenCount\":8}}\n\n",
+			"data: {not json at all\n\n",
+			"data: {\"candidates\":[{\"finishReason\":\"STOP\"}],",
+			"\"usageMetadata\":{\"promptTokenCount\":7,\"candidatesTokenCount\":2,\"totalTokenCount\":9}}\n\n",
+		);
+		let captured = captured_info();
+		let out = run_passthrough(axum_core::body::Body::from(input), &captured).await;
+
+		assert_eq!(out.as_ref(), input.as_bytes());
+		let info = captured.lock().unwrap();
+		assert_eq!(info.response.total_tokens, Some(9), "last valid event wins");
+		assert_eq!(info.response.completion, Some(vec!["Hi".to_string()]));
+	}
+
+	/// A body that never completes an SSE event — the JSON-array variant Google serves without
+	/// `alt=sse`, or a stream cut mid-event — surfaces as a stream error at EOF rather than as a
+	/// silently-truncated success. Same strict `json_passthrough` behaviour as the completions,
+	/// messages, and responses passthroughs; requests are what keep it unreachable, since
+	/// `process_gemini_request` rejects `:streamGenerateContent` without `alt=sse` with a 400.
+	#[tokio::test]
+	async fn passthrough_stream_errors_on_bodies_that_are_not_sse() {
+		let non_sse = r#"[{"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]}}]}]"#;
+		let truncated = "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\"";
+		for input in [non_sse, truncated] {
+			let captured = captured_info();
+			let err = passthrough_stream(
+				axum_core::body::Body::from(input),
+				1024 * 1024,
+				StreamingUsageGuard::new(Box::new(Capture(captured.clone()))),
+				LogContentFields::default(),
+			)
+			.collect()
+			.await
+			.expect_err("a body with no complete SSE event must not report success");
+			assert!(
+				err.to_string().contains("unexpected end of stream"),
+				"{err}"
+			);
+			assert_eq!(captured.lock().unwrap().response.total_tokens, None);
+		}
+	}
+}

--- a/crates/llm/src/conversion/vertex_gemini_tests.rs
+++ b/crates/llm/src/conversion/vertex_gemini_tests.rs
@@ -1160,19 +1160,20 @@ fn usage_maps_cached_and_reasoning_tokens() {
 
 #[test]
 fn cel_usage_fields_match_usage_metadata() {
-	// The CEL/log token fields (via to_llm_response) must equal Gemini's usageMetadata exactly,
-	// so rate limiting and telemetry see native counts rather than shim numbers.
+	// The CEL/log token fields (via to_llm_response) come from Gemini's usageMetadata, with
+	// output normalized to the cross-provider convention: candidates + thoughts (Gemini
+	// reports them disjointly, other providers include reasoning in output).
 	let r = llm_resp(json!({
 		"candidates": [{ "content": { "role": "model", "parts": [{ "text": "x" }] },
 			"finishReason": "STOP" }],
 		"usageMetadata": {
-			"promptTokenCount": 100, "candidatesTokenCount": 50, "totalTokenCount": 150,
+			"promptTokenCount": 100, "candidatesTokenCount": 50, "totalTokenCount": 170,
 			"cachedContentTokenCount": 30, "thoughtsTokenCount": 20
 		}
 	}));
 	assert_eq!(r.input_tokens, Some(100));
-	assert_eq!(r.output_tokens, Some(50));
-	assert_eq!(r.total_tokens, Some(150));
+	assert_eq!(r.output_tokens, Some(70));
+	assert_eq!(r.total_tokens, Some(170));
 	assert_eq!(r.cached_input_tokens, Some(30));
 	assert_eq!(r.reasoning_tokens, Some(20));
 }
@@ -1291,7 +1292,8 @@ fn streaming_trailing_usage_chunk_has_empty_choices() {
 	.unwrap();
 	assert!(c["choices"].as_array().unwrap().is_empty());
 	assert_eq!(c["usage"]["prompt_tokens"], 5);
-	assert_eq!(c["usage"]["completion_tokens"], 2);
+	// completion_tokens includes thoughts (OpenAI semantics); the breakdown stays in details.
+	assert_eq!(c["usage"]["completion_tokens"], 3);
 	assert_eq!(c["usage"]["total_tokens"], 7);
 	assert_eq!(
 		c["usage"]["completion_tokens_details"]["reasoning_tokens"],
@@ -1405,7 +1407,11 @@ mod passthrough {
 		);
 		let info = captured.lock().unwrap();
 		assert_eq!(info.response.input_tokens, Some(7));
-		assert_eq!(info.response.output_tokens, Some(4), "last event wins");
+		assert_eq!(
+			info.response.output_tokens,
+			Some(6),
+			"last event wins; candidates + thoughts"
+		);
 		assert_eq!(info.response.total_tokens, Some(13));
 		assert_eq!(info.response.reasoning_tokens, Some(2));
 		assert_eq!(

--- a/crates/llm/src/custom.rs
+++ b/crates/llm/src/custom.rs
@@ -208,6 +208,7 @@ pub enum ProviderFormat {
 	Responses,
 	Embeddings,
 	AnthropicTokenCount,
+	GenerateContent,
 	GeminiCountTokens,
 	Realtime,
 	Rerank,
@@ -221,13 +222,11 @@ impl ProviderFormat {
 			RouteType::Responses => Self::Responses,
 			RouteType::Embeddings => Self::Embeddings,
 			RouteType::AnthropicTokenCount => Self::AnthropicTokenCount,
+			RouteType::GenerateContent => Self::GenerateContent,
 			RouteType::GeminiCountTokens => Self::GeminiCountTokens,
 			RouteType::Realtime => Self::Realtime,
 			RouteType::Rerank => Self::Rerank,
 			RouteType::Models | RouteType::Passthrough | RouteType::Detect => return None,
-			// TODO: custom providers have no way to advertise the native Gemini chat format yet
-			// (it is a ChatFormat, not a ProviderFormat)
-			RouteType::GenerateContent => return None,
 		})
 	}
 
@@ -238,6 +237,7 @@ impl ProviderFormat {
 			Self::Responses => InputFormat::Responses,
 			Self::Embeddings => InputFormat::Embeddings,
 			Self::AnthropicTokenCount => InputFormat::CountTokens,
+			Self::GenerateContent => InputFormat::Gemini,
 			Self::GeminiCountTokens => InputFormat::GeminiCountTokens,
 			Self::Realtime => InputFormat::Realtime,
 			Self::Rerank => InputFormat::Rerank,
@@ -251,6 +251,7 @@ impl ProviderFormat {
 			Self::Responses => RouteType::Responses,
 			Self::Embeddings => RouteType::Embeddings,
 			Self::AnthropicTokenCount => RouteType::AnthropicTokenCount,
+			Self::GenerateContent => RouteType::GenerateContent,
 			Self::GeminiCountTokens => RouteType::GeminiCountTokens,
 			Self::Realtime => RouteType::Realtime,
 			Self::Rerank => RouteType::Rerank,

--- a/crates/llm/src/custom.rs
+++ b/crates/llm/src/custom.rs
@@ -223,6 +223,8 @@ impl ProviderFormat {
 			RouteType::Realtime => Self::Realtime,
 			RouteType::Rerank => Self::Rerank,
 			RouteType::Models | RouteType::Passthrough | RouteType::Detect => return None,
+			// TODO: custom providers have no way to advertise the native Gemini format yet
+			RouteType::GeminiGenerateContent | RouteType::GeminiCountTokens => return None,
 		})
 	}
 

--- a/crates/llm/src/custom.rs
+++ b/crates/llm/src/custom.rs
@@ -227,7 +227,7 @@ impl ProviderFormat {
 			RouteType::Models | RouteType::Passthrough | RouteType::Detect => return None,
 			// TODO: custom providers have no way to advertise the native Gemini chat format yet
 			// (it is a ChatFormat, not a ProviderFormat)
-			RouteType::GeminiGenerateContent => return None,
+			RouteType::GenerateContent => return None,
 		})
 	}
 

--- a/crates/llm/src/custom.rs
+++ b/crates/llm/src/custom.rs
@@ -208,6 +208,7 @@ pub enum ProviderFormat {
 	Responses,
 	Embeddings,
 	AnthropicTokenCount,
+	GeminiCountTokens,
 	Realtime,
 	Rerank,
 }
@@ -220,11 +221,13 @@ impl ProviderFormat {
 			RouteType::Responses => Self::Responses,
 			RouteType::Embeddings => Self::Embeddings,
 			RouteType::AnthropicTokenCount => Self::AnthropicTokenCount,
+			RouteType::GeminiCountTokens => Self::GeminiCountTokens,
 			RouteType::Realtime => Self::Realtime,
 			RouteType::Rerank => Self::Rerank,
 			RouteType::Models | RouteType::Passthrough | RouteType::Detect => return None,
-			// TODO: custom providers have no way to advertise the native Gemini format yet
-			RouteType::GeminiGenerateContent | RouteType::GeminiCountTokens => return None,
+			// TODO: custom providers have no way to advertise the native Gemini chat format yet
+			// (it is a ChatFormat, not a ProviderFormat)
+			RouteType::GeminiGenerateContent => return None,
 		})
 	}
 
@@ -235,6 +238,7 @@ impl ProviderFormat {
 			Self::Responses => InputFormat::Responses,
 			Self::Embeddings => InputFormat::Embeddings,
 			Self::AnthropicTokenCount => InputFormat::CountTokens,
+			Self::GeminiCountTokens => InputFormat::GeminiCountTokens,
 			Self::Realtime => InputFormat::Realtime,
 			Self::Rerank => InputFormat::Rerank,
 		}
@@ -247,6 +251,7 @@ impl ProviderFormat {
 			Self::Responses => RouteType::Responses,
 			Self::Embeddings => RouteType::Embeddings,
 			Self::AnthropicTokenCount => RouteType::AnthropicTokenCount,
+			Self::GeminiCountTokens => RouteType::GeminiCountTokens,
 			Self::Realtime => RouteType::Realtime,
 			Self::Rerank => RouteType::Rerank,
 		}

--- a/crates/llm/src/gemini.rs
+++ b/crates/llm/src/gemini.rs
@@ -1,5 +1,6 @@
 use agent_core::strng;
 use agent_core::strng::Strng;
+use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 
 use crate::{RouteType, apply};
 
@@ -22,5 +23,72 @@ pub fn path(route: RouteType) -> &'static str {
 		RouteType::Embeddings => "/v1beta/openai/embeddings",
 		RouteType::Rerank => "/rerank",
 		_ => "/v1beta/openai/chat/completions",
+	}
+}
+
+/// Native `{model}:{method}` path, used instead of [`path`] when the request was rendered in the
+/// native Gemini format. `?alt=sse` is required on the streaming endpoint; without it Google
+/// returns a JSON array rather than an SSE stream.
+pub fn native_gemini_path(route: RouteType, request_model: &str, streaming: bool) -> Strng {
+	let model = model_resource_name(request_model);
+	match route {
+		RouteType::GeminiCountTokens => strng::format!("/v1beta/{model}:countTokens"),
+		_ if streaming => strng::format!("/v1beta/{model}:streamGenerateContent?alt=sse"),
+		_ => strng::format!("/v1beta/{model}:generateContent"),
+	}
+}
+
+/// `{collection}/{id}` for the `/v1beta/{model}:{method}` URL bindings, which accept `models/*`
+/// and `tunedModels/*`. Configs and clients write either the bare id or the full resource name,
+/// and the router percent-encodes a target's `/` to keep it in one segment, so both arrive here.
+/// The id is escaped rather than interpolated: it can never open a path segment of its own.
+fn model_resource_name(request_model: &str) -> String {
+	const MODEL_SEGMENT: &AsciiSet = &CONTROLS.add(b'/').add(b'%');
+	let (collection, id) = match request_model.split_once('/') {
+		Some(("models", id)) => ("models", id),
+		Some(("tunedModels", id)) => ("tunedModels", id),
+		_ => ("models", request_model),
+	};
+	format!("{collection}/{}", utf8_percent_encode(id, MODEL_SEGMENT))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[rstest::rstest]
+	#[case::bare("gemini-2.5-flash", "/v1beta/models/gemini-2.5-flash:generateContent")]
+	#[case::resource_name(
+		"models/gemini-2.5-flash",
+		"/v1beta/models/gemini-2.5-flash:generateContent"
+	)]
+	#[case::tuned_model("tunedModels/abc", "/v1beta/tunedModels/abc:generateContent")]
+	#[case::traversal(
+		"gemini-2.5-flash/../../v1beta/models/other",
+		"/v1beta/models/gemini-2.5-flash%2F..%2F..%2Fv1beta%2Fmodels%2Fother:generateContent"
+	)]
+	#[case::absolute(
+		"/v1beta/models/other",
+		"/v1beta/models/%2Fv1beta%2Fmodels%2Fother:generateContent"
+	)]
+	#[case::empty("", "/v1beta/models/:generateContent")]
+	fn native_gemini_path_keeps_the_model_in_one_segment(
+		#[case] request_model: &str,
+		#[case] expected: &str,
+	) {
+		let path = native_gemini_path(RouteType::GeminiGenerateContent, request_model, false);
+		assert_eq!(path.as_str(), expected);
+	}
+
+	#[test]
+	fn native_gemini_path_covers_the_other_two_methods() {
+		assert_eq!(
+			native_gemini_path(RouteType::GeminiCountTokens, "tunedModels/abc", false).as_str(),
+			"/v1beta/tunedModels/abc:countTokens"
+		);
+		assert_eq!(
+			native_gemini_path(RouteType::GeminiGenerateContent, "tunedModels/abc", true).as_str(),
+			"/v1beta/tunedModels/abc:streamGenerateContent?alt=sse"
+		);
 	}
 }

--- a/crates/llm/src/gemini.rs
+++ b/crates/llm/src/gemini.rs
@@ -80,7 +80,7 @@ mod tests {
 		#[case] request_model: &str,
 		#[case] expected: &str,
 	) {
-		let path = native_gemini_path(RouteType::GeminiGenerateContent, request_model, false);
+		let path = native_gemini_path(RouteType::GenerateContent, request_model, false);
 		assert_eq!(path.as_str(), expected);
 	}
 
@@ -91,7 +91,7 @@ mod tests {
 			"/v1beta/tunedModels/abc:countTokens"
 		);
 		assert_eq!(
-			native_gemini_path(RouteType::GeminiGenerateContent, "tunedModels/abc", true).as_str(),
+			native_gemini_path(RouteType::GenerateContent, "tunedModels/abc", true).as_str(),
 			"/v1beta/tunedModels/abc:streamGenerateContent?alt=sse"
 		);
 	}

--- a/crates/llm/src/gemini.rs
+++ b/crates/llm/src/gemini.rs
@@ -17,6 +17,10 @@ impl super::Provider for Provider {
 }
 pub const DEFAULT_HOST_STR: &str = "generativelanguage.googleapis.com";
 pub const DEFAULT_HOST: Strng = strng::literal!(DEFAULT_HOST_STR);
+/// Google API keys are uniformly `AIza`-prefixed. Used to distinguish API keys (which the
+/// native endpoints authenticate via `x-goog-api-key`) from OAuth access tokens (which stay
+/// in `Authorization: Bearer`).
+pub const API_KEY_PREFIX: &str = "AIza";
 
 pub fn path(route: RouteType) -> &'static str {
 	match route {

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -40,6 +40,7 @@ const BEDROCK_COHERE: &str = "bedrock-cohere";
 const BEDROCK_NOVA: &str = "bedrock-nova";
 const COHERE: &str = "cohere";
 const VERTEX_GEMINI: &str = "vertex-gemini";
+const GEMINI_NATIVE: &str = "gemini-native";
 
 mod requests {
 	use super::*;
@@ -97,6 +98,11 @@ mod requests {
 	}
 
 	fn apply_test_prompts<R: RequestType + Serialize>(r: &mut R) -> Result<Vec<u8>, AIError> {
+		apply_test_prompts_to(r);
+		serde_json::to_vec(r).map_err(AIError::RequestMarshal)
+	}
+
+	fn apply_test_prompts_to<R: RequestType + ?Sized>(r: &mut R) {
 		r.prepend_prompts(vec![
 			SimpleChatCompletionMessage {
 				role: strng::new("system"),
@@ -125,7 +131,6 @@ mod requests {
 				content: strng::new("append assistant prompt"),
 			},
 		]);
-		serde_json::to_vec(r).map_err(AIError::RequestMarshal)
 	}
 
 	const COMPLETION_REQUESTS: &[(&str, &[&str])] = &[
@@ -186,6 +191,17 @@ mod requests {
 	const RERANK_REQUESTS: &[(&str, &[&str])] = &[
 		("basic", &[COHERE, BEDROCK, VERTEX]),
 		("passthrough-fields", &[COHERE, BEDROCK, VERTEX]),
+	];
+
+	/// Native Gemini inbound bodies, used for both the render snapshots and the fidelity assertions
+	/// in [`gemini_request_passthrough_is_lossless`].
+	const GEMINI_REQUESTS: &[&str] = &[
+		"text",
+		"tools",
+		"thinking",
+		"structured-output",
+		"image-inline",
+		"passthrough-fields",
 	];
 
 	#[test]
@@ -423,6 +439,68 @@ mod requests {
 	}
 
 	#[test]
+	fn gemini_native() {
+		// Native Gemini inbound: the "translation" is a re-serialize, so these snapshots exist to make
+		// any change to the wire body visible in review. `gemini_request_passthrough_is_lossless`
+		// asserts the fidelity property itself.
+		for name in GEMINI_REQUESTS {
+			let path = format!("requests/gemini/{name}.json");
+			test_request(GEMINI_NATIVE, &path, |i: &mut types::gemini::Request| {
+				serde_json::to_vec(&i.inner).map_err(AIError::RequestMarshal)
+			});
+		}
+
+		test_request(
+			GEMINI_NATIVE,
+			"requests/policies/gemini_with_system.json",
+			|i: &mut types::gemini::Request| {
+				apply_test_prompts_to(i);
+				serde_json::to_vec(&i.inner).map_err(AIError::RequestMarshal)
+			},
+		);
+	}
+
+	/// Parse + render must lose nothing on the native Gemini path. JSON key order is not preserved
+	/// (typed fields serialize in declaration order, then the `rest` flattens), so the assertion is
+	/// deep value equality plus byte-stability from the second pass onwards.
+	#[test]
+	fn gemini_request_passthrough_is_lossless() {
+		for name in GEMINI_REQUESTS {
+			let relative = format!("requests/gemini/{name}.json");
+			let input = fs::read_to_string(fixture_path(&relative)).expect("failed to read input file");
+			let expected: Value = serde_json::from_str(&input).expect("failed to parse input JSON");
+
+			let parsed: types::gemini::Request = serde_json::from_str(&input).expect("failed to parse");
+			let rendered = serde_json::to_vec(&parsed.inner).expect("failed to render");
+			let round_tripped: Value = serde_json::from_slice(&rendered).expect("rendered JSON");
+			assert_eq!(round_tripped, expected, "{name}: passthrough lost content");
+
+			let reparsed: types::gemini::Request =
+				serde_json::from_slice(&rendered).expect("failed to re-parse");
+			let rerendered = serde_json::to_vec(&reparsed.inner).expect("failed to re-render");
+			assert_eq!(
+				String::from_utf8_lossy(&rerendered),
+				String::from_utf8_lossy(&rendered),
+				"{name}: render is not byte-stable"
+			);
+		}
+	}
+
+	/// The only shape change the passthrough makes: `GenerationConfig`'s float fields are typed, so an
+	/// integer-valued JSON number comes back as a float. Both forms are valid proto3 JSON.
+	#[test]
+	fn gemini_request_normalizes_integer_valued_floats() {
+		let parsed: types::gemini::Request =
+			serde_json::from_value(json!({ "generationConfig": { "temperature": 1, "topK": 40 } }))
+				.expect("failed to parse");
+		let rendered = serde_json::to_vec(&parsed.inner).expect("failed to render");
+		assert_eq!(
+			String::from_utf8_lossy(&rendered),
+			r#"{"generationConfig":{"temperature":1.0,"topK":40}}"#
+		);
+	}
+
+	#[test]
 	fn get_messages() {
 		fn extract<R: RequestType + DeserializeOwned>(fixture: &str, provider: &str) {
 			let path = fixture_path(fixture);
@@ -462,6 +540,8 @@ mod requests {
 			"requests/responses/assistant-history.json",
 			"get-messages-responses",
 		);
+		extract::<types::gemini::Request>("requests/gemini/tools.json", "get-messages-gemini");
+		extract::<types::gemini::Request>("requests/gemini/image-inline.json", "get-messages-gemini");
 	}
 }
 
@@ -834,8 +914,52 @@ mod responses {
 			test_response(VERTEX_GEMINI_TO_COMPLETIONS, &path, |i| {
 				conversion::vertex_gemini::to_completions::translate_response(&i)
 			});
+			// The same responses served to a native Gemini client: body untouched, usage extracted.
+			test_response(GEMINI_NATIVE, &path, |i| {
+				serde_json::from_slice::<types::gemini::Response>(&i)
+					.map(|e| Box::new(e) as Box<dyn ResponseType>)
+					.map_err(AIError::ResponseParsing)
+			});
 		}
 	}
+
+	/// Parse + render must lose nothing on the native Gemini path. JSON key order is not preserved
+	/// (typed fields serialize in declaration order, then the `rest` flattens), so the assertion is
+	/// deep value equality plus byte-stability from the second pass onwards.
+	#[test]
+	fn gemini_response_passthrough_is_lossless() {
+		for name in ["basic", "tool", "reasoning"] {
+			let relative = format!("response/vertex-gemini/{name}.json");
+			let input = fs::read_to_string(fixture_path(&relative)).expect("failed to read input file");
+			let expected: Value = serde_json::from_str(&input).expect("failed to parse input JSON");
+
+			let parsed: types::gemini::Response = serde_json::from_str(&input).expect("failed to parse");
+			let rendered = ResponseType::serialize(&parsed).expect("failed to render");
+			let round_tripped: Value = serde_json::from_slice(&rendered).expect("rendered JSON");
+			assert_eq!(round_tripped, expected, "{name}: passthrough lost content");
+		}
+	}
+
+	/// The one documented exception to response fidelity: an empty `candidates` array is dropped,
+	/// which is what Google's own proto3 JSON encoder does with empty repeated fields (real blocked
+	/// responses omit the key entirely). Every other field of a blocked response survives.
+	#[test]
+	fn gemini_response_omits_empty_candidates_array() {
+		let input = fs::read_to_string(fixture_path("response/vertex-gemini/blocked.json"))
+			.expect("failed to read input file");
+		let mut expected: Value = serde_json::from_str(&input).expect("failed to parse input JSON");
+		assert_eq!(expected["candidates"], json!([]));
+		expected
+			.as_object_mut()
+			.expect("object")
+			.shift_remove("candidates");
+
+		let parsed: types::gemini::Response = serde_json::from_str(&input).expect("failed to parse");
+		let rendered = ResponseType::serialize(&parsed).expect("failed to render");
+		let round_tripped: Value = serde_json::from_slice(&rendered).expect("rendered JSON");
+		assert_eq!(round_tripped, expected);
+	}
+
 	#[test]
 	fn embeddings() {
 		for (path, provider) in EMBEDDING_RESPONSES {

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -28,6 +28,72 @@ pub trait Provider {
 	const NAME: Strng;
 }
 
+/// A model id is interpolated into a single-segment slot of an upstream path
+/// (`.../models/{model}:generateContent`), so a `/` in one is either a resource-style name
+/// (`models/x`, `tunedModels/x`, a Bedrock inference-profile ARN) or an attempt to choose the
+/// upstream path. Deciding that here keeps extraction and every path builder on the same answer.
+pub mod model_path {
+	/// One path segment: not a separator, not a dot segment, and nothing that changes meaning when
+	/// the URL we build is parsed again upstream.
+	pub fn is_safe_segment(segment: &str) -> bool {
+		!segment.is_empty()
+			&& segment != "."
+			&& segment != ".."
+			&& !segment.contains([
+				'/', '\\', '%', '?', '#', '<', '>', '"', '`', '{', '}', '|', '^',
+			]) && !segment.chars().any(|c| c.is_control() || c.is_whitespace())
+	}
+
+	pub fn is_safe_resource_name(model: &str) -> bool {
+		!model.is_empty() && model.split('/').all(is_safe_segment)
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use super::*;
+
+		#[test]
+		fn safe_names_are_accepted() {
+			for model in [
+				"gemini-2.5-flash",
+				"gemini@001",
+				"claude-3-5-sonnet-20241022-v2:0",
+				"models/gemini-2.5-flash",
+				"tunedModels/abc",
+				"publishers/google/models/gemini-2.5-flash",
+				"arn:aws:bedrock:us-east-1:1234:application-inference-profile/my-profile",
+			] {
+				assert!(is_safe_resource_name(model), "{model}");
+			}
+		}
+
+		#[test]
+		fn unsafe_names_are_rejected() {
+			for model in [
+				"",
+				" ",
+				"..",
+				".",
+				"gemini-2.5-flash/../../locations/global/endpoints/openapi/chat/completions",
+				"gemini-2.5-flash/..",
+				"/gemini-2.5-flash",
+				"gemini-2.5-flash/",
+				"gemini//flash",
+				"gemini-2.5-flash%2F..",
+				"gemini\\..\\..",
+				"gemini 2.5 flash",
+				"gemini\n",
+				// A query or fragment would re-shape the path we build, dropping the `:method` suffix.
+				"gemini-2.5-flash?alt=sse",
+				"gemini-2.5-flash#frag",
+				"gemini-2.5-flash<x",
+			] {
+				assert!(!is_safe_resource_name(model), "{model}");
+			}
+		}
+	}
+}
+
 pub mod json {
 	use serde::Serialize;
 	use serde::de::DeserializeOwned;
@@ -102,6 +168,10 @@ pub enum RouteType {
 	Realtime,
 	/// Anthropic /v1/messages/count_tokens
 	AnthropicTokenCount,
+	/// Gemini models/{model}:generateContent and models/{model}:streamGenerateContent
+	GeminiGenerateContent,
+	/// Gemini models/{model}:countTokens
+	GeminiCountTokens,
 	/// Cohere /v2/rerank (document reranking)
 	Rerank,
 }
@@ -113,16 +183,24 @@ pub enum InputFormat {
 	Responses,
 	Embeddings,
 	Realtime,
+	/// Anthropic-shaped /v1/messages/count_tokens body
 	CountTokens,
 	Detect,
 	Rerank,
+	/// Native Gemini generateContent body
+	Gemini,
+	/// Native Gemini countTokens body
+	GeminiCountTokens,
 }
 
 impl InputFormat {
 	pub fn is_chat(&self) -> bool {
 		matches!(
 			self,
-			InputFormat::Completions | InputFormat::Messages | InputFormat::Responses
+			InputFormat::Completions
+				| InputFormat::Messages
+				| InputFormat::Responses
+				| InputFormat::Gemini
 		)
 	}
 
@@ -131,9 +209,11 @@ impl InputFormat {
 			InputFormat::Completions => true,
 			InputFormat::Messages => true,
 			InputFormat::Responses => true,
+			InputFormat::Gemini => true,
 			InputFormat::Realtime => false,
 			InputFormat::Embeddings => false,
 			InputFormat::CountTokens => false,
+			InputFormat::GeminiCountTokens => false,
 			InputFormat::Detect => false,
 			InputFormat::Rerank => false,
 		}

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -169,7 +169,7 @@ pub enum RouteType {
 	/// Anthropic /v1/messages/count_tokens
 	AnthropicTokenCount,
 	/// Gemini models/{model}:generateContent and models/{model}:streamGenerateContent
-	GeminiGenerateContent,
+	GenerateContent,
 	/// Gemini models/{model}:countTokens
 	GeminiCountTokens,
 	/// Cohere /v2/rerank (document reranking)

--- a/crates/llm/src/tests/requests/gemini/image-inline.gemini-native.snap
+++ b/crates/llm/src/tests/requests/gemini/image-inline.gemini-native.snap
@@ -1,0 +1,72 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/gemini/image-inline.json
+info:
+  contents:
+    - role: user
+      parts:
+        - text: What is in these?
+        - inlineData:
+            mimeType: image/png
+            data: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==
+        - fileData:
+            mimeType: video/mp4
+            fileUri: "gs://bucket/clip.mp4"
+          videoMetadata:
+            startOffset: 0s
+            endOffset: 5s
+            fps: 2
+  generationConfig:
+    responseModalities:
+      - TEXT
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "What is in these?"
+          },
+          {
+            "inlineData": {
+              "mimeType": "image/png",
+              "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+            }
+          },
+          {
+            "fileData": {
+              "mimeType": "video/mp4",
+              "fileUri": "gs://bucket/clip.mp4"
+            },
+            "videoMetadata": {
+              "startOffset": "0s",
+              "endOffset": "5s",
+              "fps": 2
+            }
+          }
+        ]
+      }
+    ],
+    "generationConfig": {
+      "responseModalities": [
+        "TEXT"
+      ]
+    }
+  },
+  "parsed": {
+    "input_format": "Gemini",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "",
+    "provider": "gemini-native",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "user",
+        "content": "What is in these?"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/gemini/image-inline.get-messages-gemini.snap
+++ b/crates/llm/src/tests/requests/gemini/image-inline.get-messages-gemini.snap
@@ -1,0 +1,28 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/gemini/image-inline.json
+info:
+  contents:
+    - role: user
+      parts:
+        - text: What is in these?
+        - inlineData:
+            mimeType: image/png
+            data: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==
+        - fileData:
+            mimeType: video/mp4
+            fileUri: "gs://bucket/clip.mp4"
+          videoMetadata:
+            startOffset: 0s
+            endOffset: 5s
+            fps: 2
+  generationConfig:
+    responseModalities:
+      - TEXT
+---
+[
+  {
+    "role": "user",
+    "content": "What is in these?"
+  }
+]

--- a/crates/llm/src/tests/requests/gemini/image-inline.json
+++ b/crates/llm/src/tests/requests/gemini/image-inline.json
@@ -1,0 +1,21 @@
+{
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        { "text": "What is in these?" },
+        {
+          "inlineData": {
+            "mimeType": "image/png",
+            "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+          }
+        },
+        {
+          "fileData": { "mimeType": "video/mp4", "fileUri": "gs://bucket/clip.mp4" },
+          "videoMetadata": { "startOffset": "0s", "endOffset": "5s", "fps": 2 }
+        }
+      ]
+    }
+  ],
+  "generationConfig": { "responseModalities": ["TEXT"] }
+}

--- a/crates/llm/src/tests/requests/gemini/passthrough-fields.gemini-native.snap
+++ b/crates/llm/src/tests/requests/gemini/passthrough-fields.gemini-native.snap
@@ -85,6 +85,16 @@ info:
       ],
       "someNewSystemField": "x"
     },
+    "generationConfig": {
+      "thinkingConfig": {
+        "thinkingBudget": 1024,
+        "someNewThinkingField": "z"
+      },
+      "someNewGenerationField": [
+        "a",
+        "b"
+      ]
+    },
     "tools": [
       {
         "functionDeclarations": [
@@ -102,16 +112,6 @@ info:
         "someNewKnob": 1
       },
       "someNewToolConfigField": 2
-    },
-    "generationConfig": {
-      "thinkingConfig": {
-        "thinkingBudget": 1024,
-        "someNewThinkingField": "z"
-      },
-      "someNewGenerationField": [
-        "a",
-        "b"
-      ]
     },
     "safetySettings": [
       {

--- a/crates/llm/src/tests/requests/gemini/passthrough-fields.gemini-native.snap
+++ b/crates/llm/src/tests/requests/gemini/passthrough-fields.gemini-native.snap
@@ -1,0 +1,154 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/gemini/passthrough-fields.json
+info:
+  contents:
+    - role: user
+      parts:
+        - text: hi
+          someNewPartField:
+            nested:
+              - 1
+              - 2
+              - 3
+      someNewContentField: true
+    - role: user
+      parts:
+        - someNewPartKind:
+            opaque: blob
+  systemInstruction:
+    parts:
+      - text: be brief
+    someNewSystemField: x
+  tools:
+    - functionDeclarations:
+        - name: f
+          someNewDeclField: 1
+      someNewToolField: y
+  toolConfig:
+    functionCallingConfig:
+      mode: AUTO
+      someNewKnob: 1
+    someNewToolConfigField: 2
+  generationConfig:
+    thinkingConfig:
+      thinkingBudget: 1024
+      someNewThinkingField: z
+    someNewGenerationField:
+      - a
+      - b
+  safetySettings:
+    - category: HARM_CATEGORY_HARASSMENT
+      threshold: "OFF"
+      someNewSafetyField: ~
+  modelArmorConfig:
+    promptTemplateName: projects/p/locations/l/templates/t
+  someNewTopLevelField:
+    deeply:
+      nested: 1
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "hi",
+            "someNewPartField": {
+              "nested": [
+                1,
+                2,
+                3
+              ]
+            }
+          }
+        ],
+        "someNewContentField": true
+      },
+      {
+        "role": "user",
+        "parts": [
+          {
+            "someNewPartKind": {
+              "opaque": "blob"
+            }
+          }
+        ]
+      }
+    ],
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "be brief"
+        }
+      ],
+      "someNewSystemField": "x"
+    },
+    "tools": [
+      {
+        "functionDeclarations": [
+          {
+            "name": "f",
+            "someNewDeclField": 1
+          }
+        ],
+        "someNewToolField": "y"
+      }
+    ],
+    "toolConfig": {
+      "functionCallingConfig": {
+        "mode": "AUTO",
+        "someNewKnob": 1
+      },
+      "someNewToolConfigField": 2
+    },
+    "generationConfig": {
+      "thinkingConfig": {
+        "thinkingBudget": 1024,
+        "someNewThinkingField": "z"
+      },
+      "someNewGenerationField": [
+        "a",
+        "b"
+      ]
+    },
+    "safetySettings": [
+      {
+        "category": "HARM_CATEGORY_HARASSMENT",
+        "threshold": "OFF",
+        "someNewSafetyField": null
+      }
+    ],
+    "modelArmorConfig": {
+      "promptTemplateName": "projects/p/locations/l/templates/t"
+    },
+    "someNewTopLevelField": {
+      "deeply": {
+        "nested": 1
+      }
+    }
+  },
+  "parsed": {
+    "input_format": "Gemini",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "",
+    "provider": "gemini-native",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "system",
+        "content": "be brief"
+      },
+      {
+        "role": "user",
+        "content": "hi"
+      },
+      {
+        "role": "user",
+        "content": ""
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/gemini/passthrough-fields.json
+++ b/crates/llm/src/tests/requests/gemini/passthrough-fields.json
@@ -1,0 +1,39 @@
+{
+  "contents": [
+    {
+      "role": "user",
+      "parts": [{ "text": "hi", "someNewPartField": { "nested": [1, 2, 3] } }],
+      "someNewContentField": true
+    },
+    { "role": "user", "parts": [{ "someNewPartKind": { "opaque": "blob" } }] }
+  ],
+  "systemInstruction": {
+    "parts": [{ "text": "be brief" }],
+    "someNewSystemField": "x"
+  },
+  "tools": [
+    {
+      "functionDeclarations": [{ "name": "f", "someNewDeclField": 1 }],
+      "someNewToolField": "y"
+    }
+  ],
+  "toolConfig": {
+    "functionCallingConfig": { "mode": "AUTO", "someNewKnob": 1 },
+    "someNewToolConfigField": 2
+  },
+  "generationConfig": {
+    "thinkingConfig": { "thinkingBudget": 1024, "someNewThinkingField": "z" },
+    "someNewGenerationField": ["a", "b"]
+  },
+  "safetySettings": [
+    {
+      "category": "HARM_CATEGORY_HARASSMENT",
+      "threshold": "OFF",
+      "someNewSafetyField": null
+    }
+  ],
+  "modelArmorConfig": {
+    "promptTemplateName": "projects/p/locations/l/templates/t"
+  },
+  "someNewTopLevelField": { "deeply": { "nested": 1 } }
+}

--- a/crates/llm/src/tests/requests/gemini/structured-output.gemini-native.snap
+++ b/crates/llm/src/tests/requests/gemini/structured-output.gemini-native.snap
@@ -1,0 +1,86 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/gemini/structured-output.json
+info:
+  contents:
+    - role: user
+      parts:
+        - text: List three planets.
+  generationConfig:
+    responseMimeType: application/json
+    responseSchema:
+      type: ARRAY
+      items:
+        type: OBJECT
+        properties:
+          name:
+            type: STRING
+          moons:
+            type: INTEGER
+          habitable:
+            type: BOOLEAN
+        required:
+          - name
+          - moons
+        propertyOrdering:
+          - name
+          - moons
+          - habitable
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "List three planets."
+          }
+        ]
+      }
+    ],
+    "generationConfig": {
+      "responseMimeType": "application/json",
+      "responseSchema": {
+        "type": "ARRAY",
+        "items": {
+          "type": "OBJECT",
+          "properties": {
+            "name": {
+              "type": "STRING"
+            },
+            "moons": {
+              "type": "INTEGER"
+            },
+            "habitable": {
+              "type": "BOOLEAN"
+            }
+          },
+          "required": [
+            "name",
+            "moons"
+          ],
+          "propertyOrdering": [
+            "name",
+            "moons",
+            "habitable"
+          ]
+        }
+      }
+    }
+  },
+  "parsed": {
+    "input_format": "Gemini",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "",
+    "provider": "gemini-native",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "user",
+        "content": "List three planets."
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/gemini/structured-output.json
+++ b/crates/llm/src/tests/requests/gemini/structured-output.json
@@ -1,0 +1,19 @@
+{
+  "contents": [{ "role": "user", "parts": [{ "text": "List three planets." }] }],
+  "generationConfig": {
+    "responseMimeType": "application/json",
+    "responseSchema": {
+      "type": "ARRAY",
+      "items": {
+        "type": "OBJECT",
+        "properties": {
+          "name": { "type": "STRING" },
+          "moons": { "type": "INTEGER" },
+          "habitable": { "type": "BOOLEAN" }
+        },
+        "required": ["name", "moons"],
+        "propertyOrdering": ["name", "moons", "habitable"]
+      }
+    }
+  }
+}

--- a/crates/llm/src/tests/requests/gemini/text.gemini-native.snap
+++ b/crates/llm/src/tests/requests/gemini/text.gemini-native.snap
@@ -69,13 +69,13 @@ info:
     "generationConfig": {
       "temperature": 0.7,
       "topP": 0.95,
-      "topK": 40,
+      "seed": 42,
       "maxOutputTokens": 1024,
+      "topK": 40,
       "stopSequences": [
         "END"
       ],
-      "candidateCount": 1,
-      "seed": 42
+      "candidateCount": 1
     },
     "safetySettings": [
       {

--- a/crates/llm/src/tests/requests/gemini/text.gemini-native.snap
+++ b/crates/llm/src/tests/requests/gemini/text.gemini-native.snap
@@ -1,0 +1,122 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/gemini/text.json
+info:
+  contents:
+    - role: user
+      parts:
+        - text: Who won the 2018 world cup?
+    - role: model
+      parts:
+        - text: France.
+    - role: user
+      parts:
+        - text: And the runner up?
+  systemInstruction:
+    parts:
+      - text: Answer in one sentence.
+  generationConfig:
+    temperature: 0.7
+    topP: 0.95
+    topK: 40
+    maxOutputTokens: 1024
+    stopSequences:
+      - END
+    candidateCount: 1
+    seed: 42
+  safetySettings:
+    - category: HARM_CATEGORY_DANGEROUS_CONTENT
+      threshold: BLOCK_ONLY_HIGH
+  cachedContent: projects/p/locations/global/cachedContents/123
+  labels:
+    team: search
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "Who won the 2018 world cup?"
+          }
+        ]
+      },
+      {
+        "role": "model",
+        "parts": [
+          {
+            "text": "France."
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "And the runner up?"
+          }
+        ]
+      }
+    ],
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "Answer in one sentence."
+        }
+      ]
+    },
+    "generationConfig": {
+      "temperature": 0.7,
+      "topP": 0.95,
+      "topK": 40,
+      "maxOutputTokens": 1024,
+      "stopSequences": [
+        "END"
+      ],
+      "candidateCount": 1,
+      "seed": 42
+    },
+    "safetySettings": [
+      {
+        "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+        "threshold": "BLOCK_ONLY_HIGH"
+      }
+    ],
+    "cachedContent": "projects/p/locations/global/cachedContents/123",
+    "labels": {
+      "team": "search"
+    }
+  },
+  "parsed": {
+    "input_format": "Gemini",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "",
+    "provider": "gemini-native",
+    "streaming": false,
+    "params": {
+      "temperature": 0.699999988079071,
+      "top_p": 0.949999988079071,
+      "seed": 42,
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "system",
+        "content": "Answer in one sentence."
+      },
+      {
+        "role": "user",
+        "content": "Who won the 2018 world cup?"
+      },
+      {
+        "role": "assistant",
+        "content": "France."
+      },
+      {
+        "role": "user",
+        "content": "And the runner up?"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/gemini/text.json
+++ b/crates/llm/src/tests/requests/gemini/text.json
@@ -1,0 +1,25 @@
+{
+  "contents": [
+    { "role": "user", "parts": [{ "text": "Who won the 2018 world cup?" }] },
+    { "role": "model", "parts": [{ "text": "France." }] },
+    { "role": "user", "parts": [{ "text": "And the runner up?" }] }
+  ],
+  "systemInstruction": { "parts": [{ "text": "Answer in one sentence." }] },
+  "generationConfig": {
+    "temperature": 0.7,
+    "topP": 0.95,
+    "topK": 40,
+    "maxOutputTokens": 1024,
+    "stopSequences": ["END"],
+    "candidateCount": 1,
+    "seed": 42
+  },
+  "safetySettings": [
+    {
+      "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+      "threshold": "BLOCK_ONLY_HIGH"
+    }
+  ],
+  "cachedContent": "projects/p/locations/global/cachedContents/123",
+  "labels": { "team": "search" }
+}

--- a/crates/llm/src/tests/requests/gemini/thinking.gemini-native.snap
+++ b/crates/llm/src/tests/requests/gemini/thinking.gemini-native.snap
@@ -1,0 +1,91 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/gemini/thinking.json
+info:
+  contents:
+    - role: user
+      parts:
+        - text: Prove that sqrt(2) is irrational.
+    - role: model
+      parts:
+        - text: The classic argument is by contradiction.
+          thought: true
+          thoughtSignature: Ck0BdGhvdWdodC1zaWduYXR1cmUtb25l
+        - text: Suppose sqrt(2) = a/b in lowest terms.
+          thoughtSignature: Ck0BdGhvdWdodC1zaWduYXR1cmUtdHdv
+    - role: user
+      parts:
+        - text: Continue.
+  generationConfig:
+    temperature: 1
+    thinkingConfig:
+      thinkingLevel: high
+      includeThoughts: true
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "Prove that sqrt(2) is irrational."
+          }
+        ]
+      },
+      {
+        "role": "model",
+        "parts": [
+          {
+            "text": "The classic argument is by contradiction.",
+            "thought": true,
+            "thoughtSignature": "Ck0BdGhvdWdodC1zaWduYXR1cmUtb25l"
+          },
+          {
+            "text": "Suppose sqrt(2) = a/b in lowest terms.",
+            "thoughtSignature": "Ck0BdGhvdWdodC1zaWduYXR1cmUtdHdv"
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "Continue."
+          }
+        ]
+      }
+    ],
+    "generationConfig": {
+      "temperature": 1.0,
+      "thinkingConfig": {
+        "thinkingLevel": "high",
+        "includeThoughts": true
+      }
+    }
+  },
+  "parsed": {
+    "input_format": "Gemini",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "",
+    "provider": "gemini-native",
+    "streaming": false,
+    "params": {
+      "temperature": 1.0
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Prove that sqrt(2) is irrational."
+      },
+      {
+        "role": "assistant",
+        "content": "The classic argument is by contradiction. Suppose sqrt(2) = a/b in lowest terms."
+      },
+      {
+        "role": "user",
+        "content": "Continue."
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/gemini/thinking.json
+++ b/crates/llm/src/tests/requests/gemini/thinking.json
@@ -1,0 +1,24 @@
+{
+  "contents": [
+    { "role": "user", "parts": [{ "text": "Prove that sqrt(2) is irrational." }] },
+    {
+      "role": "model",
+      "parts": [
+        {
+          "text": "The classic argument is by contradiction.",
+          "thought": true,
+          "thoughtSignature": "Ck0BdGhvdWdodC1zaWduYXR1cmUtb25l"
+        },
+        {
+          "text": "Suppose sqrt(2) = a/b in lowest terms.",
+          "thoughtSignature": "Ck0BdGhvdWdodC1zaWduYXR1cmUtdHdv"
+        }
+      ]
+    },
+    { "role": "user", "parts": [{ "text": "Continue." }] }
+  ],
+  "generationConfig": {
+    "temperature": 1.0,
+    "thinkingConfig": { "thinkingLevel": "high", "includeThoughts": true }
+  }
+}

--- a/crates/llm/src/tests/requests/gemini/tools.gemini-native.snap
+++ b/crates/llm/src/tests/requests/gemini/tools.gemini-native.snap
@@ -1,0 +1,164 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/gemini/tools.json
+info:
+  contents:
+    - role: user
+      parts:
+        - text: What is the weather in Boston?
+    - role: model
+      parts:
+        - functionCall:
+            name: get_weather
+            id: fc_1
+            args:
+              location: Boston
+              unit: celsius
+          thoughtSignature: CjEBc2lnbmF0dXJlLWZvci10aGUtY2FsbA==
+    - role: user
+      parts:
+        - functionResponse:
+            name: get_weather
+            id: fc_1
+            response:
+              temperature: 12
+              conditions: rain
+  tools:
+    - functionDeclarations:
+        - name: get_weather
+          description: Get the current weather for a city
+          parameters:
+            type: object
+            properties:
+              location:
+                type: string
+              unit:
+                type: string
+                enum:
+                  - celsius
+                  - fahrenheit
+            required:
+              - location
+          behavior: BLOCKING
+    - googleSearch: {}
+    - codeExecution: {}
+    - urlContext: {}
+  toolConfig:
+    functionCallingConfig:
+      mode: ANY
+      allowedFunctionNames:
+        - get_weather
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "What is the weather in Boston?"
+          }
+        ]
+      },
+      {
+        "role": "model",
+        "parts": [
+          {
+            "functionCall": {
+              "name": "get_weather",
+              "id": "fc_1",
+              "args": {
+                "location": "Boston",
+                "unit": "celsius"
+              }
+            },
+            "thoughtSignature": "CjEBc2lnbmF0dXJlLWZvci10aGUtY2FsbA=="
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "parts": [
+          {
+            "functionResponse": {
+              "name": "get_weather",
+              "id": "fc_1",
+              "response": {
+                "temperature": 12,
+                "conditions": "rain"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "tools": [
+      {
+        "functionDeclarations": [
+          {
+            "name": "get_weather",
+            "description": "Get the current weather for a city",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "location": {
+                  "type": "string"
+                },
+                "unit": {
+                  "type": "string",
+                  "enum": [
+                    "celsius",
+                    "fahrenheit"
+                  ]
+                }
+              },
+              "required": [
+                "location"
+              ]
+            },
+            "behavior": "BLOCKING"
+          }
+        ]
+      },
+      {
+        "googleSearch": {}
+      },
+      {
+        "codeExecution": {}
+      },
+      {
+        "urlContext": {}
+      }
+    ],
+    "toolConfig": {
+      "functionCallingConfig": {
+        "mode": "ANY",
+        "allowedFunctionNames": [
+          "get_weather"
+        ]
+      }
+    }
+  },
+  "parsed": {
+    "input_format": "Gemini",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "",
+    "provider": "gemini-native",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "user",
+        "content": "What is the weather in Boston?"
+      },
+      {
+        "role": "assistant",
+        "content": ""
+      },
+      {
+        "role": "user",
+        "content": ""
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/gemini/tools.get-messages-gemini.snap
+++ b/crates/llm/src/tests/requests/gemini/tools.get-messages-gemini.snap
@@ -1,0 +1,65 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/gemini/tools.json
+info:
+  contents:
+    - role: user
+      parts:
+        - text: What is the weather in Boston?
+    - role: model
+      parts:
+        - functionCall:
+            name: get_weather
+            id: fc_1
+            args:
+              location: Boston
+              unit: celsius
+          thoughtSignature: CjEBc2lnbmF0dXJlLWZvci10aGUtY2FsbA==
+    - role: user
+      parts:
+        - functionResponse:
+            name: get_weather
+            id: fc_1
+            response:
+              temperature: 12
+              conditions: rain
+  tools:
+    - functionDeclarations:
+        - name: get_weather
+          description: Get the current weather for a city
+          parameters:
+            type: object
+            properties:
+              location:
+                type: string
+              unit:
+                type: string
+                enum:
+                  - celsius
+                  - fahrenheit
+            required:
+              - location
+          behavior: BLOCKING
+    - googleSearch: {}
+    - codeExecution: {}
+    - urlContext: {}
+  toolConfig:
+    functionCallingConfig:
+      mode: ANY
+      allowedFunctionNames:
+        - get_weather
+---
+[
+  {
+    "role": "user",
+    "content": "What is the weather in Boston?"
+  },
+  {
+    "role": "assistant",
+    "content": ""
+  },
+  {
+    "role": "user",
+    "content": ""
+  }
+]

--- a/crates/llm/src/tests/requests/gemini/tools.json
+++ b/crates/llm/src/tests/requests/gemini/tools.json
@@ -1,0 +1,58 @@
+{
+  "contents": [
+    { "role": "user", "parts": [{ "text": "What is the weather in Boston?" }] },
+    {
+      "role": "model",
+      "parts": [
+        {
+          "functionCall": {
+            "name": "get_weather",
+            "id": "fc_1",
+            "args": { "location": "Boston", "unit": "celsius" }
+          },
+          "thoughtSignature": "CjEBc2lnbmF0dXJlLWZvci10aGUtY2FsbA=="
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "parts": [
+        {
+          "functionResponse": {
+            "name": "get_weather",
+            "id": "fc_1",
+            "response": { "temperature": 12, "conditions": "rain" }
+          }
+        }
+      ]
+    }
+  ],
+  "tools": [
+    {
+      "functionDeclarations": [
+        {
+          "name": "get_weather",
+          "description": "Get the current weather for a city",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": { "type": "string" },
+              "unit": { "type": "string", "enum": ["celsius", "fahrenheit"] }
+            },
+            "required": ["location"]
+          },
+          "behavior": "BLOCKING"
+        }
+      ]
+    },
+    { "googleSearch": {} },
+    { "codeExecution": {} },
+    { "urlContext": {} }
+  ],
+  "toolConfig": {
+    "functionCallingConfig": {
+      "mode": "ANY",
+      "allowedFunctionNames": ["get_weather"]
+    }
+  }
+}

--- a/crates/llm/src/tests/requests/policies/gemini_with_system.gemini-native.snap
+++ b/crates/llm/src/tests/requests/policies/gemini_with_system.gemini-native.snap
@@ -1,0 +1,114 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/policies/gemini_with_system.json
+info:
+  systemInstruction:
+    parts:
+      - text: system prompt
+  contents:
+    - role: user
+      parts:
+        - text: "Hello, world"
+        - inlineData:
+            mimeType: image/png
+            data: AAAA
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "prepend user message"
+          }
+        ]
+      },
+      {
+        "role": "model",
+        "parts": [
+          {
+            "text": "prepend assistant message"
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "Hello, world"
+          },
+          {
+            "inlineData": {
+              "mimeType": "image/png",
+              "data": "AAAA"
+            }
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "append user message"
+          }
+        ]
+      },
+      {
+        "role": "model",
+        "parts": [
+          {
+            "text": "append assistant prompt"
+          }
+        ]
+      }
+    ],
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "prepend system prompt"
+        },
+        {
+          "text": "system prompt"
+        },
+        {
+          "text": "append system prompt"
+        }
+      ]
+    }
+  },
+  "parsed": {
+    "input_format": "Gemini",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "",
+    "provider": "gemini-native",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "system",
+        "content": "prepend system prompt\nsystem prompt\nappend system prompt"
+      },
+      {
+        "role": "user",
+        "content": "prepend user message"
+      },
+      {
+        "role": "assistant",
+        "content": "prepend assistant message"
+      },
+      {
+        "role": "user",
+        "content": "Hello, world"
+      },
+      {
+        "role": "user",
+        "content": "append user message"
+      },
+      {
+        "role": "assistant",
+        "content": "append assistant prompt"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/policies/gemini_with_system.json
+++ b/crates/llm/src/tests/requests/policies/gemini_with_system.json
@@ -1,0 +1,12 @@
+{
+  "systemInstruction": { "parts": [{ "text": "system prompt" }] },
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        { "text": "Hello, world" },
+        { "inlineData": { "mimeType": "image/png", "data": "AAAA" } }
+      ]
+    }
+  ]
+}

--- a/crates/llm/src/tests/response/vertex-gemini/basic.gemini-native.snap
+++ b/crates/llm/src/tests/response/vertex-gemini/basic.gemini-native.snap
@@ -1,0 +1,49 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/vertex-gemini/basic.json
+info:
+  candidates:
+    - content:
+        role: model
+        parts:
+          - text: The provider is Gemini.
+      finishReason: STOP
+      index: 0
+  usageMetadata:
+    promptTokenCount: 8
+    candidatesTokenCount: 6
+    totalTokenCount: 14
+  modelVersion: gemini-2.5-pro
+  responseId: resp-basic-1
+---
+{
+  "response": {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "text": "The provider is Gemini."
+            }
+          ]
+        },
+        "finishReason": "STOP",
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 8,
+      "candidatesTokenCount": 6,
+      "totalTokenCount": 14
+    },
+    "responseId": "resp-basic-1",
+    "modelVersion": "gemini-2.5-pro"
+  },
+  "parsed": {
+    "input_tokens": 8,
+    "output_tokens": 6,
+    "total_tokens": 14,
+    "provider_model": "gemini-2.5-pro"
+  }
+}

--- a/crates/llm/src/tests/response/vertex-gemini/blocked.gemini-native.snap
+++ b/crates/llm/src/tests/response/vertex-gemini/blocked.gemini-native.snap
@@ -1,0 +1,30 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/vertex-gemini/blocked.json
+info:
+  candidates: []
+  promptFeedback:
+    blockReason: SAFETY
+  usageMetadata:
+    promptTokenCount: 12
+    totalTokenCount: 12
+  modelVersion: gemini-2.5-pro
+---
+{
+  "response": {
+    "promptFeedback": {
+      "blockReason": "SAFETY"
+    },
+    "usageMetadata": {
+      "promptTokenCount": 12,
+      "totalTokenCount": 12
+    },
+    "modelVersion": "gemini-2.5-pro"
+  },
+  "parsed": {
+    "input_tokens": 12,
+    "output_tokens": 0,
+    "total_tokens": 12,
+    "provider_model": "gemini-2.5-pro"
+  }
+}

--- a/crates/llm/src/tests/response/vertex-gemini/reasoning.gemini-native.snap
+++ b/crates/llm/src/tests/response/vertex-gemini/reasoning.gemini-native.snap
@@ -48,7 +48,7 @@ info:
   },
   "parsed": {
     "input_tokens": 10,
-    "output_tokens": 12,
+    "output_tokens": 17,
     "total_tokens": 27,
     "reasoning_tokens": 5,
     "provider_model": "gemini-2.5-pro"

--- a/crates/llm/src/tests/response/vertex-gemini/reasoning.gemini-native.snap
+++ b/crates/llm/src/tests/response/vertex-gemini/reasoning.gemini-native.snap
@@ -1,0 +1,56 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/vertex-gemini/reasoning.json
+info:
+  candidates:
+    - content:
+        role: model
+        parts:
+          - text: Let me think about the weather.
+            thought: true
+          - text: It is sunny.
+      finishReason: STOP
+      index: 0
+  usageMetadata:
+    promptTokenCount: 10
+    candidatesTokenCount: 12
+    thoughtsTokenCount: 5
+    totalTokenCount: 27
+  modelVersion: gemini-2.5-pro
+---
+{
+  "response": {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Let me think about the weather.",
+              "thought": true
+            },
+            {
+              "text": "It is sunny."
+            }
+          ]
+        },
+        "finishReason": "STOP",
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 10,
+      "candidatesTokenCount": 12,
+      "totalTokenCount": 27,
+      "thoughtsTokenCount": 5
+    },
+    "modelVersion": "gemini-2.5-pro"
+  },
+  "parsed": {
+    "input_tokens": 10,
+    "output_tokens": 12,
+    "total_tokens": 27,
+    "reasoning_tokens": 5,
+    "provider_model": "gemini-2.5-pro"
+  }
+}

--- a/crates/llm/src/tests/response/vertex-gemini/reasoning.vertex-gemini-completions.snap
+++ b/crates/llm/src/tests/response/vertex-gemini/reasoning.vertex-gemini-completions.snap
@@ -23,7 +23,7 @@ info:
     "model": "gemini-2.5-pro",
     "usage": {
       "prompt_tokens": 10,
-      "completion_tokens": 12,
+      "completion_tokens": 17,
       "total_tokens": 27,
       "completion_tokens_details": {
         "reasoning_tokens": 5
@@ -46,7 +46,7 @@ info:
   },
   "parsed": {
     "input_tokens": 10,
-    "output_tokens": 12,
+    "output_tokens": 17,
     "total_tokens": 27,
     "reasoning_tokens": 5,
     "provider_model": "gemini-2.5-pro"

--- a/crates/llm/src/tests/response/vertex-gemini/tool.gemini-native.snap
+++ b/crates/llm/src/tests/response/vertex-gemini/tool.gemini-native.snap
@@ -1,0 +1,73 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/vertex-gemini/tool.json
+info:
+  candidates:
+    - content:
+        role: model
+        parts:
+          - functionCall:
+              name: get_weather
+              id: fc_get_weather_1
+              args:
+                location: Columbus
+      finishReason: STOP
+      index: 0
+  usageMetadata:
+    promptTokenCount: 20
+    candidatesTokenCount: 8
+    totalTokenCount: 28
+  modelVersion: gemini-2.5-pro
+---
+{
+  "response": {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "functionCall": {
+                "name": "get_weather",
+                "id": "fc_get_weather_1",
+                "args": {
+                  "location": "Columbus"
+                }
+              }
+            }
+          ]
+        },
+        "finishReason": "STOP",
+        "index": 0
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 20,
+      "candidatesTokenCount": 8,
+      "totalTokenCount": 28
+    },
+    "modelVersion": "gemini-2.5-pro"
+  },
+  "parsed": {
+    "input_tokens": 20,
+    "output_tokens": 8,
+    "total_tokens": 28,
+    "provider_model": "gemini-2.5-pro",
+    "output_messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_call",
+            "id": "fc_get_weather_1",
+            "name": "get_weather",
+            "arguments": {
+              "location": "Columbus"
+            }
+          }
+        ],
+        "finish_reason": "STOP"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/types/detect.rs
+++ b/crates/llm/src/types/detect.rs
@@ -141,14 +141,22 @@ pub fn amend_request_info(llm_info: &mut LLMRequest, path: &str) {
 }
 
 pub fn extract_model_from_path(path: &str) -> Option<Strng> {
-	let model = if path.ends_with(":streamRawPredict")
-		|| path.ends_with(":rawPredict")
-		|| path.ends_with(":streamGenerateContent")
-		|| path.ends_with(":generateContent")
-	{
+	let model = if path.ends_with(":streamRawPredict") || path.ends_with(":rawPredict") {
 		path
 			.split_once("/publishers/")
 			.and_then(|(_, rest)| rest.split_once("/models/"))
+			.and_then(|(_, rest)| rest.split_once(':').map(|(model, _)| model))
+	} else if path.ends_with(":streamGenerateContent")
+		|| path.ends_with(":generateContent")
+		|| path.ends_with(":countTokens")
+	{
+		// Vertex nests models under publishers/{publisher}/models/; the Gemini API uses a
+		// bare /v1beta/models/{model}:suffix with no publisher segment.
+		let scoped = path
+			.split_once("/publishers/")
+			.map_or(path, |(_, rest)| rest);
+		scoped
+			.split_once("/models/")
 			.and_then(|(_, rest)| rest.split_once(':').map(|(model, _)| model))
 	} else if path.ends_with("/invoke-with-response-stream")
 		|| path.ends_with("/invoke")
@@ -161,7 +169,12 @@ pub fn extract_model_from_path(path: &str) -> Option<Strng> {
 	} else {
 		None
 	};
-	model.map(|model| strng::new(percent_decode_str(model).decode_utf8_lossy()))
+	// Every shape above spans `/`, and the result is interpolated into upstream paths. Percent
+	// decoding is what makes this load-bearing: `models/a%2F..%2F..:generateContent` matches an
+	// `[^/]+` route regex, so the traversal only appears after this decode.
+	model
+		.map(|model| strng::new(percent_decode_str(model).decode_utf8_lossy()))
+		.filter(|model| crate::model_path::is_safe_resource_name(model))
 }
 
 fn strip_bedrock_model_suffix(rest: &str) -> Option<&str> {
@@ -293,6 +306,72 @@ mod tests {
 
 		assert_eq!(llm_info.request_model, "gemini-2.5-flash");
 		assert!(llm_info.streaming);
+	}
+
+	#[test]
+	fn extract_model_from_path_handles_bare_gemini_api_paths() {
+		assert_eq!(
+			extract_model_from_path("/v1beta/models/gemini-2.5-flash:generateContent").as_deref(),
+			Some("gemini-2.5-flash")
+		);
+		assert_eq!(
+			extract_model_from_path("/v1beta/models/gemini-2.5-flash:streamGenerateContent").as_deref(),
+			Some("gemini-2.5-flash")
+		);
+		assert_eq!(
+			extract_model_from_path("/v1beta/models/gemini-2.5-flash:countTokens").as_deref(),
+			Some("gemini-2.5-flash")
+		);
+	}
+
+	#[test]
+	fn extract_model_from_path_handles_vertex_count_tokens() {
+		assert_eq!(
+			extract_model_from_path(
+				"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash:countTokens"
+			)
+			.as_deref(),
+			Some("gemini-2.5-flash")
+		);
+	}
+
+	#[rstest::rstest]
+	#[case::vertex_publisher(
+		"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash/../../../../locations/global/endpoints/openapi/chat/completions:generateContent"
+	)]
+	#[case::vertex_publisher_encoded(
+		"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash%2F..%2F..%2Fendpoints%2Fopenapi%2Fchat%2Fcompletions:generateContent"
+	)]
+	#[case::vertex_raw_predict(
+		"/v1/projects/p/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-5%2F..%2F..%2Fendpoints%2Fopenapi%2Fchat%2Fcompletions:rawPredict"
+	)]
+	#[case::bare_gemini("/v1beta/models/gemini-2.5-flash/../../foo:generateContent")]
+	#[case::bare_gemini_encoded(
+		"/v1beta/models/gemini-2.5-flash%2F..%2F..%2Ffoo:streamGenerateContent"
+	)]
+	#[case::double_encoded("/v1beta/models/gemini-2.5-flash%252F..%252F..:countTokens")]
+	#[case::backslash("/v1beta/models/gemini-2.5-flash%5C..%5C..:generateContent")]
+	#[case::empty("/v1beta/models/:generateContent")]
+	#[case::whitespace_only("/v1beta/models/%20%20:generateContent")]
+	#[case::dot_dot_segment("/v1beta/models/..:generateContent")]
+	fn extract_model_from_path_rejects_unsafe_model_segments(#[case] path: &str) {
+		// A `/` here reaches the upstream path builders, which interpolate into a single-segment
+		// slot; `%2F` is the interesting case because it still matches an `[^/]+` route regex.
+		assert_eq!(extract_model_from_path(path), None, "{path}");
+	}
+
+	#[test]
+	fn extract_model_from_path_keeps_resource_style_names() {
+		// The model router percent-encodes `/` in a virtual-model target so it stays one segment
+		// (`rewrite_path_model`); decoding it back must not look like traversal.
+		assert_eq!(
+			extract_model_from_path("/v1beta/models/tunedModels%2Fabc:generateContent").as_deref(),
+			Some("tunedModels/abc")
+		);
+		assert_eq!(
+			extract_model_from_path("/v1beta/models/models%2Fgemini-2.5-flash:countTokens").as_deref(),
+			Some("models/gemini-2.5-flash")
+		);
 	}
 
 	#[test]

--- a/crates/llm/src/types/gemini.rs
+++ b/crates/llm/src/types/gemini.rs
@@ -5,10 +5,16 @@
 //! - <https://ai.google.dev/api/tokens>
 //! - <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference>
 //!
-//! The wire DTOs live in `types::vertex_gemini`; this wraps them with the request
-//! metadata the gateway needs (model and streaming), which Gemini carries in the
-//! URI (`models/{model}:generateContent` vs `:streamGenerateContent`) rather than
-//! the body.
+//! Inbound requests are passthrough, so the request types here are deliberately minimal:
+//! only the fields the gateway reads are typed (prompt guard walks `contents` and
+//! `systemInstruction`; telemetry reads the `generationConfig` sampling params), and
+//! everything else rides a `rest` flatten untouched. A field shape we got slightly wrong
+//! can then never reject a request Google would accept. The complete typed request in
+//! `types::vertex_gemini` is reserved for conversions, which construct it themselves.
+//! The content tree (`Content`/`Part`) is shared with `types::vertex_gemini`.
+//!
+//! Request metadata the gateway needs (model and streaming) is carried in the URI
+//! (`models/{model}:generateContent` vs `:streamGenerateContent`) rather than the body.
 
 use agent_core::prelude::Strng;
 use agent_core::strng;
@@ -22,13 +28,69 @@ use crate::{
 	SimpleChatCompletionMessage, logged_response_parsing, webhook,
 };
 
+/// Minimal inbound `generateContent` body; see the module docs for why only read fields
+/// are typed. proto3 JSON accepts snake_case alongside camelCase field names, so the
+/// multi-word fields carry `alias`es; re-serialization normalizes them to camelCase.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerateContentRequest {
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub contents: Vec<vg::Content>,
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		alias = "system_instruction"
+	)]
+	pub system_instruction: Option<vg::Content>,
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		alias = "generation_config"
+	)]
+	pub generation_config: Option<GenerationConfig>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
+}
+
+/// The `generationConfig` sampling parameters the gateway logs; everything else rides `rest`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenerationConfig {
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub temperature: Option<f32>,
+	#[serde(default, skip_serializing_if = "Option::is_none", alias = "top_p")]
+	pub top_p: Option<f32>,
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		alias = "frequency_penalty"
+	)]
+	pub frequency_penalty: Option<f32>,
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		alias = "presence_penalty"
+	)]
+	pub presence_penalty: Option<f32>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub seed: Option<i64>,
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		alias = "max_output_tokens"
+	)]
+	pub max_output_tokens: Option<u32>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct Request {
 	/// Filled from the URI by the caller; never serialized into the wire body.
 	pub model: Option<String>,
 	/// Filled from the URI by the caller (`:streamGenerateContent`); there is no body flag.
 	pub streaming: bool,
-	pub inner: vg::GenerateContentRequest,
+	pub inner: GenerateContentRequest,
 }
 
 impl<'de> Deserialize<'de> for Request {
@@ -43,7 +105,7 @@ impl<'de> Deserialize<'de> for Request {
 			Some(serde_json::Value::String(model)) => Some(model),
 			_ => None,
 		};
-		let inner = vg::GenerateContentRequest::deserialize(body).map_err(serde::de::Error::custom)?;
+		let inner = GenerateContentRequest::deserialize(body).map_err(serde::de::Error::custom)?;
 		Ok(Request {
 			model,
 			streaming: false,
@@ -164,7 +226,11 @@ pub struct CountTokensRequest {
 	pub model: Option<String>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub contents: Vec<vg::Content>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		alias = "system_instruction"
+	)]
 	pub system_instruction: Option<vg::Content>,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
@@ -574,6 +640,53 @@ mod tests {
 
 		let bare = request(json!({ "contents": [] }));
 		assert_eq!(bare.model, None);
+	}
+
+	#[test]
+	fn snake_case_field_names_parse_like_camel_case() {
+		// proto3 JSON accepts the original snake_case proto field names alongside camelCase;
+		// both spellings must reach the typed fields (prompt guard, params) rather than
+		// silently riding `rest`.
+		let req = request(json!({
+			"system_instruction": { "parts": [{ "text": "be brief" }] },
+			"contents": [{ "role": "user", "parts": [
+				{ "function_call": { "name": "f", "args": {} } },
+				{ "inline_data": { "mime_type": "image/png", "data": "aGk=" } }
+			] }],
+			"generation_config": { "top_p": 0.5, "max_output_tokens": 100 }
+		}));
+		assert!(req.inner.system_instruction.is_some());
+		assert!(matches!(
+			req.inner.contents[0].parts[0],
+			vg::Part::FunctionCall(_)
+		));
+		assert!(matches!(
+			req.inner.contents[0].parts[1],
+			vg::Part::InlineData(_)
+		));
+		let gc = req.inner.generation_config.as_ref().unwrap();
+		assert_eq!(gc.top_p, Some(0.5));
+		assert_eq!(gc.max_output_tokens, Some(100));
+		// Nothing leaked into the catch-alls.
+		assert_eq!(req.inner.rest, json!({}));
+		assert_eq!(gc.rest, json!({}));
+	}
+
+	#[test]
+	fn unread_fields_pass_through_regardless_of_shape() {
+		// Only the fields the gateway reads are typed; a field we do not read must never be
+		// able to fail parsing, even with a shape the current API docs would not predict.
+		let raw = json!({
+			"contents": [{ "role": "user", "parts": [{ "text": "hi" }] }],
+			"labels": ["not", "a", "map"],
+			"cachedContent": { "name": "cachedContents/abc" },
+			"tools": "surprising-string"
+		});
+		let req = request(raw.clone());
+		let out = serde_json::to_value(&req.inner).expect("serialize");
+		assert_eq!(out["labels"], raw["labels"]);
+		assert_eq!(out["cachedContent"], raw["cachedContent"]);
+		assert_eq!(out["tools"], raw["tools"]);
 	}
 
 	#[test]

--- a/crates/llm/src/types/gemini.rs
+++ b/crates/llm/src/types/gemini.rs
@@ -985,7 +985,8 @@ mod tests {
 			tool_calls: true,
 		});
 		assert_eq!(llm.input_tokens, Some(10));
-		assert_eq!(llm.output_tokens, Some(5));
+		// Output is normalized to candidates + thoughts (5 + 2), matching other providers.
+		assert_eq!(llm.output_tokens, Some(7));
 		assert_eq!(llm.total_tokens, Some(17));
 		assert_eq!(llm.reasoning_tokens, Some(2));
 		assert_eq!(llm.cached_input_tokens, Some(3));

--- a/crates/llm/src/types/gemini.rs
+++ b/crates/llm/src/types/gemini.rs
@@ -1,0 +1,1098 @@
+//! Inbound native Gemini `generateContent`/`streamGenerateContent`/`countTokens` requests.
+//!
+//! References:
+//! - <https://ai.google.dev/api/generate-content>
+//! - <https://ai.google.dev/api/tokens>
+//! - <https://docs.cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference>
+//!
+//! The wire DTOs live in `types::vertex_gemini`; this wraps them with the request
+//! metadata the gateway needs (model and streaming), which Gemini carries in the
+//! URI (`models/{model}:generateContent` vs `:streamGenerateContent`) rather than
+//! the body.
+
+use agent_core::prelude::Strng;
+use agent_core::strng;
+use bytes::Bytes;
+use itertools::Itertools;
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::types::{OutputMessage, OutputMessagePart, ResponseType, vertex_gemini as vg};
+use crate::{
+	AIError, InputFormat, LLMRequest, LLMRequestParams, LLMResponse, RequestType,
+	SimpleChatCompletionMessage, logged_response_parsing, webhook,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct Request {
+	/// Filled from the URI by the caller; never serialized into the wire body.
+	pub model: Option<String>,
+	/// Filled from the URI by the caller (`:streamGenerateContent`); there is no body flag.
+	pub streaming: bool,
+	pub inner: vg::GenerateContentRequest,
+}
+
+impl<'de> Deserialize<'de> for Request {
+	fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+		// `read_gemini_body_and_default_model` injects the resolved model into the body JSON — the
+		// URI's, the backend pin, or whatever the operator's body mutations made of it — so keep
+		// it, but take it out of the body: the passthrough `rest` flatten would otherwise forward
+		// it upstream, where the path already carries the model and Vertex rejects the unknown
+		// field.
+		let mut body = serde_json::Value::deserialize(deserializer)?;
+		let model = match body.as_object_mut().and_then(|obj| obj.remove("model")) {
+			Some(serde_json::Value::String(model)) => Some(model),
+			_ => None,
+		};
+		let inner = vg::GenerateContentRequest::deserialize(body).map_err(serde::de::Error::custom)?;
+		Ok(Request {
+			model,
+			streaming: false,
+			inner,
+		})
+	}
+}
+
+/// Applies `f` to the text of every visible (non-thought) `Text` part in `content`, scanning
+/// consecutive text parts as one run so guard patterns can span parts — matching how the other
+/// request/response types expose text to prompt guard.
+fn visit_content_text(content: &mut vg::Content, f: &mut dyn FnMut(&mut String)) {
+	crate::types::scan_text_runs(
+		&mut content.parts,
+		"\n",
+		|p| match p {
+			vg::Part::Text(tp) if tp.thought != Some(true) => Some(&mut tp.text),
+			_ => None,
+		},
+		f,
+	);
+}
+
+impl RequestType for Request {
+	fn body_is_json(&self) -> bool {
+		true
+	}
+
+	fn model(&mut self) -> &mut Option<String> {
+		&mut self.model
+	}
+
+	fn prepend_prompts(&mut self, prompts: Vec<SimpleChatCompletionMessage>) {
+		prepend_prompts_helper(
+			&mut self.inner.contents,
+			&mut self.inner.system_instruction,
+			prompts,
+		);
+	}
+
+	fn append_prompts(&mut self, prompts: Vec<SimpleChatCompletionMessage>) {
+		append_prompts_helper(
+			&mut self.inner.contents,
+			&mut self.inner.system_instruction,
+			prompts,
+		);
+	}
+
+	fn to_llm_request(&self, provider: Strng, tokenize: bool) -> Result<LLMRequest, AIError> {
+		let model = strng::new(self.model.as_deref().unwrap_or_default());
+		let input_tokens = if tokenize {
+			let messages = self.get_messages();
+			Some(crate::tokenizer::num_tokens_from_messages(
+				&model, &messages,
+			)?)
+		} else {
+			None
+		};
+		let gc = self.inner.generation_config.as_ref();
+		Ok(LLMRequest {
+			input_tokens,
+			input_format: InputFormat::Gemini,
+			cache_convention: crate::CacheTokenConvention::pending(),
+			request_model: model,
+			provider,
+			streaming: self.streaming,
+			params: LLMRequestParams {
+				temperature: gc.and_then(|g| g.temperature).map(f64::from),
+				top_p: gc.and_then(|g| g.top_p).map(f64::from),
+				frequency_penalty: gc.and_then(|g| g.frequency_penalty).map(f64::from),
+				presence_penalty: gc.and_then(|g| g.presence_penalty).map(f64::from),
+				seed: gc.and_then(|g| g.seed),
+				max_tokens: gc.and_then(|g| g.max_output_tokens).map(u64::from),
+				encoding_format: None,
+				dimensions: None,
+			},
+			prompt: Default::default(),
+			provider_state: None,
+		})
+	}
+
+	fn get_messages(&self) -> Vec<SimpleChatCompletionMessage> {
+		get_messages_helper(&self.inner.contents, &self.inner.system_instruction)
+	}
+
+	fn set_messages(&mut self, messages: Vec<SimpleChatCompletionMessage>) {
+		set_messages_helper(
+			&mut self.inner.contents,
+			&mut self.inner.system_instruction,
+			messages,
+		);
+	}
+
+	fn to_value(&self) -> serde_json::Result<serde_json::Value> {
+		serde_json::to_value(&self.inner)
+	}
+
+	fn visit_text_mut(&mut self, f: &mut dyn FnMut(&mut String)) {
+		if let Some(system) = &mut self.inner.system_instruction {
+			visit_content_text(system, f);
+		}
+		for content in &mut self.inner.contents {
+			visit_content_text(content, f);
+		}
+	}
+}
+
+/// Inbound native Gemini `countTokens` body. Passthrough in both directions, so only the
+/// fields the gateway reads are typed; the alternative `generateContentRequest` form and any
+/// other field ride `rest`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CountTokensRequest {
+	/// Comes from the URI, like the generateContent routes. `read_gemini_body_and_default_model`
+	/// injects it into the body JSON, so it is captured by a typed field rather than landing in
+	/// `rest`; it is never serialized back onto the wire, where the upstream path carries it.
+	#[serde(default, skip_serializing)]
+	pub model: Option<String>,
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub contents: Vec<vg::Content>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub system_instruction: Option<vg::Content>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
+}
+
+impl RequestType for CountTokensRequest {
+	fn body_is_json(&self) -> bool {
+		true
+	}
+
+	fn model(&mut self) -> &mut Option<String> {
+		&mut self.model
+	}
+
+	fn prepend_prompts(&mut self, prompts: Vec<SimpleChatCompletionMessage>) {
+		prepend_prompts_helper(&mut self.contents, &mut self.system_instruction, prompts);
+	}
+
+	fn append_prompts(&mut self, prompts: Vec<SimpleChatCompletionMessage>) {
+		append_prompts_helper(&mut self.contents, &mut self.system_instruction, prompts);
+	}
+
+	fn to_llm_request(&self, provider: Strng, _tokenize: bool) -> Result<LLMRequest, AIError> {
+		Ok(LLMRequest {
+			// We never tokenize these, so always empty
+			input_tokens: None,
+			input_format: InputFormat::GeminiCountTokens,
+			cache_convention: crate::CacheTokenConvention::pending(),
+			request_model: strng::new(self.model.as_deref().unwrap_or_default()),
+			provider,
+			streaming: false,
+			params: Default::default(),
+			prompt: Default::default(),
+			provider_state: None,
+		})
+	}
+
+	fn get_messages(&self) -> Vec<SimpleChatCompletionMessage> {
+		get_messages_helper(&self.contents, &self.system_instruction)
+	}
+
+	fn set_messages(&mut self, messages: Vec<SimpleChatCompletionMessage>) {
+		set_messages_helper(&mut self.contents, &mut self.system_instruction, messages);
+	}
+
+	fn to_value(&self) -> serde_json::Result<serde_json::Value> {
+		serde_json::to_value(self)
+	}
+
+	fn visit_text_mut(&mut self, _f: &mut dyn FnMut(&mut String)) {
+		unimplemented!(
+			"visit_text_mut is used for prompt guard; prompt guard is disabled for gemini countTokens."
+		)
+	}
+}
+
+/// Native Gemini `countTokens` response: forwarded as-is, parsed only for the token count.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CountTokensResponse {
+	// proto3 JSON omits zero-valued fields, so an empty request comes back without the key.
+	#[serde(default)]
+	pub total_tokens: u64,
+}
+
+impl CountTokensResponse {
+	pub fn translate_response(bytes: Bytes) -> Result<(Bytes, u64), AIError> {
+		let resp: Self = serde_json::from_slice(&bytes).map_err(logged_response_parsing(&bytes))?;
+		Ok((bytes, resp.total_tokens))
+	}
+}
+
+fn get_messages_helper(
+	contents: &[vg::Content],
+	system_instruction: &Option<vg::Content>,
+) -> Vec<SimpleChatCompletionMessage> {
+	let mut out = Vec::new();
+	if let Some(si) = system_instruction {
+		let content = joined_text(si, '\n');
+		if !content.is_empty() {
+			out.push(SimpleChatCompletionMessage {
+				role: strng::literal!("system"),
+				content,
+			});
+		}
+	}
+	out.extend(contents.iter().map(|c| {
+		let role = match c.role.as_deref() {
+			Some("model") => strng::literal!("assistant"),
+			Some(role) => strng::new(role),
+			None => strng::literal!("user"),
+		};
+		SimpleChatCompletionMessage {
+			role,
+			content: joined_text(c, ' '),
+		}
+	}));
+	out
+}
+
+fn set_messages_helper(
+	contents: &mut Vec<vg::Content>,
+	system_instruction: &mut Option<vg::Content>,
+	messages: Vec<SimpleChatCompletionMessage>,
+) {
+	let (system, chat) = partition_system(messages);
+	if !system.is_empty() {
+		let text = system.iter().map(|m| m.content.as_str()).join("\n");
+		match system_instruction {
+			Some(si) => set_content_text(si, &text),
+			None => {
+				*system_instruction = Some(vg::Content {
+					role: None,
+					parts: vec![text_part(&text)],
+					rest: Default::default(),
+				})
+			},
+		}
+	}
+	if chat.len() == contents.len() {
+		// Same shape get_messages() returned: rewrite the text in place so non-text
+		// parts (inlineData, functionCall, ...) survive guardrail masking.
+		for (content, msg) in contents.iter_mut().zip(chat) {
+			set_content_text(content, &msg.content);
+		}
+	} else {
+		*contents = chat.into_iter().map(content_from_message).collect();
+	}
+}
+
+fn prepend_prompts_helper(
+	contents: &mut Vec<vg::Content>,
+	system_instruction: &mut Option<vg::Content>,
+	prompts: Vec<SimpleChatCompletionMessage>,
+) {
+	let (system, chat) = partition_system(prompts);
+	if !system.is_empty() {
+		let si = system_instruction.get_or_insert_default();
+		si.parts
+			.splice(0..0, system.into_iter().map(|p| text_part(&p.content)));
+	}
+	if !chat.is_empty() {
+		contents.splice(0..0, chat.into_iter().map(content_from_message));
+	}
+}
+
+fn append_prompts_helper(
+	contents: &mut Vec<vg::Content>,
+	system_instruction: &mut Option<vg::Content>,
+	prompts: Vec<SimpleChatCompletionMessage>,
+) {
+	let (system, chat) = partition_system(prompts);
+	if !system.is_empty() {
+		let si = system_instruction.get_or_insert_default();
+		si.parts
+			.extend(system.into_iter().map(|p| text_part(&p.content)));
+	}
+	if !chat.is_empty() {
+		contents.extend(chat.into_iter().map(content_from_message));
+	}
+}
+
+/// Non-streaming native Gemini response: forwarded as-is (unknown fields ride the
+/// `rest` flattens), parsed only to fill telemetry and serve response guardrails.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(transparent)]
+pub struct Response(pub vg::GenerateContentResponse);
+
+impl ResponseType for Response {
+	fn to_llm_response(&self, log_content: crate::LogContentFields) -> LLMResponse {
+		let um = self.0.usage_metadata.as_ref();
+		let counts = um.map(vg::UsageMetadata::counts);
+		LLMResponse {
+			input_tokens: counts.map(|c| c.0),
+			output_tokens: counts.map(|c| c.1),
+			total_tokens: counts.map(|c| c.2),
+			reasoning_tokens: um.and_then(|u| u.thoughts_token_count),
+			cached_input_tokens: um.and_then(|u| u.cached_content_token_count),
+			provider_model: self.0.model_version.as_deref().map(strng::new),
+			completion: log_content.completion.then(|| {
+				self
+					.0
+					.candidates
+					.iter()
+					.map(|c| c.content.as_ref().map(candidate_text).unwrap_or_default())
+					.collect()
+			}),
+			output_messages: if log_content.tool_calls {
+				extract_output_messages(&self.0)
+			} else {
+				None
+			},
+			..Default::default()
+		}
+	}
+
+	fn to_webhook_choices(&self) -> Vec<webhook::ResponseChoice> {
+		self
+			.0
+			.candidates
+			.iter()
+			.map(|c| webhook::ResponseChoice {
+				message: webhook::Message {
+					role: strng::literal!("assistant"),
+					content: strng::new(c.content.as_ref().map(candidate_text).unwrap_or_default()),
+				},
+			})
+			.collect()
+	}
+
+	fn set_webhook_choices(&mut self, choices: Vec<webhook::ResponseChoice>) -> anyhow::Result<()> {
+		if self.0.candidates.len() != choices.len() {
+			anyhow::bail!("webhook response message count mismatch");
+		}
+		for (cand, wh) in self.0.candidates.iter_mut().zip(choices) {
+			if let Some(content) = &mut cand.content {
+				set_visible_text(content, &wh.message.content);
+			}
+		}
+		Ok(())
+	}
+
+	fn serialize(&self) -> serde_json::Result<Vec<u8>> {
+		serde_json::to_vec(&self.0)
+	}
+
+	fn visit_text_mut(&mut self, f: &mut dyn FnMut(&mut String)) {
+		for candidate in &mut self.0.candidates {
+			if let Some(content) = &mut candidate.content {
+				visit_content_text(content, f);
+			}
+		}
+	}
+}
+
+/// Visible (non-thought) text of a candidate, concatenated like the OpenAI translation does.
+fn candidate_text(content: &vg::Content) -> String {
+	content
+		.parts
+		.iter()
+		.filter_map(|p| match p {
+			vg::Part::Text(t) if t.thought != Some(true) => Some(t.text.as_str()),
+			_ => None,
+		})
+		.collect()
+}
+
+/// Rewrite the visible text of a candidate: the first non-thought text part carries the new
+/// text, later non-thought text parts are dropped; thought and non-text parts are untouched.
+fn set_visible_text(content: &mut vg::Content, text: &str) {
+	let mut replaced = false;
+	content.parts.retain_mut(|p| match p {
+		vg::Part::Text(t) if t.thought != Some(true) => {
+			// Masking to "" drops the part instead of leaving `{"text":""}`; see `set_content_text`.
+			let keep = !replaced && !text.is_empty();
+			replaced = true;
+			if keep {
+				t.text = text.to_string();
+			}
+			keep
+		},
+		_ => true,
+	});
+	// A tool-call-only candidate has no visible text; see `set_content_text`.
+	if !replaced && !text.is_empty() {
+		content.parts.push(text_part(text));
+	}
+}
+
+fn extract_output_messages(resp: &vg::GenerateContentResponse) -> Option<Vec<OutputMessage>> {
+	let out: Vec<OutputMessage> = resp
+		.candidates
+		.iter()
+		.filter_map(|cand| {
+			let content = cand.content.as_ref()?;
+			let calls: Vec<OutputMessagePart> = content
+				.parts
+				.iter()
+				.filter_map(|p| match p {
+					vg::Part::FunctionCall(fc) => Some(OutputMessagePart::ToolCall {
+						id: strng::new(fc.function_call.id.as_deref().unwrap_or_default()),
+						name: strng::new(&fc.function_call.name),
+						arguments: fc.function_call.args.clone(),
+					}),
+					_ => None,
+				})
+				.collect();
+			if calls.is_empty() {
+				return None;
+			}
+			Some(OutputMessage {
+				role: strng::literal!("assistant"),
+				content: calls,
+				finish_reason: cand.finish_reason.as_deref().map(strng::new),
+			})
+		})
+		.collect();
+	(!out.is_empty()).then_some(out)
+}
+
+fn partition_system(
+	messages: Vec<SimpleChatCompletionMessage>,
+) -> (
+	Vec<SimpleChatCompletionMessage>,
+	Vec<SimpleChatCompletionMessage>,
+) {
+	messages
+		.into_iter()
+		.partition(|m| m.role.as_str() == "system")
+}
+
+fn joined_text(content: &vg::Content, sep: char) -> Strng {
+	let text = content
+		.parts
+		.iter()
+		.filter_map(|p| match p {
+			vg::Part::Text(t) => Some(t.text.as_str()),
+			_ => None,
+		})
+		.fold(String::new(), |mut acc, s| {
+			if !acc.is_empty() {
+				acc.push(sep);
+			}
+			acc.push_str(s);
+			acc
+		});
+	strng::new(&text)
+}
+
+fn set_content_text(content: &mut vg::Content, text: &str) {
+	// Collapse all text parts into one carrying the new text; everything else is untouched.
+	// An empty replacement (a guardrail masking the whole turn away) drops every text part
+	// rather than leaving `{"text":""}`, which Vertex rejects with "empty text parameter". A
+	// content left with no parts at all serializes without a `parts` key, the same shape Google
+	// itself emits for a candidate it blocked.
+	let mut replaced = false;
+	content.parts.retain_mut(|p| match p {
+		vg::Part::Text(t) => {
+			let keep = !replaced && !text.is_empty();
+			replaced = true;
+			if keep {
+				t.text = text.to_string();
+			}
+			keep
+		},
+		_ => true,
+	});
+	// Turns made only of functionCall/functionResponse parts read back as empty text; adding a
+	// part for that would both corrupt the passthrough and make Vertex reject the request
+	// ("empty text parameter").
+	if !replaced && !text.is_empty() {
+		content.parts.push(text_part(text));
+	}
+}
+
+fn content_from_message(m: SimpleChatCompletionMessage) -> vg::Content {
+	let role = match m.role.as_str() {
+		"assistant" => "model".to_string(),
+		role => role.to_string(),
+	};
+	vg::Content {
+		role: Some(role),
+		parts: vec![text_part(&m.content)],
+		rest: Default::default(),
+	}
+}
+
+fn text_part(text: &str) -> vg::Part {
+	vg::Part::Text(vg::TextPart {
+		text: text.to_string(),
+		thought: None,
+		thought_signature: None,
+		rest: Default::default(),
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use serde_json::json;
+
+	use super::*;
+
+	fn request(body: serde_json::Value) -> Request {
+		serde_json::from_value(body).expect("valid request")
+	}
+
+	#[test]
+	fn deserialize_lifts_the_injected_model_out_of_the_body() {
+		// The gateway injects the resolved model (URI, backend pin, or whatever the operator's body
+		// mutations made of it) so the wrapper is where it must be read back from — but the wire
+		// body has no such field and Vertex rejects unknown ones.
+		let req = request(json!({
+			"model": "gemini-2.5-flash",
+			"contents": [{ "role": "user", "parts": [{ "text": "hi" }] }],
+			"someNewTopLevelField": { "a": true }
+		}));
+		assert_eq!(req.model.as_deref(), Some("gemini-2.5-flash"));
+		assert!(!req.streaming);
+		assert_eq!(req.inner.contents.len(), 1);
+
+		let out = serde_json::to_value(&req.inner).expect("serialize");
+		assert!(
+			out.get("model").is_none(),
+			"the gateway-injected model must not reach the wire: {out}"
+		);
+		assert_eq!(out["someNewTopLevelField"], json!({ "a": true }));
+
+		let bare = request(json!({ "contents": [] }));
+		assert_eq!(bare.model, None);
+	}
+
+	#[test]
+	fn get_messages_maps_system_instruction_and_contents() {
+		let req = request(json!({
+			"systemInstruction": { "parts": [{ "text": "be brief" }, { "text": "be kind" }] },
+			"contents": [
+				{ "role": "user", "parts": [{ "text": "hello" }, { "text": "there" }] },
+				{ "role": "model", "parts": [{ "text": "hi!" }] },
+				{ "parts": [{ "text": "and you?" }] }
+			]
+		}));
+		let msgs = req.get_messages();
+		assert_eq!(msgs.len(), 4);
+		assert_eq!(msgs[0].role, "system");
+		assert_eq!(msgs[0].content, "be brief\nbe kind");
+		assert_eq!(msgs[1].role, "user");
+		assert_eq!(msgs[1].content, "hello there");
+		assert_eq!(msgs[2].role, "assistant");
+		assert_eq!(msgs[2].content, "hi!");
+		// Missing role defaults to user.
+		assert_eq!(msgs[3].role, "user");
+	}
+
+	/// Guardrail masking rewrites every message, not just the ones it changed, so an unchanged
+	/// round-trip must leave the wire body exactly as it arrived.
+	#[test]
+	fn get_then_set_messages_unchanged_is_a_no_op() {
+		let body = json!({
+			"systemInstruction": { "parts": [{ "text": "be brief" }] },
+			"contents": [
+				{ "role": "user", "parts": [
+					{ "text": "what is in this?" },
+					{ "inlineData": { "mimeType": "image/png", "data": "iVBORw0KGgo=" } }
+				] },
+				{ "role": "model", "parts": [
+					{ "text": "thinking", "thought": true, "thoughtSignature": "sig-a" },
+					{ "functionCall": { "name": "get_weather", "id": "fc_1", "args": { "city": "Boston" } },
+						"thoughtSignature": "sig-b" }
+				] },
+				{ "role": "user", "parts": [
+					{ "functionResponse": { "name": "get_weather", "id": "fc_1", "response": { "c": 12 } } }
+				] }
+			]
+		});
+		let mut req = request(body.clone());
+		let msgs = req.get_messages();
+		req.set_messages(msgs);
+		assert_eq!(
+			serde_json::to_value(&req.inner).expect("serialize"),
+			body,
+			"an unchanged round-trip must not rewrite the body"
+		);
+	}
+
+	#[test]
+	fn get_messages_round_trips_roles() {
+		let body = json!({
+			"contents": [
+				{ "role": "user", "parts": [{ "text": "a" }] },
+				{ "role": "model", "parts": [{ "text": "b" }] }
+			]
+		});
+		let mut req = request(body.clone());
+		let msgs = req.get_messages();
+		assert_eq!(
+			msgs.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
+			["user", "assistant"]
+		);
+		// Force the rebuild path (the count no longer matches) so role mapping runs both ways.
+		let mut msgs = msgs;
+		msgs.push(SimpleChatCompletionMessage {
+			role: strng::literal!("assistant"),
+			content: strng::literal!("c"),
+		});
+		req.set_messages(msgs);
+		assert_eq!(
+			req
+				.inner
+				.contents
+				.iter()
+				.map(|c| c.role.as_deref().unwrap_or_default())
+				.collect::<Vec<_>>(),
+			["user", "model", "model"]
+		);
+	}
+
+	#[test]
+	fn masking_one_message_leaves_multimodal_and_tool_turns_untouched() {
+		let body = json!({
+			"contents": [
+				{ "role": "user", "parts": [
+					{ "text": "my SSN is 123-45-6789" },
+					{ "inlineData": { "mimeType": "image/png", "data": "iVBORw0KGgo=" } }
+				] },
+				{ "role": "model", "parts": [
+					{ "functionCall": { "name": "lookup", "id": "fc_1", "args": { "q": "x" } } }
+				] }
+			]
+		});
+		let mut req = request(body.clone());
+		let mut msgs = req.get_messages();
+		msgs[0].content = "my SSN is [MASKED]".into();
+		req.set_messages(msgs);
+
+		let out = serde_json::to_value(&req.inner).expect("serialize");
+		assert_eq!(out["contents"][0]["parts"][0]["text"], "my SSN is [MASKED]");
+		assert_eq!(
+			out["contents"][0]["parts"][1], body["contents"][0]["parts"][1],
+			"inlineData must survive masking byte-identically"
+		);
+		assert_eq!(
+			out["contents"][1], body["contents"][1],
+			"a tool-call turn with no text must not be rewritten"
+		);
+	}
+
+	#[test]
+	fn masking_a_turn_to_empty_drops_the_text_part() {
+		// A `{"text":""}` part is what Vertex rejects with "empty text parameter", so an empty
+		// mask must remove the part. On a mixed turn the remaining parts keep the turn valid; on
+		// a text-only turn the content is left with no parts at all, which serializes with no
+		// `parts` key.
+		let mut req = request(json!({
+			"contents": [
+				{ "role": "user", "parts": [{ "text": "secret" }] },
+				{ "role": "user", "parts": [
+					{ "text": "secret" },
+					{ "functionCall": { "name": "f", "id": "fc_1", "args": {} } }
+				] }
+			]
+		}));
+		let mut msgs = req.get_messages();
+		msgs[0].content = "".into();
+		msgs[1].content = "".into();
+		req.set_messages(msgs);
+
+		let out = serde_json::to_value(&req.inner).expect("serialize");
+		assert_eq!(out["contents"][0], json!({ "role": "user" }));
+		assert_eq!(
+			out["contents"][1],
+			json!({
+				"role": "user",
+				"parts": [{ "functionCall": { "name": "f", "id": "fc_1", "args": {} } }]
+			})
+		);
+		assert!(
+			!out.to_string().contains(r#""text":"""#),
+			"no empty text part may survive: {out}"
+		);
+	}
+
+	#[test]
+	fn masking_a_candidate_to_empty_drops_the_visible_text_part() {
+		let mut resp = response(json!({
+			"candidates": [{
+				"content": { "role": "model", "parts": [
+					{ "text": "internal reasoning", "thought": true },
+					{ "text": "secret answer" },
+					{ "functionCall": { "name": "f", "args": {} } }
+				] },
+				"finishReason": "STOP"
+			}]
+		}));
+		let mut choices = resp.to_webhook_choices();
+		choices[0].message.content = "".into();
+		resp.set_webhook_choices(choices).expect("set choices");
+
+		let out: serde_json::Value =
+			serde_json::from_slice(&ResponseType::serialize(&resp).expect("serialize")).unwrap();
+		assert_eq!(
+			out["candidates"][0]["content"]["parts"],
+			json!([
+				{ "text": "internal reasoning", "thought": true },
+				{ "functionCall": { "name": "f", "args": {} } }
+			])
+		);
+	}
+
+	#[test]
+	fn masking_a_text_only_candidate_to_empty_leaves_no_parts() {
+		let mut resp = response(json!({
+			"candidates": [{
+				"content": { "role": "model", "parts": [{ "text": "secret answer" }] },
+				"finishReason": "STOP"
+			}]
+		}));
+		let mut choices = resp.to_webhook_choices();
+		choices[0].message.content = "".into();
+		resp.set_webhook_choices(choices).expect("set choices");
+
+		let out: serde_json::Value =
+			serde_json::from_slice(&ResponseType::serialize(&resp).expect("serialize")).unwrap();
+		// The same shape Google emits for a candidate it blocked itself.
+		assert_eq!(
+			out["candidates"][0],
+			json!({ "content": { "role": "model" }, "finishReason": "STOP" })
+		);
+	}
+
+	#[test]
+	fn set_messages_preserves_non_text_parts() {
+		let mut req = request(json!({
+			"contents": [{
+				"role": "user",
+				"parts": [
+					{ "text": "describe this" },
+					{ "inlineData": { "mimeType": "image/png", "data": "iVBORw0KG..." } }
+				]
+			}]
+		}));
+		let mut msgs = req.get_messages();
+		msgs[0].content = "MASKED".into();
+		req.set_messages(msgs);
+
+		assert_eq!(req.inner.contents.len(), 1);
+		let parts = &req.inner.contents[0].parts;
+		assert_eq!(parts.len(), 2);
+		let vg::Part::Text(t) = &parts[0] else {
+			panic!("expected text part first");
+		};
+		assert_eq!(t.text, "MASKED");
+		assert!(matches!(parts[1], vg::Part::InlineData(_)));
+	}
+
+	#[test]
+	fn set_messages_rewrites_system_instruction_in_place() {
+		let mut req = request(json!({
+			"systemInstruction": { "parts": [{ "text": "secret system" }] },
+			"contents": [{ "role": "user", "parts": [{ "text": "hi" }] }]
+		}));
+		let mut msgs = req.get_messages();
+		msgs[0].content = "masked system".into();
+		req.set_messages(msgs);
+
+		let si = req.inner.system_instruction.as_ref().unwrap();
+		let vg::Part::Text(t) = &si.parts[0] else {
+			panic!("expected text part");
+		};
+		assert_eq!(t.text, "masked system");
+		assert_eq!(req.inner.contents.len(), 1);
+	}
+
+	#[test]
+	fn prepend_and_append_prompts_map_roles() {
+		let mut req = request(json!({
+			"contents": [{ "role": "user", "parts": [{ "text": "question" }] }]
+		}));
+		req.prepend_prompts(vec![
+			SimpleChatCompletionMessage {
+				role: strng::literal!("system"),
+				content: strng::literal!("sys"),
+			},
+			SimpleChatCompletionMessage {
+				role: strng::literal!("assistant"),
+				content: strng::literal!("earlier answer"),
+			},
+		]);
+		req.append_prompts(vec![SimpleChatCompletionMessage {
+			role: strng::literal!("user"),
+			content: strng::literal!("suffix"),
+		}]);
+
+		let si = req.inner.system_instruction.as_ref().unwrap();
+		assert_eq!(si.parts.len(), 1);
+		assert_eq!(req.inner.contents.len(), 3);
+		assert_eq!(req.inner.contents[0].role.as_deref(), Some("model"));
+		assert_eq!(req.inner.contents[2].role.as_deref(), Some("user"));
+	}
+
+	fn response(body: serde_json::Value) -> Response {
+		serde_json::from_value(body).expect("valid response")
+	}
+
+	#[test]
+	fn response_to_llm_response_extracts_usage_and_visible_completion() {
+		let resp = response(json!({
+			"candidates": [{
+				"content": { "role": "model", "parts": [
+					{ "text": "internal reasoning", "thought": true },
+					{ "text": "hello" }
+				] },
+				"finishReason": "STOP"
+			}],
+			"usageMetadata": {
+				"promptTokenCount": 10,
+				"candidatesTokenCount": 5,
+				"totalTokenCount": 17,
+				"thoughtsTokenCount": 2,
+				"cachedContentTokenCount": 3
+			},
+			"modelVersion": "gemini-2.5-flash"
+		}));
+		let llm = resp.to_llm_response(crate::LogContentFields {
+			completion: true,
+			tool_calls: true,
+		});
+		assert_eq!(llm.input_tokens, Some(10));
+		assert_eq!(llm.output_tokens, Some(5));
+		assert_eq!(llm.total_tokens, Some(17));
+		assert_eq!(llm.reasoning_tokens, Some(2));
+		assert_eq!(llm.cached_input_tokens, Some(3));
+		assert_eq!(llm.provider_model.as_deref(), Some("gemini-2.5-flash"));
+		assert_eq!(llm.completion, Some(vec!["hello".to_string()]));
+		assert!(llm.output_messages.is_none());
+	}
+
+	#[test]
+	fn response_total_tokens_fall_back_to_prompt_plus_candidates() {
+		let resp = response(json!({
+			"usageMetadata": { "promptTokenCount": 4, "candidatesTokenCount": 6 }
+		}));
+		let llm = resp.to_llm_response(Default::default());
+		assert_eq!(llm.total_tokens, Some(10));
+	}
+
+	#[test]
+	fn response_serialize_preserves_unknown_fields() {
+		let raw = json!({
+			"candidates": [{
+				"content": { "role": "model", "parts": [{ "text": "hi", "someNewPartField": 1 }] },
+				"finishReason": "STOP",
+				"someNewCandidateField": { "a": true }
+			}],
+			"usageMetadata": { "promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2 },
+			"someNewTopLevelField": "x"
+		});
+		let resp = response(raw.clone());
+		let out: serde_json::Value =
+			serde_json::from_slice(&ResponseType::serialize(&resp).expect("serialize")).unwrap();
+		assert_eq!(out, raw);
+	}
+
+	#[test]
+	fn response_webhook_masking_rewrites_visible_text_only() {
+		let mut resp = response(json!({
+			"candidates": [{
+				"content": { "role": "model", "parts": [
+					{ "text": "internal reasoning", "thought": true },
+					{ "text": "secret answer" },
+					{ "functionCall": { "name": "f", "args": {} } }
+				] },
+				"finishReason": "STOP"
+			}]
+		}));
+		let mut choices = resp.to_webhook_choices();
+		assert_eq!(choices.len(), 1);
+		assert_eq!(choices[0].message.content, "secret answer");
+		choices[0].message.content = strng::literal!("MASKED");
+		resp.set_webhook_choices(choices).expect("set choices");
+
+		let parts = &resp.0.candidates[0].content.as_ref().unwrap().parts;
+		assert_eq!(parts.len(), 3);
+		let vg::Part::Text(thought) = &parts[0] else {
+			panic!("expected thought part first");
+		};
+		assert_eq!(thought.text, "internal reasoning");
+		let vg::Part::Text(visible) = &parts[1] else {
+			panic!("expected visible text part");
+		};
+		assert_eq!(visible.text, "MASKED");
+		assert!(matches!(parts[2], vg::Part::FunctionCall(_)));
+	}
+
+	#[test]
+	fn response_webhook_masking_leaves_tool_call_only_candidates_alone() {
+		let body = json!({
+			"candidates": [
+				{ "content": { "role": "model", "parts": [{ "text": "secret" }] }, "finishReason": "STOP" },
+				{ "content": { "role": "model", "parts": [
+					{ "functionCall": { "name": "f", "id": "fc_1", "args": {} } }
+				] }, "finishReason": "STOP" }
+			]
+		});
+		let mut resp = response(body.clone());
+		let mut choices = resp.to_webhook_choices();
+		assert_eq!(choices[1].message.content, "");
+		choices[0].message.content = strng::literal!("MASKED");
+		resp.set_webhook_choices(choices).expect("set choices");
+
+		let out: serde_json::Value =
+			serde_json::from_slice(&ResponseType::serialize(&resp).expect("serialize")).unwrap();
+		assert_eq!(
+			out["candidates"][0]["content"]["parts"][0]["text"],
+			"MASKED"
+		);
+		assert_eq!(
+			out["candidates"][1], body["candidates"][1],
+			"a tool-call-only candidate must not gain an empty text part"
+		);
+	}
+
+	#[test]
+	fn response_tool_calls_surface_as_output_messages() {
+		let resp = response(json!({
+			"candidates": [{
+				"content": { "role": "model", "parts": [
+					{ "functionCall": { "name": "get_weather", "id": "c1", "args": { "city": "Berlin" } } }
+				] },
+				"finishReason": "STOP"
+			}]
+		}));
+		let llm = resp.to_llm_response(crate::LogContentFields {
+			completion: false,
+			tool_calls: true,
+		});
+		let messages = llm.output_messages.expect("output messages");
+		assert_eq!(messages.len(), 1);
+		let tool_calls = messages[0].tool_calls();
+		assert_eq!(tool_calls.len(), 1);
+		assert_eq!(tool_calls[0].name, "get_weather");
+		assert_eq!(tool_calls[0].id, "c1");
+		assert_eq!(tool_calls[0].arguments["city"], "Berlin");
+	}
+
+	#[test]
+	fn to_llm_request_reports_gemini_format_and_uri_derived_fields() {
+		let mut req = request(json!({
+			"contents": [{ "role": "user", "parts": [{ "text": "hi" }] }],
+			"generationConfig": { "temperature": 0.5, "topP": 0.9, "maxOutputTokens": 128, "seed": 7 }
+		}));
+		req.model = Some("gemini-2.5-flash".to_string());
+		req.streaming = true;
+
+		let llm = req
+			.to_llm_request(strng::literal!("vertex"), false)
+			.expect("llm request");
+		assert_eq!(llm.input_format, InputFormat::Gemini);
+		assert_eq!(llm.request_model, "gemini-2.5-flash");
+		assert!(llm.streaming);
+		assert_eq!(llm.params.temperature, Some(0.5f32 as f64));
+		assert_eq!(llm.params.top_p, Some(0.9f32 as f64));
+		assert_eq!(llm.params.max_tokens, Some(128));
+		assert_eq!(llm.params.seed, Some(7));
+	}
+
+	fn count_tokens_request(body: serde_json::Value) -> CountTokensRequest {
+		serde_json::from_value(body).expect("valid countTokens request")
+	}
+
+	#[test]
+	fn count_tokens_request_strips_model_and_keeps_unknown_fields() {
+		let mut req = count_tokens_request(json!({
+			"model": "injected-by-the-gateway",
+			"contents": [{ "role": "user", "parts": [{ "text": "hi" }] }],
+			"generateContentRequest": {
+				"model": "models/gemini-2.5-flash",
+				"contents": [{ "role": "user", "parts": [{ "text": "hi" }] }],
+				"tools": [{ "googleSearch": {} }]
+			}
+		}));
+		assert_eq!(req.model.as_deref(), Some("injected-by-the-gateway"));
+
+		*req.model() = Some("gemini-2.5-flash".to_string());
+		let out: serde_json::Value = serde_json::to_value(&req).expect("serialize");
+		assert!(
+			out.get("model").is_none(),
+			"the gateway-injected model must not reach the wire: {out}"
+		);
+		assert_eq!(
+			out["generateContentRequest"]["tools"][0]["googleSearch"],
+			json!({})
+		);
+		assert_eq!(out["contents"][0]["parts"][0]["text"], "hi");
+	}
+
+	#[test]
+	fn count_tokens_request_reports_its_own_input_format() {
+		let mut req = count_tokens_request(json!({
+			"systemInstruction": { "parts": [{ "text": "be brief" }] },
+			"contents": [{ "role": "user", "parts": [{ "text": "hi" }] }]
+		}));
+		*req.model() = Some("gemini-2.5-flash".to_string());
+
+		let llm = req
+			.to_llm_request(strng::literal!("vertex"), true)
+			.expect("llm request");
+		assert_eq!(llm.input_format, InputFormat::GeminiCountTokens);
+		assert_eq!(llm.request_model, "gemini-2.5-flash");
+		assert!(!llm.streaming);
+		assert_eq!(llm.input_tokens, None);
+
+		let msgs = req.get_messages();
+		assert_eq!(msgs.len(), 2);
+		assert_eq!(msgs[0].role, "system");
+		assert_eq!(msgs[1].content, "hi");
+	}
+
+	#[test]
+	fn count_tokens_request_enrichment_appends_contents() {
+		let mut req = count_tokens_request(json!({
+			"contents": [{ "role": "user", "parts": [{ "text": "hi" }] }]
+		}));
+		req.append_prompts(vec![SimpleChatCompletionMessage {
+			role: strng::literal!("user"),
+			content: strng::literal!("suffix"),
+		}]);
+		assert_eq!(req.contents.len(), 2);
+		let out: serde_json::Value = serde_json::to_value(&req).expect("serialize");
+		assert_eq!(out["contents"][1]["parts"][0]["text"], "suffix");
+	}
+
+	#[test]
+	fn count_tokens_response_extracts_total_tokens() {
+		let body = Bytes::from_static(
+			br#"{"totalTokens":31,"totalBillableCharacters":96,"promptTokensDetails":[{"modality":"TEXT","tokenCount":31}]}"#,
+		);
+		let (out, count) = CountTokensResponse::translate_response(body.clone()).expect("parse");
+		assert_eq!(count, 31);
+		assert_eq!(
+			out, body,
+			"the countTokens response is passed through as-is"
+		);
+	}
+
+	#[test]
+	fn count_tokens_response_defaults_missing_total_to_zero() {
+		let body = Bytes::from_static(br#"{"promptTokensDetails":[]}"#);
+		let (_, count) = CountTokensResponse::translate_response(body).expect("parse");
+		assert_eq!(count, 0);
+	}
+}

--- a/crates/llm/src/types/mod.rs
+++ b/crates/llm/src/types/mod.rs
@@ -3,6 +3,7 @@ pub mod completions;
 pub mod count_tokens;
 pub mod detect;
 pub mod embeddings;
+pub mod gemini;
 pub mod messages;
 pub mod rerank;
 pub mod responses;
@@ -19,6 +20,9 @@ pub enum ChatRequest {
 	Completions(completions::Request),
 	Messages(messages::Request),
 	Responses(responses::Request),
+	/// Native Gemini generateContent/streamGenerateContent body (boxed: it is
+	/// much larger than the other variants)
+	Gemini(Box<vertex_gemini::GenerateContentRequest>),
 }
 
 pub(crate) fn thinking_budget_for_reasoning_effort(

--- a/crates/llm/src/types/mod.rs
+++ b/crates/llm/src/types/mod.rs
@@ -20,9 +20,8 @@ pub enum ChatRequest {
 	Completions(completions::Request),
 	Messages(messages::Request),
 	Responses(responses::Request),
-	/// Native Gemini generateContent/streamGenerateContent body (boxed: it is
-	/// much larger than the other variants)
-	Gemini(Box<vertex_gemini::GenerateContentRequest>),
+	/// Native Gemini generateContent/streamGenerateContent body
+	Gemini(gemini::GenerateContentRequest),
 }
 
 pub(crate) fn thinking_budget_for_reasoning_effort(

--- a/crates/llm/src/types/vertex_gemini.rs
+++ b/crates/llm/src/types/vertex_gemini.rs
@@ -354,9 +354,16 @@ pub struct UsageMetadata {
 impl UsageMetadata {
 	/// Prompt, completion, and total token counts (total falls back to prompt + completion
 	/// when absent).
+	///
+	/// Gemini reports thinking tokens in `thoughtsTokenCount`, disjoint from
+	/// `candidatesTokenCount` (`total = prompt + candidates + thoughts`), while every other
+	/// provider includes reasoning in its output count — and Google bills thoughts at the
+	/// output rate. Normalize to the common convention: completion includes thoughts, with
+	/// `thoughtsTokenCount` still reported separately as the reasoning breakdown.
 	pub fn counts(&self) -> (u64, u64, u64) {
 		let prompt = self.prompt_token_count.unwrap_or(0);
-		let completion = self.candidates_token_count.unwrap_or(0);
+		let completion =
+			self.candidates_token_count.unwrap_or(0) + self.thoughts_token_count.unwrap_or(0);
 		let total = self.total_token_count.unwrap_or(prompt + completion);
 		(prompt, completion, total)
 	}

--- a/crates/llm/src/types/vertex_gemini.rs
+++ b/crates/llm/src/types/vertex_gemini.rs
@@ -32,6 +32,8 @@ pub struct GenerateContentRequest {
 	pub cached_content: Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub labels: Option<serde_json::Map<String, serde_json::Value>>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -175,11 +177,14 @@ pub struct FileData {
 
 // ---------- Tools and tool config ----------
 
+/// Built-in tools (`googleSearch`, `codeExecution`, `urlContext`, ...) ride in `rest`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Tool {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub function_declarations: Vec<FunctionDeclaration>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -189,6 +194,8 @@ pub struct FunctionDeclaration {
 	pub description: Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub parameters: Option<serde_json::Value>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -196,6 +203,8 @@ pub struct FunctionDeclaration {
 pub struct ToolConfig {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub function_calling_config: Option<FunctionCallingConfig>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -206,6 +215,8 @@ pub struct FunctionCallingConfig {
 	pub mode: Option<String>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub allowed_function_names: Vec<String>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 // ---------- GenerationConfig and thinking ----------
@@ -237,6 +248,8 @@ pub struct GenerationConfig {
 	pub response_schema: Option<serde_json::Value>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub thinking_config: Option<ThinkingConfig>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
@@ -250,6 +263,8 @@ pub struct ThinkingConfig {
 	pub thinking_budget: Option<i32>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub include_thoughts: Option<bool>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -257,6 +272,8 @@ pub struct ThinkingConfig {
 pub struct SafetySetting {
 	pub category: String,
 	pub threshold: String,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 // ---------- Response ----------
@@ -316,6 +333,17 @@ pub struct UsageMetadata {
 	pub thoughts_token_count: Option<u64>,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
+}
+
+impl UsageMetadata {
+	/// Prompt, completion, and total token counts (total falls back to prompt + completion
+	/// when absent).
+	pub fn counts(&self) -> (u64, u64, u64) {
+		let prompt = self.prompt_token_count.unwrap_or(0);
+		let completion = self.candidates_token_count.unwrap_or(0);
+		let total = self.total_token_count.unwrap_or(prompt + completion);
+		(prompt, completion, total)
+	}
 }
 
 #[cfg(test)]
@@ -553,7 +581,9 @@ mod tests {
 			function_calling_config: Some(FunctionCallingConfig {
 				mode: Some("ANY".into()),
 				allowed_function_names: vec!["get_weather".into()],
+				rest: Default::default(),
 			}),
+			rest: Default::default(),
 		};
 		let s = serde_json::to_string(&cfg).unwrap();
 		assert!(s.contains("\"functionCallingConfig\""));

--- a/crates/llm/src/types/vertex_gemini.rs
+++ b/crates/llm/src/types/vertex_gemini.rs
@@ -71,7 +71,11 @@ pub struct TextPart {
 	pub text: String,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub thought: Option<bool>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		alias = "thought_signature"
+	)]
 	pub thought_signature: Option<String>,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
@@ -80,10 +84,15 @@ pub struct TextPart {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FunctionCallPart {
+	#[serde(alias = "function_call")]
 	pub function_call: FunctionCall,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub thought: Option<bool>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		alias = "thought_signature"
+	)]
 	pub thought_signature: Option<String>,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
@@ -92,6 +101,7 @@ pub struct FunctionCallPart {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FunctionResponsePart {
+	#[serde(alias = "function_response")]
 	pub function_response: FunctionResponse,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
@@ -100,6 +110,7 @@ pub struct FunctionResponsePart {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InlineDataPart {
+	#[serde(alias = "inline_data")]
 	pub inline_data: Blob,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
@@ -108,6 +119,7 @@ pub struct InlineDataPart {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FileDataPart {
+	#[serde(alias = "file_data")]
 	pub file_data: FileData,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
@@ -116,6 +128,7 @@ pub struct FileDataPart {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutableCodePart {
+	#[serde(alias = "executable_code")]
 	pub executable_code: serde_json::Value,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
@@ -124,6 +137,7 @@ pub struct ExecutableCodePart {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodeExecutionResultPart {
+	#[serde(alias = "code_execution_result")]
 	pub code_execution_result: serde_json::Value,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,
@@ -157,6 +171,7 @@ pub struct FunctionResponse {
 #[serde(rename_all = "camelCase")]
 pub struct Blob {
 	// Field order matters: Vertex returns 400 if `mimeType` comes after `data`.
+	#[serde(alias = "mime_type")]
 	pub mime_type: String,
 	pub data: String,
 	#[serde(flatten, default)]
@@ -168,8 +183,9 @@ pub struct Blob {
 pub struct FileData {
 	// Field order matters: `mimeType` must precede `fileUri` in serialised JSON.
 	// `mime_type` is optional; Vertex resolves it server-side for Files API URLs.
-	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde(default, skip_serializing_if = "Option::is_none", alias = "mime_type")]
 	pub mime_type: Option<String>,
+	#[serde(alias = "file_uri")]
 	pub file_uri: String,
 	#[serde(flatten, default)]
 	pub rest: serde_json::Value,

--- a/crates/llm/src/vertex.rs
+++ b/crates/llm/src/vertex.rs
@@ -150,11 +150,9 @@ impl Provider {
 
 			// `?alt=sse` is required on the streaming endpoint; without it Vertex returns a
 			// JSON array rather than an SSE stream. Native Gemini inbound arrives here as
-			// RouteType::Completions (its upstream provider format); GeminiGenerateContent is
+			// RouteType::Completions (its upstream provider format); GenerateContent is
 			// matched for completeness.
-			(RouteType::Completions | RouteType::GeminiGenerateContent, None, Some(model))
-				if native_gemini =>
-			{
+			(RouteType::Completions | RouteType::GenerateContent, None, Some(model)) if native_gemini => {
 				let method = if streaming {
 					"streamGenerateContent?alt=sse"
 				} else {
@@ -487,7 +485,7 @@ mod tests {
 		let got = p.get_path_for_model(RouteType::Completions, req_model, streaming, true);
 		assert_eq!(got.as_str(), expected);
 		// The native arm also matches the client-facing route type.
-		let got = p.get_path_for_model(RouteType::GeminiGenerateContent, req_model, streaming, true);
+		let got = p.get_path_for_model(RouteType::GenerateContent, req_model, streaming, true);
 		assert_eq!(got.as_str(), expected);
 	}
 

--- a/crates/llm/src/vertex.rs
+++ b/crates/llm/src/vertex.rs
@@ -137,9 +137,24 @@ impl Provider {
 				)
 			},
 
+			// Native countTokens has no upstream provider format to translate through, so it keeps
+			// its client-facing route type all the way here.
+			(RouteType::GeminiCountTokens, _, Some(model)) => {
+				strng::format!(
+					"/v1/projects/{}/locations/{}/publishers/google/models/{}:countTokens",
+					self.project_id,
+					location,
+					model
+				)
+			},
+
 			// `?alt=sse` is required on the streaming endpoint; without it Vertex returns a
-			// JSON array rather than an SSE stream.
-			(RouteType::Completions, None, Some(model)) if native_gemini => {
+			// JSON array rather than an SSE stream. Native Gemini inbound arrives here as
+			// RouteType::Completions (its upstream provider format); GeminiGenerateContent is
+			// matched for completeness.
+			(RouteType::Completions | RouteType::GeminiGenerateContent, None, Some(model))
+				if native_gemini =>
+			{
 				let method = if streaming {
 					"streamGenerateContent?alt=sse"
 				} else {
@@ -188,6 +203,12 @@ impl Provider {
 			.or_else(|| model.strip_prefix("models/"))
 			.or_else(|| model.strip_prefix("google/"))
 			.unwrap_or(model);
+
+		// The publisher path supplies its own `.../models/` prefix, so what is left has to be a
+		// single segment; a `/` still in it would be choosing the upstream path, not a model.
+		if !crate::model_path::is_safe_segment(stripped) {
+			return None;
+		}
 
 		// Embedding models can share the gemini- prefix (e.g. gemini-embedding-001) but
 		// route via the Embeddings arm, not :generateContent.
@@ -359,6 +380,32 @@ mod tests {
 		assert_eq!(actual.as_deref(), expected);
 	}
 
+	#[rstest::rstest]
+	#[case::traversal(
+		"gemini-2.5-flash/../../../../locations/global/endpoints/openapi/chat/completions"
+	)]
+	#[case::extra_segment("gemini-2.5-flash/foo")]
+	#[case::traversal_under_resource_name("publishers/google/models/gemini-2.5-flash/../../other")]
+	#[case::encoded_traversal("gemini-2.5-flash%2F..%2F..")]
+	#[case::backslash("gemini-2.5-flash\\..\\..")]
+	#[case::dot_dot("..")]
+	fn test_gemini_model_rejects_unsafe_segments(#[case] model: &str) {
+		let p = Provider {
+			project_id: strng::new("p"),
+			model: None,
+			region: None,
+		};
+		assert_eq!(p.gemini_model(Some(model)), None, "{model}");
+		// And so the publisher path can never be chosen by the model: it falls to the fixed
+		// OpenAI-compat endpoint instead.
+		let path = p.get_path_for_model(RouteType::Completions, Some(model), false, true);
+		assert_eq!(
+			path.as_str(),
+			"/v1/projects/p/locations/global/endpoints/openapi/chat/completions",
+			"{model}"
+		);
+	}
+
 	#[test]
 	fn test_is_gemini_model_consistency_with_optional() {
 		let p = Provider {
@@ -438,6 +485,40 @@ mod tests {
 			region: region.map(strng::new),
 		};
 		let got = p.get_path_for_model(RouteType::Completions, req_model, streaming, true);
+		assert_eq!(got.as_str(), expected);
+		// The native arm also matches the client-facing route type.
+		let got = p.get_path_for_model(RouteType::GeminiGenerateContent, req_model, streaming, true);
+		assert_eq!(got.as_str(), expected);
+	}
+
+	#[rstest::rstest]
+	#[case::global(
+		None,
+		Some("gemini-2.5-flash"),
+		"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash:countTokens"
+	)]
+	#[case::regional(
+		Some("us-central1"),
+		Some("gemini-3-pro"),
+		"/v1/projects/p/locations/us-central1/publishers/google/models/gemini-3-pro:countTokens"
+	)]
+	#[case::models_prefix_normalized(
+		None,
+		Some("models/gemini-2.5-flash"),
+		"/v1/projects/p/locations/global/publishers/google/models/gemini-2.5-flash:countTokens"
+	)]
+	fn test_get_path_for_gemini_count_tokens(
+		#[case] region: Option<&str>,
+		#[case] req_model: Option<&str>,
+		#[case] expected: &str,
+	) {
+		let p = Provider {
+			project_id: strng::new("p"),
+			model: None,
+			region: region.map(strng::new),
+		};
+		// countTokens never streams and carries no native_gemini provider state.
+		let got = p.get_path_for_model(RouteType::GeminiCountTokens, req_model, false, false);
 		assert_eq!(got.as_str(), expected);
 	}
 

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1457,6 +1457,10 @@ message BackendPolicySpec {
       REALTIME = 8;
       // Processes Cohere /v2/rerank format requests
       RERANK = 10;
+      // Processes Gemini models/{model}:generateContent and :streamGenerateContent format requests
+      GEMINI_GENERATE_CONTENT = 11;
+      // Processes Gemini models/{model}:countTokens format requests
+      GEMINI_COUNT_TOKENS = 12;
     }
 
     // Routes defines how to identify the type of LLM request to handle.

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1458,7 +1458,7 @@ message BackendPolicySpec {
       // Processes Cohere /v2/rerank format requests
       RERANK = 10;
       // Processes Gemini models/{model}:generateContent and :streamGenerateContent format requests
-      GEMINI_GENERATE_CONTENT = 11;
+      GENERATE_CONTENT = 11;
       // Processes Gemini models/{model}:countTokens format requests
       GEMINI_COUNT_TOKENS = 12;
     }

--- a/schema/config.json
+++ b/schema/config.json
@@ -8387,6 +8387,7 @@
         "responses",
         "embeddings",
         "anthropicTokenCount",
+        "generateContent",
         "geminiCountTokens",
         "realtime",
         "rerank"

--- a/schema/config.json
+++ b/schema/config.json
@@ -8387,6 +8387,7 @@
         "responses",
         "embeddings",
         "anthropicTokenCount",
+        "geminiCountTokens",
         "realtime",
         "rerank"
       ]

--- a/schema/config.json
+++ b/schema/config.json
@@ -5464,6 +5464,16 @@
           "const": "anthropicTokenCount"
         },
         {
+          "description": "Gemini models/{model}:generateContent and models/{model}:streamGenerateContent",
+          "type": "string",
+          "const": "geminiGenerateContent"
+        },
+        {
+          "description": "Gemini models/{model}:countTokens",
+          "type": "string",
+          "const": "geminiCountTokens"
+        },
+        {
           "description": "Cohere /v2/rerank (document reranking)",
           "type": "string",
           "const": "rerank"

--- a/schema/config.json
+++ b/schema/config.json
@@ -5466,7 +5466,7 @@
         {
           "description": "Gemini models/{model}:generateContent and models/{model}:streamGenerateContent",
           "type": "string",
-          "const": "geminiGenerateContent"
+          "const": "generateContent"
         },
         {
           "description": "Gemini models/{model}:countTokens",

--- a/schema/config.md
+++ b/schema/config.md
@@ -5342,7 +5342,7 @@
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`binds[].listeners[].routes[].backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`binds[].listeners[].routes[].backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
@@ -8655,7 +8655,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
@@ -23200,7 +23200,7 @@
 |`backends[].ai.provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`backends[].ai.provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
@@ -26513,7 +26513,7 @@
 |`backends[].ai.groups[].providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`backends[].ai.groups[].providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
@@ -38286,7 +38286,7 @@
 |`routeGroups[].routes[].backends[].ai.provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routeGroups[].routes[].backends[].ai.provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`routeGroups[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`routeGroups[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`routeGroups[].routes[].backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routeGroups[].routes[].backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`routeGroups[].routes[].backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
@@ -41599,7 +41599,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
@@ -55952,7 +55952,7 @@
 |`routes[].backends[].ai.provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`routes[].backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routes[].backends[].ai.provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`routes[].backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routes[].backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`routes[].backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
@@ -59265,7 +59265,7 @@
 |`routes[].backends[].ai.groups[].providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`routes[].backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routes[].backends[].ai.groups[].providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routes[].backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`routes[].backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
@@ -66158,7 +66158,7 @@
 |`llm.providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`llm.providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`llm.providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`llm.providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`llm.providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`llm.providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`llm.providers[].defaults`|object|defaults defines provider-level policy defaults. Model-level policy fields override these.|
 |`llm.providers[].defaults.defaults`|object|Request payload fields to set when not already present in the request.|
@@ -66861,7 +66861,7 @@
 |`llm.models[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`llm.models[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`llm.models[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`llm.models[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `realtime`, `rerank`.|
+|`llm.models[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`llm.models[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`llm.models[].passthrough`|enum|passthrough controls how requests are handled.<br>By default, requests will be parsed and translated as needed.<br>With passthrough, they will be unmodified and optionally inspected (with `detect`).<br>In this mode, requests must be sent in the native format of the provider.<br>Possible values: `detect`, `opaque`.|
 |`llm.models[].authorization`|object|authorization configures HTTP authorization rules for requests to this model.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -5342,7 +5342,7 @@
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`binds[].listeners[].routes[].backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`binds[].listeners[].routes[].backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`binds[].listeners[].routes[].backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
@@ -8655,7 +8655,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
@@ -23200,7 +23200,7 @@
 |`backends[].ai.provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`backends[].ai.provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
@@ -26513,7 +26513,7 @@
 |`backends[].ai.groups[].providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`backends[].ai.groups[].providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
@@ -38286,7 +38286,7 @@
 |`routeGroups[].routes[].backends[].ai.provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routeGroups[].routes[].backends[].ai.provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`routeGroups[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`routeGroups[].routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`routeGroups[].routes[].backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routeGroups[].routes[].backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`routeGroups[].routes[].backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
@@ -41599,7 +41599,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
@@ -55952,7 +55952,7 @@
 |`routes[].backends[].ai.provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`routes[].backends[].ai.provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routes[].backends[].ai.provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`routes[].backends[].ai.provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`routes[].backends[].ai.provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routes[].backends[].ai.hostOverride`|string|Override the upstream host for this provider.|
 |`routes[].backends[].ai.pathOverride`|string|Override the upstream path for this provider.|
@@ -59265,7 +59265,7 @@
 |`routes[].backends[].ai.groups[].providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`routes[].backends[].ai.groups[].providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`routes[].backends[].ai.groups[].providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`routes[].backends[].ai.groups[].providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`routes[].backends[].ai.groups[].providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`routes[].backends[].ai.groups[].providers[].hostOverride`|string|Override the upstream host for this provider.|
 |`routes[].backends[].ai.groups[].providers[].pathOverride`|string|Override the upstream path for this provider.|
@@ -66158,7 +66158,7 @@
 |`llm.providers[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`llm.providers[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`llm.providers[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`llm.providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`llm.providers[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`llm.providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`llm.providers[].defaults`|object|defaults defines provider-level policy defaults. Model-level policy fields override these.|
 |`llm.providers[].defaults.defaults`|object|Request payload fields to set when not already present in the request.|
@@ -66861,7 +66861,7 @@
 |`llm.models[].provider.custom.model`|string|Model ID to send to the provider, overriding the model in the client request.|
 |`llm.models[].provider.custom.providerOverride`|string|Provider identity for cost-catalog lookup and telemetry. Built-in named providers<br>(cohere, mistral, ...) set this so their cost resolves under the right catalog key;<br>a bare custom provider may set it to match a catalog entry. Falls back to "custom".|
 |`llm.models[].provider.custom.formats`|[]object|Supported API payload formats and optional path overrides for this provider.|
-|`llm.models[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `geminiCountTokens`, `realtime`, `rerank`.|
+|`llm.models[].provider.custom.formats[].type`|enum|Upstream API shape this custom provider says it accepts.<br>Possible values: `completions`, `messages`, `responses`, `embeddings`, `anthropicTokenCount`, `generateContent`, `geminiCountTokens`, `realtime`, `rerank`.|
 |`llm.models[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`llm.models[].passthrough`|enum|passthrough controls how requests are handled.<br>By default, requests will be parsed and translated as needed.<br>With passthrough, they will be unmodified and optionally inspected (with `detect`).<br>In this mode, requests must be sent in the native format of the provider.<br>Possible values: `detect`, `opaque`.|
 |`llm.models[].authorization`|object|authorization configures HTTP authorization rules for requests to this model.|

--- a/ui/src/pages/models/CustomFormats.tsx
+++ b/ui/src/pages/models/CustomFormats.tsx
@@ -10,6 +10,7 @@ const formats: ProviderFormat[] = [
 	'responses',
 	'embeddings',
 	'anthropicTokenCount',
+	'geminiCountTokens',
 	'realtime',
 	'rerank'
 ];
@@ -20,6 +21,7 @@ const formatLabels: Record<ProviderFormat, string> = {
 	responses: 'Responses (/v1/responses)',
 	embeddings: 'Embeddings (/v1/embeddings)',
 	anthropicTokenCount: 'Anthropic token count (/v1/messages/count_tokens)',
+	geminiCountTokens: 'Gemini token count (models/{model}:countTokens)',
 	realtime: 'Realtime (/v1/realtime)',
 	rerank: 'Rerank (/v2/rerank)'
 };

--- a/ui/src/pages/models/CustomFormats.tsx
+++ b/ui/src/pages/models/CustomFormats.tsx
@@ -10,6 +10,7 @@ const formats: ProviderFormat[] = [
 	'responses',
 	'embeddings',
 	'anthropicTokenCount',
+	'generateContent',
 	'geminiCountTokens',
 	'realtime',
 	'rerank'
@@ -21,6 +22,7 @@ const formatLabels: Record<ProviderFormat, string> = {
 	responses: 'Responses (/v1/responses)',
 	embeddings: 'Embeddings (/v1/embeddings)',
 	anthropicTokenCount: 'Anthropic token count (/v1/messages/count_tokens)',
+	generateContent: 'Gemini chat (models/{model}:generateContent)',
 	geminiCountTokens: 'Gemini token count (models/{model}:countTokens)',
 	realtime: 'Realtime (/v1/realtime)',
 	rerank: 'Rerank (/v2/rerank)'


### PR DESCRIPTION
Fixes #2717.

### Summary

This change adds a native Gemini **inbound** API to the gateway. Clients built on the Gemini / Vertex SDKs can call the gateway directly via `models/{model}:generateContent`, `:streamGenerateContent?alt=sse`, or `:countTokens` in Gemini's native wire format. This is the inbound counterpart of #2023

### Worth mentioning / notes

- **Model pass-through:** the model comes from the path segment (`models/{model}:...`), so any `gemini-*` model works without per-model gateway configuration.
- **Streaming:** `:streamGenerateContent` requires `alt=sse`. Gemini's default JSON-array streaming mode is not supported.
- **Prompt guard** is wired for `generateContent`/`streamGenerateContent` (request and response text visiting, skipping `thought` parts); it is disabled for `countTokens` endpoint.
- **Thinking:** `generationConfig.thinkingConfig` and returned thought parts / `thoughtsTokenCount` pass through unchanged.
- Native Gemini inbound currently targets Gemini-family backends (Vertex / Gemini API). Cross-format conversion from a Gemini inbound request to non-Gemini providers returns an explicit `UnsupportedConversion` .
- The new `ChatRequest::Gemini` enum variant is boxed to keep the enum size in check (clippy `large_enum_variant`).

### What changed

**Data plane (Rust):**
- Adds native Gemini as an inbound format alongside the existing OpenAI-compat ones.
- Two new route types, `geminiGenerateContent` and `geminiCountTokens`. By default, paths ending in `:generateContent` or `:streamGenerateContent` map to the first, and `:countTokens` maps to the second.
- The model name is extracted from the request path (`models/{model}:...`).

**Controller (Go) + CRD:**
- The `ai.routes` enum on `AgentgatewayBackend`/`AgentgatewayPolicy` gains `GeminiGenerateContent` and `GeminiCountTokens`, with matching xDS proto values (`GEMINI_GENERATE_CONTENT`, `GEMINI_COUNT_TOKENS`). This lets in-cluster backends classify native Gemini routes.
- CRDs and generated proto code are regenerated. The CRD change is additive, with no apiVersion bump.

**Tests:**
- Golden request fixtures for the native format (text, tools, thinking, structured output, inline images, unknown-field passthrough) and response fixtures (basic, blocked, reasoning).
- Lossless-passthrough assertions for both requests and responses.
- Path traversal tests for security.


### What was tested

- Manual tests were executed against Vertex Gemini models on a locally built instance of the gateway alongside the test suite . 
- Beyond that, we have been running this on an internal fork for a while on a GKE cluster (data plane, controller, and CRDs) through the real controller/CRD/xDS path against live Vertex, with clients on the Gemini SDK. An end-to-end validation suite covering both path shapes, streaming (`alt=sse` required), `countTokens`, thinking round-trip, model pass-through, auth rejection, prompt-guard bocking, and path-traversal rejection passes against that deployment.

### Use of AI assistance

Parts of the implementation and all of the test suite were developed with the help of an LLM. I have reviewed the code, verified my understanding of its behaviour, and taken ownership of the implementation. I reviewed the tests for correctness and coverage, and validated the change end-to-end against live Vertex to confirm it behaves as expected.
