### PR TITLE
Add ReadOnly storage mode to lock down UI/API writes

### DIFF
--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -369,12 +369,12 @@ pub fn parse_config(
 		anyhow::bail!("config.logging.database.maxConnections must be greater than zero");
 	}
 	let logging_database = explicit_logging_database.or_else(|| database.clone());
-	let storage = StorageConfig {
-		mode: raw.storage.clone().unwrap_or_default().mode,
+
+	let mut storage_mode = raw.storage.clone().unwrap_or_default().mode;
+	if parse::<bool>("UI_READ_ONLY")?.unwrap_or(false) {
+		storage_mode = ConfigStoreMode::ReadOnly;
 	};
-	let ui_read_only = parse::<bool>("UI_READ_ONLY")?
-		.or(raw.ui_read_only)
-		.unwrap_or(false);
+	let storage = StorageConfig { mode: storage_mode };
 	if storage.mode == ConfigStoreMode::Hybrid && database.is_none() {
 		anyhow::bail!("config.storage.mode=hybrid requires config.database.url");
 	}
@@ -575,7 +575,6 @@ pub fn parse_config(
 		},
 		database,
 		storage,
-		ui_read_only,
 		session_encoder,
 		oidc_cookie_encoder,
 			hbone: Arc::new(agent_hbone::Config {
@@ -1268,7 +1267,7 @@ config:
 		let _env_lock = lock_env();
 		let config = parse_config("{}".to_string(), None).expect("config should parse");
 
-		assert!(!config.ui_read_only);
+		assert!(!config.storage.mode == ConfigStoreMode::ReadOnly);
 	}
 
 	#[test]
@@ -1277,14 +1276,15 @@ config:
 		let config = parse_config(
 			r#"
 config:
-  uiReadOnly: true
+  storage:
+    mode: read_only
 "#
 			.to_string(),
 			None,
 		)
 		.expect("config should parse");
 
-		assert!(config.ui_read_only);
+		assert!(config.storage.mode == ConfigStoreMode::ReadOnly);
 	}
 
 	#[test]
@@ -1294,14 +1294,15 @@ config:
 		let config = parse_config(
 			r#"
 config:
-  uiReadOnly: false
+  storage:
+    mode: file
 "#
 			.to_string(),
 			None,
 		)
 		.expect("config should parse");
 
-		assert!(config.ui_read_only);
+		assert!(config.storage.mode == ConfigStoreMode::ReadOnly);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -1263,49 +1263,6 @@ config:
 	}
 
 	#[test]
