### PR TITLE
llm: route gemini-embedding-2 models to Vertex embedContent

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1928,7 +1928,7 @@ impl AIProvider {
 			| AIProvider::Azure(_)
 			| AIProvider::Gemini(_)
 			| AIProvider::Anthropic(_) => serde_json::to_vec(req).map_err(AIError::RequestMarshal),
-			AIProvider::Vertex(_) => conversion::vertex::from_embeddings::translate(req),
+			AIProvider::Vertex(p) => conversion::vertex::from_embeddings::translate(req, p),
 			AIProvider::Bedrock(p) => conversion::bedrock::from_embeddings::translate(req, p),
 		}
 	}
@@ -2539,7 +2539,7 @@ impl AIProvider {
 			},
 			AIProvider::Vertex(p) if !p.is_anthropic_model(Some(&req.request_model)) => {
 				let translated =
-					conversion::vertex::from_embeddings::translate_response(&bytes, &req.request_model)?;
+					conversion::vertex::from_embeddings::translate_response(&bytes, p, &req.request_model)?;
 				let llm_resp = translated.to_llm_response(LogContentFields::default());
 				let body = translated.serialize().map_err(AIError::ResponseParsing)?;
 				Ok((llm_resp, Bytes::from(body)))

--- a/crates/llm/src/conversion/vertex.rs
+++ b/crates/llm/src/conversion/vertex.rs
@@ -77,38 +77,80 @@ pub mod from_rerank {
 }
 
 pub mod from_embeddings {
+	use serde_json::Value;
+
 	use super::*;
 	use crate::json;
+	use crate::types::vertex_gemini as vg;
 
-	pub fn translate(req: &types::embeddings::Request) -> Result<Vec<u8>, AIError> {
-		let typed = json::convert::<_, types::embeddings::typed::Request>(req)
-			.map_err(AIError::RequestMarshal)?;
+	/// Vertex embedding knobs, resolved once and shared by both endpoints. Everything except
+	/// `output_dimensionality` has no OpenAI equivalent and arrives via the passthrough `rest`.
+	struct Params {
+		task_type: Option<String>,
+		title: Option<String>,
+		auto_truncate: Option<bool>,
+		output_dimensionality: Option<u64>,
+	}
 
-		let input = typed.input.as_strings();
-
-		let task_type = req
-			.rest
-			.get("task_type")
-			.and_then(|v| v.as_str())
-			.unwrap_or("RETRIEVAL_QUERY")
-			.to_string();
-
-		// Vertex natively supports batching via the instances array,
-		// so we map each input string to an Instance directly.
-		let instances = input
-			.into_iter()
-			.map(|content| types::vertex::Instance {
-				content,
-				task_type: Some(task_type.clone()),
+	impl Params {
+		fn extract(
+			req: &types::embeddings::Request,
+			typed: &types::embeddings::typed::Request,
+		) -> Self {
+			Self {
+				task_type: req
+					.rest
+					.get("task_type")
+					.and_then(|v| v.as_str().map(|s| s.to_string())),
 				title: req
 					.rest
 					.get("title")
 					.and_then(|v| v.as_str().map(|s| s.to_string())),
+				auto_truncate: req.rest.get("auto_truncate").and_then(|v| v.as_bool()),
+				output_dimensionality: typed.dimensions.map(|d| d as u64),
+			}
+		}
+	}
+
+	pub fn translate(
+		req: &types::embeddings::Request,
+		provider: &crate::vertex::Provider,
+	) -> Result<Vec<u8>, AIError> {
+		let typed = json::convert::<_, types::embeddings::typed::Request>(req)
+			.map_err(AIError::RequestMarshal)?;
+		let params = Params::extract(req, &typed);
+
+		if provider.uses_embed_content(req.model.as_deref()) {
+			translate_embed_content_request(&typed, params)
+		} else {
+			translate_predict_request(&typed, params)
+		}
+	}
+
+	fn translate_predict_request(
+		typed: &types::embeddings::typed::Request,
+		params: Params,
+	) -> Result<Vec<u8>, AIError> {
+		let Params {
+			task_type,
+			title,
+			auto_truncate,
+			output_dimensionality,
+		} = params;
+		let task_type = task_type.unwrap_or_else(|| "RETRIEVAL_QUERY".to_string());
+
+		// Vertex natively supports batching via the instances array,
+		// so we map each input string to an Instance directly.
+		let instances = typed
+			.input
+			.as_strings()
+			.into_iter()
+			.map(|content| types::vertex::Instance {
+				content,
+				task_type: Some(task_type.clone()),
+				title: title.clone(),
 			})
 			.collect();
-
-		let auto_truncate = req.rest.get("auto_truncate").and_then(|v| v.as_bool());
-		let output_dimensionality = typed.dimensions.map(|d| d as u64);
 
 		let parameters = if auto_truncate.is_some() || output_dimensionality.is_some() {
 			Some(types::vertex::Parameters {
@@ -126,7 +168,86 @@ pub mod from_embeddings {
 		serde_json::to_vec(&vertex_req).map_err(AIError::RequestMarshal)
 	}
 
-	pub fn translate_response(bytes: &[u8], model: &str) -> Result<Box<dyn ResponseType>, AIError> {
+	fn translate_embed_content_request(
+		typed: &types::embeddings::typed::Request,
+		params: Params,
+	) -> Result<Vec<u8>, AIError> {
+		// embedContent embeds one content and returns one embedding. Vertex has no batch
+		// variant, and extra parts would silently collapse into a single vector.
+		let mut inputs = typed.input.as_strings();
+		if inputs.len() != 1 {
+			return Err(AIError::RequestParsing(serde::de::Error::custom(
+				"Vertex embedContent does not support batching; `input` must contain exactly one string",
+			)));
+		}
+
+		let Params {
+			task_type,
+			title,
+			auto_truncate,
+			output_dimensionality,
+		} = params;
+
+		let embed_content_config = if task_type.is_some()
+			|| title.is_some()
+			|| output_dimensionality.is_some()
+			|| auto_truncate.is_some()
+		{
+			Some(vg::EmbedContentConfig {
+				task_type,
+				title,
+				output_dimensionality,
+				auto_truncate,
+			})
+		} else {
+			None
+		};
+
+		let vertex_req = vg::EmbedContentRequest {
+			content: vg::Content {
+				role: None,
+				parts: vec![vg::Part::Text(vg::TextPart {
+					text: inputs.remove(0),
+					thought: None,
+					thought_signature: None,
+					rest: Value::Null,
+				})],
+				rest: Value::Null,
+			},
+			embed_content_config,
+		};
+		serde_json::to_vec(&vertex_req).map_err(AIError::RequestMarshal)
+	}
+
+	pub fn translate_response(
+		bytes: &[u8],
+		provider: &crate::vertex::Provider,
+		model: &str,
+	) -> Result<Box<dyn ResponseType>, AIError> {
+		let (data, prompt_tokens) = if provider.uses_embed_content(Some(model)) {
+			translate_embed_content_response(bytes)?
+		} else {
+			translate_predict_response(bytes)?
+		};
+
+		let typed_resp = types::embeddings::typed::Response {
+			object: "list".to_string(),
+			data,
+			model: model.to_string(),
+			usage: types::embeddings::typed::Usage {
+				prompt_tokens: prompt_tokens as u32,
+				total_tokens: prompt_tokens as u32,
+			},
+		};
+		// Convert the normalized internal typed response back to the passthrough-preserving OpenAI format
+		let openai_resp = json::convert::<_, types::embeddings::Response>(&typed_resp)
+			.map_err(AIError::ResponseParsing)?;
+		Ok(Box::new(openai_resp))
+	}
+
+	fn translate_predict_response(
+		bytes: &[u8],
+	) -> Result<(Vec<types::embeddings::typed::Embedding>, u64), AIError> {
 		let resp: types::vertex::PredictResponse =
 			serde_json::from_slice(bytes).map_err(logged_response_parsing(bytes))?;
 
@@ -146,19 +267,26 @@ pub mod from_embeddings {
 				index: i as u32,
 			});
 		}
+		Ok((data, total_prompt_tokens))
+	}
 
-		let typed_resp = types::embeddings::typed::Response {
-			object: "list".to_string(),
-			data,
-			model: model.to_string(),
-			usage: types::embeddings::typed::Usage {
-				prompt_tokens: total_prompt_tokens as u32,
-				total_tokens: total_prompt_tokens as u32,
-			},
-		};
-		// Convert the normalized internal typed response back to the passthrough-preserving OpenAI format
-		let openai_resp = json::convert::<_, types::embeddings::Response>(&typed_resp)
-			.map_err(AIError::ResponseParsing)?;
-		Ok(Box::new(openai_resp))
+	fn translate_embed_content_response(
+		bytes: &[u8],
+	) -> Result<(Vec<types::embeddings::typed::Embedding>, u64), AIError> {
+		let mut resp: vg::EmbedContentResponse =
+			serde_json::from_slice(bytes).map_err(logged_response_parsing(bytes))?;
+
+		let prompt_tokens = resp
+			.usage_metadata
+			.as_ref()
+			.and_then(|u| u.prompt_token_count.or(u.total_token_count))
+			.unwrap_or_default();
+
+		let data = vec![types::embeddings::typed::Embedding {
+			object: "embedding".to_string(),
+			embedding: std::mem::take(&mut resp.embedding.values),
+			index: 0,
+		}];
+		Ok((data, prompt_tokens))
 	}
 }

--- a/crates/llm/src/conversion/vertex_tests.rs
+++ b/crates/llm/src/conversion/vertex_tests.rs
@@ -1,21 +1,34 @@
+use agent_core::strng;
 use serde_json::json;
 
 use super::*;
 use crate::types;
 
+fn provider() -> crate::vertex::Provider {
+	crate::vertex::Provider {
+		model: None,
+		region: Some(strng::new("global")),
+		project_id: strng::new("test-project"),
+	}
+}
+
+fn request(model: &str, input: serde_json::Value) -> types::embeddings::Request {
+	types::embeddings::Request {
+		model: Some(model.to_string()),
+		input,
+		user: None,
+		encoding_format: None,
+		dimensions: None,
+		rest: json!({}),
+	}
+}
+
 #[test]
 fn test_embeddings_rejects_invalid_input() {
 	let bad_inputs = vec![json!(42), json!(["hello", 42])];
 	for input in bad_inputs {
-		let req = types::embeddings::Request {
-			model: Some("text-embedding-004".to_string()),
-			input,
-			user: None,
-			encoding_format: None,
-			dimensions: None,
-			rest: json!({}),
-		};
-		assert!(from_embeddings::translate(&req).is_err());
+		let req = request("text-embedding-004", input);
+		assert!(from_embeddings::translate(&req, &provider()).is_err());
 	}
 }
 
@@ -28,7 +41,70 @@ fn test_embeddings_response_missing_statistics() {
 	});
 	let bytes = serde_json::to_vec(&vertex_resp).unwrap();
 
-	let translated = from_embeddings::translate_response(&bytes, "model").unwrap();
+	let translated =
+		from_embeddings::translate_response(&bytes, &provider(), "text-embedding-004").unwrap();
+	let resp = translated
+		.serialize()
+		.and_then(|b| serde_json::from_slice::<types::embeddings::Response>(&b))
+		.unwrap();
+
+	assert_eq!(resp.usage.unwrap().prompt_tokens, 0);
+}
+
+#[test]
+fn test_embed_content_rejects_multiple_inputs() {
+	let req = request("gemini-embedding-2", json!(["hello", "world"]));
+	assert!(from_embeddings::translate(&req, &provider()).is_err());
+}
+
+#[test]
+fn test_embed_content_accepts_single_element_array() {
+	let req = request("gemini-embedding-2", json!(["hello"]));
+	let body = from_embeddings::translate(&req, &provider()).unwrap();
+	let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+	assert_eq!(body["content"]["parts"], json!([{"text": "hello"}]));
+	// Unlike :predict, no task type is invented when the client did not ask for one.
+	assert!(body.get("embedContentConfig").is_none());
+}
+
+#[test]
+fn test_embed_content_passes_through_rest_params() {
+	let mut req = request("gemini-embedding-2", json!("hello"));
+	req.rest = json!({
+		"task_type": "RETRIEVAL_DOCUMENT",
+		"title": "My Document",
+		"auto_truncate": true,
+	});
+	let body = from_embeddings::translate(&req, &provider()).unwrap();
+	let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+	assert_eq!(
+		body["embedContentConfig"],
+		json!({
+			"taskType": "RETRIEVAL_DOCUMENT",
+			"title": "My Document",
+			"autoTruncate": true,
+		})
+	);
+}
+
+#[test]
+fn test_predict_still_defaults_task_type() {
+	let req = request("text-embedding-005", json!("hello"));
+	let body = from_embeddings::translate(&req, &provider()).unwrap();
+	let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+	assert_eq!(body["instances"][0]["task_type"], json!("RETRIEVAL_QUERY"));
+}
+
+#[test]
+fn test_embed_content_response_missing_usage_metadata() {
+	let vertex_resp = json!({ "embedding": { "values": [0.1, 0.2] } });
+	let bytes = serde_json::to_vec(&vertex_resp).unwrap();
+
+	let translated =
+		from_embeddings::translate_response(&bytes, &provider(), "gemini-embedding-2").unwrap();
 	let resp = translated
 		.serialize()
 		.and_then(|b| serde_json::from_slice::<types::embeddings::Response>(&b))

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -42,6 +42,7 @@ const COHERE: &str = "cohere";
 const VERTEX_GEMINI: &str = "vertex-gemini";
 const GEMINI_NATIVE: &str = "gemini-native";
 const RESPONSES: &str = "responses";
+const VERTEX_EMBED_CONTENT: &str = "vertex-embed-content";
 
 mod requests {
 	use super::*;
@@ -196,6 +197,7 @@ mod requests {
 		("cohere-v4", &[BEDROCK_COHERE]),
 		("array", &[OPENAI, BEDROCK_COHERE, VERTEX]),
 		("full", &[VERTEX]),
+		("embed-content", &[VERTEX]),
 	];
 	const RERANK_REQUESTS: &[(&str, &[&str])] = &[
 		("basic", &[COHERE, BEDROCK, VERTEX]),
@@ -330,6 +332,11 @@ mod requests {
 			guardrail_identifier: None,
 			guardrail_version: None,
 		};
+		let vertex = vertex::Provider {
+			model: None,
+			region: Some(strng::new("global")),
+			project_id: strng::new("test-project-123"),
+		};
 		for (name, providers) in EMBEDDINGS_REQUESTS {
 			let path = format!("requests/embeddings/{name}.json");
 			for provider in *providers {
@@ -352,7 +359,7 @@ mod requests {
 						conversion::bedrock::from_embeddings::translate(i, &nova)
 					}),
 					VERTEX => test_request(VERTEX, &path, |i: &mut types::embeddings::Request| {
-						conversion::vertex::from_embeddings::translate(i)
+						conversion::vertex::from_embeddings::translate(i, &vertex)
 					}),
 					other => panic!("unsupported provider in EMBEDDINGS_REQUESTS: {other}"),
 				}
@@ -822,6 +829,7 @@ mod responses {
 		("response/bedrock-cohere/embeddings.json", BEDROCK_COHERE),
 		("response/bedrock-nova/embeddings.json", BEDROCK_NOVA),
 		("response/vertex/embeddings.json", VERTEX),
+		("response/vertex/embed-content.json", VERTEX_EMBED_CONTENT),
 		("response/openai/embeddings.json", OPENAI),
 		("response/openai/gemini-embeddings.json", OPENAI),
 	];
@@ -1026,6 +1034,11 @@ mod responses {
 
 	#[test]
 	fn embeddings() {
+		let vertex = vertex::Provider {
+			model: None,
+			region: Some(strng::new("global")),
+			project_id: strng::new("test-project-123"),
+		};
 		for (path, provider) in EMBEDDING_RESPONSES {
 			match *provider {
 				BEDROCK_TITAN | BEDROCK_COHERE | BEDROCK_NOVA => {
@@ -1043,7 +1056,10 @@ mod responses {
 					});
 				},
 				VERTEX => test_response(provider, path, |i| {
-					conversion::vertex::from_embeddings::translate_response(&i, "text-embedding-004")
+					conversion::vertex::from_embeddings::translate_response(&i, &vertex, "text-embedding-004")
+				}),
+				VERTEX_EMBED_CONTENT => test_response(provider, path, |i| {
+					conversion::vertex::from_embeddings::translate_response(&i, &vertex, "gemini-embedding-2")
 				}),
 				OPENAI => test_response(provider, path, |i| {
 					serde_json::from_slice::<types::embeddings::Response>(&i)

--- a/crates/llm/src/tests/requests/embeddings/embed-content.json
+++ b/crates/llm/src/tests/requests/embeddings/embed-content.json
@@ -1,0 +1,5 @@
+{
+  "model": "gemini-embedding-2",
+  "input": "hello world",
+  "dimensions": 512
+}

--- a/crates/llm/src/tests/requests/embeddings/embed-content.vertex.snap
+++ b/crates/llm/src/tests/requests/embeddings/embed-content.vertex.snap
@@ -1,0 +1,32 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/embeddings/embed-content.json
+info:
+  model: gemini-embedding-2
+  input: hello world
+  dimensions: 512
+---
+{
+  "request": {
+    "content": {
+      "parts": [
+        {
+          "text": "hello world"
+        }
+      ]
+    },
+    "embedContentConfig": {
+      "outputDimensionality": 512
+    }
+  },
+  "parsed": {
+    "input_format": "Embeddings",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gemini-embedding-2",
+    "provider": "vertex",
+    "streaming": false,
+    "params": {
+      "dimensions": 512
+    }
+  }
+}

--- a/crates/llm/src/tests/response/vertex/embed-content.json
+++ b/crates/llm/src/tests/response/vertex/embed-content.json
@@ -1,0 +1,10 @@
+{
+  "embedding": {
+    "values": [-0.006603240966796875,-0.054168701171875,0.0121917724609375]
+  },
+  "usageMetadata": {
+    "promptTokenCount": 4,
+    "totalTokenCount": 4
+  },
+  "truncated": false
+}

--- a/crates/llm/src/tests/response/vertex/embed-content.vertex-embed-content.snap
+++ b/crates/llm/src/tests/response/vertex/embed-content.vertex-embed-content.snap
@@ -1,0 +1,40 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/vertex/embed-content.json
+info:
+  embedding:
+    values:
+      - -0.006603240966796875
+      - -0.054168701171875
+      - 0.0121917724609375
+  usageMetadata:
+    promptTokenCount: 4
+    totalTokenCount: 4
+  truncated: false
+---
+{
+  "response": {
+    "object": "list",
+    "model": "gemini-embedding-2",
+    "usage": {
+      "prompt_tokens": 4,
+      "total_tokens": 4
+    },
+    "data": [
+      {
+        "index": 0,
+        "object": "embedding",
+        "embedding": [
+          -0.006603240966796875,
+          -0.054168701171875,
+          0.0121917724609375
+        ]
+      }
+    ]
+  },
+  "parsed": {
+    "input_tokens": 4,
+    "total_tokens": 4,
+    "provider_model": "gemini-embedding-2"
+  }
+}

--- a/crates/llm/src/types/vertex_gemini.rs
+++ b/crates/llm/src/types/vertex_gemini.rs
@@ -1,10 +1,11 @@
 //! Wire DTOs for the Vertex native Gemini API (`:generateContent` /
-//! `:streamGenerateContent`).
+//! `:streamGenerateContent` / `:embedContent`).
 //!
 //! References:
 //! - <https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/models/inference>
 //! - <https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.publishers.models/generateContent>
 //! - <https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.publishers.models/streamGenerateContent>
+//! - <https://docs.cloud.google.com/gemini-enterprise-agent-platform/reference/rest/v1/projects.locations.publishers.models/embedContent>
 //!
 //! Deserialized types tolerate unknown fields (flattened into `rest`, no `deny_unknown_fields`)
 //! so Google's additive changes don't break parsing.
@@ -367,6 +368,49 @@ impl UsageMetadata {
 		let total = self.total_token_count.unwrap_or(prompt + completion);
 		(prompt, completion, total)
 	}
+}
+
+// ---------- embedContent ----------
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbedContentRequest {
+	pub content: Content,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub embed_content_config: Option<EmbedContentConfig>,
+}
+
+/// embedContent also accepts these four fields at the top level of the request, but Vertex
+/// marks that form deprecated in favour of this nested config.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbedContentConfig {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub task_type: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub title: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub output_dimensionality: Option<u64>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub auto_truncate: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbedContentResponse {
+	pub embedding: EmbedContentEmbedding,
+	#[serde(default)]
+	pub usage_metadata: Option<UsageMetadata>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct EmbedContentEmbedding {
+	pub values: Vec<f32>,
+	#[serde(flatten, default)]
+	pub rest: serde_json::Value,
 }
 
 #[cfg(test)]

--- a/crates/llm/src/vertex.rs
+++ b/crates/llm/src/vertex.rs
@@ -115,12 +115,18 @@ impl Provider {
 				)
 			},
 			(RouteType::Embeddings, _, _) => {
-				let model = self.configured_model(request_model).unwrap_or_default();
+				let model = self.embeddings_model(request_model);
+				let method = if self.uses_embed_content(request_model) {
+					"embedContent"
+				} else {
+					"predict"
+				};
 				strng::format!(
-					"/v1/projects/{}/locations/{}/publishers/google/models/{}:predict",
+					"/v1/projects/{}/locations/{}/publishers/google/models/{}:{}",
 					self.project_id,
 					location,
-					model
+					model,
+					method
 				)
 			},
 			(_, Some(model), _) => {
@@ -192,15 +198,24 @@ impl Provider {
 		}
 	}
 
+	fn embeddings_model<'a>(&'a self, request_model: Option<&'a str>) -> &'a str {
+		self
+			.configured_model(request_model)
+			.map(strip_google_model_prefix)
+			.unwrap_or_default()
+	}
+
+	/// `gemini-embedding-2` and later are served only by `:embedContent`; `:predict`
+	/// returns FAILED_PRECONDITION for them. `-001` stays on `:predict`, that supports
+	/// batch prediction and avoids regression
+	pub fn uses_embed_content(&self, request_model: Option<&str>) -> bool {
+		let model = self.embeddings_model(request_model);
+		model.starts_with("gemini-embedding-") && !model.starts_with("gemini-embedding-001")
+	}
+
 	fn gemini_model<'a>(&'a self, request_model: Option<&'a str>) -> Option<Strng> {
 		let model = self.configured_model(request_model)?;
-
-		let stripped: &str = model
-			.split_once("publishers/google/models/")
-			.map(|(_, m)| m)
-			.or_else(|| model.strip_prefix("models/"))
-			.or_else(|| model.strip_prefix("google/"))
-			.unwrap_or(model);
+		let stripped = strip_google_model_prefix(model);
 
 		// The publisher path supplies its own `.../models/` prefix, so what is left has to be a
 		// single segment; a `/` still in it would be choosing the upstream path, not a model.
@@ -255,6 +270,17 @@ impl Provider {
 			Some(strng::new(model))
 		}
 	}
+}
+
+/// Reduce a Google publisher model to its bare id, so callers can match on the model
+/// family regardless of how fully qualified the configured value is.
+fn strip_google_model_prefix(model: &str) -> &str {
+	model
+		.split_once("publishers/google/models/")
+		.map(|(_, m)| m)
+		.or_else(|| model.strip_prefix("models/"))
+		.or_else(|| model.strip_prefix("google/"))
+		.unwrap_or(model)
 }
 
 fn remove_unsupported_vertex_fields(body: &mut Map<String, Value>) {
@@ -593,6 +619,37 @@ mod tests {
 			!path.as_str().contains(":generateContent"),
 			"embedding route must not produce :generateContent, got {path}"
 		);
+	}
+
+	#[rstest::rstest]
+	#[case::gemini_embedding_2(
+		"gemini-embedding-2",
+		"/v1/projects/p/locations/global/publishers/google/models/gemini-embedding-2:embedContent"
+	)]
+	#[case::gemini_embedding_1_keeps_predict(
+		"gemini-embedding-001",
+		"/v1/projects/p/locations/global/publishers/google/models/gemini-embedding-001:predict"
+	)]
+	#[case::text_embedding_keeps_predict(
+		"text-embedding-005",
+		"/v1/projects/p/locations/global/publishers/google/models/text-embedding-005:predict"
+	)]
+	#[case::publishers_prefix_normalized(
+		"publishers/google/models/gemini-embedding-2",
+		"/v1/projects/p/locations/global/publishers/google/models/gemini-embedding-2:embedContent"
+	)]
+	#[case::models_prefix_normalized(
+		"models/text-embedding-005",
+		"/v1/projects/p/locations/global/publishers/google/models/text-embedding-005:predict"
+	)]
+	fn test_get_path_for_embeddings(#[case] req_model: &str, #[case] expected: &str) {
+		let p = Provider {
+			project_id: strng::new("p"),
+			model: None,
+			region: None,
+		};
+		let got = p.get_path_for_model(RouteType::Embeddings, Some(req_model), false, false);
+		assert_eq!(got.as_str(), expected);
 	}
 
 	#[rstest::rstest]


