### PR TITLE
extmcp: enforce auth on mutated resource ids

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -2391,6 +2391,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			prompt: None,
 			resource: None,
 			task: None,
+			original_resource: None,
 			error: None,
 		}),
 		backend: Some(BackendContext {

--- a/crates/agentgateway/src/mcp/guardrails/methods.rs
+++ b/crates/agentgateway/src/mcp/guardrails/methods.rs
@@ -1,6 +1,7 @@
 use rmcp::model::{
-	CallToolRequestMethod, CompleteRequestMethod, ConstString, GetPromptRequestMethod,
-	ReadResourceRequestMethod, SubscribeRequestMethod, UnsubscribeRequestMethod,
+	CallToolRequestMethod, CancelTaskMethod, CompleteRequestMethod, ConstString,
+	GetPromptRequestMethod, GetTaskMethod, ReadResourceRequestMethod, SubscribeRequestMethod,
+	UnsubscribeRequestMethod, UpdateTaskMethod,
 };
 
 // Method names for the non-fanout requests that carry a mutable body. The
@@ -8,11 +9,13 @@ use rmcp::model::{
 pub const TOOLS_CALL: &str = CallToolRequestMethod::VALUE;
 pub const PROMPTS_GET: &str = GetPromptRequestMethod::VALUE;
 pub const RESOURCES_READ: &str = ReadResourceRequestMethod::VALUE;
+pub const RESOURCES_SUBSCRIBE: &str = SubscribeRequestMethod::VALUE;
+pub const RESOURCES_UNSUBSCRIBE: &str = UnsubscribeRequestMethod::VALUE;
+pub const TASKS_GET: &str = GetTaskMethod::VALUE;
+pub const TASKS_UPDATE: &str = UpdateTaskMethod::VALUE;
+pub const TASKS_CANCEL: &str = CancelTaskMethod::VALUE;
 
 // Single-target methods that don't run the request-phase hook yet; only the
-// response phase fires for them.
-pub const REQUEST_PHASE_UNSUPPORTED: &[&str] = &[
-	SubscribeRequestMethod::VALUE,
-	UnsubscribeRequestMethod::VALUE,
-	CompleteRequestMethod::VALUE,
-];
+// response phase fires for them. `completion/complete` targets a prompt or a
+// resource through its `ref`, which doesn't fit the single-identity hook.
+pub const REQUEST_PHASE_UNSUPPORTED: &[&str] = &[CompleteRequestMethod::VALUE];

--- a/crates/agentgateway/src/mcp/guardrails/mod.rs
+++ b/crates/agentgateway/src/mcp/guardrails/mod.rs
@@ -346,11 +346,11 @@ processors:
 
 	#[test]
 	fn warns_on_request_phase_for_unsupported_methods() {
-		// A catchall request phase matches subscribe/unsubscribe/complete, none of
-		// which run the request hook.
+		// A catchall request phase matches completion/complete, which doesn't run
+		// the request hook.
 		let warnings = ext_with_methods(&[("*", Phase::Full)]).load_warnings();
-		assert_eq!(warnings.len(), 3, "{warnings:?}");
-		assert!(warnings[0].contains("resources/subscribe"));
+		assert_eq!(warnings.len(), 1, "{warnings:?}");
+		assert!(warnings[0].contains("completion/complete"));
 
 		// Response-only and supported-method configs are clean.
 		assert!(

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -5951,6 +5951,52 @@ mod guardrails_test_support {
 			.find_map(|c| c.as_text().map(|t| t.text.clone()))
 			.expect("echo returned text")
 	}
+
+	pub fn tool_name(req: &protos::ext_mcp::McpRequest) -> String {
+		req
+			.mcp_request
+			.as_deref()
+			.and_then(|b| serde_json::from_slice::<serde_json::Value>(b).ok())
+			.and_then(|v| v.get("name").and_then(|n| n.as_str()).map(str::to_owned))
+			.unwrap_or_default()
+	}
+
+	pub fn methods_full(methods: &[&str]) -> HashMap<String, guardrails::Phase> {
+		methods
+			.iter()
+			.map(|m| (m.to_string(), guardrails::Phase::Full))
+			.collect()
+	}
+
+	/// Pass-through processor that records every request-phase method it sees.
+	pub async fn recording_mock() -> (
+		crate::test_helpers::MockInstance,
+		Arc<std::sync::Mutex<Vec<String>>>,
+	) {
+		use crate::test_helpers::extmcpmock::{closure_mock, pass_request, pass_response};
+		let seen: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+		let seen_req = seen.clone();
+		let mock = closure_mock(
+			move |req| {
+				seen_req.lock().unwrap().push(req.method.clone());
+				pass_request()
+			},
+			|_| pass_response(),
+		)
+		.spawn()
+		.await;
+		(mock, seen)
+	}
+
+	pub fn assert_saw(seen: &std::sync::Mutex<Vec<String>>, methods: &[&str]) {
+		let seen = seen.lock().unwrap();
+		for m in methods {
+			assert!(
+				seen.iter().any(|s| s == m),
+				"processor saw {m}, got: {seen:?}"
+			);
+		}
+	}
 }
 
 // ============================== mcpGuardrails tests ===============================
@@ -6164,6 +6210,153 @@ async fn mcp_guardrails_mutated_request_reaches_upstream() {
 	// Mutated numbers keep their JSON form: integers don't become 10.0.
 	assert!(text.contains("\"limit\":10,"), "got: {text}");
 	assert!(text.contains("\"ratio\":2.5"), "got: {text}");
+}
+
+// extmcp rewrites an approved tool to one that is rejected by
+// the McpAuthorization policy and gets denied
+#[tokio::test]
+async fn mcp_guardrails_retarget_authz_sees_executed_tool() {
+	use crate::test_helpers::extmcpmock::{
+		closure_mock, mutated_request_json, pass_request, pass_response,
+	};
+
+	let extmcp_mock = closure_mock(
+		|req| {
+			if req.method == "tools/call" && guardrails_test_support::tool_name(req) == "echo" {
+				mutated_request_json(serde_json::json!({"name": "increment", "arguments": {}}))
+			} else {
+				pass_request()
+			}
+		},
+		|_| pass_response(),
+	)
+	.spawn()
+	.await;
+
+	let deny_increment = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![],
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"mcp.tool.name == "increment""#).unwrap(),
+		)],
+		vec![],
+	)));
+
+	let mock = mock_streamable_http_server(true).await;
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		true,
+		false,
+		vec![
+			BackendTrafficPolicy::McpAuthorization(deny_increment),
+			guardrails_test_support::policy(extmcp_mock.address),
+		],
+	)
+	.await;
+	let client = mcp_streamable_client(io).await;
+
+	let err = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("echo").with_arguments(serde_json::Map::new()),
+		)
+		.await
+		.expect_err("call retargeted to a denied tool should be blocked");
+	let rmcp::ServiceError::McpError(e) = &err else {
+		panic!("expected McpError, got {err:?}");
+	};
+	assert_eq!(e.code.0, -32602, "authz denial maps to INVALID_PARAMS");
+
+	let value = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("get_value").with_arguments(serde_json::Map::new()),
+		)
+		.await
+		.expect("non-denied tools still work");
+	assert_eq!(guardrails_test_support::echo_text(&value), "0");
+}
+
+#[tokio::test]
+#[allow(deprecated)]
+async fn mcp_guardrails_request_phase_covers_subscriptions() {
+	const METHODS: &[&str] = &["resources/subscribe", "resources/unsubscribe"];
+	let (extmcp_mock, seen) = guardrails_test_support::recording_mock().await;
+	let mock = mock_streamable_http_server(true).await;
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		true,
+		false,
+		vec![guardrails_test_support::policy_with(
+			extmcp_mock.address,
+			guardrails::FailureMode::FailClosed,
+			guardrails_test_support::methods_full(METHODS),
+			HashMap::new(),
+		)],
+	)
+	.await;
+	let client = mcp_streamable_client(io).await;
+
+	client
+		.subscribe(rmcp::model::SubscribeRequestParams::new("memo://insights"))
+		.await
+		.expect("subscribe should pass through");
+	client
+		.unsubscribe(rmcp::model::UnsubscribeRequestParams::new(
+			"memo://insights",
+		))
+		.await
+		.expect("unsubscribe should pass through");
+
+	guardrails_test_support::assert_saw(&seen, METHODS);
+}
+
+#[tokio::test]
+async fn mcp_guardrails_request_phase_covers_tasks() {
+	const METHODS: &[&str] = &["tools/call", "tasks/get", "tasks/cancel"];
+	let (extmcp_mock, seen) = guardrails_test_support::recording_mock().await;
+	let mock = mock_task_streamable_http_server().await;
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		false,
+		false,
+		vec![guardrails_test_support::policy_with(
+			extmcp_mock.address,
+			guardrails::FailureMode::FailClosed,
+			guardrails_test_support::methods_full(METHODS),
+			HashMap::new(),
+		)],
+	)
+	.await;
+
+	let create = modern_request(
+		io,
+		1,
+		"tools/call",
+		"slow_job",
+		serde_json::json!({"_meta": task_meta(), "name": "slow_job", "arguments": {}}),
+	)
+	.await;
+	assert_eq!(create["result"]["taskId"], "task-abc");
+
+	let get = modern_request(
+		io,
+		2,
+		"tasks/get",
+		"task-abc",
+		serde_json::json!({"taskId": "task-abc"}),
+	)
+	.await;
+	assert_eq!(get["result"]["status"], "completed");
+
+	let cancel = modern_request(
+		io,
+		3,
+		"tasks/cancel",
+		"task-abc",
+		serde_json::json!({"taskId": "task-abc"}),
+	)
+	.await;
+	assert_eq!(cancel["result"]["resultType"], "complete");
+
+	guardrails_test_support::assert_saw(&seen, METHODS);
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -349,6 +349,8 @@ pub struct MCPInfo {
 	pub resource: Option<ResourceId>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub task: Option<MCPTask>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub original_resource: Option<ResourceId>,
 	// Terminal errors arrive while the response body is drained. Keep them out of CEL so policy
 	// evaluation cannot depend on asynchronous stream timing; they are emitted as access-log fields.
 	#[dynamic(skip)]
@@ -365,6 +367,7 @@ impl MCPInfo {
 			&& self.prompt.is_none()
 			&& self.resource.is_none()
 			&& self.task.is_none()
+			&& self.original_resource.is_none()
 			&& self.error.is_none()
 	}
 
@@ -411,6 +414,15 @@ impl MCPInfo {
 			.map(|tool| tool.name.as_str())
 			.or_else(|| self.prompt.as_ref().map(ResourceId::name))
 			.or_else(|| self.resource.as_ref().map(ResourceId::name))
+	}
+
+	pub fn set_resource_type(&mut self, res: &ResourceType) {
+		match res {
+			ResourceType::Tool(t) => self.set_tool(t.target().to_string(), t.name().to_string()),
+			ResourceType::Prompt(p) => self.set_prompt(p.target().to_string(), p.name().to_string()),
+			ResourceType::Resource(r) => self.set_resource(r.target().to_string(), r.name().to_string()),
+			ResourceType::Task(t) => self.set_task(t.target().to_string(), t.name().to_string()),
+		}
 	}
 
 	pub fn set_tool(&mut self, target: String, name: String) {

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -63,6 +63,51 @@ impl McpAuthorizationSet {
 	}
 }
 
+// ResourceIdentity extracts the ResourceType and ID from
+// a type containing that info, such as a request parameter struct.
+pub trait ResourceIdentity {
+	const KIND: &'static str;
+	fn to_resource_type(&self, service: impl Into<String>) -> ResourceType;
+	/// Point the access log at this request's identity.
+	fn record(&self, log: &mut crate::mcp::MCPInfo, service: impl Into<String>) {
+		log.set_resource_type(&self.to_resource_type(service));
+	}
+}
+
+macro_rules! resource_identity {
+	($($ty:ty => ($kind:literal, $variant:ident, $field:ident),)+) => {$(
+		impl ResourceIdentity for $ty {
+			const KIND: &'static str = $kind;
+			fn to_resource_type(&self, service: impl Into<String>) -> ResourceType {
+				ResourceType::$variant(ResourceId::new(service.into(), self.$field.to_string()))
+			}
+		}
+	)+};
+}
+
+resource_identity! {
+	rmcp::model::GetPromptRequestParams => ("prompt", Prompt, name),
+	rmcp::model::ReadResourceRequestParams => ("resource", Resource, uri),
+	rmcp::model::SubscribeRequestParams => ("resource", Resource, uri),
+	rmcp::model::UnsubscribeRequestParams => ("resource", Resource, uri),
+	rmcp::model::GetTaskParams => ("task", Task, task_id),
+	rmcp::model::UpdateTaskParams => ("task", Task, task_id),
+	rmcp::model::CancelTaskParams => ("task", Task, task_id),
+}
+
+// Outside the macro: tool calls also carry arguments, which `set_resource_type`
+// preserves as-is, so recording must recapture them.
+impl ResourceIdentity for rmcp::model::CallToolRequestParams {
+	const KIND: &'static str = "tool";
+	fn to_resource_type(&self, service: impl Into<String>) -> ResourceType {
+		ResourceType::Tool(ResourceId::new(service.into(), self.name.to_string()))
+	}
+	fn record(&self, log: &mut crate::mcp::MCPInfo, service: impl Into<String>) {
+		log.set_resource_type(&self.to_resource_type(service));
+		log.capture_call_arguments(self.arguments.clone());
+	}
+}
+
 #[apply(schema!)]
 #[derive(Eq, PartialEq)]
 pub enum ResourceType {
@@ -74,6 +119,17 @@ pub enum ResourceType {
 	Resource(ResourceId),
 	/// The task being accessed (SEP-2663); `name` is the task ID.
 	Task(ResourceId),
+}
+
+impl ResourceType {
+	pub fn id(self) -> ResourceId {
+		match self {
+			ResourceType::Tool(id)
+			| ResourceType::Prompt(id)
+			| ResourceType::Resource(id)
+			| ResourceType::Task(id) => id,
+		}
+	}
 }
 
 impl cel::DynamicType for ResourceType {

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -241,61 +241,45 @@ impl Session {
 		Ok(())
 	}
 
-	// task_id here is the resolved upstream id, not the client-visible `target+id` form.
-	fn authorize_task_request(
-		&self,
-		service_name: &str,
-		task_id: &str,
-		method: &str,
-		span: &mut SpanWriteOnDrop,
-		log: &AsyncLog<mcp::MCPInfo>,
-		cel: &rbac::CelExecWrapper,
-	) -> Result<(), UpstreamError> {
-		span.rename_span(format!("{method} {service_name}"));
-		log.non_atomic_mutate(|l| {
-			l.set_task(service_name.to_string(), task_id.to_string());
-		});
-		if !self.relay.policies.validate(
-			&rbac::ResourceType::Task(rbac::ResourceId::new(
-				service_name.to_string(),
-				task_id.to_string(),
-			)),
-			cel,
-		) {
-			return Err(UpstreamError::Authorization {
-				resource_type: "task".to_string(),
-				resource_name: task_id.to_string(),
-			});
-		}
-		Ok(())
-	}
-
-	#[allow(clippy::too_many_arguments)]
 	async fn authorize_with_ctx<P>(
 		&self,
 		backend: &str,
 		method: &str,
 		params: &mut P,
 		ctx: &mut IncomingRequestContext,
-		res: rbac::ResourceType,
-		resource_type: &str,
-		resource_name: &str,
+		log: &AsyncLog<mcp::MCPInfo>,
+		client_resource_name: &str,
 	) -> Result<(), UpstreamError>
 	where
-		P: serde::Serialize + serde::de::DeserializeOwned,
+		P: serde::Serialize + serde::de::DeserializeOwned + rbac::ResourceIdentity,
 	{
+		let original_res = params.to_resource_type(backend);
+
 		// run guardrails before other policies, as it may add context to CEL
+		// or mutate the resource (e.g. retargeting to another tool name)
 		self
 			.relay
 			.maybe_run_guardrails_call_request(backend, method, params, ctx)
 			.await?;
+		let res = params.to_resource_type(backend);
+
+		// logs should see the resource we're actually forwarding upstream
+		// but we should store the original resource for auditing purposes
+		if res != original_res {
+			log.non_atomic_mutate(|l| {
+				params.record(l, backend);
+				l.original_resource = Some(original_res.id());
+			});
+		}
 		let cel = rbac::CelExecWrapper::new(ctx.as_request().map(|_| ()));
 		if self.relay.policies.validate(&res, &cel) {
 			Ok(())
 		} else {
+			// errors should be in terms of the client-facing reosurce ID,
+			// not our multiplexed or guardrail-mutated one.
 			Err(UpstreamError::Authorization {
-				resource_type: resource_type.to_string(),
-				resource_name: resource_name.to_string(),
+				resource_type: P::KIND.to_string(),
+				resource_name: client_resource_name.to_string(),
 			})
 		}
 	}
@@ -573,32 +557,27 @@ impl Session {
 						.await
 					},
 					ClientRequest::CallToolRequest(ctr) => {
-						let name = ctr.params.name.clone();
-						let (service_name, tool) = Box::pin(self.relay.resolve_resource_name(
+						let client_name = ctr.params.name.clone();
+						let (service_name, upstream_tool) = Box::pin(self.relay.resolve_resource_name(
 							ResolveKind::Tool,
-							&name,
+							&client_name,
 							&ctx,
 						))
 						.await?;
 						span.rename_span(format!("{method} {service_name}"));
 						let call_arguments = ctr.params.arguments.clone();
 						log.non_atomic_mutate(|l| {
-							l.set_tool(service_name.to_string(), tool.to_string());
+							l.set_tool(service_name.to_string(), upstream_tool.to_string());
 							l.capture_call_arguments(call_arguments);
 						});
-						let tn = tool.to_string();
-						ctr.params.name = tn.into();
+						ctr.params.name = upstream_tool.to_string().into();
 						Box::pin(self.authorize_with_ctx(
 							&service_name,
 							mcp::guardrails::methods::TOOLS_CALL,
 							&mut ctr.params,
 							&mut ctx,
-							rbac::ResourceType::Tool(rbac::ResourceId::new(
-								service_name.to_string(),
-								tool.to_string(),
-							)),
-							"tool",
-							&name,
+							&log,
+							&client_name,
 						))
 						.await?;
 						Box::pin(
@@ -609,125 +588,145 @@ impl Session {
 						.await
 					},
 					ClientRequest::GetPromptRequest(gpr) => {
-						let name = gpr.params.name.clone();
-						let (service_name, prompt) = Box::pin(self.relay.resolve_resource_name(
+						let client_name = gpr.params.name.clone();
+						let (service_name, upstream_prompt) = Box::pin(self.relay.resolve_resource_name(
 							ResolveKind::Prompt,
-							&name,
+							&client_name,
 							&ctx,
 						))
 						.await?;
 						span.rename_span(format!("{method} {service_name}"));
 						log.non_atomic_mutate(|l| {
-							l.set_prompt(service_name.to_string(), prompt.to_string());
+							l.set_prompt(service_name.to_string(), upstream_prompt.to_string());
 						});
-						gpr.params.name = prompt.to_string();
+						gpr.params.name = upstream_prompt.to_string();
 						Box::pin(self.authorize_with_ctx(
 							&service_name,
 							mcp::guardrails::methods::PROMPTS_GET,
 							&mut gpr.params,
 							&mut ctx,
-							rbac::ResourceType::Prompt(rbac::ResourceId::new(
-								service_name.to_string(),
-								prompt.to_string(),
-							)),
-							"prompt",
-							&name,
+							&log,
+							&client_name,
 						))
 						.await?;
 						Box::pin(self.relay.send_single(r, ctx, &service_name, None)).await
 					},
 					ClientRequest::ReadResourceRequest(rrr) => {
-						let uri = rrr.params.uri.clone();
-						let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
+						let client_uri = rrr.params.uri.clone();
+						let (service_name, upstream_uri) = self.relay.parse_resource_uri(&client_uri)?;
 						span.rename_span(format!("{method} {service_name}"));
 						log.non_atomic_mutate(|l| {
-							l.set_resource(service_name.to_string(), original_uri.to_string());
+							l.set_resource(service_name.to_string(), upstream_uri.clone());
 						});
-						rrr.params.uri = original_uri.clone();
+						rrr.params.uri = upstream_uri;
 						Box::pin(self.authorize_with_ctx(
 							service_name,
 							mcp::guardrails::methods::RESOURCES_READ,
 							&mut rrr.params,
 							&mut ctx,
-							rbac::ResourceType::Resource(rbac::ResourceId::new(
-								service_name.to_string(),
-								original_uri,
-							)),
-							"resource",
-							&uri,
+							&log,
+							&client_uri,
 						))
 						.await?;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::SubscribeRequest(sr) => {
-						let uri = sr.params.uri.clone();
-						let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
-						self.authorize_resource_request(
+						let client_uri = sr.params.uri.clone();
+						let (service_name, upstream_uri) = self.relay.parse_resource_uri(&client_uri)?;
+						span.rename_span(format!("{method} {service_name}"));
+						log.non_atomic_mutate(|l| {
+							l.set_resource(service_name.to_string(), upstream_uri.clone());
+						});
+						sr.params.uri = upstream_uri;
+						Box::pin(self.authorize_with_ctx(
 							service_name,
-							&original_uri,
-							&method,
-							&mut span,
+							mcp::guardrails::methods::RESOURCES_SUBSCRIBE,
+							&mut sr.params,
+							&mut ctx,
 							&log,
-							&cel,
-						)?;
-						sr.params.uri = original_uri;
+							&client_uri,
+						))
+						.await?;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::UnsubscribeRequest(ur) => {
-						let uri = ur.params.uri.clone();
-						let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
-						self.authorize_resource_request(
+						let client_uri = ur.params.uri.clone();
+						let (service_name, upstream_uri) = self.relay.parse_resource_uri(&client_uri)?;
+						span.rename_span(format!("{method} {service_name}"));
+						log.non_atomic_mutate(|l| {
+							l.set_resource(service_name.to_string(), upstream_uri.clone());
+						});
+						ur.params.uri = upstream_uri;
+						Box::pin(self.authorize_with_ctx(
 							service_name,
-							&original_uri,
-							&method,
-							&mut span,
+							mcp::guardrails::methods::RESOURCES_UNSUBSCRIBE,
+							&mut ur.params,
+							&mut ctx,
 							&log,
-							&cel,
-						)?;
-						ur.params.uri = original_uri;
+							&client_uri,
+						))
+						.await?;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 
 					ClientRequest::GetTaskRequest(gtr) => {
-						let (service_name, original_id) =
-							mcp::handler::parse_task_id(&self.relay.upstreams, &gtr.params.task_id)?;
-						self.authorize_task_request(
+						let client_task_id = gtr.params.task_id.clone();
+						let (service_name, upstream_task_id) =
+							mcp::handler::parse_task_id(&self.relay.upstreams, &client_task_id)?;
+						span.rename_span(format!("{method} {service_name}"));
+						log.non_atomic_mutate(|l| {
+							l.set_task(service_name.to_string(), upstream_task_id.clone());
+						});
+						gtr.params.task_id = upstream_task_id;
+						Box::pin(self.authorize_with_ctx(
 							service_name,
-							&original_id,
-							&method,
-							&mut span,
+							mcp::guardrails::methods::TASKS_GET,
+							&mut gtr.params,
+							&mut ctx,
 							&log,
-							&cel,
-						)?;
-						gtr.params.task_id = original_id;
+							&client_task_id,
+						))
+						.await?;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::UpdateTaskRequest(utr) => {
-						let (service_name, original_id) =
-							mcp::handler::parse_task_id(&self.relay.upstreams, &utr.params.task_id)?;
-						self.authorize_task_request(
+						let client_task_id = utr.params.task_id.clone();
+						let (service_name, upstream_task_id) =
+							mcp::handler::parse_task_id(&self.relay.upstreams, &client_task_id)?;
+						span.rename_span(format!("{method} {service_name}"));
+						log.non_atomic_mutate(|l| {
+							l.set_task(service_name.to_string(), upstream_task_id.clone());
+						});
+						utr.params.task_id = upstream_task_id;
+						Box::pin(self.authorize_with_ctx(
 							service_name,
-							&original_id,
-							&method,
-							&mut span,
+							mcp::guardrails::methods::TASKS_UPDATE,
+							&mut utr.params,
+							&mut ctx,
 							&log,
-							&cel,
-						)?;
-						utr.params.task_id = original_id;
+							&client_task_id,
+						))
+						.await?;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::CancelTaskRequest(ctr) => {
-						let (service_name, original_id) =
-							mcp::handler::parse_task_id(&self.relay.upstreams, &ctr.params.task_id)?;
-						self.authorize_task_request(
+						let client_task_id = ctr.params.task_id.clone();
+						let (service_name, upstream_task_id) =
+							mcp::handler::parse_task_id(&self.relay.upstreams, &client_task_id)?;
+						span.rename_span(format!("{method} {service_name}"));
+						log.non_atomic_mutate(|l| {
+							l.set_task(service_name.to_string(), upstream_task_id.clone());
+						});
+						ctr.params.task_id = upstream_task_id;
+						Box::pin(self.authorize_with_ctx(
 							service_name,
-							&original_id,
-							&method,
-							&mut span,
+							mcp::guardrails::methods::TASKS_CANCEL,
+							&mut ctr.params,
+							&mut ctx,
 							&log,
-							&cel,
-						)?;
-						ctr.params.task_id = original_id;
+							&client_task_id,
+						))
+						.await?;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::CustomRequest(_) => {
@@ -742,26 +741,31 @@ impl Session {
 					},
 					ClientRequest::CompleteRequest(cr) => match &cr.params.r#ref {
 						Reference::Prompt(prompt) => {
-							let name = prompt.name.clone();
-							let (service_name, prompt_name) = Box::pin(
-								self.authorize_prompt_request(&name, &method, &mut span, &log, &cel, &ctx),
-							)
+							let client_name = prompt.name.clone();
+							let (service_name, upstream_prompt) = Box::pin(self.authorize_prompt_request(
+								&client_name,
+								&method,
+								&mut span,
+								&log,
+								&cel,
+								&ctx,
+							))
 							.await?;
-							cr.params.r#ref = Reference::for_prompt(prompt_name.to_string());
+							cr.params.r#ref = Reference::for_prompt(upstream_prompt.to_string());
 							Box::pin(self.relay.send_single(r, ctx, &service_name, None)).await
 						},
 						Reference::Resource(resource) => {
-							let uri = resource.uri.clone();
-							let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
+							let client_uri = resource.uri.clone();
+							let (service_name, upstream_uri) = self.relay.parse_resource_uri(&client_uri)?;
 							self.authorize_resource_request(
 								service_name,
-								&original_uri,
+								&upstream_uri,
 								&method,
 								&mut span,
 								&log,
 								&cel,
 							)?;
-							cr.params.r#ref = Reference::for_resource(original_uri);
+							cr.params.r#ref = Reference::for_resource(upstream_uri);
 							Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 						},
 						_ => Err(UpstreamError::InvalidMethod(method)),

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -1024,6 +1024,26 @@
             "target",
             "name"
           ]
+        },
+        "originalResource": {
+          "description": "The client-requested resource when an mcpGuardrails processor retargeted the\nrequest; `tool`/`prompt`/`resource`/`task` record what executed.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "properties": {
+            "target": {
+              "description": "The target of the resource",
+              "type": "string",
+              "default": ""
+            },
+            "name": {
+              "description": "The name of the resource",
+              "type": "string",
+              "default": ""
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -144,6 +144,9 @@
 |`mcp.task`|object||
 |`mcp.task.target`|string|The target handling the task.|
 |`mcp.task.name`|string|The task ID.|
+|`mcp.originalResource`|object|The client-requested resource when an mcpGuardrails processor retargeted the<br>request; `tool`/`prompt`/`resource`/`task` record what executed.|
+|`mcp.originalResource.target`|string|The target of the resource|
+|`mcp.originalResource.name`|string|The name of the resource|
 |`backend`|object|`backend` contains information about the backend being used.|
 |`backend.name`|string|The name of the backend being used. For example, `my-service` or `service/my-namespace/my-service:8080`.|
 |`backend.type`|enum|The type of backend.<br>Possible values: `ai`, `mcp`, `static`, `dynamic`, `service`, `unknown`.|


### PR DESCRIPTION
Previously ExtMcp mutations to the resource id (the tool name, prompt id, resource uri, etc) was not visible to McpAuthorization. A client tool call to `echo` which is allowed getting rewritten to `delete_bucket` by a guardrail server would still be allowed. This changes it so that authz sees the mutated resource (if any). 

This also starts applying guardrails to the legacy subscriptions stuff, and to the new tasks methods.

It's worth discussing whether we should allow such mutations to begin with. Envoy's extproc has [header mutation rules](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/common/mutation_rules/v3/mutation_rules.proto). We could add a config field to allow users to make that decision. 