### PR TITLE
report errors on invalid inline jwks

### DIFF
--- a/controller/pkg/agentgateway/plugins/jwks_translation_test.go
+++ b/controller/pkg/agentgateway/plugins/jwks_translation_test.go
@@ -98,7 +98,7 @@ func TestProcessJWKSInvalidInline(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid inline JWKS, got nil")
 	}
-	if got := len(policy.GetTraffic().GetJwt().GetProviders()); got != 0 {
+	if got := len(policy.GetTraffic().GetJwt().GetProviders()); got != 1 {
 		t.Fatalf("expected the bad provider to be dropped (0 providers), got %d", got)
 	}
 }

--- a/controller/pkg/agentgateway/plugins/jwks_translation_test.go
+++ b/controller/pkg/agentgateway/plugins/jwks_translation_test.go
@@ -76,6 +76,33 @@ func TestProcessJWTAuthenticationPolicyWhenLookupReturnsErrorOmitsRemoteProvider
 	}
 }
 
+func TestProcessJWKSInvalidInline(t *testing.T) {
+	inlineBad := agentgateway.LongString(`{"keys":[{"e":"AQAB","kid":"3161","kty":"RSB","n":"tmzcODUF5T9p"}]}`)
+	jwtAuth := &agentgateway.JWTAuthentication{
+		Mode: agentgateway.JWTAuthenticationModeStrict,
+		Providers: []agentgateway.JWTProvider{{
+			Issuer: "cool-issuer.corp",
+			JWKS: agentgateway.JWKS{
+				Inline: &inlineBad,
+			},
+		}},
+	}
+	policy, err := processJWTAuthenticationPolicy(
+		PolicyCtx{Krt: krt.TestingDummyContext{}},
+		jwtAuth,
+		nil,
+		"default/test:jwt",
+		types.NamespacedName{Namespace: "default", Name: "test"},
+	)
+
+	if err == nil {
+		t.Fatal("expected error for invalid inline JWKS, got nil")
+	}
+	if got := len(policy.GetTraffic().GetJwt().GetProviders()); got != 0 {
+		t.Fatalf("expected the bad provider to be dropped (0 providers), got %d", got)
+	}
+}
+
 func TestTranslateMCPAuthenticationSpecWhenLookupReturnsErrorLeavesInlineEmptyAndReturnsError(t *testing.T) {
 	sentinel := errors.New("lookup failed")
 	authn := &agentgateway.MCPAuthentication{

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -771,10 +771,8 @@ func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthenti
 
 			var ks jose.JSONWebKeySet
 			if err := json.Unmarshal([]byte(*i), &ks); err != nil {
-				errs = append(errs, fmt.Errorf("provider %d (issuer %q): invalid inline JWKS: %w", idx, pp.Issuer, err))
-				continue
+				errs = append(errs, fmt.Errorf("provider %d (issuer %q): invalid inline JWKS", idx, pp.Issuer))
 			}
-
 			jp.JwksSource = &api.TrafficPolicySpec_JWTProvider_Inline{Inline: *i}
 			p.Providers = append(p.Providers, jp)
 			continue

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/google/cel-go/cel"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -767,6 +768,13 @@ func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthenti
 			Audiences: pp.Audiences,
 		}
 		if i := pp.JWKS.Inline; i != nil {
+
+			var ks jose.JSONWebKeySet
+			if err := json.Unmarshal([]byte(*i), &ks); err != nil {
+				errs = append(errs, fmt.Errorf("provider %d (issuer %q): invalid inline JWKS: %w", idx, pp.Issuer, err))
+				continue
+			}
+
 			jp.JwksSource = &api.TrafficPolicySpec_JWTProvider_Inline{Inline: *i}
 			p.Providers = append(p.Providers, jp)
 			continue

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -768,7 +768,6 @@ func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthenti
 			Audiences: pp.Audiences,
 		}
 		if i := pp.JWKS.Inline; i != nil {
-
 			var ks jose.JSONWebKeySet
 			if err := json.Unmarshal([]byte(*i), &ks); err != nil {
 				errs = append(errs, fmt.Errorf("provider %d (issuer %q): invalid inline JWKS", idx, pp.Issuer))

--- a/controller/test/e2e/jwtauth_test.go
+++ b/controller/test/e2e/jwtauth_test.go
@@ -82,8 +82,8 @@ func testJwtAuthInvalidInlineJwks(t base.Test) {
 	})
 	assertJwtResponse(t, "invalidjwksroute.com", "", http.StatusUnauthorized)
 
+	// assert that we are still accepting new config by checking secure route
 	assertJwtResponse(t, "secureroute.com", jwt1, http.StatusNotFound)
-
 	t.Apply(manifest("jwtauth", "secured-route.yaml"))
 	t.HTTPRouteAccepted("route-secure", base.Namespace)
 	assertJwtResponse(t, "secureroute.com", jwt1, http.StatusOK)

--- a/controller/test/e2e/jwtauth_test.go
+++ b/controller/test/e2e/jwtauth_test.go
@@ -3,9 +3,16 @@
 package e2e_test
 
 import (
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
+	"istio.io/istio/pkg/test/util/retry"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 	"github.com/agentgateway/agentgateway/controller/pkg/utils/requestutils/curl"
 	"github.com/agentgateway/agentgateway/controller/test/e2e/base"
 )
@@ -40,6 +47,46 @@ func TestJwtAuth(tt *testing.T) {
 	t.Run("GatewayPolicyWithRBAC", func(t base.Test) {
 		testJwtAuthGatewayPolicyWithRbac(t)
 	})
+	t.Run("InvalidInlineJwks", func(t base.Test) {
+		testJwtAuthInvalidInlineJwks(t)
+	})
+}
+
+func testJwtAuthInvalidInlineJwks(t base.Test) {
+	t.Apply(
+		manifest("jwtauth", "invalid-inline.yaml"),
+	)
+
+	t.HTTPRouteAccepted("route-invalid-jwks", base.Namespace)
+
+	retry.UntilSuccessOrFail(t, func() error {
+		policy := &agentgateway.AgentgatewayPolicy{}
+		if err := t.TestInstallation.ClusterContext.ControllerClient.Get(
+			t.Ctx,
+			types.NamespacedName{Name: "route-invalid-inline-jwks-policy", Namespace: base.Namespace},
+			policy,
+		); err != nil {
+			return err
+		}
+		for _, ancestor := range policy.Status.Ancestors {
+			for _, condition := range ancestor.Conditions {
+				if condition.Type == string(agentgateway.PolicyConditionAccepted) &&
+					condition.Status == metav1.ConditionTrue &&
+					condition.Reason == string(agentgateway.PolicyReasonPartiallyValid) &&
+					strings.Contains(condition.Message, "invalid inline") {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("policy status does not report the invalid inline JWKS as PartiallyValid: %+v", policy.Status)
+	})
+	assertJwtResponse(t, "invalidjwksroute.com", "", http.StatusUnauthorized)
+
+	assertJwtResponse(t, "secureroute.com", jwt1, http.StatusNotFound)
+
+	t.Apply(manifest("jwtauth", "secured-route.yaml"))
+	t.HTTPRouteAccepted("route-secure", base.Namespace)
+	assertJwtResponse(t, "secureroute.com", jwt1, http.StatusOK)
 }
 
 func testJwtAuthRoutePolicy(t base.Test) {

--- a/controller/test/e2e/testdata/jwtauth/invalid-inline.yaml
+++ b/controller/test/e2e/testdata/jwtauth/invalid-inline.yaml
@@ -1,0 +1,32 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-invalid-jwks
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+    - name: gateway
+  hostnames:
+    - "invalidjwksroute.com"
+  rules:
+    - backendRefs:
+        - name: backend
+          port: 80
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: route-invalid-inline-jwks-policy
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-invalid-jwks
+  traffic:
+    jwtAuthentication:
+      mode: Strict
+      providers:
+      - issuer: https://agentgateway.dev
+        jwks:
+          inline: '{"keys":[{"e":"AQAB","kid":"3161","kty":"RSB","n":"tmzcODUF5T9p"}]}'


### PR DESCRIPTION
right now inline jwks can be invalid but accepted

this makes the controller error


the test is a little wonky in that it inlines an example but since its meant to be invalid it felt ok that to do it this way rather than using a struct that we marshal