### PR TITLE
health: add scoped health configuration

### DIFF
--- a/controller/pkg/cli/proxy/config/backends.go
+++ b/controller/pkg/cli/proxy/config/backends.go
@@ -37,7 +37,8 @@ type backendEndpointState struct {
 		WorkloadUID string `json:"workloadUid"`
 		Name        string `json:"name"`
 	} `json:"endpoint"`
-	Info backendEndpointInfo `json:"info"`
+	Info       backendEndpointInfo   `json:"info"`
+	ScopedInfo []backendEndpointInfo `json:"scoped_info"`
 }
 
 type backendEndpointInfo struct {
@@ -175,10 +176,21 @@ func backendRowsForEndpointStates(
 		if rejected {
 			row.Health = formatEvictedHealth(state.Info)
 		}
-		if !showAll && row.Requests == 0 {
-			continue
+		if showAll || row.Requests != 0 {
+			rows = append(rows, row)
 		}
-		rows = append(rows, row)
+		for scope, info := range state.ScopedInfo {
+			scopedState := state
+			scopedState.Info = info
+			scopedRow := buildBackendRow(backendType, fmt.Sprintf("%s (scope %d)", name, scope), namespace, endpointName, scopedState)
+			if rejected || info.EvictedUntil != nil {
+				scopedRow.Health = formatEvictedHealth(info)
+			}
+			if !showAll && scopedRow.Requests == 0 {
+				continue
+			}
+			rows = append(rows, scopedRow)
+		}
 	}
 	return rows
 }

--- a/controller/pkg/cli/proxy/config/backends_test.go
+++ b/controller/pkg/cli/proxy/config/backends_test.go
@@ -193,6 +193,40 @@ func TestParseBackendRowsIncludesTopLevelBackendProviders(t *testing.T) {
 	}
 }
 
