### PR TITLE
fix(llm): honor final Anthropic stream input usage

### DIFF
--- a/crates/llm/src/conversion/messages.rs
+++ b/crates/llm/src/conversion/messages.rs
@@ -720,6 +720,9 @@ pub mod from_completions {
 						.as_ref()
 						.and_then(crate::types::serialize_str);
 					log.update(|r| {
+						if let Some(inp) = usage.input_tokens {
+							r.response.input_tokens = Some(inp as u64);
+						}
 						if let Some(crt) = usage.cache_read_input_tokens {
 							r.response.cached_input_tokens = Some(crt as u64);
 						}
@@ -963,6 +966,9 @@ pub fn passthrough_stream(
 					.as_ref()
 					.and_then(crate::types::serialize_str);
 				log.update(|r| {
+					if let Some(inp) = usage.input_tokens {
+						r.response.input_tokens = Some(inp as u64);
+					}
 					if let Some(o) = usage.output_tokens {
 						r.response.output_tokens = Some(o as u64);
 					}

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -1097,6 +1097,64 @@ data: [DONE]
 		);
 	}
 
+	#[tokio::test]
+	async fn anthropic_message_delta_usage_overrides_message_start() {
+		let input = r#"event:message_start
+data:{"type":"message_start","message":{"id":"msg","type":"message","role":"assistant","content":[],"model":"glm-5.2","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":34824,"output_tokens":0}}}
+
+event:message_delta
+data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":3883,"output_tokens":49,"cache_creation_input_tokens":0,"cache_read_input_tokens":30464,"prompt_tokens_details":{"cached_tokens":30464}}}
+
+event:message_stop
+data:{"type":"message_stop"}
+
+"#;
+
+		for translate_to_completions in [false, true] {
+			let info = Arc::new(Mutex::new(LLMInfo::new(
+				LLMRequest {
+					input_tokens: None,
+					input_format: InputFormat::Messages,
+					cache_convention: CacheTokenConvention::InputExcludesCache,
+					request_model: strng::literal!("glm-5.2"),
+					provider: strng::literal!("anthropic"),
+					streaming: true,
+					params: Default::default(),
+					prompt: None,
+					provider_state: None,
+				},
+				LLMResponse::default(),
+			)));
+			let reporter =
+				StreamingUsageGuard::new(Box::new(TestStreamingReporter { info: info.clone() }));
+			let body = axum_core::body::Body::from(input);
+			let body = if translate_to_completions {
+				conversion::messages::from_completions::translate_stream(
+					body,
+					1024 * 1024,
+					reporter,
+					crate::LogContentFields::default(),
+				)
+			} else {
+				conversion::messages::passthrough_stream(
+					body,
+					1024 * 1024,
+					reporter,
+					crate::LogContentFields::default(),
+				)
+			};
+			body.collect().await.unwrap();
+
+			let info = info.lock().unwrap();
+			assert_eq!(info.response.input_tokens, Some(3883));
+			assert_eq!(info.response.cached_input_tokens, Some(30464));
+			assert_eq!(info.response.cache_creation_input_tokens, Some(0));
+			assert_eq!(info.response.output_tokens, Some(49));
+			assert_eq!(info.response.total_tokens, Some(3932));
+			assert_eq!(info.normalized_input_tokens(), Some(34347));
+		}
+	}
+
 	#[test]
 	fn responses_usage_allows_missing_cache_write_tokens() {
 		let event = serde_json::from_value::<types::responses::typed::ResponseStreamEvent>(json!({

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -707,6 +707,10 @@ mod responses {
 		("stream_basic", ALL_ANTHROPIC),
 		("stream_thinking", ALL_ANTHROPIC),
 		(
+			"stream_message_delta_usage",
+			&[MESSAGES_TO_MESSAGES, MESSAGES_TO_COMPLETIONS],
+		),
+		(
 			"stream_tool",
 			&[MESSAGES_TO_MESSAGES, MESSAGES_TO_COMPLETIONS],
 		),
@@ -1095,64 +1099,6 @@ data: [DONE]
 				"cache_read_input_tokens": 20,
 			})
 		);
-	}
-
-	#[tokio::test]
-	async fn anthropic_message_delta_usage_overrides_message_start() {
-		let input = r#"event:message_start
-data:{"type":"message_start","message":{"id":"msg","type":"message","role":"assistant","content":[],"model":"glm-5.2","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":34824,"output_tokens":0}}}
-
-event:message_delta
-data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":3883,"output_tokens":49,"cache_creation_input_tokens":0,"cache_read_input_tokens":30464,"prompt_tokens_details":{"cached_tokens":30464}}}
-
-event:message_stop
-data:{"type":"message_stop"}
-
-"#;
-
-		for translate_to_completions in [false, true] {
-			let info = Arc::new(Mutex::new(LLMInfo::new(
-				LLMRequest {
-					input_tokens: None,
-					input_format: InputFormat::Messages,
-					cache_convention: CacheTokenConvention::InputExcludesCache,
-					request_model: strng::literal!("glm-5.2"),
-					provider: strng::literal!("anthropic"),
-					streaming: true,
-					params: Default::default(),
-					prompt: None,
-					provider_state: None,
-				},
-				LLMResponse::default(),
-			)));
-			let reporter =
-				StreamingUsageGuard::new(Box::new(TestStreamingReporter { info: info.clone() }));
-			let body = axum_core::body::Body::from(input);
-			let body = if translate_to_completions {
-				conversion::messages::from_completions::translate_stream(
-					body,
-					1024 * 1024,
-					reporter,
-					crate::LogContentFields::default(),
-				)
-			} else {
-				conversion::messages::passthrough_stream(
-					body,
-					1024 * 1024,
-					reporter,
-					crate::LogContentFields::default(),
-				)
-			};
-			body.collect().await.unwrap();
-
-			let info = info.lock().unwrap();
-			assert_eq!(info.response.input_tokens, Some(3883));
-			assert_eq!(info.response.cached_input_tokens, Some(30464));
-			assert_eq!(info.response.cache_creation_input_tokens, Some(0));
-			assert_eq!(info.response.output_tokens, Some(49));
-			assert_eq!(info.response.total_tokens, Some(3932));
-			assert_eq!(info.normalized_input_tokens(), Some(34347));
-		}
 	}
 
 	#[test]

--- a/crates/llm/src/tests/response/anthropic/stream_message_delta_usage.json
+++ b/crates/llm/src/tests/response/anthropic/stream_message_delta_usage.json
@@ -1,0 +1,9 @@
+event:message_start
+data:{"type":"message_start","message":{"id":"msg","type":"message","role":"assistant","content":[],"model":"glm-5.2","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":34824,"output_tokens":0}}}
+
+event:message_delta
+data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":3883,"output_tokens":49,"cache_creation_input_tokens":0,"cache_read_input_tokens":30464,"prompt_tokens_details":{"cached_tokens":30464}}}
+
+event:message_stop
+data:{"type":"message_stop"}
+

--- a/crates/llm/src/tests/response/anthropic/stream_message_delta_usage.messages-completions-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_message_delta_usage.messages-completions-streaming.snap
@@ -1,0 +1,21 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/stream_message_delta_usage.json
+---
+data: {"id":"msg","choices":[{"index":0,"delta":{"content":null},"finish_reason":"stop"}],"created":123,"model":"glm-5.2","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":3883,"completion_tokens":49,"total_tokens":3932,"prompt_tokens_details":{"cached_tokens":30464,"cache_write_tokens":0},"cache_read_input_tokens":30464,"cache_creation_input_tokens":0}}
+
+data: [DONE]
+
+
+
+{
+  "input_tokens": 3883,
+  "output_tokens": 49,
+  "total_tokens": 3932,
+  "cache_creation_input_tokens": 0,
+  "cached_input_tokens": 30464,
+  "provider_model": "glm-5.2",
+  "completion": [
+    ""
+  ]
+}

--- a/crates/llm/src/tests/response/anthropic/stream_message_delta_usage.messages-messages-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_message_delta_usage.messages-messages-streaming.snap
@@ -1,0 +1,26 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/stream_message_delta_usage.json
+---
+event:message_start
+data:{"type":"message_start","message":{"id":"msg","type":"message","role":"assistant","content":[],"model":"glm-5.2","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":34824,"output_tokens":0}}}
+
+event:message_delta
+data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":3883,"output_tokens":49,"cache_creation_input_tokens":0,"cache_read_input_tokens":30464,"prompt_tokens_details":{"cached_tokens":30464}}}
+
+event:message_stop
+data:{"type":"message_stop"}
+
+
+
+{
+  "input_tokens": 3883,
+  "output_tokens": 49,
+  "total_tokens": 3932,
+  "cache_creation_input_tokens": 0,
+  "cached_input_tokens": 30464,
+  "provider_model": "glm-5.2",
+  "completion": [
+    ""
+  ]
+}


### PR DESCRIPTION
## Summary

- Use `message_delta.usage.input_tokens` as the final Anthropic streaming input usage when present.
- Apply the fix to both passthrough and Anthropic-to-OpenAI streaming paths.
- Add regression coverage for Anthropic-compatible endpoints with cached input tokens.

## Testing

- `cargo test -p agent-llm` — 252 passed