-	fn ui_read_only_defaults_to_false() {
-		let _env_lock = lock_env();
-		let config = parse_config("{}".to_string(), None).expect("config should parse");
-
-		assert!(!config.storage.mode == ConfigStoreMode::ReadOnly);
-	}
-
-	#[test]
-	fn ui_read_only_from_config_file() {
-		let _env_lock = lock_env();
-		let config = parse_config(
-			r#"
-config:
-  storage:
-    mode: read_only
-"#
-			.to_string(),
-			None,
-		)
-		.expect("config should parse");
-
-		assert!(config.storage.mode == ConfigStoreMode::ReadOnly);
-	}
-
-	#[test]
-	fn ui_read_only_env_var_overrides_config_file() {
-		let _env_lock = lock_env();
-		let _env = TempEnvVar::set("UI_READ_ONLY", "true");
-		let config = parse_config(
-			r#"
-config:
-  storage:
-    mode: file
-"#
-			.to_string(),
-			None,
-		)
-		.expect("config should parse");
-
-		assert!(config.storage.mode == ConfigStoreMode::ReadOnly);
-	}
-
-	#[test]
 	fn storage_hybrid_uses_shared_database_url() {
 		let _env_lock = lock_env();
 		let config = parse_config(

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -372,6 +372,9 @@ pub fn parse_config(
 	let storage = StorageConfig {
 		mode: raw.storage.clone().unwrap_or_default().mode,
 	};
+	let ui_read_only = parse::<bool>("UI_READ_ONLY")?
+		.or(raw.ui_read_only)
+		.unwrap_or(false);
 	if storage.mode == ConfigStoreMode::Hybrid && database.is_none() {
 		anyhow::bail!("config.storage.mode=hybrid requires config.database.url");
 	}
@@ -572,6 +575,7 @@ pub fn parse_config(
 		},
 		database,
 		storage,
+		ui_read_only,
 		session_encoder,
 		oidc_cookie_encoder,
 			hbone: Arc::new(agent_hbone::Config {
@@ -1257,6 +1261,47 @@ config:
 
 		assert_eq!(config.storage.mode, ConfigStoreMode::File);
 		assert!(config.database.is_none());
+	}
+
+	#[test]
+	fn ui_read_only_defaults_to_false() {
+		let _env_lock = lock_env();
+		let config = parse_config("{}".to_string(), None).expect("config should parse");
+
+		assert!(!config.ui_read_only);
+	}
+
+	#[test]
+	fn ui_read_only_from_config_file() {
+		let _env_lock = lock_env();
+		let config = parse_config(
+			r#"
+config:
+  uiReadOnly: true
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should parse");
+
+		assert!(config.ui_read_only);
+	}
+
+	#[test]
+	fn ui_read_only_env_var_overrides_config_file() {
+		let _env_lock = lock_env();
+		let _env = TempEnvVar::set("UI_READ_ONLY", "true");
+		let config = parse_config(
+			r#"
+config:
+  uiReadOnly: false
+"#
+			.to_string(),
+			None,
+		)
+		.expect("config should parse");
+
+		assert!(config.ui_read_only);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -192,9 +192,6 @@ pub struct RawConfig {
 
 	/// Admin UI address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"
 	admin_addr: Option<String>,
-	/// When true, disables all UI/API actions that write configuration (config file, config
-	/// resources, cost catalog refresh). Can also be set via the `UI_READ_ONLY` environment variable.
-	ui_read_only: Option<bool>,
 	/// Standard request log attributes populated for database-backed local runtime features.
 	standard_attributes: Option<RawStandardAttributes>,
 	/// Stats/metrics server address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"
@@ -434,6 +431,8 @@ pub enum ConfigStoreMode {
 	File,
 	/// Read a file baseline and store UI-managed overlay resources in the configured database.
 	Hybrid,
+	/// Disallow write operations to the config from the UI
+	ReadOnly,
 }
 
 #[apply(schema_de!)]
@@ -627,7 +626,6 @@ pub struct Config {
 	pub logging: crate::telemetry::log::Config,
 	pub database: Option<telemetry::log_store::Config>,
 	pub storage: StorageConfig,
-	pub ui_read_only: bool,
 
 	pub dns: client::Config,
 	pub proxy_metadata: ProxyMetadata,

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -192,6 +192,9 @@ pub struct RawConfig {
 
 	/// Admin UI address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"
 	admin_addr: Option<String>,
+	/// When true, disables all UI/API actions that write configuration (config file, config
+	/// resources, cost catalog refresh). Can also be set via the `UI_READ_ONLY` environment variable.
+	ui_read_only: Option<bool>,
 	/// Standard request log attributes populated for database-backed local runtime features.
 	standard_attributes: Option<RawStandardAttributes>,
 	/// Stats/metrics server address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"
@@ -624,6 +627,7 @@ pub struct Config {
 	pub logging: crate::telemetry::log::Config,
 	pub database: Option<telemetry::log_store::Config>,
 	pub storage: StorageConfig,
+	pub ui_read_only: bool,
 
 	pub dns: client::Config,
 	pub proxy_metadata: ProxyMetadata,

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -50,7 +50,7 @@ impl App {
 	}
 
 	fn ensure_writable(&self) -> Result<(), ErrorResponse> {
-		if self.state.ui_read_only {
+		if self.state.storage.mode == ConfigStoreMode::ReadOnly {
 			return Err(ErrorResponse::Status(
 				StatusCode::FORBIDDEN,
 				"UI is configured as read-only".to_string(),
@@ -141,7 +141,6 @@ struct RuntimeBuildInfo {
 struct RuntimeUiInfo {
 	gateway_mode: GatewayRuntimeMode,
 	config_store_mode: ConfigStoreMode,
-	read_only: bool,
 }
 
 #[derive(Serialize)]
@@ -226,7 +225,6 @@ async fn get_runtime(State(app): State<App>) -> Json<RuntimeInfo> {
 				GatewayRuntimeMode::Standalone
 			},
 			config_store_mode: app.state.storage.mode,
-			read_only: app.state.ui_read_only,
 		},
 	})
 }

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -49,6 +49,16 @@ impl App {
 			.ok_or(ErrorResponse::String("local config not setup".to_string()))
 	}
 
+	fn ensure_writable(&self) -> Result<(), ErrorResponse> {
+		if self.state.ui_read_only {
+			return Err(ErrorResponse::Status(
+				StatusCode::FORBIDDEN,
+				"UI is configured as read-only".to_string(),
+			));
+		}
+		Ok(())
+	}
+
 	fn config_resource_store(&self) -> Result<ConfigResourceStore, ErrorResponse> {
 		if self.state.storage.mode != ConfigStoreMode::Hybrid {
 			return Err(ErrorResponse::Status(
@@ -131,6 +141,7 @@ struct RuntimeBuildInfo {
 struct RuntimeUiInfo {
 	gateway_mode: GatewayRuntimeMode,
 	config_store_mode: ConfigStoreMode,
+	read_only: bool,
 }
 
 #[derive(Serialize)]
@@ -215,6 +226,7 @@ async fn get_runtime(State(app): State<App>) -> Json<RuntimeInfo> {
 				GatewayRuntimeMode::Standalone
 			},
 			config_store_mode: app.state.storage.mode,
+			read_only: app.state.ui_read_only,
 		},
 	})
 }
@@ -302,6 +314,7 @@ async fn write_config(
 	State(app): State<App>,
 	Json(config_json): Json<Value>,
 ) -> Result<Json<Value>, ErrorResponse> {
+	app.ensure_writable()?;
 	persist_file_config(&app, &config_json).await?;
 	Ok(Json(
 		serde_json::json!({"status": "success", "message": "Configuration written successfully"}),
@@ -387,6 +400,7 @@ async fn upsert_config_resources_by_kind(
 	Path(kind): Path<String>,
 	Json(request): Json<ConfigResourceUpsertRequest>,
 ) -> Result<Json<UiConfigResourcesResponse>, ErrorResponse> {
+	app.ensure_writable()?;
 	let kind = kind
 		.parse::<ConfigResourceKind>()
 		.map_err(resource_api_error)?;
@@ -435,6 +449,7 @@ async fn update_config_resource(
 	Path((kind, id)): Path<(String, String)>,
 	Json(mut resource): Json<crate::config_store::ConfigResourceUpsert>,
 ) -> Result<Json<UiConfigResourcesResponse>, ErrorResponse> {
+	app.ensure_writable()?;
 	let kind = kind
 		.parse::<ConfigResourceKind>()
 		.map_err(resource_api_error)?;
@@ -566,6 +581,7 @@ async fn delete_config_resource(
 	State(app): State<App>,
 	Path((kind, id)): Path<(String, String)>,
 ) -> Result<Json<Value>, ErrorResponse> {
+	app.ensure_writable()?;
 	let kind = kind
 		.parse::<ConfigResourceKind>()
 		.map_err(resource_api_error)?;
@@ -635,6 +651,7 @@ fn resource_api_error(err: impl Into<anyhow::Error>) -> ErrorResponse {
 }
 
 async fn refresh_base_costs(State(app): State<App>) -> Result<Json<Value>, ErrorResponse> {
+	app.ensure_writable()?;
 	let configured_file = app.state.model_catalog.sources.iter().find_map(|source| {
 		if let crate::ModelCatalogSource::File { file } = source {
 			Some(file)
@@ -871,4 +888,48 @@ async fn tail_logs(
 	});
 
 	Ok(Sse::new(ReceiverStream::new(rx)))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::client::{self, Client};
+
+	fn test_app(read_only: bool) -> App {
+		let mut config =
+			crate::config::parse_config("{}".to_string(), None).expect("parse default config");
+		config.ui_read_only = read_only;
+		let client = Client::new(
+			&client::Config {
+				resolver_cfg: hickory_resolver::config::ResolverConfig::default(),
+				resolver_opts: hickory_resolver::config::ResolverOpts::default(),
+			},
+			None,
+			crate::BackendConfig::default(),
+			None,
+		);
+		App {
+			state: Arc::new(config),
+			config_resource_store: None,
+			resource_manager: crate::resource_manager::ResourceManager::new(client)
+				.expect("resource manager"),
+			model_catalog: Arc::new(crate::llm::cost::ModelCatalog::default()),
+		}
+	}
+
+	#[tokio::test]
+	async fn ensure_writable_blocks_when_read_only() {
+		let app = test_app(true);
+		let response = app
+			.ensure_writable()
+			.expect_err("should be forbidden")
+			.into_response();
+		assert_eq!(response.status(), StatusCode::FORBIDDEN);
+	}
+
+	#[tokio::test]
+	async fn ensure_writable_allows_when_not_read_only() {
+		let app = test_app(false);
+		assert!(app.ensure_writable().is_ok());
+	}
 }

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -896,7 +896,9 @@ mod tests {
 	fn test_app(read_only: bool) -> App {
 		let mut config =
 			crate::config::parse_config("{}".to_string(), None).expect("parse default config");
-		config.ui_read_only = read_only;
+		if read_only {
+			config.storage.mode = ConfigStoreMode::ReadOnly;
+		}
 		let client = Client::new(
 			&client::Config {
 				resolver_cfg: hickory_resolver::config::ResolverConfig::default(),

--- a/schema/config.json
+++ b/schema/config.json
@@ -273,6 +273,13 @@
             "null"
           ]
         },
+        "uiReadOnly": {
+          "description": "When true, disables all UI/API actions that write configuration (config file, config\nresources, cost catalog refresh). Can also be set via the `UI_READ_ONLY` environment variable.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "standardAttributes": {
           "description": "Standard request log attributes populated for database-backed local runtime features.",
           "anyOf": [

--- a/schema/config.json
+++ b/schema/config.json
@@ -273,13 +273,6 @@
             "null"
           ]
         },
-        "uiReadOnly": {
-          "description": "When true, disables all UI/API actions that write configuration (config file, config\nresources, cost catalog refresh). Can also be set via the `UI_READ_ONLY` environment variable.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "standardAttributes": {
           "description": "Standard request log attributes populated for database-backed local runtime features.",
           "anyOf": [
@@ -711,6 +704,11 @@
           "description": "Read a file baseline and store UI-managed overlay resources in the configured database.",
           "type": "string",
           "const": "hybrid"
+        },
+        {
+          "description": "Disallow write operations to the config from the UI",
+          "type": "string",
+          "const": "readOnly"
         }
       ]
     },

--- a/schema/config.md
+++ b/schema/config.md
@@ -36,7 +36,7 @@
 |`config.database.url`|string|Connection URL for the request log database. A postgres:// or postgresql:// URL uses Postgres; any other value is treated as a SQLite database.|
 |`config.database.maxConnections`|integer|Maximum number of connections to open in this database's connection pool. Defaults to 5.<br>When the request log and config stores have matching database settings, they share one pool<br>with this limit.|
 |`config.storage`|object|Controls whether UI-managed configuration is written to the config file or a DB overlay.|
-|`config.storage.mode`|enum|Possible values: `file`, `hybrid`.|
+|`config.storage.mode`|enum|Possible values: `file`, `hybrid`, `readOnly`.|
 |`config.caAddress`|string|Address of the Certificate Authority used to issue SPIFFE certificates.|
 |`config.caAuthToken`|string|Authentication token for communicating with the Certificate Authority.|
 |`config.xdsAddress`|string|Address of the xDS control plane used for dynamic configuration.|
@@ -50,7 +50,6 @@
 |`config.clusterId`|string|Identifier for the cluster this gateway runs in. Defaults to "Kubernetes".|
 |`config.network`|string|Network name for this gateway, used for locality-aware routing.|
 |`config.adminAddr`|string|Admin UI address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"|
-|`config.uiReadOnly`|boolean|When true, disables all UI/API actions that write configuration (config file, config<br>resources, cost catalog refresh). Can also be set via the `UI_READ_ONLY` environment variable.|
 |`config.standardAttributes`|object|Standard request log attributes populated for database-backed local runtime features.|
 |`config.standardAttributes.user`|string|CEL expression used to populate the `agentgateway.user` request log attribute.|
 |`config.standardAttributes.group`|string|CEL expression used to populate the `agentgateway.group` request log attribute.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -50,6 +50,7 @@
 |`config.clusterId`|string|Identifier for the cluster this gateway runs in. Defaults to "Kubernetes".|
 |`config.network`|string|Network name for this gateway, used for locality-aware routing.|
 |`config.adminAddr`|string|Admin UI address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"|
+|`config.uiReadOnly`|boolean|When true, disables all UI/API actions that write configuration (config file, config<br>resources, cost catalog refresh). Can also be set via the `UI_READ_ONLY` environment variable.|
 |`config.standardAttributes`|object|Standard request log attributes populated for database-backed local runtime features.|
 |`config.standardAttributes.user`|string|CEL expression used to populate the `agentgateway.user` request log attribute.|
 |`config.standardAttributes.group`|string|CEL expression used to populate the `agentgateway.group` request log attribute.|

--- a/ui/src/api/runtimeApi.ts
+++ b/ui/src/api/runtimeApi.ts
@@ -11,6 +11,7 @@ export interface RuntimeInfo {
   ui: {
     gatewayMode: "standalone" | "xds";
     configStoreMode: "file" | "hybrid";
+    readOnly: boolean;
   };
 }
 

--- a/ui/src/api/runtimeApi.ts
+++ b/ui/src/api/runtimeApi.ts
@@ -10,8 +10,7 @@ export interface RuntimeInfo {
   };
   ui: {
     gatewayMode: "standalone" | "xds";
-    configStoreMode: "file" | "hybrid";
-    readOnly: boolean;
+    configStoreMode: "file" | "hybrid" | "read_only";
   };
 }
 

--- a/ui/src/api/runtimeApi.ts
+++ b/ui/src/api/runtimeApi.ts
@@ -10,7 +10,7 @@ export interface RuntimeInfo {
   };
   ui: {
     gatewayMode: "standalone" | "xds";
-    configStoreMode: "file" | "hybrid" | "read_only";
+    configStoreMode: "file" | "hybrid" | "readOnly";
   };
 }
 

--- a/ui/src/components/Shell.tsx
+++ b/ui/src/components/Shell.tsx
@@ -238,7 +238,7 @@ export function Shell() {
           </div>
         </header>
         <main className="content">
-          {runtime.data?.ui.readOnly && (
+          {runtime.data?.ui.configStoreMode == "read_only" && (
             <StatusBanner state="info" title="Read-only mode">
               The UI is configured as read-only. Editing is disabled.
             </StatusBanner>

--- a/ui/src/components/Shell.tsx
+++ b/ui/src/components/Shell.tsx
@@ -31,11 +31,12 @@ import {
   Sun,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { Tooltip, useDismissiblePopover } from "./Primitives";
+import { StatusBanner, Tooltip, useDismissiblePopover } from "./Primitives";
 import {
   useConfigDumpMode,
   useEffectiveGatewayConfig,
   useMcpConfigData,
+  useRuntimeInfo,
   useTrafficConfigData,
 } from "../hooks";
 import logoDark from "../assets/agw-dark.svg";
@@ -70,6 +71,7 @@ const projectLinks = [
 
 export function Shell() {
   const router = useRouterState();
+  const runtime = useRuntimeInfo();
   const mode = useConfigDumpMode();
   const dumpMode = mode.data?.mode === "dump";
   const config = useEffectiveGatewayConfig({
@@ -236,6 +238,11 @@ export function Shell() {
           </div>
         </header>
         <main className="content">
+          {runtime.data?.ui.readOnly && (
+            <StatusBanner state="info" title="Read-only mode">
+              The UI is configured as read-only. Editing is disabled.
+            </StatusBanner>
+          )}
           <Outlet />
         </main>
       </div>

--- a/ui/src/components/Shell.tsx
+++ b/ui/src/components/Shell.tsx
@@ -238,7 +238,7 @@ export function Shell() {
           </div>
         </header>
         <main className="content">
-          {runtime.data?.ui.configStoreMode == "read_only" && (
+          {runtime.data?.ui.configStoreMode == "readOnly" && (
             <StatusBanner state="info" title="Read-only mode">
               The UI is configured as read-only. Editing is disabled.
             </StatusBanner>

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -203,7 +203,7 @@ async function requireWritableRuntime(
     queryClient.getQueryData<Awaited<ReturnType<typeof getRuntimeInfo>>>([
       "runtime",
     ]) ?? (await getRuntimeInfo());
-  if (runtime.ui.storageMode == "readOnly") {
+  if (runtime.ui.configStoreMode == "readOnly") {
     throw new Error("The UI is configured as read-only.");
   }
   return runtime;

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -196,6 +196,19 @@ export function useConfigDumpMode() {
   });
 }
 
+async function requireWritableRuntime(
+  queryClient: ReturnType<typeof useQueryClient>,
+) {
+  const runtime =
+    queryClient.getQueryData<Awaited<ReturnType<typeof getRuntimeInfo>>>([
+      "runtime",
+    ]) ?? (await getRuntimeInfo());
+  if (runtime.ui.readOnly) {
+    throw new Error("The UI is configured as read-only.");
+  }
+  return runtime;
+}
+
 function invalidateConfigViews(queryClient: ReturnType<typeof useQueryClient>) {
   void queryClient.invalidateQueries({ queryKey: ["configResources"] });
   void queryClient.invalidateQueries({ queryKey: ["config"] });
@@ -211,10 +224,7 @@ export function useUpdateConfig() {
     mutationFn: async (
       updater: (config: GatewayConfig) => GatewayConfig | void,
     ) => {
-      const runtime =
-        queryClient.getQueryData<Awaited<ReturnType<typeof getRuntimeInfo>>>([
-          "runtime",
-        ]) ?? (await getRuntimeInfo());
+      const runtime = await requireWritableRuntime(queryClient);
       const overrideHybridFileWrite = takeHybridFileWriteOverride();
       if (runtime.ui.configStoreMode === "hybrid" && !overrideHybridFileWrite) {
         throw new Error(
@@ -242,6 +252,7 @@ export function useUpsertConfigResource() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: UpsertConfigResourceInput) => {
+      await requireWritableRuntime(queryClient);
       if (input.previousId) {
         await updateConfigResource(input.kind, input.previousId, input.value);
         return;
@@ -263,8 +274,10 @@ type UpsertConfigResourceInput = {
 export function useDeleteConfigResource() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (input: { kind: ConfigResourceKind; id: string }) =>
-      deleteConfigResource(input.kind, input.id),
+    mutationFn: async (input: { kind: ConfigResourceKind; id: string }) => {
+      await requireWritableRuntime(queryClient);
+      return deleteConfigResource(input.kind, input.id);
+    },
     onSuccess: () => invalidateConfigViews(queryClient),
   });
 }
@@ -272,11 +285,14 @@ export function useDeleteConfigResource() {
 export function useUpsertPolicyResource() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (input: {
+    mutationFn: async (input: {
       kind: PolicyResourceKind;
       id: string;
       value: unknown;
-    }) => updateConfigResource(input.kind, input.id, input.value),
+    }) => {
+      await requireWritableRuntime(queryClient);
+      return updateConfigResource(input.kind, input.id, input.value);
+    },
     onSuccess: () => invalidateConfigViews(queryClient),
   });
 }

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -203,7 +203,7 @@ async function requireWritableRuntime(
     queryClient.getQueryData<Awaited<ReturnType<typeof getRuntimeInfo>>>([
       "runtime",
     ]) ?? (await getRuntimeInfo());
-  if (runtime.ui.readOnly) {
+  if (runtime.ui.storageMode == "read_only") {
     throw new Error("The UI is configured as read-only.");
   }
   return runtime;

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -203,7 +203,7 @@ async function requireWritableRuntime(
     queryClient.getQueryData<Awaited<ReturnType<typeof getRuntimeInfo>>>([
       "runtime",
     ]) ?? (await getRuntimeInfo());
-  if (runtime.ui.storageMode == "read_only") {
+  if (runtime.ui.storageMode == "readOnly") {
     throw new Error("The UI is configured as read-only.");
   }
   return runtime;


### PR DESCRIPTION
Adds a `config.storage.mode.readOnly` setting (env override `UI_READ_ONLY`) that locks the standalone UI down to read-only.

Every handler that mutates state: config file writes, config resource upsert/delete, cost catalog refresh now returns 403 when enabled, via a single `App::ensure_writable()` check. Read-only endpoints (`/cel`, `/api/logs/*`, all GETs) are unaffected. The frontend surfaces this with a banner and blocks the same write paths client-side before hitting the API.

Fixes #1599.

Validated in UI with `UI_READ_ONLY=true ./target/debug/agentgateway`
<img width="1840" height="1168" alt="image" src="https://github.com/user-attachments/assets/765921e0-4b2f-4f5e-9b08-623a32996557" />
<img width="1840" height="1168" alt="image" src="https://github.com/user-attachments/assets/2590108e-c867-4fc6-8c34-b27c66e89631" />
