### PR TITLE
build: mark generated Go and schema files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,12 @@
+**/mocks/mock_*.go linguist-generated=true
+**/zz_generated.*.go linguist-generated=true
+api/*.pb.go linguist-generated=true
+api/*_json.gen.go linguist-generated=true
 controller/api/applyconfiguration/** linguist-generated=true
 controller/pkg/client/** linguist-generated=true
 controller/pkg/generated/** linguist-generated=true
 crates/agentgateway/src/llm/tests/** text eol=lf
 crates/agentgateway/src/llm/tests/**/*.bin -text
+schema/*.json linguist-generated=true
+schema/cel.md linguist-generated=true
+schema/config.md linguist-generated=true


### PR DESCRIPTION
`make gen` was only partly covered by `.gitattributes`