### PR TITLE
refactor(llm): expose stream termination to converters

### DIFF
--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -511,6 +511,7 @@ pub mod from_messages {
 		>(b, buffer_limit, move |evt| {
 			let mut events: Vec<(&'static str, messages::MessagesStreamEvent)> = Vec::new();
 			match evt {
+				SseJsonEvent::Eof | SseJsonEvent::Error => return events,
 				SseJsonEvent::Done => {
 					flush_message_end(&mut state, &mut events, &log, true, log_content.tool_calls);
 					return events;

--- a/crates/llm/src/conversion/openai_compat.rs
+++ b/crates/llm/src/conversion/openai_compat.rs
@@ -634,6 +634,7 @@ pub mod to_responses {
 				let mut events: Vec<(&'static str, ResponseStreamEvent)> = Vec::new();
 
 				match evt {
+					SseJsonEvent::Eof | SseJsonEvent::Error => return events,
 					SseJsonEvent::Done => {
 						if !flushed {
 							flushed = true;

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -1330,7 +1330,9 @@ pub mod to_completions {
 					tracing::debug!("failed to parse gemini stream chunk: {e}");
 					return vec![];
 				},
-				parse::sse::SseJsonEvent::Done => return vec![],
+				parse::sse::SseJsonEvent::Done
+				| parse::sse::SseJsonEvent::Eof
+				| parse::sse::SseJsonEvent::Error => return vec![],
 			};
 
 			if !saw_token {

--- a/crates/llm/src/parse/aws_sse.rs
+++ b/crates/llm/src/parse/aws_sse.rs
@@ -6,7 +6,7 @@ use futures_util::StreamExt;
 use serde::Serialize;
 use tokio_util::codec::{BytesCodec, Decoder};
 
-use super::transform::parser as transform_parser;
+use super::transform::{TransformEvent, parser as transform_parser};
 
 /// Error type for EventStream decoding.
 ///
@@ -143,7 +143,10 @@ pub fn transform<O: Serialize>(
 	let decoder = EventStreamCodec::with_max_size(buffer_limit);
 	let encoder = BytesCodec::new();
 
-	transform_parser(b, decoder, encoder, move |o| {
+	transform_parser(b, decoder, encoder, move |event| {
+		let TransformEvent::Item(o) = event else {
+			return None;
+		};
 		let transformed = f(o)?;
 		let json_bytes = serde_json::to_vec(&transformed).ok()?;
 		Some(crate::parse::encode_sse_event("", Bytes::from(json_bytes)))
@@ -158,7 +161,10 @@ pub fn transform_multi<O: Serialize>(
 	let decoder = EventStreamCodec::with_max_size(buffer_limit);
 	let encoder = BytesCodec::new();
 
-	transform_parser(b, decoder, encoder, move |msg| {
+	transform_parser(b, decoder, encoder, move |event| {
+		let TransformEvent::Item(msg) = event else {
+			return Vec::new();
+		};
 		f(msg)
 			.into_iter()
 			.filter_map(|(event_name, event)| {

--- a/crates/llm/src/parse/parse_tests.rs
+++ b/crates/llm/src/parse/parse_tests.rs
@@ -61,6 +61,11 @@ struct Test {
 	msg: u8,
 }
 
+#[derive(Serialize)]
+struct StatusOutput {
+	status: &'static str,
+}
+
 #[tokio::test]
 async fn test_sse_json() {
 	let msg1 = r#"data: {"msg": 1}
@@ -247,6 +252,7 @@ async fn test_sse_json_transform_multi_named_events_and_done() {
 					status: "done",
 				},
 			)],
+			sse::SseJsonEvent::Eof | sse::SseJsonEvent::Error => Vec::new(),
 		});
 
 	let result = transformed.collect().await.unwrap().to_bytes();
@@ -310,6 +316,7 @@ async fn test_sse_json_transform_multi_parse_error_path() {
 				},
 			)],
 			sse::SseJsonEvent::Done => vec![("done", Output { status: "done" })],
+			sse::SseJsonEvent::Eof | sse::SseJsonEvent::Error => Vec::new(),
 		});
 
 	let result = transformed.collect().await.unwrap().to_bytes();
@@ -326,4 +333,123 @@ async fn test_sse_json_transform_multi_parse_error_path() {
 		result.contains("event: done"),
 		"missing done event after parse error:\n{result}"
 	);
+}
+
+#[tokio::test]
+async fn test_sse_json_transform_multi_reports_eof() {
+	let body = Body::from("data: {\"msg\": 1}\n\n");
+	let transformed =
+		sse::json_transform_multi::<Test, StatusOutput, _>(body, 1024, |event| match event {
+			sse::SseJsonEvent::Data(Ok(_)) => Vec::new(),
+			sse::SseJsonEvent::Data(Err(_)) | sse::SseJsonEvent::Done => Vec::new(),
+			sse::SseJsonEvent::Eof => vec![("eof", StatusOutput { status: "eof" })],
+			sse::SseJsonEvent::Error => Vec::new(),
+		});
+	let result = transformed.collect().await.unwrap().to_bytes();
+	let result = String::from_utf8_lossy(&result);
+
+	assert!(
+		result.contains("event: eof"),
+		"missing EOF event:\n{result}"
+	);
+	assert!(
+		result.contains(r#"data: {"status":"eof"}"#),
+		"missing EOF payload:\n{result}"
+	);
+}
+
+#[tokio::test]
+async fn test_sse_json_transform_multi_reports_body_error() {
+	let body = Body::from_stream(futures_util::stream::iter(vec![Err::<Bytes, io::Error>(
+		io::Error::other("upstream failed"),
+	)]));
+	let transformed = sse::json_transform_multi::<Test, StatusOutput, _>(body, 1024, |event| {
+		if matches!(event, sse::SseJsonEvent::Error) {
+			vec![("error", StatusOutput { status: "error" })]
+		} else {
+			Vec::new()
+		}
+	});
+	let result = transformed.collect().await.unwrap().to_bytes();
+	let result = String::from_utf8_lossy(&result);
+
+	assert!(
+		result.contains("event: error"),
+		"missing body error event:\n{result}"
+	);
+	assert!(result.contains(r#"data: {"status":"error"}"#));
+}
+
+#[tokio::test]
+async fn test_sse_json_transform_multi_reports_decoder_error() {
+	let body = Body::from("data: {\"msg\": 123456789}\n\n");
+	let transformed = sse::json_transform_multi::<Test, StatusOutput, _>(body, 8, |event| {
+		if matches!(event, sse::SseJsonEvent::Error) {
+			vec![("error", StatusOutput { status: "error" })]
+		} else {
+			Vec::new()
+		}
+	});
+	let result = transformed.collect().await.unwrap().to_bytes();
+	let result = String::from_utf8_lossy(&result);
+
+	assert!(
+		result.contains("event: error"),
+		"missing decoder error event:\n{result}"
+	);
+	assert!(result.contains(r#"data: {"status":"error"}"#));
+}
+
+#[tokio::test]
+async fn test_sse_json_transform_multi_reports_truncated_frame_as_error() {
+	let observed = Arc::new(Mutex::new(Vec::new()));
+	let captured = observed.clone();
+	let body = Body::from("data: {\"msg\":1}\n");
+	let transformed =
+		sse::json_transform_multi::<Test, StatusOutput, _>(body, 1024, move |event| match event {
+			sse::SseJsonEvent::Error => {
+				captured.lock().unwrap().push("error");
+				vec![("error", StatusOutput { status: "error" })]
+			},
+			sse::SseJsonEvent::Eof => {
+				captured.lock().unwrap().push("eof");
+				Vec::new()
+			},
+			_ => Vec::new(),
+		});
+	let result = transformed.collect().await.unwrap().to_bytes();
+
+	assert_eq!(*observed.lock().unwrap(), ["error"]);
+	assert!(String::from_utf8_lossy(&result).contains(r#"data: {"status":"error"}"#));
+}
+
+#[tokio::test]
+async fn test_sse_json_transform_multi_propagates_decoder_error_after_output() {
+	let body = Body::from("data: {\"msg\":1}\n\ndata: {\"msg\":123456789}\n\n");
+	let saw_error = Arc::new(Mutex::new(false));
+	let captured_error = saw_error.clone();
+	let mut transformed =
+		sse::json_transform_multi::<Test, StatusOutput, _>(body, 12, move |event| match event {
+			sse::SseJsonEvent::Data(Ok(_)) => vec![("delta", StatusOutput { status: "ok" })],
+			sse::SseJsonEvent::Error => {
+				*captured_error.lock().unwrap() = true;
+				Vec::new()
+			},
+			_ => Vec::new(),
+		});
+
+	let first = transformed
+		.frame()
+		.await
+		.expect("valid output must precede the decoder error")
+		.expect("the first frame must contain the valid output");
+	let data = first.data_ref().expect("the first frame must be data");
+	assert!(String::from_utf8_lossy(data).contains(r#"data: {"status":"ok"}"#));
+
+	transformed
+		.frame()
+		.await
+		.expect("the decoder error must be returned")
+		.expect_err("decoder error after valid output must propagate");
+	assert!(*saw_error.lock().unwrap(), "decoder error was not observed");
 }

--- a/crates/llm/src/parse/sse.rs
+++ b/crates/llm/src/parse/sse.rs
@@ -8,7 +8,7 @@ use tokio_sse_codec::{Event, Frame, SseDecoder};
 use tokio_util::codec::BytesCodec;
 
 use super::passthrough::parser as passthrough_parser;
-use super::transform::parser as transform_parser;
+use super::transform::{TransformEvent, parser as transform_parser};
 
 /// Append an OpenAI `[DONE]` event after a body closes successfully.
 pub fn append_done_on_success(body: Body) -> Body {
@@ -79,8 +79,16 @@ pub fn json_transform<I: DeserializeOwned, O: Serialize>(
 	let decoder = SseDecoder::<Bytes>::with_max_size(buffer_limit);
 	let encoder = BytesCodec::new();
 
-	transform_parser(b, decoder, encoder, move |o| {
-		let data = unwrap_sse_data(o)?;
+	transform_parser(b, decoder, encoder, move |event| {
+		let data = match event {
+			TransformEvent::Item(frame) => unwrap_sse_data(frame)?,
+			TransformEvent::Eof => return None,
+			TransformEvent::Error => {
+				let transformed = f(Err(anyhow::anyhow!("upstream SSE stream failed")))?;
+				let json_bytes = serde_json::to_vec(&transformed).ok()?;
+				return Some(crate::parse::encode_sse_event("", Bytes::from(json_bytes)));
+			},
+		};
 		// Pass through [DONE] events unchanged
 		if data.as_ref() == b"[DONE]" {
 			return Some(crate::parse::encode_sse_event(
@@ -98,6 +106,8 @@ pub fn json_transform<I: DeserializeOwned, O: Serialize>(
 pub enum SseJsonEvent<I> {
 	Data(anyhow::Result<I>),
 	Done,
+	Eof,
+	Error,
 }
 
 pub fn json_transform_multi<I: DeserializeOwned, O: Serialize, It>(
@@ -112,28 +122,23 @@ where
 	let decoder = SseDecoder::<Bytes>::with_max_size(buffer_limit);
 	let encoder = BytesCodec::new();
 
-	transform_parser(b, decoder, encoder, move |o| {
-		let data = unwrap_sse_data(o);
-		if let Some(data) = &data
-			&& data.as_ref() == b"[DONE]"
-		{
-			return f(SseJsonEvent::Done)
-				.into_iter()
-				.filter_map(|(event_name, item)| {
-					let json_bytes = serde_json::to_vec(&item).ok()?;
-					Some(crate::parse::encode_sse_event(
-						event_name,
-						Bytes::from(json_bytes),
-					))
-				})
-				.collect();
-		}
-		let Some(data) = data else {
-			return vec![];
+	transform_parser(b, decoder, encoder, move |event| {
+		let event = match event {
+			TransformEvent::Eof => SseJsonEvent::Eof,
+			TransformEvent::Error => SseJsonEvent::Error,
+			TransformEvent::Item(frame) => {
+				let Some(data) = unwrap_sse_data(frame) else {
+					return Vec::new();
+				};
+				if data.as_ref() == b"[DONE]" {
+					SseJsonEvent::Done
+				} else {
+					let obj = serde_json::from_slice::<I>(&data);
+					SseJsonEvent::Data(obj.map_err(anyhow::Error::from))
+				}
+			},
 		};
-
-		let obj = serde_json::from_slice::<I>(&data);
-		f(SseJsonEvent::Data(obj.map_err(anyhow::Error::from)))
+		f(event)
 			.into_iter()
 			.filter_map(|(event_name, item)| {
 				let json_bytes = serde_json::to_vec(&item).ok()?;

--- a/crates/llm/src/parse/transform.rs
+++ b/crates/llm/src/parse/transform.rs
@@ -18,15 +18,72 @@ pin_project! {
 		encoder: E,
 		handler: F,
 		finished: bool,
+		pending_error: Option<axum_core::Error>,
 		_phantom: std::marker::PhantomData<T>,
 	}
+}
+
+pub enum TransformEvent<T> {
+	Item(T),
+	Eof,
+	Error,
+}
+
+fn encode_event<Input, E, F, I, T>(
+	event: TransformEvent<Input>,
+	handler: &mut F,
+	encoder: &mut E,
+	buffer: &mut BytesMut,
+) -> Result<(), axum_core::Error>
+where
+	F: FnMut(TransformEvent<Input>) -> I,
+	I: IntoIterator<Item = T>,
+	E: Encoder<T>,
+	E::Error: Into<axum_core::BoxError>,
+{
+	for item in handler(event) {
+		encoder
+			.encode(item, buffer)
+			.map_err(axum_core::Error::new)?;
+	}
+	Ok(())
+}
+
+fn terminal_error_frame<Input, E, F, I, T>(
+	error: axum_core::Error,
+	handler: &mut F,
+	encoder: &mut E,
+	mut preceding_output: BytesMut,
+	pending_error: &mut Option<axum_core::Error>,
+) -> Result<http_body::Frame<Bytes>, axum_core::Error>
+where
+	F: FnMut(TransformEvent<Input>) -> I,
+	I: IntoIterator<Item = T>,
+	E: Encoder<T>,
+	E::Error: Into<axum_core::BoxError>,
+{
+	let preceding_output_len = preceding_output.len();
+	encode_event(
+		TransformEvent::Error,
+		handler,
+		encoder,
+		&mut preceding_output,
+	)?;
+	if preceding_output.len() == preceding_output_len {
+		if !preceding_output.is_empty() {
+			*pending_error = Some(error);
+			return Ok(http_body::Frame::data(preceding_output.freeze()));
+		}
+		return Err(error);
+	}
+	Ok(http_body::Frame::data(preceding_output.freeze()))
 }
 
 pub fn parser<D, E, F, I, T>(body: AxumBody, decoder: D, encoder: E, handler: F) -> AxumBody
 where
 	D: Decoder + Send + 'static,
 	D::Error: Send + Into<axum_core::BoxError> + 'static,
-	F: FnMut(D::Item) -> I + Send + 'static,
+	F: FnMut(TransformEvent<D::Item>) -> I + Send + 'static,
 	I: IntoIterator<Item = T>,
 	E: Encoder<T> + Send + 'static,
 	E::Error: Send + Into<axum_core::BoxError> + 'static,
@@ -40,6 +97,7 @@ where
 		buffered_trailers: None,
 		encoder,
 		finished: false,
+		pending_error: None,
 		_phantom: std::marker::PhantomData,
 	})
 }
@@ -50,7 +108,7 @@ where
 	D::Error: Send + Into<axum_core::BoxError> + 'static,
 	E: Encoder<T> + Send + 'static,
 	E::Error: Send + Into<axum_core::BoxError> + 'static,
-	F: FnMut(D::Item) -> I + Send + 'static,
+	F: FnMut(TransformEvent<D::Item>) -> I + Send + 'static,
 	I: IntoIterator<Item = T>,
 {
 	type Data = Bytes;
@@ -61,6 +119,9 @@ where
 		cx: &mut Context<'_>,
 	) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
 		let mut this = self.project();
+		if let Some(error) = this.pending_error.take() {
+			return Poll::Ready(Some(Err(error)));
+		}
 		// If we're finished and have no more data, we're done
 		if *this.finished {
 			if let Some(trailer) = std::mem::take(this.buffered_trailers) {
@@ -86,14 +147,17 @@ where
 				};
 				match decode {
 					Ok(Some(decoded_item)) => {
-						for transformed_item in (handler)(decoded_item) {
-							match encoder.encode(transformed_item, encode_buf) {
-								Ok(()) => {},
-								Err(e) => return Err(axum_core::Error::new(e)),
-							}
-						}
+						encode_event(
+							TransformEvent::Item(decoded_item),
+							handler,
+							encoder,
+							encode_buf,
+						)?;
 					},
 					Ok(None) => {
+						if finished {
+							encode_event(TransformEvent::Eof, handler, encoder, encode_buf)?;
+						}
 						return Ok(());
 					},
 					Err(e) => {
@@ -112,7 +176,14 @@ where
 			&mut *this.encoder,
 			&mut encode_buffer,
 		) {
-			return Poll::Ready(Some(Err(e)));
+			*this.finished = true;
+			return Poll::Ready(Some(terminal_error_frame(
+				e,
+				this.handler,
+				&mut *this.encoder,
+				encode_buffer,
+				this.pending_error,
+			)));
 		}
 
 		// If we have encoded data to send, send it
@@ -135,7 +206,16 @@ where
 				cx.waker().wake_by_ref();
 				Poll::Pending
 			},
-			Some(Err(e)) => Poll::Ready(Some(Err(e))),
+			Some(Err(e)) => {
+				*this.finished = true;
+				Poll::Ready(Some(terminal_error_frame(
+					e,
+					this.handler,
+					&mut *this.encoder,
+					encode_buffer,
+					this.pending_error,
+				)))
+			},
 			None => {
 				*this.finished = true;
 				// Try one more decode/encode cycle
@@ -160,7 +240,13 @@ where
 							Poll::Ready(None)
 						}
 					},
-					Err(e) => Poll::Ready(Some(Err(e))),
+					Err(e) => Poll::Ready(Some(terminal_error_frame(
+						e,
+						this.handler,
+						&mut *this.encoder,
+						encode_buffer,
+						this.pending_error,
+					))),
 				}
 			},
 		}


### PR DESCRIPTION
## Summary

This is the generic prerequisite for the Responses-to-Messages refactor in #2662, which can consume these signals without owning parser-specific termination logic.

The shared transform callback only receives decoded items today. That leaves protocol bridges guessing at the end of a stream: `[DONE]` is visible, while a clean HTTP close, decoder failure, and body error all disappear behind the parser.

This patch passes `TransformEvent::Item`, `Eof`, and `Error` to the callback. `SseJsonEvent` carries the same states into SSE converters, and the AWS EventStream adapter plus the existing Completions, OpenAI-compatible, and Vertex Gemini converters keep their current behavior.

The parser tests exercise clean EOF, truncated SSE frames, upstream body errors, decoder failures both before and after valid output, named events, `[DONE]`, and malformed JSON.

## Verification

```text
cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true
cargo test -p agent-llm parse
cargo test -p agent-llm
cargo clippy -p agent-llm --all-targets -- -D warnings
git diff --check
```
