### PR TITLE
sec: CVE bump go 1.26.5

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ env:
   CI: true
   RUST_VERSION: "1.97.0"
   CARGO_BUILD_WARNINGS: deny
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 jobs:
   #### Proxy jobs ####

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ env:
   CI: true
   RUST_VERSION: "1.97.0"
   CARGO_BUILD_WARNINGS: deny
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/agentgateway
   CONTROLLER_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/controller
   VEX_FILE: .github/vex/openvex.json


### PR DESCRIPTION
## What Changed

Bump the Go toolchain used by pull request and release workflows from 1.26.4 to 1.26.5.

The release workflow compiles the controller binary before copying it into the container image. Building with Go 1.26.5 includes the patched standard library and resolves the Go vulnerabilities reported by Trivy, including [CVE-2026-39822](https://nvd.nist.gov/vuln/detail/CVE-2026-39822) and [CVE-2026-42505](https://nvd.nist.gov/vuln/detail/CVE-2026-42505).

Existing published images are unchanged. They must be rebuilt from a release containing this update to pick up the patched standard library.
