### PR TITLE
llm: fix "Input should be a valid dictionary" when previous turn returned empty args

### DIFF
--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -186,8 +186,7 @@ pub mod from_messages {
 		if let Some(tool_calls) = choice.message.tool_calls {
 			content.extend(tool_calls.into_iter().filter_map(|tc| match tc {
 				completions::MessageToolCalls::Function(f) => {
-					let input =
-						serde_json::from_str::<serde_json::Value>(&f.function.arguments).unwrap_or_default();
+					let input = crate::conversion::tool_arguments_to_input(&f.function.arguments);
 					Some(messages::ContentBlock::ToolUse {
 						id: f.id,
 						name: f.function.name,

--- a/crates/llm/src/conversion/messages.rs
+++ b/crates/llm/src/conversion/messages.rs
@@ -200,8 +200,7 @@ pub mod from_completions {
 			for tool_call in tool_calls {
 				match tool_call {
 					completions::MessageToolCalls::Function(call) => {
-						let input = serde_json::from_str::<serde_json::Value>(&call.function.arguments)
-							.unwrap_or_else(|_| serde_json::Value::String(call.function.arguments.clone()));
+						let input = crate::conversion::tool_arguments_to_input(&call.function.arguments);
 						out.push(messages::ContentBlock::ToolUse {
 							id: call.id.clone(),
 							name: call.function.name.clone(),
@@ -210,8 +209,7 @@ pub mod from_completions {
 						});
 					},
 					completions::MessageToolCalls::Custom(call) => {
-						let input = serde_json::from_str::<serde_json::Value>(&call.custom_tool.input)
-							.unwrap_or_else(|_| serde_json::Value::String(call.custom_tool.input.clone()));
+						let input = crate::conversion::tool_arguments_to_input(&call.custom_tool.input);
 						out.push(messages::ContentBlock::ToolUse {
 							id: call.id.clone(),
 							name: call.custom_tool.name.clone(),
@@ -574,6 +572,14 @@ pub mod from_completions {
 		log: StreamingUsageGuard,
 		log_content: crate::LogContentFields,
 	) -> Body {
+		/// An ongoing `tool_use` block. `emitted_arguments` tracks whether we have put any argument
+		/// text on the wire yet, so `content_block_stop` can synthesize `{}` when Anthropic
+		/// streamed nothing at all.
+		struct OngoingToolCall {
+			tool_index: u32,
+			emitted_arguments: bool,
+		}
+
 		let mut message_id = None;
 		let mut model = String::new();
 		let mut service_tier = None;
@@ -581,7 +587,7 @@ pub mod from_completions {
 		// let mut finish_reason = None;
 		let mut saw_token = false;
 		let mut next_tool_index = 0u32;
-		let mut tool_index_map: HashMap<usize, u32> = HashMap::new();
+		let mut ongoing_tool_calls: HashMap<usize, OngoingToolCall> = HashMap::new();
 		let mut completion = log_content.completion.then(String::new);
 		let mut tool_calls = super::StreamingToolCalls::new(log_content.tool_calls);
 
@@ -637,8 +643,15 @@ pub mod from_completions {
 					} => {
 						let tool_index = next_tool_index;
 						next_tool_index += 1;
-						tool_index_map.insert(index, tool_index);
 						tool_calls.start(index, id.as_str(), name.as_str(), &input);
+						// `input` is always `{}` here: the payload arrives as `input_json_delta`s.
+						ongoing_tool_calls.insert(
+							index,
+							OngoingToolCall {
+								tool_index,
+								emitted_arguments: false,
+							},
+						);
 
 						let choice = completions::ChatChoiceStream {
 							index: 0,
@@ -682,18 +695,21 @@ pub mod from_completions {
 						},
 						messages::ContentBlockDelta::InputJsonDelta { partial_json } => {
 							tool_calls.append_arguments(index, &partial_json);
-							if let Some(&tool_index) = tool_index_map.get(&index) {
-								dr.tool_calls = Some(vec![completions::ChatCompletionMessageToolCallChunk {
-									index: tool_index,
-									id: None,
-									r#type: None,
-									function: Some(completions::FunctionCallStream {
-										name: None,
-										arguments: Some(partial_json),
-									}),
-								}]);
-							} else {
-								emit_chunk = false;
+							match ongoing_tool_calls.get_mut(&index) {
+								Some(_) if partial_json.is_empty() => emit_chunk = false,
+								Some(ongoing) => {
+									ongoing.emitted_arguments = true;
+									dr.tool_calls = Some(vec![completions::ChatCompletionMessageToolCallChunk {
+										index: ongoing.tool_index,
+										id: None,
+										r#type: None,
+										function: Some(completions::FunctionCallStream {
+											name: None,
+											arguments: Some(partial_json),
+										}),
+									}]);
+								},
+								None => emit_chunk = false,
 							}
 						},
 						messages::ContentBlockDelta::SignatureDelta { .. }
@@ -776,8 +792,31 @@ pub mod from_completions {
 					)
 				},
 				messages::MessagesStreamEvent::ContentBlockStop { index } => {
-					tool_index_map.remove(&index);
-					None
+					match ongoing_tool_calls.remove(&index) {
+						Some(ongoing) if !ongoing.emitted_arguments => {
+							// If no arguments were emitted for a tool call, send a synthetic `{}`
+							// for compatibility.
+							let choice = completions::ChatChoiceStream {
+								index: 0,
+								logprobs: None,
+								delta: completions::StreamResponseDelta {
+									tool_calls: Some(vec![completions::ChatCompletionMessageToolCallChunk {
+										index: ongoing.tool_index,
+										id: None,
+										r#type: None,
+										function: Some(completions::FunctionCallStream {
+											name: None,
+											arguments: Some("{}".to_string()),
+										}),
+									}]),
+									..Default::default()
+								},
+								finish_reason: None,
+							};
+							mk(vec![choice], None)
+						},
+						_ => None,
+					}
 				},
 				messages::MessagesStreamEvent::MessageStop => {
 					log.update(|r| {

--- a/crates/llm/src/conversion/mod.rs
+++ b/crates/llm/src/conversion/mod.rs
@@ -7,5 +7,52 @@ pub mod responses;
 pub mod vertex;
 pub mod vertex_gemini;
 
+/// Translate an OpenAI `tool_calls[].function.arguments` string into an Anthropic
+/// `tool_use.input` value.
+///
+/// A tool call with no arguments is conventionally encoded as the empty string, which is not
+/// valid JSON. Anthropic requires `tool_use.input` to be an object, so that becomes `{}`.
+///
+/// Everything else is parsed and passed through unchanged, including values that are malformed
+/// or not an object (this would avoid changing silently the upstream response).
+pub(crate) fn tool_arguments_to_input(arguments: &str) -> serde_json::Value {
+	if arguments.is_empty() {
+		return serde_json::json!({});
+	}
+	serde_json::from_str::<serde_json::Value>(arguments)
+		.unwrap_or_else(|_| serde_json::Value::String(arguments.to_string()))
+}
+
 #[cfg(test)]
 mod rerank_tests;
+
+#[cfg(test)]
+mod tests {
+	use serde_json::json;
+
+	use super::tool_arguments_to_input;
+
+	#[test]
+	fn empty_arguments_become_an_empty_object() {
+		assert_eq!(tool_arguments_to_input(""), json!({}));
+	}
+
+	#[test]
+	fn everything_else_passes_through() {
+		// Valid JSON is forwarded as parsed, whatever shape it has.
+		assert_eq!(tool_arguments_to_input("{}"), json!({}));
+		assert_eq!(
+			tool_arguments_to_input("{\"a\":1,\"b\":[2,null]}"),
+			json!({"a": 1, "b": [2, null]})
+		);
+		assert_eq!(tool_arguments_to_input("[]"), json!([]));
+		// Non-object JSON is forwarded as parsed; malformed JSON is kept verbatim as a string instead of being degraded to `{}`
+		assert_eq!(tool_arguments_to_input("null"), json!(null));
+		assert_eq!(tool_arguments_to_input("5"), json!(5));
+		assert_eq!(
+			tool_arguments_to_input("{\"location\": \"Par"),
+			json!("{\"location\": \"Par")
+		);
+		assert_eq!(tool_arguments_to_input("  "), json!("  "));
+	}
+}

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -664,7 +664,11 @@ mod responses {
 		("tool_call", ALL_COMPLETIONS),
 		(
 			"truncated_tool_call",
-			&[COMPLETIONS_TO_COMPLETIONS, COMPLETIONS_TO_RESPONSES],
+			&[
+				COMPLETIONS_TO_COMPLETIONS,
+				COMPLETIONS_TO_MESSAGES,
+				COMPLETIONS_TO_RESPONSES,
+			],
 		),
 	];
 	const RESPONSES_RESPONSES: &[(&str, &[&str])] = &[
@@ -708,6 +712,10 @@ mod responses {
 		("stream_thinking", ALL_ANTHROPIC),
 		(
 			"stream_tool",
+			&[MESSAGES_TO_MESSAGES, MESSAGES_TO_COMPLETIONS],
+		),
+		(
+			"stream_tool_empty_args",
 			&[MESSAGES_TO_MESSAGES, MESSAGES_TO_COMPLETIONS],
 		),
 	];
@@ -1072,7 +1080,7 @@ data: [DONE]
 			axum_core::body::Body::from(input),
 			1024 * 1024,
 			StreamingUsageGuard::default(),
-			crate::LogContentFields::default(),
+			LogContentFields::default(),
 		)
 		.collect()
 		.await
@@ -1095,6 +1103,56 @@ data: [DONE]
 				"cache_read_input_tokens": 20,
 			})
 		);
+	}
+
+	/// Anthropic streams a single empty `input_json_delta` for a tool call with no arguments.
+	/// OpenAI clients concatenate the deltas and parse the result, so the concatenation has to be
+	/// a JSON object: forwarding `""` verbatim makes the client's *next* request fail upstream with
+	/// `tool_use.input: Input should be a valid dictionary`.
+	#[tokio::test]
+	async fn messages_to_completions_stream_emits_object_for_empty_tool_arguments() {
+		let input = r#"event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01A","name":"get_time","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"#;
+		let output = conversion::messages::from_completions::translate_stream(
+			axum_core::body::Body::from(input),
+			1024 * 1024,
+			StreamingUsageGuard::default(),
+			LogContentFields::default(),
+		)
+		.collect()
+		.await
+		.unwrap()
+		.to_bytes();
+
+		// Accumulate `arguments` across chunks exactly as an OpenAI client does.
+		let arguments: String = String::from_utf8(output.to_vec())
+			.unwrap()
+			.lines()
+			.filter_map(|line| line.strip_prefix("data: "))
+			.filter_map(|data| serde_json::from_str::<Value>(data).ok())
+			.filter_map(|chunk| {
+				chunk["choices"][0]["delta"]["tool_calls"][0]["function"]["arguments"]
+					.as_str()
+					.map(str::to_string)
+			})
+			.collect();
+
+		assert!(
+			serde_json::from_str::<serde_json::Map<String, Value>>(&arguments).is_ok(),
+			"streamed tool arguments must concatenate to a JSON object, got {arguments:?}"
+		);
+		assert_eq!(arguments, "{}");
 	}
 
 	#[test]

--- a/crates/llm/src/tests/requests/completions/tool-call.anthropic.snap
+++ b/crates/llm/src/tests/requests/completions/tool-call.anthropic.snap
@@ -14,10 +14,19 @@ info:
           function:
             name: get_weather
             arguments: "{\"format\":\"celsius\",\"location\":\"Columbus, OH\"}"
+        - id: call_5rQmXtLpZ9wKvNbJhGyDsFcE
+          type: function
+          function:
+            name: get_time
+            arguments: ""
     - role: tool
       tool_call_id: call_iMGPsr4Xx1u0G5sOzFsTCbQU
       name: get_weather
       content: "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    - role: tool
+      tool_call_id: call_5rQmXtLpZ9wKvNbJhGyDsFcE
+      name: get_time
+      content: "{ \"time\": \"2026-08-12T12:00:00Z\" }"
 ---
 {
   "request": {
@@ -42,6 +51,12 @@ info:
               "format": "celsius",
               "location": "Columbus, OH"
             }
+          },
+          {
+            "type": "tool_use",
+            "id": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+            "name": "get_time",
+            "input": {}
           }
         ]
       },
@@ -52,6 +67,16 @@ info:
             "type": "tool_result",
             "tool_use_id": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
             "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+            "content": "{ \"time\": \"2026-08-12T12:00:00Z\" }"
           }
         ]
       }
@@ -78,6 +103,10 @@ info:
       {
         "role": "tool",
         "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+      },
+      {
+        "role": "tool",
+        "content": "{ \"time\": \"2026-08-12T12:00:00Z\" }"
       }
     ]
   }

--- a/crates/llm/src/tests/requests/completions/tool-call.bedrock.snap
+++ b/crates/llm/src/tests/requests/completions/tool-call.bedrock.snap
@@ -14,10 +14,19 @@ info:
           function:
             name: get_weather
             arguments: "{\"format\":\"celsius\",\"location\":\"Columbus, OH\"}"
+        - id: call_5rQmXtLpZ9wKvNbJhGyDsFcE
+          type: function
+          function:
+            name: get_time
+            arguments: ""
     - role: tool
       tool_call_id: call_iMGPsr4Xx1u0G5sOzFsTCbQU
       name: get_weather
       content: "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    - role: tool
+      tool_call_id: call_5rQmXtLpZ9wKvNbJhGyDsFcE
+      name: get_time
+      content: "{ \"time\": \"2026-08-12T12:00:00Z\" }"
 ---
 {
   "request": {
@@ -42,6 +51,13 @@ info:
                 "location": "Columbus, OH"
               }
             }
+          },
+          {
+            "toolUse": {
+              "toolUseId": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+              "name": "get_time",
+              "input": {}
+            }
           }
         ]
       },
@@ -54,6 +70,17 @@ info:
               "content": [
                 {
                   "text": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+                }
+              ],
+              "status": null
+            }
+          },
+          {
+            "toolResult": {
+              "toolUseId": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+              "content": [
+                {
+                  "text": "{ \"time\": \"2026-08-12T12:00:00Z\" }"
                 }
               ],
               "status": null
@@ -100,6 +127,10 @@ info:
       {
         "role": "tool",
         "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+      },
+      {
+        "role": "tool",
+        "content": "{ \"time\": \"2026-08-12T12:00:00Z\" }"
       }
     ]
   }

--- a/crates/llm/src/tests/requests/completions/tool-call.json
+++ b/crates/llm/src/tests/requests/completions/tool-call.json
@@ -16,6 +16,14 @@
             "name": "get_weather",
             "arguments": "{\"format\":\"celsius\",\"location\":\"Columbus, OH\"}"
           }
+        },
+        {
+          "id": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+          "type": "function",
+          "function": {
+            "name": "get_time",
+            "arguments": ""
+          }
         }
       ]
     },
@@ -24,6 +32,12 @@
       "tool_call_id": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
       "name": "get_weather",
       "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+      "name": "get_time",
+      "content": "{ \"time\": \"2026-08-12T12:00:00Z\" }"
     }
   ]
 }

--- a/crates/llm/src/tests/requests/completions/tool-call.vertex-gemini.snap
+++ b/crates/llm/src/tests/requests/completions/tool-call.vertex-gemini.snap
@@ -14,10 +14,19 @@ info:
           function:
             name: get_weather
             arguments: "{\"format\":\"celsius\",\"location\":\"Columbus, OH\"}"
+        - id: call_5rQmXtLpZ9wKvNbJhGyDsFcE
+          type: function
+          function:
+            name: get_time
+            arguments: ""
     - role: tool
       tool_call_id: call_iMGPsr4Xx1u0G5sOzFsTCbQU
       name: get_weather
       content: "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    - role: tool
+      tool_call_id: call_5rQmXtLpZ9wKvNbJhGyDsFcE
+      name: get_time
+      content: "{ \"time\": \"2026-08-12T12:00:00Z\" }"
 ---
 {
   "request": {
@@ -41,6 +50,12 @@ info:
                 "location": "Columbus, OH"
               }
             }
+          },
+          {
+            "functionCall": {
+              "name": "get_time",
+              "args": {}
+            }
           }
         ]
       },
