### PR TITLE
fix(status): surface policy targetRef sectionName missing on targets

### DIFF
--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"istio.io/istio/pkg/kube/controllers"
@@ -9,6 +10,7 @@ import (
 	"istio.io/istio/pkg/ptr"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -25,6 +27,7 @@ type ResolvedPolicySelectorTarget struct {
 	Name          gwv1.ObjectName
 	Namespace     string
 	PolicyTargets []*api.PolicyTarget
+	TargetErr     error
 }
 
 type ReferenceTypes struct {
@@ -35,7 +38,7 @@ type ReferenceTypes struct {
 	// ReferenceGrant to entries. Extension authors must add their kinds here
 	// when they need ReferenceGrant permission checks to recognize those targets.
 	KnownToReferences       sets.Set[schema.GroupKind]
-	PolicyTargets           func(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName, port *gwv1.PortNumber) ([]*api.PolicyTarget, bool)
+	PolicyTargets           func(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName, port *gwv1.PortNumber) ([]*api.PolicyTarget, error)
 	PolicyTargetsBySelector func(krtctx krt.HandlerContext, policyNamespace string, selector agentgateway.LocalPolicyTargetSelectorWithSectionName) []ResolvedPolicySelectorTarget
 	PolicyBackend           func(krtctx krt.HandlerContext, defaultNamespace string, gk schema.GroupKind, name gwv1.ObjectName, namespace *gwv1.Namespace, port *gwv1.PortNumber) (*api.BackendReference, error)
 	RouteBackend            func(krtctx krt.HandlerContext, defaultNamespace string, gk schema.GroupKind, name gwv1.ObjectName, namespace *gwv1.Namespace, port *gwv1.PortNumber) (*api.BackendReference, error)
@@ -89,40 +92,39 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 			wellknown.AgentgatewayBackendGVK.GroupKind(),
 		),
 		// AgentgatewayPolicy targets
-		PolicyTargets: func(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName, port *gwv1.PortNumber) ([]*api.PolicyTarget, bool) {
-			key := namespace + "/" + string(name)
+		PolicyTargets: func(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName, port *gwv1.PortNumber) ([]*api.PolicyTarget, error) {
 			switch gk {
 			case wellknown.GatewayGVK.GroupKind():
 				return []*api.PolicyTarget{{
 					Kind: utils.GatewayTarget(namespace, string(name), sectionName, port),
-				}}, ResourceExists(krtctx, agw.Gateways, key)
+				}}, checkGatewayTarget(krtctx, agw.Gateways, namespace, string(name), sectionName, port)
 			case wellknown.HTTPRouteGVK.GroupKind():
 				return []*api.PolicyTarget{{
 					Kind: utils.RouteTarget(namespace, string(name), wellknown.HTTPRouteGVK.Kind, sectionName),
-				}}, ResourceExists(krtctx, agw.HTTPRoutes, key)
+				}}, checkSectionedTarget(krtctx, agw.HTTPRoutes, gk.Kind, namespace, string(name), sectionName, validateHTTPRouteRule)
 			case wellknown.GRPCRouteGVK.GroupKind():
 				return []*api.PolicyTarget{{
 					Kind: utils.RouteTarget(namespace, string(name), wellknown.GRPCRouteGVK.Kind, sectionName),
-				}}, ResourceExists(krtctx, agw.GRPCRoutes, key)
+				}}, checkSectionedTarget(krtctx, agw.GRPCRoutes, gk.Kind, namespace, string(name), sectionName, validateGRPCRouteRule)
 			case wellknown.AgentgatewayBackendGVK.GroupKind():
 				return []*api.PolicyTarget{{
 					Kind: utils.BackendTarget(namespace, string(name), sectionName),
-				}}, ResourceExists(krtctx, agw.Backends, key)
+				}}, checkSectionedTarget(krtctx, agw.Backends, gk.Kind, namespace, string(name), sectionName, validateBackendSection)
 			case wellknown.ServiceGVK.GroupKind():
 				return []*api.PolicyTarget{{
 					Kind: utils.ServiceTarget(namespace, string(name), sectionName),
-				}}, ResourceExists(krtctx, agw.Services, key)
+				}}, checkSectionedTarget(krtctx, agw.Services, gk.Kind, namespace, string(name), sectionName, validateServicePort)
 			case wellknown.ListenerSetGVK.GroupKind():
 				return []*api.PolicyTarget{{
 					Kind: utils.ListenerSetTarget(namespace, string(name), sectionName),
-				}}, ResourceExists(krtctx, agw.ListenerSets, key)
+				}}, checkSectionedTarget(krtctx, agw.ListenerSets, gk.Kind, namespace, string(name), sectionName, validateListenerSetListener)
 			case wellknown.InferencePoolGVK.GroupKind():
 				hostname := kubeutils.GetInferenceServiceHostname(string(name), namespace)
 				return []*api.PolicyTarget{{
 					Kind: utils.ServiceTargetWithHostname(namespace, hostname, nil),
-				}}, ResourceExists(krtctx, agw.InferencePools, key)
+				}}, checkExists(krtctx, agw.InferencePools, gk.Kind, namespace, string(name))
 			}
