### PR TITLE
llm: set role on the first Anthropic streaming delta

### DIFF
--- a/crates/llm/src/conversion/messages.rs
+++ b/crates/llm/src/conversion/messages.rs
@@ -576,6 +576,9 @@ pub mod from_completions {
 	) -> Body {
 		let mut message_id = None;
 		let mut model = String::new();
+		// Anthropic states the role once in `message_start`, but the OpenAI chunk has no top-level
+		// role field — it belongs on `choices[].delta`, so hold it until there is a chunk for it.
+		let mut pending_role = None;
 		let mut service_tier = None;
 		let created = chrono::Utc::now().timestamp() as u32;
 		// let mut finish_reason = None;
@@ -590,7 +593,11 @@ pub mod from_completions {
 			messages::MessagesStreamEvent,
 			completions::StreamResponse,
 		>(b, buffer_limit, move |f| {
-			let mk = |choices: Vec<completions::ChatChoiceStream>, usage: Option<completions::Usage>| {
+			let mut mk = |mut choices: Vec<completions::ChatChoiceStream>,
+			              usage: Option<completions::Usage>| {
+				if let Some(first) = choices.first_mut() {
+					first.delta.role = pending_role.take();
+				}
 				Some(completions::StreamResponse {
 					id: message_id.clone().unwrap_or_else(|| "unknown".to_string()),
 					model: model.clone(),
@@ -609,6 +616,11 @@ pub mod from_completions {
 			match f {
 				messages::MessagesStreamEvent::MessageStart { message } => {
 					message_id = Some(message.id);
+					pending_role = Some(match message.role {
+						messages::Role::Assistant => completions::Role::Assistant,
+						messages::Role::User => completions::Role::User,
+						messages::Role::System => completions::Role::System,
+					});
 					model = message.model.clone();
 					service_tier = message.usage.service_tier.clone();
 					log.update(|r| {

--- a/crates/llm/src/tests/response/anthropic/stream_basic.messages-completions-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_basic.messages-completions-streaming.snap
@@ -2,7 +2,7 @@
 source: crates/llm/src/golden_tests.rs
 description: src/tests/response/anthropic/stream_basic.json
 ---
-data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":"Hi there! How are"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":"standard","system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":"Hi there! How are","role":"assistant"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":"standard","system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 data: {"id":"msg_016wbjv5k86nxxd8CEZwSQnA","choices":[{"index":0,"delta":{"content":" you doing today?"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":"standard","system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 

--- a/crates/llm/src/tests/response/anthropic/stream_message_delta_usage.messages-completions-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_message_delta_usage.messages-completions-streaming.snap
@@ -2,7 +2,7 @@
 source: crates/llm/src/golden_tests.rs
 description: src/tests/response/anthropic/stream_message_delta_usage.json
 ---
-data: {"id":"msg","choices":[{"index":0,"delta":{"content":null},"finish_reason":"stop"}],"created":123,"model":"glm-5.2","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":3883,"completion_tokens":49,"total_tokens":3932,"prompt_tokens_details":{"cached_tokens":30464,"cache_write_tokens":0},"cache_read_input_tokens":30464,"cache_creation_input_tokens":0}}
+data: {"id":"msg","choices":[{"index":0,"delta":{"content":null,"role":"assistant"},"finish_reason":"stop"}],"created":123,"model":"glm-5.2","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":3883,"completion_tokens":49,"total_tokens":3932,"prompt_tokens_details":{"cached_tokens":30464,"cache_write_tokens":0},"cache_read_input_tokens":30464,"cache_creation_input_tokens":0}}
 
 data: [DONE]
 

--- a/crates/llm/src/tests/response/anthropic/stream_thinking.messages-completions-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_thinking.messages-completions-streaming.snap
@@ -2,7 +2,7 @@
 source: crates/llm/src/golden_tests.rs
 description: src/tests/response/anthropic/stream_thinking.json
 ---
-data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":"The user is"}}],"created":123,"model":"claude-opus-4-6","service_tier":"standard","system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"role":"assistant","reasoning_content":"The user is"}}],"created":123,"model":"claude-opus-4-6","service_tier":"standard","system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 data: {"id":"msg_018XasA6jgabsibaUtstx4bg","choices":[{"index":0,"delta":{"content":null,"reasoning_content":" asking me about the weather in"}}],"created":123,"model":"claude-opus-4-6","service_tier":"standard","system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 

--- a/crates/llm/src/tests/response/anthropic/stream_tool.messages-completions-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_tool.messages-completions-streaming.snap
@@ -2,7 +2,7 @@
 source: crates/llm/src/golden_tests.rs
 description: src/tests/response/anthropic/stream_tool.json
 ---
-data: {"id":"msg_tool","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"toolu_01A","type":"function","function":{"name":"get_weather"}}]}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+data: {"id":"msg_tool","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"toolu_01A","type":"function","function":{"name":"get_weather"}}],"role":"assistant"}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 
 data: {"id":"msg_tool","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"{\"location\":"}}]}}],"created":123,"model":"claude-haiku-4-5-20251001","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
 


### PR DESCRIPTION
## What it fix?

Streaming responses translated from Anthropic Messages to OpenAI chat completions never
carried the author role. Clients that rebuild the assistant message from the chunks had no
`role` to read.

### Example with `stream: false` - Role is present:
```json
{
    "model": "claude-haiku-4-5-20251001",
    "usage": {
        "prompt_tokens": 81,
        "completion_tokens": 28,
        "total_tokens": 109,
        "prompt_tokens_details": {
            "cached_tokens": 0,
            "cache_write_tokens": 0
        },
        "cache_read_input_tokens": 0,
        "cache_creation_input_tokens": 0
    },
    "choices": [
        {
            "message": {
                "content": "The current time is **12:00 PM (noon) UTC** on **August 12, 2026**.",
                "role": "assistant"
            },
            "index": 0,
            "finish_reason": "stop"
        }
    ],
    "id": "<redacted>",
    "created": 1786608738,
    "object": "chat.completion"
}
```

### Example with `stream: true` before the fix - no chunk carry the role:
```json
[
    {
        "id": "<redacted>",
        "choices": [
            {
                "index": 0,
                "delta": {
                    "content": null,
                    "tool_calls": [
                        {
                            "index": 0,
                            "id": "<redacted>",
                            "type": "function",
                            "function": {
                                "name": "get_time"
                            }
                        }
                    ]
                }
            }
        ],
        "created": 1786610163,
        "model": "claude-haiku-4-5-20251001",
        "service_tier": null,
        "system_fingerprint": null,
        "object": "chat.completion.chunk",
        "usage": null
    },
    {
        "id": "<redacted>",
        "choices": [
            {
                "index": 0,
                "delta": {
                    "content": null,
                    "tool_calls": [
                        {
                            "index": 0,
                            "id": null,
                            "type": null,
                            "function": {
                                "arguments": ""
                            }
                        }
                    ]
                }
            }
        ],
        "created": 1786610163,
        "model": "claude-haiku-4-5-20251001",
        "service_tier": null,
        "system_fingerprint": null,
        "object": "chat.completion.chunk",
        "usage": null
    },
    {
        "id": "<redacted>",
        "choices": [
            {
                "index": 0,
                "delta": {
                    "content": null
                },
                "finish_reason": "tool_calls"
            }
        ],
        "created": 1786610163,
        "model": "claude-haiku-4-5-20251001",
        "service_tier": null,
        "system_fingerprint": null,
        "object": "chat.completion.chunk",
        "usage": {
            "prompt_tokens": 558,
            "completion_tokens": 37,
            "total_tokens": 595,
            "prompt_tokens_details": {
                "cached_tokens": 0,
                "cache_write_tokens": 0
            },
            "cache_read_input_tokens": 0,
            "cache_creation_input_tokens": 0
        }
    }
]
```

## How it fix?

Anthropic states the role once in `message_start`, an event that emits no chunk of its own.
The role is now held until the first chunk is emitted and set on `choices[].delta.role`,
which is where the OpenAI chunk shape carries it.

### Example with `stream: true` after the fix - the first delta carries the role:
```json
[
    {
        "id": "<redacted>",
        "choices": [
            {
                "index": 0,
                "delta": {
                    "content": null,
                    "tool_calls": [
                        {
                            "index": 0,
                            "id": "<redacted>",
                            "type": "function",
                            "function": {
                                "name": "get_time"
                            }
                        }
                    ],
                    "role": "assistant"
                }
            }
        ],
        "created": 1786610676,
        "model": "claude-haiku-4-5-20251001",
        "service_tier": null,
        "system_fingerprint": null,
        "object": "chat.completion.chunk",
        "usage": null
    },
    {
        "id": "<redacted>",
        "choices": [
            {
                "index": 0,
                "delta": {
                    "content": null,
                    "tool_calls": [
                        {
                            "index": 0,
                            "id": null,
                            "type": null,
                            "function": {
                                "arguments": "{}"
                            }
                        }
                    ]
                }
            }
        ],
        "created": 1786610676,
        "model": "claude-haiku-4-5-20251001",
        "service_tier": null,
        "system_fingerprint": null,
        "object": "chat.completion.chunk",
        "usage": null
    },
    {
        "id": "<redacted>",
        "choices": [
            {
                "index": 0,
                "delta": {
                    "content": null
                },
                "finish_reason": "tool_calls"
            }
        ],
        "created": 1786610676,
        "model": "claude-haiku-4-5-20251001",
        "service_tier": null,
        "system_fingerprint": null,
        "object": "chat.completion.chunk",
        "usage": {
            "prompt_tokens": 558,
            "completion_tokens": 37,
            "total_tokens": 595,
            "prompt_tokens_details": {
                "cached_tokens": 0,
                "cache_write_tokens": 0
            },
            "cache_read_input_tokens": 0,
            "cache_creation_input_tokens": 0
        }
    }
]
```

## Testing

- Four golden streaming snapshots updated — text, thinking, tool call, and tool call with
  empty arguments — each covering a different first chunk and asserting the role appears
  once, on that chunk only.
- `make lint` and `make test` pass.