@@ -52,6 +67,14 @@ info:
               "name": "get_weather",
               "response": {
                 "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+              }
+            }
+          },
+          {
+            "functionResponse": {
+              "name": "get_time",
+              "response": {
+                "content": "{ \"time\": \"2026-08-12T12:00:00Z\" }"
               }
             }
           }
@@ -78,6 +101,10 @@ info:
       {
         "role": "tool",
         "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+      },
+      {
+        "role": "tool",
+        "content": "{ \"time\": \"2026-08-12T12:00:00Z\" }"
       }
     ]
   }

--- a/crates/llm/src/tests/response/anthropic/stream_tool_empty_args.json
+++ b/crates/llm/src/tests/response/anthropic/stream_tool_empty_args.json
@@ -1,0 +1,19 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_tool_empty","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01A","name":"get_time","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":15,"output_tokens":8}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+: stream complete

--- a/crates/llm/src/tests/response/anthropic/stream_tool_empty_args.messages-completions-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_tool_empty_args.messages-completions-streaming.snap
@@ -1,0 +1,37 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/stream_tool_empty_args.json
+---
+data: {"id":"msg_tool_empty","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"toolu_01A","type":"function","function":{"name":"get_time"}}]}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_tool_empty","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"{}"}}]}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+
+data: {"id":"msg_tool_empty","choices":[{"index":0,"delta":{"content":null},"finish_reason":"tool_calls"}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":15,"completion_tokens":8,"total_tokens":23}}
+
+data: [DONE]
+
+
+
+{
+  "input_tokens": 15,
+  "output_tokens": 8,
+  "total_tokens": 23,
+  "provider_model": "claude-haiku-4-5-20251001",
+  "completion": [
+    ""
+  ],
+  "output_messages": [
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_call",
+          "id": "toolu_01A",
+          "name": "get_time",
+          "arguments": {}
+        }
+      ],
+      "finish_reason": "tool_use"
+    }
+  ]
+}