+func TestParseBackendRowsIncludesScopedHealth(t *testing.T) {
+	raw := []byte(`{
+		"backends": [{
+			"backend": {"ai": {
+				"name": "model",
+				"target": {"providers": [{
+					"active": {"*": {
+						"endpoint": {"name": "*"},
+						"info": {"health": 1, "totalRequests": 0},
+						"scoped_info": [
+							{"health": 0.5, "requestLatency": 0.25, "totalRequests": 2},
+							{"health": 0, "requestLatency": 0.5, "totalRequests": 1, "evictedUntil": "30s"}
+						]
+					}}
+				}]}
+			}}
+		}]
+	}`)
+
+	rows, err := parseBackendRows(raw, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2: %#v", len(rows), rows)
+	}
+	if rows[0].Name != "model (scope 0)" || rows[0].Health != "0.50" || rows[0].Requests != 2 {
+		t.Fatalf("unexpected first scope: %#v", rows[0])
+	}
+	if rows[1].Name != "model (scope 1)" || rows[1].Health != "Evict (30.0s)" || rows[1].Requests != 1 {
+		t.Fatalf("unexpected second scope: %#v", rows[1])
+	}
+}
+
 func TestParseBackendRowsIgnoresTopLevelBackendStringTargets(t *testing.T) {
 	raw := []byte(`{
 		"backends": [

--- a/crates/agentgateway/src/http/health.rs
+++ b/crates/agentgateway/src/http/health.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::cel::{ContextBuilder, Expression};
+use crate::types::loadbalancer::hash_affinity_key;
 use crate::{serde_dur_option, *};
 
 /// Eviction sub-policy: how long to remove a backend from the active set after an unhealthy response.
@@ -49,6 +50,11 @@ pub struct Eviction {
 #[derive(Default)]
 #[apply(schema_ser!)]
 pub struct Policy {
+	/// CEL expression evaluated against the request to isolate health state. The resulting string or
+	/// bytes value is hashed before use. Evaluation failures fall back to global health state.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub scope: Option<Arc<Expression>>,
+
 	/// CEL expression evaluated per response; `true` means this response is unhealthy (evict).
 	/// When absent, any 5xx response, non-zero gRPC status, or a connection failure is treated as unhealthy.
 	/// This default lowers the backend's health score but does not trigger eviction on its own.
@@ -64,9 +70,43 @@ const DEFAULT_EVICTION_SECS: u64 = 3;
 
 impl Policy {
 	pub fn register_expressions(&self, ctx: &mut ContextBuilder) {
+		if let Some(expr) = self.scope.as_ref() {
+			ctx.register_expression(expr.as_ref());
+		}
 		if let Some(expr) = self.unhealthy_expression.as_ref() {
 			ctx.register_expression(expr.as_ref());
 		}
+	}
+
+	/// Returns the hashed health scope. Missing, invalid, and empty values intentionally fall back
+	/// to the global scope.
+	pub fn scope_key(&self, req: &http::Request) -> Option<u64> {
+		let expression = self.scope.as_ref()?;
+		let executor = crate::cel::Executor::new_request(req);
+		let value = match executor.eval(expression) {
+			Ok(value) => value,
+			Err(err) => {
+				trace!(
+					expression = %expression.original_expression,
+					error = %err,
+					"health scope: expression evaluation failed; falling back to global scope"
+				);
+				return None;
+			},
+		};
+		let value = value.always_materialize();
+		let Ok(bytes) = value.as_bytes_pre_materialized() else {
+			trace!(
+				expression = %expression.original_expression,
+				value_type = value.type_of().as_str(),
+				"health scope: expression did not return a string or bytes value; falling back to global scope"
+			);
+			return None;
+		};
+		if bytes.is_empty() {
+			return None;
+		}
+		Some(hash_affinity_key(bytes))
 	}
 
 	/// Returns the configured base eviction duration, if any.
@@ -163,6 +203,9 @@ pub struct LocalEviction {
 #[derive(Default)]
 #[apply(schema_de!)]
 pub struct LocalHealthPolicy {
+	/// CEL expression whose string or bytes result scopes health state.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub scope: Option<String>,
 	/// CEL expression where `true` marks the backend response as unhealthy.
 	/// When unset, any 5xx response or connection failure is treated as unhealthy.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -203,7 +246,12 @@ impl TryFrom<LocalHealthPolicy> for Policy {
 			Some(s) if !s.trim().is_empty() => Some(Arc::new(Expression::new_strict(&s)?)),
 			_ => None,
 		};
+		let scope = match local.scope {
+			Some(s) if !s.trim().is_empty() => Some(Arc::new(Expression::new_strict(&s)?)),
+			_ => None,
+		};
 		Ok(Policy {
+			scope,
 			unhealthy_expression,
 			eviction,
 		})
@@ -213,6 +261,7 @@ impl TryFrom<LocalHealthPolicy> for Policy {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::http::transformation_cel::TransformationMetadata;
 
 	fn policy_with_threshold(threshold: f64) -> Policy {
 		Policy {
@@ -242,6 +291,35 @@ mod tests {
 			}),
 			..Default::default()
 		}
+	}
+
+	#[test]
+	fn scope_hashes_metadata_and_falls_back_to_global() {
+		let policy = Policy {
+			scope: Some(Arc::new(
+				Expression::new_strict(r#"metadata["agentgateway.dev/backend-auth"]"#).unwrap(),
+			)),
+			..Default::default()
+		};
+		let mut first = http::Request::new(http::Body::empty());
+		first
+			.extensions_mut()
+			.insert(TransformationMetadata(serde_json::Map::from_iter([(
+				"agentgateway.dev/backend-auth".to_string(),
+				serde_json::Value::String("tenant-a".to_string()),
+			)])));
+		let mut same = http::Request::new(http::Body::empty());
+		same
+			.extensions_mut()
+			.insert(TransformationMetadata(serde_json::Map::from_iter([(
+				"agentgateway.dev/backend-auth".to_string(),
+				serde_json::Value::String("tenant-a".to_string()),
+			)])));
+		let missing = http::Request::new(http::Body::empty());
+
+		assert_eq!(policy.scope_key(&first), policy.scope_key(&same));
+		assert!(policy.scope_key(&first).is_some());
+		assert_eq!(policy.scope_key(&missing), None);
 	}
 
 	// --- healthy responses never trigger eviction ---

--- a/crates/agentgateway/src/llm/anthropic_tests.rs
+++ b/crates/agentgateway/src/llm/anthropic_tests.rs
@@ -1,6 +1,7 @@
 use crate::http::auth::AppliedBackendAuthLocation;
+use crate::http::transformation_cel::TransformationMetadata;
 use crate::llm::anthropic::OAUTH_TOKEN_PREFIX;
-use crate::llm::{AIProvider, RouteType, anthropic};
+use crate::llm::{AIProvider, RouteType, anthropic, openai};
 
 // ── set_required_fields integration tests ───────────────────────────────────
 
@@ -81,6 +82,49 @@ fn set_required_fields_api_key_token() {
 	assert!(req.headers().contains_key("x-api-key"));
 	// anthropic-version must be set.
 	assert!(req.headers().contains_key("anthropic-version"));
+}
+
+#[test]
+fn set_required_fields_uses_generic_backend_auth_metadata() {
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let mut req = make_bearer_request_with_explicit_auth("configured-key");
+	req
+		.extensions_mut()
+		.insert(TransformationMetadata(serde_json::Map::from_iter([(
+			crate::llm::BACKEND_AUTH_OVERRIDE_METADATA.to_string(),
+			serde_json::Value::String("sk-ant-scoped".to_string()),
+		)])));
+
+	provider
+		.set_required_fields(&mut req, RouteType::Messages, None)
+		.unwrap();
+
+	assert_eq!(req.headers().get("x-api-key").unwrap(), "sk-ant-scoped");
+	assert!(!req.headers().contains_key(::http::header::AUTHORIZATION));
+}
+
+#[test]
+fn openai_uses_generic_backend_auth_metadata() {
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: None,
+		moderation: None,
+	});
+	let mut req = make_bearer_request_with_explicit_auth("configured-key");
+	req
+		.extensions_mut()
+		.insert(TransformationMetadata(serde_json::Map::from_iter([(
+			crate::llm::BACKEND_AUTH_OVERRIDE_METADATA.to_string(),
+			serde_json::Value::String("sk-openai-scoped".to_string()),
+		)])));
+
+	provider
+		.set_required_fields(&mut req, RouteType::Completions, None)
+		.unwrap();
+
+	assert_eq!(
+		req.headers().get(::http::header::AUTHORIZATION).unwrap(),
+		"Bearer sk-openai-scoped"
+	);
 }
 
 // ── Explicit backend auth location tests ────────────────────────────────────

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -20,15 +20,17 @@ use rand::RngExt;
 use serde::de::DeserializeOwned;
 
 use crate::http::auth::{
-	AppliedBackendAuthLocation, AwsAuth, AzureAuth, BackendAuth, BackendAuthKind, GcpAuth,
+	AppliedBackendAuthLocation, AuthorizationLocation, AwsAuth, AzureAuth, BackendAuth,
+	BackendAuthKind, GcpAuth,
 };
 use crate::http::jwt::Claims;
+use crate::http::transformation_cel::TransformationMetadata;
 use crate::http::{Body, Request, Response};
 use crate::proxy::httpproxy::PolicyClient;
 use crate::store::{BackendPolicies, LLMResponsePolicies};
 use crate::telemetry::log::{AsyncLog, RequestLog};
 use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference, Target};
-use crate::types::loadbalancer::{ActiveHandle, EndpointWithInfo};
+use crate::types::loadbalancer::ActiveHandle;
 use crate::*;
 pub mod model_router;
 pub use agent_llm::{azure, bedrock, vertex};
@@ -44,6 +46,7 @@ use crate::proxy::dtrace;
 use crate::store;
 
 pub const LOCAL_LISTENER_NAME: &str = "llm";
+pub const BACKEND_AUTH_OVERRIDE_METADATA: &str = "agentgateway.dev/backend-auth";
 
 #[cfg(test)]
 mod anthropic_tests;
@@ -70,32 +73,67 @@ impl AIBackend {
 	pub fn select_provider(
 		&self,
 		affinity_key: Option<u64>,
+		health_scope: Option<u64>,
 	) -> Option<(Arc<NamedAIProvider>, ActiveHandle)> {
-		if let Some(affinity_key) = affinity_key {
-			let (provider, info) = self.providers.select_by_affinity(affinity_key)?;
-			let handle = self.providers.start_request(provider.name.clone(), &info);
-			return Some((provider, handle));
+		type Candidate = (
+			Arc<NamedAIProvider>,
+			Arc<crate::types::loadbalancer::EndpointInfo>,
+			u64,
+		);
+		let mut groups = self.providers.active_priority_groups();
+		if groups.iter().all(Vec::is_empty) {
+			groups = vec![self.providers.rejected_fallback()];
 		}
-		let iter = self.providers.iter();
-		let index = iter.index();
-		if index.is_empty() {
-			return None;
+		let mut fallback: Option<Vec<Candidate>> = None;
+		let mut available = None;
+		for group in groups {
+			if group.is_empty() {
+				continue;
+			}
+			let candidates = group
+				.into_iter()
+				.map(|candidate| {
+					let info = candidate.info_for_scope(health_scope);
+					let affinity_score = affinity_key
+						.map(|key| candidate.affinity_score(key))
+						.unwrap_or_default();
+					(candidate.endpoint, info, affinity_score)
+				})
+				.collect::<Vec<_>>();
+			fallback.get_or_insert_with(|| candidates.clone());
+			let healthy = candidates
+				.into_iter()
+				.filter(|(_, info, _)| health_scope.is_none() || !info.is_ejected())
+				.collect::<Vec<_>>();
+			if !healthy.is_empty() {
+				available = Some(healthy);
+				break;
+			}
 		}
-		// Intentionally allow `rand::seq::index::sample` so we can pick the same element twice
-		// This avoids starvation where the worst endpoint gets 0 traffic
-		let a = rand::rng().random_range(0..index.len());
-		let b = rand::rng().random_range(0..index.len());
-		let best = [a, b]
-			.into_iter()
-			.map(|idx| {
-				let (_, EndpointWithInfo { endpoint, info, .. }) =
-					index.get_index(idx).expect("index already checked");
-				(endpoint.clone(), info)
-			})
-			.max_by(|(_, a), (_, b)| a.score().total_cmp(&b.score()));
-		let (ep, ep_info) = best?;
-		let handle = self.providers.start_request(ep.name.clone(), ep_info);
-		Some((ep, handle))
+		// Preserve the existing degraded fallback within this scope when every priority is evicted.
+		let available = available.or(fallback)?;
+		let (provider, info, _) = if affinity_key.is_some() {
+			available
+				.into_iter()
+				.max_by_key(|(_, _, affinity_score)| *affinity_score)?
+		} else {
+			// Intentionally allow `rand::seq::index::sample` so we can pick the same element twice
+			// This avoids starvation where the worst endpoint gets 0 traffic
+			let a = rand::rng().random_range(0..available.len());
+			let b = rand::rng().random_range(0..available.len());
+			[a, b]
+				.into_iter()
+				.map(|idx| &available[idx])
+				.max_by(|(_, a, _), (_, b, _)| a.score().total_cmp(&b.score()))?
+				.clone()
+		};
+		let handle = match health_scope {
+			Some(_) => self
+				.providers
+				.start_scoped_request(provider.name.clone(), &info),
+			None => self.providers.start_request(provider.name.clone(), &info),
+		};
+		Some((provider.clone(), handle))
 	}
 }
 
@@ -1299,6 +1337,23 @@ impl AIProvider {
 		route_type: RouteType,
 		llm_request: Option<&LLMRequest>,
 	) -> anyhow::Result<()> {
+		if matches!(self, AIProvider::Anthropic(_) | AIProvider::OpenAI(_))
+			&& let Some(key) = req
+				.extensions()
+				.get::<TransformationMetadata>()
+				.and_then(|metadata| metadata.0.get(BACKEND_AUTH_OVERRIDE_METADATA))
+				.and_then(serde_json::Value::as_str)
+				.filter(|key| !key.is_empty())
+				.map(str::to_owned)
+		{
+			AuthorizationLocation::bearer_header().insert(req, &key)?;
+			// The metadata credential is the final provider auth override, even when another backend
+			// credential was configured explicitly. Treat its standard Authorization location as
+			// implicit so Anthropic can perform its normal Bearer -> x-api-key rewrite.
+			req
+				.extensions_mut()
+				.insert(AppliedBackendAuthLocation { explicit: false });
+		}
 		match self {
 			AIProvider::Anthropic(_) => {
 				http::modify_req(req, |req| {

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -8,6 +8,47 @@ use serde_json::{Value, json};
 use super::*;
 use crate::http::x_headers::TRACEPARENT;
 
+fn scoped_test_provider(name: &str) -> NamedAIProvider {
+	NamedAIProvider {
+		name: name.into(),
+		provider: AIProvider::OpenAI(openai::Provider {
+			model: None,
+			moderation: None,
+		}),
+		provider_backend: None,
+		host_override: None,
+		path_override: None,
+		path_prefix: None,
+		tokenize: false,
+		inline_policies: vec![],
+	}
+}
+
+#[test]
+fn scoped_provider_eviction_fails_over_without_affecting_another_scope() {
+	let first = scoped_test_provider("first");
+	let second = scoped_test_provider("second");
+	let backend = AIBackend {
+		providers: crate::types::loadbalancer::EndpointSet::new(vec![
+			vec![(first.name.clone(), first)],
+			vec![(second.name.clone(), second)],
+		]),
+	};
+	let (selected, handle) = backend.select_provider(None, Some(1)).unwrap();
+	assert_eq!(selected.name.as_str(), "first");
+	handle.finish_request(
+		false,
+		std::time::Duration::ZERO,
+		Some(std::time::Duration::from_secs(30)),
+		None,
+	);
+
+	let (same_scope, _) = backend.select_provider(None, Some(1)).unwrap();
+	let (other_scope, _) = backend.select_provider(None, Some(2)).unwrap();
+	assert_eq!(same_scope.name.as_str(), "second");
+	assert_eq!(other_scope.name.as_str(), "first");
+}
+
 fn llm_request_with_tokens(input_tokens: Option<u64>) -> LLMRequest {
 	LLMRequest {
 		input_tokens,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1903,6 +1903,10 @@ async fn apply_inference_routing(
 			),
 		inference_failed_open: inference_result.failed_open,
 		affinity_key,
+		health_scope: policies
+			.health
+			.as_ref()
+			.and_then(|health| health.scope_key(req)),
 	};
 
 	Ok((maybe_inference, service_override))
@@ -2082,8 +2086,12 @@ async fn make_backend_call(
 				.session_affinity
 				.as_ref()
 				.and_then(|policy| policy.affinity_key(&req));
+			let health_scope = policies
+				.health
+				.as_ref()
+				.and_then(|health| health.scope_key(&req));
 			let (provider, handle) = ai
-				.select_provider(affinity_key)
+				.select_provider(affinity_key, health_scope)
 				.ok_or(ProxyError::NoHealthyEndpoints)?;
 			log.add(move |l| l.request_handle = Some(handle));
 			let sub_backend_name = BackendTargetRef::Backend {
@@ -2732,6 +2740,10 @@ fn build_connect_backend_call(
 					.session_affinity
 					.as_ref()
 					.and_then(|policy| policy.affinity_key(req)),
+				health_scope: policies
+					.health
+					.as_ref()
+					.and_then(|health| health.scope_key(req)),
 				..Default::default()
 			};
 			build_service_call(
@@ -2804,6 +2816,7 @@ pub fn build_service_call(
 			port,
 			service_override.destination,
 			service_override.affinity_key,
+			service_override.health_scope,
 		)
 		.ok_or(ProxyError::NoHealthyEndpoints)?;
 
@@ -4010,6 +4023,7 @@ pub struct ServiceCallOverride {
 	pub destination_passthrough: bool,
 	pub inference_failed_open: bool,
 	pub affinity_key: Option<u64>,
+	pub health_scope: Option<u64>,
 }
 
 #[derive(Debug, Default)]

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2403,6 +2403,7 @@ fn convert_health(
 		health_threshold: ev.health_threshold,
 	});
 	health::Policy {
+		scope: None,
 		unhealthy_expression,
 		eviction,
 	}

--- a/crates/agentgateway/src/types/loadbalancer.rs
+++ b/crates/agentgateway/src/types/loadbalancer.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashMap};
 use std::future::pending;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
 
@@ -29,6 +29,7 @@ type EndpointKey = Strng;
 // Keep these stable across replicas and releases: changing either value remaps affinity assignments.
 const AFFINITY_KEY_HASH_SEED: u64 = 0x9e37_79b1_85eb_ca87;
 const ENDPOINT_KEY_HASH_SEED: u64 = 0xc2b2_ae3d_27d4_eb4f;
+const MAX_SCOPED_HEALTH_ENTRIES: usize = 10_000;
 
 // Hash the arbitrary-length affinity value once per request. Endpoint selection then operates only
 // on this u64 and the cached endpoint hashes below.
@@ -40,11 +41,40 @@ fn hash_endpoint_key(value: &[u8]) -> u64 {
 	XxHash3_64::oneshot_with_seed(ENDPOINT_KEY_HASH_SEED, value)
 }
 
+fn scoped_info_is_empty(info: &Arc<Mutex<HashMap<u64, Arc<EndpointInfo>>>>) -> bool {
+	info.lock().is_ok_and(|info| info.is_empty())
+}
+
+fn serialize_scoped_info<S>(
+	info: &Arc<Mutex<HashMap<u64, Arc<EndpointInfo>>>>,
+	serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+	S: serde::Serializer,
+{
+	let info = info
+		.lock()
+		.map_err(|_| serde::ser::Error::custom("scoped endpoint health mutex poisoned"))?;
+	let mut entries = info.iter().collect::<Vec<_>>();
+	entries.sort_unstable_by_key(|(scope, _)| **scope);
+	let mut seq = serializer.serialize_seq(Some(entries.len()))?;
+	for (_, info) in entries {
+		seq.serialize_element(info)?;
+	}
+	seq.end()
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct EndpointWithInfo<T> {
 	pub endpoint: Arc<T>,
 	pub info: Arc<EndpointInfo>,
 	pub capacity: u32,
+	/// Health state isolated by the request's hashed health scope.
+	#[serde(
+		skip_serializing_if = "scoped_info_is_empty",
+		serialize_with = "serialize_scoped_info"
+	)]
+	scoped_info: Arc<Mutex<HashMap<u64, Arc<EndpointInfo>>>>,
 	/// Hash of the endpoint's stable key, computed with the endpoint so there is no uninitialized
 	/// state. Affinity selection therefore needs only an integer mix per candidate.
 	#[serde(skip)]
@@ -63,8 +93,35 @@ impl<T> EndpointWithInfo<T> {
 			endpoint: Arc::new(ep),
 			info: Default::default(),
 			capacity,
+			scoped_info: Default::default(),
 			endpoint_hash: hash_endpoint_key(key.as_bytes()),
 		}
+	}
+
+	pub(crate) fn info_for_scope(&self, scope: Option<u64>) -> Arc<EndpointInfo> {
+		let Some(scope) = scope else {
+			return self.info.clone();
+		};
+		let mut entries = self
+			.scoped_info
+			.lock()
+			.expect("scoped endpoint health mutex poisoned");
+		if entries.len() >= MAX_SCOPED_HEALTH_ENTRIES
+			&& !entries.contains_key(&scope)
+			&& let Some(oldest) = entries.keys().next().copied()
+		{
+			// POC-quality cardinality bound. A follow-up can replace this arbitrary eviction with
+			// access-ordered TTL/LRU expiration without changing the health key semantics.
+			entries.remove(&oldest);
+		}
+		entries
+			.entry(scope)
+			.or_insert_with(|| Arc::new(EndpointInfo::default()))
+			.clone()
+	}
+
+	pub(crate) fn affinity_score(&self, affinity_key: u64) -> u64 {
+		rendezvous_hash(affinity_key, self.endpoint_hash)
 	}
 }
 
@@ -223,6 +280,12 @@ struct Candidate {
 	workload: Arc<Workload>,
 }
 
+struct ScopedCandidate {
+	candidate: Candidate,
+	capacity: u32,
+	endpoint_hash: u64,
+}
+
 impl EndpointSet<Endpoint> {
 	pub fn insert(&self, ep: Endpoint, dest_workload: &Workload, ranker: &LocalityRanker) {
 		let bucket = match ranker.bucket_for(dest_workload) {
@@ -241,7 +304,7 @@ impl EndpointSet<Endpoint> {
 		svc_port: u16,
 		override_dest: Option<SocketAddr>,
 	) -> Option<(Arc<Endpoint>, ActiveHandle, Arc<Workload>)> {
-		self.select_endpoint_with_affinity(workloads, svc, svc_port, override_dest, None)
+		self.select_endpoint_with_affinity(workloads, svc, svc_port, override_dest, None, None)
 	}
 
 	pub fn select_endpoint_with_affinity(
@@ -251,6 +314,7 @@ impl EndpointSet<Endpoint> {
 		svc_port: u16,
 		override_dest: Option<SocketAddr>,
 		affinity_key: Option<u64>,
+		health_scope: Option<u64>,
 	) -> Option<(Arc<Endpoint>, ActiveHandle, Arc<Workload>)> {
 		let Some(target_port) = svc.ports.get(&svc_port).copied() else {
 			debug!("service {} does not have port {}", svc.hostname, svc_port);
@@ -258,19 +322,128 @@ impl EndpointSet<Endpoint> {
 		};
 
 		let c = match override_dest {
-			Some(o) => self.select_override(workloads, o)?,
-			None => match affinity_key {
-				Some(key) => self.select_affinity(workloads, svc_port, target_port, key)?,
-				None => self
-					.select_p2c(workloads, svc, svc_port, target_port)
-					.or_else(|| self.select_fallback(workloads, svc_port, target_port))?,
+			Some(o) => self.select_override(workloads, o, health_scope)?,
+			None => {
+				if let Some(scope) = health_scope {
+					self.select_scoped(workloads, svc_port, target_port, affinity_key, scope)?
+				} else {
+					match affinity_key {
+						Some(key) => self.select_affinity(workloads, svc_port, target_port, key)?,
+						None => self
+							.select_p2c(workloads, svc, svc_port, target_port)
+							.or_else(|| self.select_fallback(workloads, svc_port, target_port))?,
+					}
+				}
 			},
 		};
 
-		let handle = svc
-			.endpoints
-			.start_request(c.endpoint.workload_uid.clone(), &c.info);
+		let handle = match health_scope {
+			Some(_) => svc
+				.endpoints
+				.start_scoped_request(c.endpoint.workload_uid.clone(), &c.info),
+			None => svc
+				.endpoints
+				.start_request(c.endpoint.workload_uid.clone(), &c.info),
+		};
 		Some((c.endpoint, handle, c.workload))
+	}
+
+	fn select_scoped(
+		&self,
+		workloads: &store::WorkloadStore,
+		svc_port: u16,
+		target_port: u16,
+		affinity_key: Option<u64>,
+		health_scope: u64,
+	) -> Option<Candidate> {
+		let mut fallback = None;
+		for bucket in &self.buckets {
+			let group = bucket.load_full();
+			if group.sampler.is_drained() {
+				continue;
+			}
+			let mut candidates = group
+				.active
+				.values()
+				.chain(group.rejected.values())
+				.filter(|ewi| ewi.capacity > 0)
+				.filter_map(|ewi| {
+					let workload = viable(workloads, target_port, svc_port, &ewi.endpoint)?;
+					Some(ScopedCandidate {
+						candidate: Candidate {
+							endpoint: ewi.endpoint.clone(),
+							info: ewi.info_for_scope(Some(health_scope)),
+							workload: workload.clone(),
+						},
+						capacity: ewi.capacity,
+						endpoint_hash: ewi.endpoint_hash,
+					})
+				})
+				.collect::<Vec<_>>();
+			if candidates.is_empty() {
+				continue;
+			}
+			fallback.get_or_insert_with(|| Self::choose_scoped(&candidates, affinity_key));
+			candidates.retain(|candidate| !candidate.candidate.info.is_ejected());
+			if !candidates.is_empty() {
+				return Some(Self::choose_scoped(&candidates, affinity_key));
+			}
+		}
+		fallback
+	}
+
+	fn choose_scoped(candidates: &[ScopedCandidate], affinity_key: Option<u64>) -> Candidate {
+		let selected = if let Some(affinity_key) = affinity_key {
+			let unit_weights = candidates.iter().all(|candidate| candidate.capacity == 1);
+			candidates
+				.iter()
+				.max_by(|a, b| {
+					let score = |candidate: &ScopedCandidate| {
+						if unit_weights {
+							RendezvousScore::Unweighted(rendezvous_hash(affinity_key, candidate.endpoint_hash))
+						} else {
+							RendezvousScore::Weighted(weighted_rendezvous_score(
+								affinity_key,
+								candidate.endpoint_hash,
+								candidate.capacity,
+							))
+						}
+					};
+					score(a).total_cmp(score(b))
+				})
+				.expect("scoped candidates are not empty")
+		} else {
+			let mut rng = rand::rng();
+			let (a, b) = if candidates.iter().all(|candidate| candidate.capacity == 1) {
+				(
+					rng.random_range(0..candidates.len()),
+					rng.random_range(0..candidates.len()),
+				)
+			} else {
+				let distribution = WeightedIndex::new(
+					candidates
+						.iter()
+						.map(|candidate| u64::from(candidate.capacity)),
+				)
+				.expect("scoped candidates have nonzero capacity");
+				(distribution.sample(&mut rng), distribution.sample(&mut rng))
+			};
+			[a, b]
+				.into_iter()
+				.map(|index| &candidates[index])
+				.max_by(|a, b| {
+					a.candidate
+						.info
+						.score()
+						.total_cmp(&b.candidate.info.score())
+				})
+				.expect("scoped candidates are not empty")
+		};
+		Candidate {
+			endpoint: selected.candidate.endpoint.clone(),
+			info: selected.candidate.info.clone(),
+			workload: selected.candidate.workload.clone(),
+		}
 	}
 
 	/// Selects one endpoint using weighted rendezvous hashing. Locality and health semantics match
@@ -337,8 +510,14 @@ impl EndpointSet<Endpoint> {
 
 	/// Explicit destination bypasses bucketing and health — search every endpoint
 	/// (active + rejected) so an evicted-but-explicitly-targeted backend is still reachable.
-	fn select_override(&self, workloads: &store::WorkloadStore, o: SocketAddr) -> Option<Candidate> {
-		self.find_endpoint(|ep, info| {
+	fn select_override(
+		&self,
+		workloads: &store::WorkloadStore,
+		o: SocketAddr,
+		health_scope: Option<u64>,
+	) -> Option<Candidate> {
+		self.find_endpoint(|ewi| {
+			let ep = &ewi.endpoint;
 			if !contains_target_port(ep, o.port()) {
 				return None;
 			}
@@ -351,7 +530,7 @@ impl EndpointSet<Endpoint> {
 			}
 			Some(Candidate {
 				endpoint: ep.clone(),
-				info: info.clone(),
+				info: ewi.info_for_scope(health_scope),
 				workload: wl,
 			})
 		})
@@ -461,7 +640,7 @@ impl RendezvousScore {
 /// The hashes use separate seeds; with either fixed, XOR is a one-to-one translation of the other
 /// and loses no entropy. SplitMix64 then avalanches the combined value.
 #[inline]
-fn rendezvous_hash(affinity_key: u64, endpoint_hash: u64) -> u64 {
+pub(crate) fn rendezvous_hash(affinity_key: u64, endpoint_hash: u64) -> u64 {
 	let mut value = affinity_key ^ endpoint_hash;
 	// Constants and algorithm from https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64
 	value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
@@ -713,6 +892,10 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		info.start_request(key, self.tx_eviction.clone(), self.eviction_worker.clone())
 	}
 
+	pub(crate) fn start_scoped_request(&self, key: Strng, info: &Arc<EndpointInfo>) -> ActiveHandle {
+		info.start_scoped_request(key)
+	}
+
 	fn find_bucket(&self, key: &EndpointKey) -> Option<Arc<EndpointGroup<T>>> {
 		self.buckets.iter().find_map(|x| {
 			let b = x.load_full();
@@ -775,19 +958,20 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 		ActiveEndpointsIter(self.best_bucket())
 	}
 
-	/// Selects an unweighted rendezvous winner from the same highest-priority healthy bucket used by
-	/// normal iteration. If no active endpoint exists there, `iter` exposes its rejected fallback.
-	/// This generic form is used for AI providers, whose stable provider names are EndpointKeys.
-	pub(crate) fn select_by_affinity(
-		&self,
-		affinity_key: u64,
-	) -> Option<(Arc<T>, Arc<EndpointInfo>)> {
-		let iter = self.iter();
-		let endpoint = iter
-			.index()
-			.values()
-			.max_by_key(|endpoint| rendezvous_hash(affinity_key, endpoint.endpoint_hash))?;
-		Some((endpoint.endpoint.clone(), endpoint.info.clone()))
+	pub(crate) fn active_priority_groups(&self) -> Vec<Vec<EndpointWithInfo<T>>> {
+		self
+			.buckets
+			.iter()
+			.map(|bucket| bucket.load_full().active.values().cloned().collect())
+			.collect()
+	}
+
+	pub(crate) fn rejected_fallback(&self) -> Vec<EndpointWithInfo<T>> {
+		self
+			.buckets
+			.first()
+			.map(|bucket| bucket.load_full().rejected.values().cloned().collect())
+			.unwrap_or_default()
 	}
 
 	/// Visit every endpoint, returning the first `Some` produced by `f`. Active
@@ -802,7 +986,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 	/// not at all — safe for "pick one and stop", unsafe for counting.
 	pub fn find_endpoint<F, R>(&self, mut f: F) -> Option<R>
 	where
-		F: FnMut(&Arc<T>, &Arc<EndpointInfo>) -> Option<R>,
+		F: FnMut(&EndpointWithInfo<T>) -> Option<R>,
 	{
 		for active_phase in [true, false] {
 			for bucket in self.buckets.iter() {
@@ -813,7 +997,7 @@ impl<T: Clone + Sync + Send + 'static> EndpointSet<T> {
 					&group.rejected
 				};
 				for (_, ewi) in map {
-					if let Some(r) = f(&ewi.endpoint, &ewi.info) {
+					if let Some(r) = f(ewi) {
 						return Some(r);
 					}
 				}
@@ -1021,6 +1205,9 @@ pub struct EndpointInfo {
 	#[serde(with = "serde_instant_option")]
 	/// evicted_until is the time at which the endpoint will be evicted.
 	evicted_until: AtomicOption<Instant>,
+	/// Restore value used by scoped entries, which expire lazily instead of through the worker.
+	#[serde(skip)]
+	scoped_restore_health: Mutex<Option<f64>>,
 }
 
 impl Default for EndpointInfo {
@@ -1034,6 +1221,7 @@ impl Default for EndpointInfo {
 			consecutive_failures: Default::default(),
 			times_ejected: Default::default(),
 			evicted_until: Arc::new(Default::default()),
+			scoped_restore_health: Default::default(),
 		}
 	}
 }
@@ -1052,6 +1240,26 @@ impl EndpointInfo {
 	pub fn times_ejected(&self) -> u64 {
 		self.times_ejected.load(AtomicOrdering::Relaxed)
 	}
+	pub(crate) fn is_ejected(&self) -> bool {
+		let until = self.evicted_until.load();
+		let Some(until) = until.as_ref() else {
+			return false;
+		};
+		if **until > Instant::now() {
+			return true;
+		}
+		// Scoped entries do not use the global eviction worker; expire them lazily.
+		self.evicted_until.store(None);
+		if let Some(restore_health) = self
+			.scoped_restore_health
+			.lock()
+			.expect("scoped restore health mutex poisoned")
+			.take()
+		{
+			self.health.set(restore_health.clamp(0.0, 1.0));
+		}
+		false
+	}
 	// Todo: fine-tune the algorithm here
 	pub fn score(&self) -> f64 {
 		let latency_penalty =
@@ -1068,8 +1276,18 @@ impl EndpointInfo {
 		ActiveHandle {
 			info: self.clone(),
 			key,
-			tx: tx_sender,
-			eviction_starter,
+			tx: Some(tx_sender),
+			eviction_starter: Some(eviction_starter),
+			counter: self.pending_requests.0.clone(),
+		}
+	}
+	fn start_scoped_request(self: &Arc<Self>, key: Strng) -> ActiveHandle {
+		self.total_requests.fetch_add(1, AtomicOrdering::Relaxed);
+		ActiveHandle {
+			info: self.clone(),
+			key,
+			tx: None,
+			eviction_starter: None,
 			counter: self.pending_requests.0.clone(),
 		}
 	}
@@ -1118,8 +1336,8 @@ impl Serialize for ActiveCounter {
 pub struct ActiveHandle {
 	info: Arc<EndpointInfo>,
 	key: Strng,
-	tx: futures::channel::mpsc::Sender<EvictionEvent>,
-	eviction_starter: Arc<dyn EvictionStarter>,
+	tx: Option<futures::channel::mpsc::Sender<EvictionEvent>>,
+	eviction_starter: Option<Arc<dyn EvictionStarter>>,
 	#[allow(dead_code)]
 	counter: Arc<()>,
 }
@@ -1172,18 +1390,28 @@ impl ActiveHandle {
 					.info
 					.times_ejected
 					.fetch_add(1, AtomicOrdering::Relaxed);
-				self.eviction_starter.start();
-				let mut tx = self.tx.clone();
-				let key = self.key.clone();
-				tokio::spawn(async move {
-					let _ = tx
-						.send(EvictionEvent::Evict {
-							key,
-							until: time,
-							restore_health,
-						})
-						.await;
-				});
+				if self.tx.is_none() {
+					*self
+						.info
+						.scoped_restore_health
+						.lock()
+						.expect("scoped restore health mutex poisoned") = restore_health;
+				}
+				if let (Some(eviction_starter), Some(mut tx)) =
+					(self.eviction_starter.as_ref(), self.tx.clone())
+				{
+					eviction_starter.start();
+					let key = self.key.clone();
+					tokio::spawn(async move {
+						let _ = tx
+							.send(EvictionEvent::Evict {
+								key,
+								until: time,
+								restore_health,
+							})
+							.await;
+					});
+				}
 			}
 		}
 	}
@@ -1315,6 +1543,62 @@ mod benches {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn scoped_health_does_not_eject_another_scope() {
+		let endpoints = EndpointSet::new(vec![vec![("provider".into(), ())]]);
+		let provider = Strng::from("provider");
+		let endpoint = endpoints.active_priority_groups()[0][0].clone();
+		let first = endpoint.info_for_scope(Some(1));
+		endpoints
+			.start_scoped_request(provider.clone(), &first)
+			.finish_request(false, Duration::ZERO, Some(Duration::from_secs(30)), None);
+		let second = endpoint.info_for_scope(Some(2));
+
+		assert!(first.is_ejected());
+		assert!(!second.is_ejected());
+	}
+
+	#[test]
+	fn service_selection_records_scoped_health() {
+		let endpoints = EndpointSet::new_empty(1);
+		let mut discovery = store::DiscoveryStore::new();
+		let workload = Arc::new(Workload {
+			uid: "workload".into(),
+			capacity: 1,
+			..Default::default()
+		});
+		discovery.workloads.insert(workload.clone());
+		endpoints.insert(
+			Endpoint {
+				workload_uid: workload.uid.clone(),
+				port: HashMap::from([(80, 8080)]),
+				status: crate::types::discovery::HealthStatus::Healthy,
+			},
+			&workload,
+			&LocalityRanker::new(None, None),
+		);
+		let service = Service {
+			hostname: "example.test".into(),
+			ports: HashMap::from([(80, 8080)]),
+			endpoints: endpoints.clone(),
+			..Default::default()
+		};
+
+		let (_, handle, _) = endpoints
+			.select_endpoint_with_affinity(&discovery.workloads, &service, 80, None, None, Some(7))
+			.expect("service endpoint should be selected");
+		handle.finish_request(true, Duration::from_secs(2), None, None);
+
+		let endpoint = endpoints.active_priority_groups()[0][0].clone();
+		assert_eq!(
+			endpoint.info.total_requests.load(AtomicOrdering::Relaxed),
+			0
+		);
+		let scoped = endpoint.info_for_scope(Some(7));
+		assert_eq!(scoped.total_requests.load(AtomicOrdering::Relaxed), 1);
+		assert_eq!(scoped.request_latency.load(), 2.0);
+	}
 
 	#[test]
 	fn rendezvous_score_is_stable_and_respects_weight() {
@@ -1691,8 +1975,8 @@ mod tests {
 
 	fn collect_values(eps: &EndpointSet<&'static str>) -> Vec<&'static str> {
 		let mut out = Vec::new();
-		eps.find_endpoint(|ep, _| -> Option<()> {
-			out.push(**ep);
+		eps.find_endpoint(|ep| -> Option<()> {
+			out.push(*ep.endpoint);
 			None
 		});
 		out

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -220,7 +220,7 @@ fn selected_ai_provider(normalized: &NormalizedLocalConfig) -> Arc<NamedAIProvid
 		panic!("expected generated AI backend");
 	};
 	let (provider, _handle) = ai
-		.select_provider(None)
+		.select_provider(None, None)
 		.expect("expected selected provider");
 	provider
 }

--- a/examples/llm-composite-auth/config.yaml
+++ b/examples/llm-composite-auth/config.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Run from the repository root so the JWKS file resolves:
+#   cargo run --bin agentgateway -- -f examples/llm-composite-auth/config.yaml
+#
+# Send a composite credential using one of the repository's example JWTs:
+#   Read manifests/jwt/example1.key into a shell variable named JWT, then run:
+#   curl localhost:4000/v1/messages \
+#     -H "Authorization: Bearer agw_composite:<ANTHROPIC_API_KEY>:<JWT>" \
+#     -H 'content-type: application/json' \
+#     -d '{"model":"claude-sonnet-4-5-20250929","max_tokens":32,"messages":[{"role":"user","content":"Hello"}]}'
+
+frontendPolicies:
+  accessLog:
+    add:
+      backend_auth_override_used: 'metadata["agentgateway.dev/backend-auth-override-used"]'
+
+llm:
+  port: 4000
+  policies:
+    # Validate only the JWT portion of:
+    #   Bearer agw_composite:<backend credential>:<JWT>
+    jwtAuth:
+      mode: permissive
+      location:
+        expression: |
+          request.headers["authorization"].split(" ")[1].with(credential,
+            credential.split(":").with(parts,
+              parts[0] == "agw_composite" ? parts[2] : credential
+            )
+          )
+      issuer: agentgateway.dev
+      audiences:
+      - test.agentgateway.dev
+      jwks:
+        # Relative to the directory where agentgateway is started.
+        file: ./manifests/jwt/pub-key
+
+    # jwtAuth runs before transformations. Expression-based JWT extraction intentionally leaves
+    # the composite Authorization header available so this policy can extract its middle field.
+    transformations:
+      request:
+        metadata:
+          agentgateway.dev/backend-auth: |
+            request.headers["authorization"].split(" ")[1].with(credential,
+              credential.split(":").with(parts,
+                parts[0] == "agw_composite" ? parts[1] : ""
+              )
+            )
+          agentgateway.dev/backend-auth-override-used: |
+            request.headers["authorization"].split(" ")[1].with(credential,
+              credential.split(":").with(parts, parts[0] == "agw_composite")
+            )
+
+  models:
+  - name: '*'
+    provider: anthropic
+    params:
+      model: claude-haiku-4-5
+      apiKey:
+        file: $HOME/.secrets/anthropic
+    # The generic agentgateway.dev/backend-auth metadata value overrides this configured fallback
+    # and is sent as x-api-key.
+    health:
+      # Agentgateway hashes this CEL result before keying health state. Missing or invalid values
+      # silently use global health state.
+      scope: 'metadata["agentgateway.dev/backend-auth"]'
+      unhealthyExpression: response.code == 429 || response.code >= 500
+      eviction:
+        duration: 30s


### PR DESCRIPTION
Example use cases:

* Segment the health score by path, so that requests to /slow do not factor into the decision for /fast
* Segment health by client, so when we pass through an API key if 1 client is getting rate limit/auth error/etc they don't impact everyone else

Signed-off-by: John Howard <john.howard@solo.io>