### PR DESCRIPTION
## Summary

- Vertex embeddings computation use `:predict` endpoint. Google no longer serves that endpoint for the `gemini-embedding-2` model, which fails with `400 FAILED_PRECONDITION`.
- Route `gemini-embedding-2` and later to `:embedContent` instead. 
- `gemini-embedding-001` and `text-embedding-*` stay on `:predict`. (`gemini-embedding-001` is available through `embedContet` API  but migrating it would produce a regression: `embedContent` doesn't support batching)
- `embedContent` embeds exactly one input per call (Vertex has no batch variant) so a multi-input array is now rejected with an explicit gateway error instead of silently collapsing into one vector.

## Root cause

Confirmed against the live API:

#### EmbedContent - 200 OK
```bash
PROJECT_ID="CHANGEME"
curl -X POST \
  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
  -H "Content-Type: application/json" \
  -H "x-goog-user-project: ${PROJECT_ID}" \
  "https://aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/global/publishers/google/models/gemini-embedding-2:embedContent" \
  -d "{'content': {'parts': [{'text': 'Hello'}]}, 'outputDimensionality': 2}"
```

#### Predict - 400 FAILED_PRECONDITION (works fine with `gemini-embedding-001` on a single region)
```bash
PROJECT_ID="CHANGEME"
curl -X POST \
  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
  -H "Content-Type: application/json" \
  -H "x-goog-user-project: ${PROJECT_ID}" \
  "https://aiplatform.eu.rep.googleapis.com/v1/projects/${PROJECT_ID}/locations/eu/publishers/google/models/gemini-embedding-2:predict" \
  -d '{"instances":[{"content":"hello"}]}'
```

The same failure and fix have been reported/shipped in other gateways:
- vercel/ai#15853
- BerriAI/litellm#23508, #23322, #23518, #24209

## Behavior changes
- `task_type` is no longer defaulted to `RETRIEVAL_QUERY` on the `embedContent` path. [Google deprecated the field ](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/embeddings/task-types) starting with `gemini-embedding-2` and the backend ignores it.
- `:predict` keeps the existing default, so `gemini-embedding-001` and `text-embedding-*` are unaffected.
- Sending an array with more than one element to a `gemini-embedding-2+` model now returns a 400, because it's not supported by the API
- Incidental fix: the embeddings path now normalizes fully-qualified model ids (e.g. `publishers/google/models/text embedding-005`), which previously produced a doubled path segment on `:predict`.

  ## Testing

- `cargo test -p agent-llm`, new golden fixtures (`requests/embeddings/embed-content.json`, `response/vertex/embed-content.json`) plus unit tests covering multi-input rejection, single-input acceptance, and missing `usageMetadata`.
- `make lint`
- `make generate-schema`: no diff, no config surface changed
- `make test` — full workspace

  Verified end-to-end against a real Vertex project:

  ```bash
  # routes to :embedContent, 200 with one embedding
  curl ... -d '{"model":"gemini-embedding-2","input":"hello world","dimensions":2}'

  # routes to :predict, unaffected (regression check)
  curl ... -d '{"model":"gemini-embedding-001","input":["hello","world"]}'