--- a/crates/llm/src/tests/response/anthropic/stream_tool_empty_args.messages-messages-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_tool_empty_args.messages-messages-streaming.snap
@@ -1,0 +1,48 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/stream_tool_empty_args.json
+---
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_tool_empty","type":"message","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01A","name":"get_time","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":15,"output_tokens":8}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+: stream complete
+
+
+{
+  "input_tokens": 15,
+  "output_tokens": 8,
+  "total_tokens": 23,
+  "provider_model": "claude-haiku-4-5-20251001",
+  "completion": [
+    ""
+  ],
+  "output_messages": [
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_call",
+          "id": "toolu_01A",
+          "name": "get_time",
+          "arguments": {}
+        }
+      ],
+      "finish_reason": "tool_use"
+    }
+  ]
+}

--- a/crates/llm/src/tests/response/completions/truncated_tool_call.completions-messages.snap
+++ b/crates/llm/src/tests/response/completions/truncated_tool_call.completions-messages.snap
@@ -1,0 +1,67 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/truncated_tool_call.json
+info:
+  id: chatcmpl-truncated-tool-call
+  object: chat.completion
+  created: 1700000000
+  model: gpt-x
+  choices:
+    - index: 0
+      message:
+        role: assistant
+        content: ~
+        tool_calls:
+          - id: call_1
+            type: function
+            function:
+              name: get_weather
+              arguments: "{\"location\": \"Par"
+      finish_reason: length
+  usage:
+    prompt_tokens: 20
+    completion_tokens: 15
+    total_tokens: 35
+---
+{
+  "response": {
+    "id": "[id]",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "tool_use",
+        "id": "call_1",
+        "name": "get_weather",
+        "input": "{\"location\": \"Par"
+      }
+    ],
+    "model": "gpt-x",
+    "stop_reason": "max_tokens",
+    "stop_sequence": null,
+    "usage": {
+      "input_tokens": 20,
+      "output_tokens": 15
+    }
+  },
+  "parsed": {
+    "input_tokens": 20,
+    "output_tokens": 15,
+    "total_tokens": 35,
+    "provider_model": "gpt-x",
+    "output_messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_call",
+            "id": "call_1",
+            "name": "get_weather",
+            "arguments": "{\"location\": \"Par"
+          }
+        ],
+        "finish_reason": "max_tokens"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- A Claude tool call that takes no arguments poisons the conversation by returning `""` as argument: the next turn fails with `messages.N.content.0.tool_use.input: Input should be a valid dictionary`. This happens when using a Claude model using the `chat/completion` conversion and streaming mode.
- Anthropic encodes a zero-argument tool call as a `content_block_start` carrying `input: {}` followed by a single `input_json_delta` whose `partial_json` is `""`.
- `messages::from_completions::translate_stream` forwarded that delta verbatim, so an OpenAI client concatenating the deltas accumulates `arguments == ""` instead of `"{}"`.

