### PR TITLE
fix: record upstream connect duration at full precision

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -389,15 +389,14 @@ impl Connector {
 			stream
 		};
 
-		let connect_ms = connect_start.elapsed().as_millis();
+		let connect_dur = connect_start.elapsed();
 		if let Some(m) = &self.metrics {
 			let labels = metrics::ConnectLabels {
 				transport: strng::RichStrng::from(transport_name).into(),
 			};
-			// Note: convert from ms to seconds since Prometheus convention for histogram buckets is seconds.
 			m.upstream_connect_duration
 				.get_or_create(&labels)
-				.observe((connect_ms as f64) / 1000.0);
+				.observe(connect_dur.as_secs_f64());
 		}
 
 		event!(
@@ -408,7 +407,7 @@ impl Connector {
 			endpoint = %ep,
 			transport = %transport_name,
 
-			connect_ms = connect_ms,
+			connect_ms = connect_dur.as_millis(),
 
 			"connected"
 		);
@@ -760,5 +759,57 @@ mod tests {
 				"tunnel protocol {tp:?} should map to no source role",
 			);
 		}
+	}
+
+	/// A loopback connect takes tens of microseconds, so millisecond granularity truncates it to 0.
+	/// One-sided by design: `elapsed()` is always positive, so this cannot fail spuriously.
+	#[tokio::test]
+	async fn upstream_connect_duration_records_sub_millisecond_connects() {
+		use frozen_collections::FzHashSet;
+		use prometheus_client::registry::Registry;
+
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = listener.local_addr().unwrap();
+		tokio::spawn(async move {
+			let _accepted = listener.accept().await;
+		});
+
+		let mut registry = Registry::default();
+		let metrics = Arc::new(crate::metrics::Metrics::new(
+			&mut registry,
+			FzHashSet::default(),
+		));
+
+		let client = Client::new(
+			&Config {
+				resolver_cfg: hickory_resolver::config::ResolverConfig::default(),
+				resolver_opts: hickory_resolver::config::ResolverOpts::default(),
+			},
+			None,
+			crate::BackendConfig::default(),
+			Some(metrics),
+		);
+		client
+			.connect_raw(
+				Target::Address(addr),
+				Transport::Plain(ApplicationTransport::Plaintext),
+			)
+			.await
+			.expect("connect to loopback listener");
+
+		let mut encoded = String::new();
+		prometheus_client::encoding::text::encode(&mut encoded, &registry).unwrap();
+		let sum = encoded
+			.lines()
+			.find_map(|l| {
+				l.strip_prefix("upstream_connect_duration_seconds_sum{transport=\"plaintext\"} ")
+			})
+			.unwrap_or_else(|| panic!("no connect duration sum in:\n{encoded}"))
+			.parse::<f64>()
+			.unwrap();
+		assert!(
+			sum > 0.0,
+			"sub-millisecond connect was recorded as {sum}s, expected the real duration"
+		);
 	}
 }

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -761,8 +761,9 @@ mod tests {
 		}
 	}
 
-	/// A loopback connect takes tens of microseconds, so millisecond granularity truncates it to 0.
-	/// One-sided by design: `elapsed()` is always positive, so this cannot fail spuriously.
+	/// Millisecond truncation put every observation on an exact multiple of 1ms, and a loopback
+	/// connect on 0. Asserting the recorded value is finer than a millisecond catches that however
+	/// long the connect actually takes.
 	#[tokio::test]
 	async fn upstream_connect_duration_records_sub_millisecond_connects() {
 		use frozen_collections::FzHashSet;
@@ -770,9 +771,7 @@ mod tests {
 
 		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
 		let addr = listener.local_addr().unwrap();
-		tokio::spawn(async move {
-			let _accepted = listener.accept().await;
-		});
+		tokio::spawn(async move { while listener.accept().await.is_ok() {} });
 
 		let mut registry = Registry::default();
 		let metrics = Arc::new(crate::metrics::Metrics::new(
@@ -807,9 +806,10 @@ mod tests {
 			.unwrap_or_else(|| panic!("no connect duration sum in:\n{encoded}"))
 			.parse::<f64>()
 			.unwrap();
+		let ms = sum * 1000.0;
 		assert!(
-			sum > 0.0,
-			"sub-millisecond connect was recorded as {sum}s, expected the real duration"
+			(ms - ms.round()).abs() > 1e-9,
+			"connect duration {ms}ms is quantized to whole milliseconds"
 		);
 	}
 }


### PR DESCRIPTION
## What

`upstream_connect_duration` is observed as `connect_start.elapsed().as_millis() / 1000.0`. `Duration::as_millis()` returns an integer, so the value is truncated before it ever reaches the histogram.

## User-visible impact

 - Every upstream connect faster than 1ms is recorded as 0 seconds, since this is quite common percentiles are not very reliable.
- The histogram's first bucket boundary is 0.5ms, so it has been useless.

## Fix

Observe `connect_dur.as_secs_f64()`. This matches `tls_handshake_duration` metric, which uses the same `CONNECT_DURATION_BUCKET` array and doesn't have this problem. 

I checked the histograms in the repo, and this was the only one using `as_millis()`.

## Test

Adds a regression test that connects to a loopback listener with metrics attached and asserts the recorded sum is greater than zero.