-			return nil, false
+			return nil, fmt.Errorf("unsupported target kind %s", gk.Kind)
 		},
 		PolicyTargetsBySelector: func(krtctx krt.HandlerContext, policyNamespace string, selector agentgateway.LocalPolicyTargetSelectorWithSectionName) []ResolvedPolicySelectorTarget {
 			targetGK := schema.GroupKind{Group: string(selector.Group), Kind: string(selector.Kind)}
@@ -135,42 +137,42 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 					policyTargets := []*api.PolicyTarget{{
 						Kind: utils.GatewayTarget(gw.Namespace, gw.Name, sectionName, selector.Port),
 					}}
-					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(gw.Name), Namespace: gw.Namespace, PolicyTargets: policyTargets})
+					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(gw.Name), Namespace: gw.Namespace, PolicyTargets: policyTargets, TargetErr: validateGatewayListener(gw, sectionName, selector.Port)})
 				}
 			case wellknown.HTTPRouteGVK.GroupKind():
 				for _, route := range krt.Fetch(krtctx, agw.HTTPRoutes, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.HTTPRoutesByNamespace, policyNamespace)) {
 					policyTargets := []*api.PolicyTarget{{
 						Kind: utils.RouteTarget(route.Namespace, route.Name, wellknown.HTTPRouteGVK.Kind, sectionName),
 					}}
-					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(route.Name), Namespace: route.Namespace, PolicyTargets: policyTargets})
+					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(route.Name), Namespace: route.Namespace, PolicyTargets: policyTargets, TargetErr: validateHTTPRouteRule(route, sectionName)})
 				}
 			case wellknown.GRPCRouteGVK.GroupKind():
 				for _, route := range krt.Fetch(krtctx, agw.GRPCRoutes, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.GRPCRoutesByNamespace, policyNamespace)) {
 					policyTargets := []*api.PolicyTarget{{
 						Kind: utils.RouteTarget(route.Namespace, route.Name, wellknown.GRPCRouteGVK.Kind, sectionName),
 					}}
-					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(route.Name), Namespace: route.Namespace, PolicyTargets: policyTargets})
+					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(route.Name), Namespace: route.Namespace, PolicyTargets: policyTargets, TargetErr: validateGRPCRouteRule(route, sectionName)})
 				}
 			case wellknown.ListenerSetGVK.GroupKind():
 				for _, ls := range krt.Fetch(krtctx, agw.ListenerSets, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.ListenerSetsByNamespace, policyNamespace)) {
 					policyTargets := []*api.PolicyTarget{{
 						Kind: utils.ListenerSetTarget(ls.Namespace, ls.Name, sectionName),
 					}}
-					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(ls.Name), Namespace: ls.Namespace, PolicyTargets: policyTargets})
+					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(ls.Name), Namespace: ls.Namespace, PolicyTargets: policyTargets, TargetErr: validateListenerSetListener(ls, sectionName)})
 				}
 			case wellknown.AgentgatewayBackendGVK.GroupKind():
 				for _, backend := range krt.Fetch(krtctx, agw.Backends, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.BackendsByNamespace, policyNamespace)) {
 					policyTargets := []*api.PolicyTarget{{
 						Kind: utils.BackendTarget(backend.Namespace, backend.Name, sectionName),
 					}}
-					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(backend.Name), Namespace: backend.Namespace, PolicyTargets: policyTargets})
+					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(backend.Name), Namespace: backend.Namespace, PolicyTargets: policyTargets, TargetErr: validateBackendSection(backend, sectionName)})
 				}
 			case wellknown.ServiceGVK.GroupKind():
 				for _, svc := range krt.Fetch(krtctx, agw.Services, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.ServicesByNamespace, policyNamespace)) {
 					policyTargets := []*api.PolicyTarget{{
 						Kind: utils.ServiceTarget(svc.Namespace, svc.Name, sectionName),
 					}}
-					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(svc.Name), Namespace: svc.Namespace, PolicyTargets: policyTargets})
+					targets = append(targets, ResolvedPolicySelectorTarget{Name: gwv1.ObjectName(svc.Name), Namespace: svc.Namespace, PolicyTargets: policyTargets, TargetErr: validateServicePort(svc, sectionName)})
 				}
 			case wellknown.InferencePoolGVK.GroupKind():
 				for _, pool := range krt.Fetch(krtctx, agw.InferencePools, krt.FilterLabel(selector.MatchLabels), krt.FilterIndex(agw.InferencePoolsByNamespace, policyNamespace)) {
@@ -472,7 +474,7 @@ func (p ReferenceIndex) WithListenerSetAttachments(references krt.IndexCollectio
 	return p
 }
 
-func (p ReferenceIndex) PolicyTarget(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName, port *gwv1.PortNumber) ([]*api.PolicyTarget, bool) {
+func (p ReferenceIndex) PolicyTarget(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName, port *gwv1.PortNumber) ([]*api.PolicyTarget, error) {
 	return p.explicitReferences.PolicyTargets(krtctx, namespace, name, gk, sectionName, port)
 }
 
@@ -486,4 +488,162 @@ func (p ReferenceIndex) PolicyBackend(krtctx krt.HandlerContext, defaultNamespac
 
 func (p ReferenceIndex) RouteBackend(krtctx krt.HandlerContext, defaultNamespace string, gk schema.GroupKind, name gwv1.ObjectName, namespace *gwv1.Namespace, port *gwv1.PortNumber) (*api.BackendReference, error) {
 	return p.explicitReferences.RouteBackend(krtctx, defaultNamespace, gk, name, namespace, port)
+}
+
+func targetNotFound(kind, namespace, name string) error {
+	return fmt.Errorf("%s %s/%s not found", kind, namespace, name)
+}
+
+func sectionNotFound[T controllers.ComparableObject](section gwv1.SectionName, kind string, obj T) error {
+	return fmt.Errorf("sectionName %q not found in %s %s/%s", section, kind, obj.GetNamespace(), obj.GetName())
+}
+
+func checkExists[T controllers.ComparableObject](krtctx krt.HandlerContext, col krt.Collection[T], kind, namespace, name string) error {
+	if !ResourceExists(krtctx, col, namespace+"/"+name) {
+		return targetNotFound(kind, namespace, name)
+	}
+	return nil
+}
+
+// fetchTarget returns the named object, adding a krt dependency on the full object.
+func fetchTarget[T controllers.ComparableObject](krtctx krt.HandlerContext, col krt.Collection[T], kind, namespace, name string) (T, error) {
+	obj := krt.FetchOne(krtctx, col, krt.FilterKey(namespace+"/"+name))
+	if obj == nil {
+		var zero T
+		return zero, targetNotFound(kind, namespace, name)
+	}
+	return *obj, nil
+}
+
+// checkSectionedTarget verifies a policy targetRef resolves. Targets scoped to a
+// section fetch the full object so validate can check the section; unscoped targets
+// only check existence to keep the krt dependency narrow.
+func checkSectionedTarget[T controllers.ComparableObject](
+	krtctx krt.HandlerContext,
+	col krt.Collection[T],
+	kind, namespace, name string,
+	sectionName *gwv1.SectionName,
+	validate func(obj T, sectionName *gwv1.SectionName) error,
+) error {
+	if sectionName == nil {
+		return checkExists(krtctx, col, kind, namespace, name)
+	}
+	obj, err := fetchTarget(krtctx, col, kind, namespace, name)
+	if err != nil {
+		return err
+	}
+	return validate(obj, sectionName)
+}
+
+// checkGatewayTarget is the Gateway flavor of checkSectionedTarget; Gateways can also
+// be scoped by listener port.
+func checkGatewayTarget(krtctx krt.HandlerContext, gateways krt.Collection[*gwv1.Gateway], namespace, name string, sectionName *gwv1.SectionName, port *gwv1.PortNumber) error {
+	if sectionName == nil && port == nil {
+		return checkExists(krtctx, gateways, wellknown.GatewayGVK.Kind, namespace, name)
+	}
+	gw, err := fetchTarget(krtctx, gateways, wellknown.GatewayGVK.Kind, namespace, name)
+	if err != nil {
+		return err
+	}
+	return validateGatewayListener(gw, sectionName, port)
+}
+
+func validateGatewayListener(gw *gwv1.Gateway, sectionName *gwv1.SectionName, port *gwv1.PortNumber) error {
+	if sectionName != nil {
+		for _, l := range gw.Spec.Listeners {
+			if l.Name == *sectionName {
+				return nil
+			}
+		}
+		return sectionNotFound(*sectionName, wellknown.GatewayGVK.Kind, gw)
+	}
+	if port != nil {
+		for _, l := range gw.Spec.Listeners {
+			if l.Port == *port {
+				return nil
+			}
+		}
+		return fmt.Errorf("port %d not found in %s %s/%s", *port, wellknown.GatewayGVK.Kind, gw.Namespace, gw.Name)
+	}
+	return nil
+}
+
+func validateListenerSetListener(ls *gwv1.ListenerSet, sectionName *gwv1.SectionName) error {
+	if sectionName == nil {
+		return nil
+	}
+	for _, l := range ls.Spec.Listeners {
+		if l.Name == *sectionName {
+			return nil
+		}
+	}
+	return sectionNotFound(*sectionName, wellknown.ListenerSetGVK.Kind, ls)
+}
+
+func validateHTTPRouteRule(route *gwv1.HTTPRoute, sectionName *gwv1.SectionName) error {
+	if sectionName == nil {
+		return nil
+	}
+	for _, r := range route.Spec.Rules {
+		if r.Name != nil && *r.Name == *sectionName {
+			return nil
+		}
+	}
+	return sectionNotFound(*sectionName, wellknown.HTTPRouteGVK.Kind, route)
+}
+
+func validateGRPCRouteRule(route *gwv1.GRPCRoute, sectionName *gwv1.SectionName) error {
+	if sectionName == nil {
+		return nil
+	}
+	for _, r := range route.Spec.Rules {
+		if r.Name != nil && *r.Name == *sectionName {
+			return nil
+		}
+	}
+	return sectionNotFound(*sectionName, wellknown.GRPCRouteGVK.Kind, route)
+}
+
+// validateBackendSection checks for sub-backends (e.g. an MCP target or an LLM provider)
+func validateBackendSection(be *agentgateway.AgentgatewayBackend, sectionName *gwv1.SectionName) error {
+	if sectionName == nil {
+		return nil
+	}
+	switch {
+	case be.Spec.MCP != nil:
+		for _, t := range be.Spec.MCP.Targets {
+			if t.Name == *sectionName {
+				return nil
+			}
+		}
+	case be.Spec.AI != nil:
+		if be.Spec.AI.LLM != nil && string(*sectionName) == utils.SingularLLMProviderSubBackendName {
+			return nil
+		}
+		for _, g := range be.Spec.AI.PriorityGroups {
+			for _, p := range g.Providers {
+				if p.Name == *sectionName {
+					return nil
+				}
+			}
+		}
+	}
+	return sectionNotFound(*sectionName, wellknown.AgentgatewayBackendGVK.Kind, be)
+}
+
+// validateServicePort checks for a port number as the sectionName.
+func validateServicePort(svc *corev1.Service, sectionName *gwv1.SectionName) error {
+	if sectionName == nil {
+		return nil
+	}
+	p, err := strconv.Atoi(string(*sectionName))
+	if err != nil {
+		return fmt.Errorf("sectionName %q is not a valid port number for %s %s/%s", *sectionName, wellknown.ServiceGVK.Kind, svc.Namespace, svc.Name)
+	}
+	for _, sp := range svc.Spec.Ports {
+		if int(sp.Port) == p {
+			return nil
+		}
+	}
+	return fmt.Errorf("port %d not found in %s %s/%s", p, wellknown.ServiceGVK.Kind, svc.Namespace, svc.Name)
 }

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-ai-provider-sectionname.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-ai-provider-sectionname.yaml
@@ -1,0 +1,89 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ai-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  rules:
+    - backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: ai-be
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: ai-be
+  namespace: default
+spec:
+  ai:
+    groups:
+      - providers:
+          - name: primary
+            openai:
+              model: gpt-4o
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: AgentgatewayBackend
+      name: ai-be
+      group: agentgateway.dev
+      sectionName: primary
+  backend:
+    http:
+      version: HTTP2
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendHttp:
+          version: HTTP2
+      key: default/agw:backend-http:default/ai-be/primary
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        backend:
+          name: ai-be
+          namespace: default
+          section: primary
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-mcp-section-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/backend-mcp-section-missing-not-attached.yaml
@@ -1,0 +1,71 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-route
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  rules:
+    - backendRefs:
+        - group: agentgateway.dev
+          kind: AgentgatewayBackend
+          name: mcp-be
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: mcp-be
+  namespace: default
+spec:
+  mcp:
+    targets:
+      - name: mcp-target
+        static:
+          host: mcp.example.com
+          port: 443
+          path: /v1/mcp
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: AgentgatewayBackend
+      name: mcp-be
+      group: agentgateway.dev
+      sectionName: no-such-target
+  backend:
+    http:
+      version: HTTP2
+
+---
+# Output
+output: []
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: sectionName "no-such-target" not found in
+          AgentgatewayBackend default/mcp-be'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/service-port-section-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/service-port-section-missing-not-attached.yaml
@@ -1,0 +1,65 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc-port
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  rules:
+    - backendRefs:
+        - name: svc-a
+          port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: default
+spec:
+  ports:
+    - name: http
+      port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: Service
+      name: svc-a
+      group: ""
+      sectionName: "9999"
+  backend:
+    http:
+      version: HTTP2
+
+---
+# Output
+output: []
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: port 9999 not found in Service default/svc-a'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/connect-port-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/frontendpolicy/connect-port-missing-not-attached.yaml
@@ -1,0 +1,72 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: connect-port-policy
+  namespace: default
+spec:
+  targetRefs:
+    - kind: Gateway
+      name: test
+      group: gateway.networking.k8s.io
+      port: 9999
+  frontend:
+    connect:
+      mode: Route
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      frontend:
+        connect:
+          mode: ROUTE
+      key: frontend/default/connect-port-policy:frontend-connect:default/test/port=9999
+      name:
+        kind: AgentgatewayPolicy
+        name: connect-port-policy
+        namespace: default
+      target:
+        gateway:
+          name: test
+          namespace: default
+          port: 9999
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: connect-port-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: port 9999 not found in Gateway default/test'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/gateway-section-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/gateway-section-missing-not-attached.yaml
@@ -1,0 +1,61 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+  - kind: Gateway
+    name: test
+    group: gateway.networking.k8s.io
+    sectionName: no-such-listener
+  traffic:
+    timeouts:
+      request: 5s
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:timeout:default/test/no-such-listener
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        gateway:
+          listener: no-such-listener
+          name: test
+          namespace: default
+      traffic:
+        timeout:
+          request: 5s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: sectionName "no-such-listener" not found
+          in Gateway default/test'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/gateway-selector-section-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/gateway-selector-section-missing-not-attached.yaml
@@ -1,0 +1,76 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: labeled-gw
+  namespace: default
+  labels:
+    app: labeled
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetSelectors:
+  - kind: Gateway
+    group: gateway.networking.k8s.io
+    matchLabels:
+      app: labeled
+    sectionName: no-such-listener
+  traffic:
+    timeouts:
+      request: 5s
+
+---
+# Output
+output:
+- gateway:
+    Name: labeled-gw
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:timeout:default/labeled-gw/no-such-listener
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        gateway:
+          listener: no-such-listener
+          name: labeled-gw
+          namespace: default
+      traffic:
+        timeout:
+          request: 5s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: sectionName "no-such-listener" not found
+          in Gateway default/labeled-gw'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/grpcroute-rule-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/grpcroute-rule-missing-not-attached.yaml
@@ -1,0 +1,76 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: grpc-named-rules
+  namespace: default
+spec:
+  parentRefs:
+    - name: test
+  rules:
+    - name: rule-one
+      backendRefs:
+        - name: reviews
+          port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+  - kind: GRPCRoute
+    name: grpc-named-rules
+    group: gateway.networking.k8s.io
+    sectionName: no-such-rule
+  traffic:
+    timeouts:
+      request: 5s
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:timeout:default/grpc-named-rules/no-such-rule
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: GRPCRoute
+          name: grpc-named-rules
+          namespace: default
+          routeRule: no-such-rule
+      traffic:
+        timeout:
+          request: 5s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: sectionName "no-such-rule" not found in
+          GRPCRoute default/grpc-named-rules'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/httproute-rule-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/httproute-rule-missing-not-attached.yaml
@@ -1,0 +1,78 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: named-rules
+  namespace: default
+spec:
+  parentRefs:
+  - name: test
+  hostnames:
+  - "rules.example.com"
+  rules:
+  - name: rule-one
+    backendRefs:
+    - name: svc1
+      port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+  - kind: HTTPRoute
+    name: named-rules
+    group: gateway.networking.k8s.io
+    sectionName: no-such-rule
+  traffic:
+    timeouts:
+      request: 5s
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:timeout:default/named-rules/no-such-rule
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: named-rules
+          namespace: default
+          routeRule: no-such-rule
+      traffic:
+        timeout:
+          request: 5s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: sectionName "no-such-rule" not found in
+          HTTPRoute default/named-rules'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/httproute-rule-sectionname.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/httproute-rule-sectionname.yaml
@@ -1,0 +1,79 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: named-rules
+  namespace: default
+spec:
+  parentRefs:
+  - name: test
+  hostnames:
+  - "rules.example.com"
+  rules:
+  - name: rule-one
+    backendRefs:
+    - name: svc1
+      port: 8080
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+  - kind: HTTPRoute
+    name: named-rules
+    group: gateway.networking.k8s.io
+    sectionName: rule-one
+  traffic:
+    timeouts:
+      request: 5s
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/agw:timeout:default/named-rules/rule-one
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: named-rules
+          namespace: default
+          routeRule: rule-one
+      traffic:
+        timeout:
+          request: 5s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-section-missing-not-attached.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/listenerset-section-missing-not-attached.yaml
@@ -1,0 +1,94 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: listenerset-gw
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  allowedListeners:
+    namespaces:
+      from: All
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: my-listenerset
+  namespace: default
+spec:
+  parentRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: listenerset-gw
+  listeners:
+  - name: extra
+    protocol: HTTP
+    port: 9090
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: ls-section-policy
+  namespace: default
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: my-listenerset
+    sectionName: no-such-listener
+  traffic:
+    timeouts:
+      request: 15s
+
+---
+# Output
+output:
+- gateway:
+    Name: listenerset-gw
+    Namespace: default
+  resource:
+    policy:
+      key: traffic/default/ls-section-policy:timeout:default/my-listenerset/no-such-listener
+      name:
+        kind: AgentgatewayPolicy
+        name: ls-section-policy
+        namespace: default
+      target:
+        listenerSet:
+          name: my-listenerset
+          namespace: default
+          section: no-such-listener
+      traffic:
+        timeout:
+          request: 15s
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: ls-section-policy
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: agentgateway.dev
+        name: StatusSummary
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Policy is not attached: sectionName "no-such-listener" not found
+          in ListenerSet default/my-listenerset'
+        reason: Pending
+        status: "False"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -204,7 +204,7 @@ func TranslateAgentgatewayPolicy(
 	baseConds := PolicyConditionMap(baseErr, len(baseTranslatedPolicies) > 0)
 	controller := gwv1.GatewayController(agw.ControllerName)
 
-	processTarget := func(name gwv1.ObjectName, targetNamespace string, gk schema.GroupKind, policyTargets []*api.PolicyTarget, targetExists bool) {
+	processTarget := func(name gwv1.ObjectName, targetNamespace string, gk schema.GroupKind, policyTargets []*api.PolicyTarget, targetErr error) {
 		if len(policyTargets) == 0 {
 			logger.Warn("unsupported target kind", "kind", gk.Kind, "policy", policy.Name)
 			return
@@ -216,12 +216,12 @@ func TranslateAgentgatewayPolicy(
 		}
 
 		for _, policyTarget := range policyTargets {
-			// For backend-like targets, skip gateway resolution when the target doesn't exist.
+			// For backend-like targets, skip gateway resolution when the target doesn't resolve.
 			// A missing backend could still resolve via PolicyAttachments if another backend
 			// chain happens to reference the same name, which would push config for a phantom target.
 			// Gateway/route targets use direct lookup (no PolicyAttachments), so they're safe.
 			var gatewayTargets []types.NamespacedName
-			if !IsBackendLikeTarget(policyTarget) || targetExists {
+			if !IsBackendLikeTarget(policyTarget) || targetErr == nil {
 				gatewayTargets = references.LookupGatewaysForPolicyTarget(ctx, targetObject, policyTarget).UnsortedList()
 				translatedPolicies := ClonePoliciesForTarget(baseTranslatedPolicies, policyTarget)
 				for _, translatedPolicy := range translatedPolicies {
@@ -234,7 +234,7 @@ func TranslateAgentgatewayPolicy(
 				}
 			}
 
-			ancestorRefs, attachmentErr := resolvePolicyAncestorRefs(targetNamespace, targetObject, gatewayTargets, targetExists)
+			ancestorRefs, attachmentErr := resolvePolicyAncestorRefs(targetNamespace, targetObject, gatewayTargets, targetErr)
 			if attachmentErr != "" {
 				attachmentErrors = append(attachmentErrors, attachmentErr)
 			}
@@ -275,8 +275,8 @@ func TranslateAgentgatewayPolicy(
 			return
 		}
 		seen[key] = struct{}{}
-		policyTargets, targetExists := references.PolicyTarget(ctx, targetNamespace, name, gk, sectionName, port)
-		processTarget(name, targetNamespace, gk, policyTargets, targetExists)
+		policyTargets, targetErr := references.PolicyTarget(ctx, targetNamespace, name, gk, sectionName, port)
+		processTarget(name, targetNamespace, gk, policyTargets, targetErr)
 	}
 
 	for _, target := range policy.Spec.TargetRefs {
@@ -290,7 +290,7 @@ func TranslateAgentgatewayPolicy(
 			attachmentErrors = append(attachmentErrors, fmt.Sprintf("Policy is not attached: no %s matching selector found in namespace %s", gk.Kind, policy.Namespace))
 		}
 		for _, target := range targets {
-			processTarget(target.Name, target.Namespace, gk, target.PolicyTargets, true)
+			processTarget(target.Name, target.Namespace, gk, target.PolicyTargets, target.TargetErr)
 		}
 	}
 
@@ -371,10 +371,10 @@ func resolvePolicyAncestorRefs(
 	policyNamespace string,
 	targetObject utils.TypedNamespacedName,
 	gatewayTargets []types.NamespacedName,
-	targetExists bool,
+	targetErr error,
 ) ([]gwv1.ParentReference, string) {
-	if !targetExists {
-		return nil, fmt.Sprintf("Policy is not attached: %s %s/%s not found", targetObject.Kind, policyNamespace, targetObject.Name)
+	if targetErr != nil {
+		return nil, fmt.Sprintf("Policy is not attached: %v", targetErr)
 	}
 
 	if len(gatewayTargets) == 0 {
@@ -2203,8 +2203,8 @@ func BackendReferencesFromPolicyForSource(
 	}
 	for _, tgt := range s.TargetRefs {
 		gk := schema.GroupKind{Group: string(tgt.Group), Kind: string(tgt.Kind)}
-		policyTarget, targetExists := references.PolicyTarget(ctx, policy.Namespace, tgt.Name, gk, tgt.SectionName, tgt.Port)
-		if policyTarget == nil || !targetExists {
+		policyTarget, targetErr := references.PolicyTarget(ctx, policy.Namespace, tgt.Name, gk, tgt.SectionName, tgt.Port)
+		if policyTarget == nil || targetErr != nil {
 			continue
 		}
 		addTarget(utils.TypedNamespacedName{
@@ -2214,7 +2214,7 @@ func BackendReferencesFromPolicyForSource(
 	}
 	for _, selector := range s.TargetSelectors {
 		for _, target := range references.PolicyTargetsBySelector(ctx, policy.Namespace, selector) {
-			if len(target.PolicyTargets) == 0 {
+			if len(target.PolicyTargets) == 0 || target.TargetErr != nil {
 				continue
 			}
 			addTarget(utils.TypedNamespacedName{


### PR DESCRIPTION
Previously we only checked for the existence of the target object, but if we specify a sectionName (e.g. a Gateway listener, a Service port, a sub-backend, etc) we would report Attached=True but the dataplane would enforce nothing. 


This adds validation for each type of reference. 