This MR fixes the issue by adding two guards:
1. Emit an additional `{}` chunk at `content_block_stop` when nothing was streamed for a tool call, and stop forwarding the now redundant empty delta.
2. Coerce an empty `arguments` string to `{}` on the request path (`messages::from_completions`) and the response path (`completions::from_messages`), so a client that already has a poisoned history recovers instead of looping on the 400.

## Root cause

Confirmed against a live gateway backed by Anthropic on Vertex.

#### The gateway returns `""` for a zero-argument tool call when streaming:

```
non-streaming : '{}'
streaming     : ''
```

Raw deltas from the streaming response: one `input_json_delta` carrying an empty `partial_json`, and nothing else:

```
[(0, 'toolu_vrtx_01TXjRpD3vVqkcnZy8Lv6WZK', 'get_time', None), (0, None, None, '')]
```

Note that a tool with required parameters is unaffected (`{"a": 2, "b": 2}` accumulates correctly), which is why this looks. Only zero-argument tools trigger it.

#### Replaying that `""` — 400 `Input should be a valid dictionary`

```bash
BASE_URL="CHANGEME"
API_KEY="CHANGEME"
curl -s "${BASE_URL}/chat/completions" \
  -H "Authorization: Bearer ${API_KEY}" \
  -H 'Content-Type: application/json' -d '{
  "model": "claude-haiku-4-5",
  "messages": [
    {"role": "user", "content": "What time is it?"},
    {"role": "assistant", "tool_calls": [{"id": "call_1", "type": "function",
      "function": {"name": "get_time", "arguments": ""}}]},
    {"role": "tool", "tool_call_id": "call_1", "content": "2026-08-12T12:00:00Z"}
  ],
  "tools": [{"type": "function", "function": {"name": "get_time",
    "parameters": {"type": "object", "properties": {}}}}]}'
```

```json
{"error":{"type":"invalid_request_error","message":"messages.1.content.0.tool_use.input: Input should be a valid dictionary"}}
```

Swapping `"arguments": ""` for `"{}"` returns 200.

## Behavior changes

- Streaming a tool call with no arguments now emits one chunk with `"arguments":"{}"` at `content_block_stop`, and no longer emits the `"arguments":""` chunk.
- Request translation: `arguments: ""` now produces `input: {}` instead of `input: ""`.
- Response translation (`completions::from_messages`): `arguments: ""` now produces `input: {}`.
- Unchanged: arguments that are malformed or valid-but-not-an-object (`null`, `[]`, `5`) are still forwarded as-is and still rejected upstream.

## Testing
  
- `cargo test -p agent-llm` — new golden fixture `response/anthropic/stream_tool_empty_args.json`
- A unit test feeds the empty-args SSE through `translate_stream` and asserts the concatenated `arguments` parse as a JSON **object**
- `make lint`
- `make test`

Verified end-to-end against a real Vertex project:

```
# before: streaming yields '', replaying it 400s
# after:  streaming yields '{}', replay returns 200
```