### PR TITLE
fix(proxy): resolve InferenceRouting policy for AI provider_backend t…

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2103,9 +2103,13 @@ async fn make_backend_call(
 			if let Some(provider_backend) = &provider.provider_backend {
 				let provider_backend =
 					super::resolve_simple_backend_with_policies(provider_backend, inputs.as_ref())?;
-				let provider_backend_policies = inputs.stores.read_binds().sub_backend_policies(
+				// Use backend_policies (not sub_backend_policies) so policies indexed without a
+				// port -- like the InferenceRouting policy the controller attaches to an
+				// InferencePool's synthesized service -- are found for the provider backend.
+				let provider_backend_policies = inputs.stores.read_binds().backend_policies(
 					provider_backend.backend.target(),
-					Some(&provider_backend.inline_policies),
+					&[&provider_backend.inline_policies],
+					None,
 				);
 				let effective_policies = provider_defaults
 					.merge(policies.as_ref().clone())


### PR DESCRIPTION
## Summary

When an `AgentgatewayBackend` uses the `custom` provider with `backendRef` pointing at an `InferencePool` (the pattern added in #1932 to close #288), the endpoint picker (EPP) is silently never invoked. Requests fall back to plain Service load-balancing across the pool's selector-matched pods instead of going through EPP's dynamic endpoint selection — which breaks routing outright in disaggregated deployments (e.g. prefill/decode pods on different ports) and defeats the whole point of using an InferencePool.

## Root cause

The `provider_backend` branch in `httpproxy.rs` looks up policies with `sub_backend_policies()`, a single exact-match lookup keyed on the backend's `target()`, port included.

The controller writes the `InferenceRouting` policy for an `InferencePool` with a **portless** target (`controller/pkg/agentgateway/plugins/inference_plugin.go:89`, via `ServiceTargetWithHostname(pool.Namespace, hostname, nil)`) — a pool has no single well-known port, so this is the only sensible target to write.

On the data-plane side, `provider_backend.backend.target()` resolves to `Service { hostname, port: Some(N) }` (the port of the pool's synthesized Service). `Some(N) != None`, so the exact-hash lookup misses, `BackendPolicies.inference_routing` stays empty, and `apply_inference_routing` becomes a silent no-op — no error, no log line.

The direct `HTTPRoute` → `InferencePool` path doesn't hit this because it goes through `backend_policies()` (`store/binds.rs`), which tries **both** the port-stripped key and the exact key. `provider_backend` only had the single exact-key lookup.

The existing test `custom_llm_provider_service_backend_runs_inference_routing` (`ext_proc_tests.rs`) doesn't catch this because it constructs its own policy target with an explicit port, which happens to match the buggy read-side key by coincidence — it doesn't exercise the port=None target the controller actually produces.

## Fix

Swap `provider_backend`'s policy lookup from `sub_backend_policies()` to `backend_policies()`, matching what the direct-route path already does:

```diff
-let provider_backend_policies = inputs.stores.read_binds().sub_backend_policies(
+let provider_backend_policies = inputs.stores.read_binds().backend_policies(
     provider_backend.backend.target(),
-    Some(&provider_backend.inline_policies),
+    &[&provider_backend.inline_policies],
+    None,
 );
```