### PR TITLE
mcp: do not mask discovery failures on failOpen mode

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -1017,6 +1017,9 @@ impl Relay {
 		target_names: Option<Vec<String>>,
 		request_for_target: impl Fn(&str, &JsonRpcRequest<ClientRequest>) -> JsonRpcRequest<ClientRequest>,
 	) -> Result<(Vec<(Strng, Messages)>, Option<Vec<String>>), UpstreamError> {
+		// A discovery rejection means "legacy protocol", not "upstream unavailable".
+		// Surface it even in FailOpen so probe clients can fall back to initialize.
+		let fail_on_discovery_rejection = matches!(&r.request, ClientRequest::DiscoverRequest(_));
 		let selected_upstreams = self
 			.upstreams
 			.iter_named()
@@ -1077,6 +1080,29 @@ impl Relay {
 			match result {
 				Ok(s) => streams.push((name, s)),
 				Err(e) => {
+					let discovery_rejection = fail_on_discovery_rejection
+						&& match &e {
+							UpstreamError::InvalidMethod(_) => true,
+							UpstreamError::Http(ClientError::Status(response)) => matches!(
+								response.status(),
+								StatusCode::BAD_REQUEST | StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+							),
+							_ => false,
+						};
+					if discovery_rejection {
+						streams.push((
+							name,
+							Messages::from(ServerJsonRpcMessage::error(
+								ErrorData::new(
+									rmcp::model::ErrorCode::METHOD_NOT_FOUND,
+									r.request.method().to_string(),
+									None,
+								),
+								Some(r.id.clone()),
+							)),
+						));
+						continue;
+					}
 					// FailOpen skips pre-stream failures. FailClosed fails before any frame streams.
 					if self.upstreams.failure_mode == FailureMode::FailOpen {
 						warn!("upstream '{}' failed during fanout, skipping: {}", name, e);
@@ -1354,6 +1380,8 @@ impl Relay {
 		target_names: Option<Vec<String>>,
 	) -> Result<Response, UpstreamError> {
 		let id = r.id.clone();
+		// Preserve discovery errors through the merge for protocol fallback.
+		let fail_on_discovery_rejection = matches!(&r.request, ClientRequest::DiscoverRequest(_));
 		let (streams, service_names) = self
 			.fanout_open_streams(&r, &mut ctx, target_names, |_, r| r.clone())
 			.await?;
@@ -1372,8 +1400,14 @@ impl Relay {
 			})
 			.collect::<Vec<_>>();
 
-		let ms =
-			mergestream::MergeStream::new(streams, id.clone(), merge, cel, self.upstreams.failure_mode);
+		let ms = mergestream::MergeStream::new(
+			streams,
+			id.clone(),
+			merge,
+			cel,
+			self.upstreams.failure_mode,
+			fail_on_discovery_rejection,
+		);
 
 		// Response-phase hook runs once on the merged (muxed) result.
 		respond_with_guardrails(

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -956,14 +956,22 @@ async fn stateless_vnext_tools_list_reaches_upstream() {
 
 #[tokio::test]
 async fn modern_client_multiplex_mixed_servers_falls_back_to_legacy_initialize() {
-	let old = mock_streamable_http_server_without_discover().await;
+	let down = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let down_addr = down.local_addr().unwrap();
+	drop(down);
+	let old = mock_streamable_http_server_rejecting_discover().await;
 	let new = mock_modern_streamable_http_server().await;
 	let t = setup_proxy_test("{}")
 		.unwrap()
-		.with_multiplex_mcp_backend(
+		.with_multiplex_mcp_backend_failure_mode(
 			"mcp",
-			vec![("old", old.addr, false), ("new", new.addr, false)],
+			vec![
+				("down", down_addr, false),
+				("old", old.addr, false),
+				("new", new.addr, false),
+			],
 			true,
+			FailureMode::FailOpen,
 		)
 		.with_bind(simple_bind())
 		.with_route(basic_named_route(strng::new("/mcp")));
@@ -994,11 +1002,8 @@ async fn modern_client_multiplex_mixed_servers_falls_back_to_legacy_initialize()
 		discover.headers().get("mcp-session-id").is_none(),
 		"modern discover must not create a legacy session"
 	);
-	let discover_body = discover.text().await.unwrap();
-	assert!(
-		discover_body.contains("server/discover") || discover_body.contains("method"),
-		"mixed old/new discover should surface an error that lets the client fall back, got {discover_body}"
-	);
+	let discover_body = read_response_message(discover).await;
+	assert_eq!(discover_body["error"]["code"], -32601, "{discover_body}");
 
 	let init = serde_json::json!({
 		"jsonrpc": "2.0",
@@ -3796,17 +3801,22 @@ async fn mock_modern_streamable_http_server() -> MockServer {
 }
 
 async fn mock_streamable_http_server_without_discover() -> MockServer {
-	mock_streamable_http_server_with_discover_versions(None).await
+	mock_streamable_http_server_with_discover_versions(None, false).await
+}
+
+async fn mock_streamable_http_server_rejecting_discover() -> MockServer {
+	mock_streamable_http_server_with_discover_versions(None, true).await
 }
 
 // Variant of `mock_modern_streamable_http_server` for tests that need custom upstream
 // `server/discover` versions.
 async fn mock_modern_streamable_http_server_with_versions(versions: &[&str]) -> MockServer {
-	mock_streamable_http_server_with_discover_versions(Some(versions)).await
+	mock_streamable_http_server_with_discover_versions(Some(versions), false).await
 }
 
 async fn mock_streamable_http_server_with_discover_versions(
 	versions: Option<&[&str]>,
+	reject_discover: bool,
 ) -> MockServer {
 	agent_core::telemetry::testing::setup_test_logging();
 	let (tx, rx) = tokio::sync::oneshot::channel();
@@ -3828,15 +3838,18 @@ async fn mock_streamable_http_server_with_discover_versions(
 				let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
 				let result = match method {
 					"server/discover" => {
+						if reject_discover {
+							return Err(http::StatusCode::BAD_REQUEST);
+						}
 						let Some(versions) = versions else {
-							return axum::Json(serde_json::json!({
+							return Ok(axum::Json(serde_json::json!({
 								"jsonrpc": "2.0",
 								"id": id,
 								"error": {
 									"code": -32601,
 									"message": method
 								}
-							}));
+							})));
 						};
 						serde_json::json!({
 							"resultType": "complete",
@@ -3876,21 +3889,21 @@ async fn mock_streamable_http_server_with_discover_versions(
 						}]
 					}),
 					_ => {
-						return axum::Json(serde_json::json!({
-							"jsonrpc": "2.0",
-							"id": id,
-							"error": {
-								"code": -32601,
-								"message": method
-							}
-						}));
+						return Ok(axum::Json(serde_json::json!({
+								"jsonrpc": "2.0",
+								"id": id,
+								"error": {
+									"code": -32601,
+									"message": method
+								}
+						})));
 					},
 				};
-				axum::Json(serde_json::json!({
+				Ok(axum::Json(serde_json::json!({
 					"jsonrpc": "2.0",
 					"id": id,
 					"result": result
-				}))
+				})))
 			}
 		}),
 	);
@@ -5870,6 +5883,7 @@ async fn test_runtime_fanout_fail_open() {
 		merge,
 		empty_cel(),
 		FailureMode::FailOpen,
+		false,
 	);
 
 	let res = ms.next().await;
@@ -5917,6 +5931,7 @@ async fn test_runtime_fanout_fail_open_skips_jsonrpc_error_frames() {
 		merge,
 		empty_cel(),
 		FailureMode::FailOpen,
+		false,
 	);
 
 	let res = ms.next().await;
@@ -5951,6 +5966,7 @@ async fn test_runtime_fanout_fail_open_all_fail() {
 		merge,
 		empty_cel(),
 		FailureMode::FailOpen,
+		false,
 	);
 
 	let res = ms.next().await;

--- a/crates/agentgateway/src/mcp/mergestream.rs
+++ b/crates/agentgateway/src/mcp/mergestream.rs
@@ -3,7 +3,7 @@ use futures_core::Stream;
 use futures_core::stream::BoxStream;
 use futures_util::StreamExt;
 use itertools::Itertools;
-use rmcp::model::{RequestId, ServerJsonRpcMessage, ServerResult};
+use rmcp::model::{ErrorCode, RequestId, ServerJsonRpcMessage, ServerResult};
 use tracing::warn;
 
 use crate::mcp::rbac::CelExecWrapper;
@@ -155,12 +155,21 @@ pub struct MergeStream {
 	// Present iff `merge` is; supplied to the merge fn for RBAC filtering.
 	cel: Option<CelExecWrapper>,
 	failure_mode: FailureMode,
+	// Discovery rejection is a compatibility signal that FailOpen must not hide.
+	fail_on_discovery_rejection: bool,
 	first_failure: Option<Result<ServerJsonRpcMessage, ClientError>>,
 }
 
 impl MergeStream {
 	pub fn new_without_merge(streams: Vec<(Strng, Messages)>, failure_mode: FailureMode) -> Self {
-		Self::new_internal(streams, RequestId::Number(0), None, None, failure_mode)
+		Self::new_internal(
+			streams,
+			RequestId::Number(0),
+			None,
+			None,
+			failure_mode,
+			false,
+		)
 	}
 	pub fn new(
 		streams: Vec<(Strng, Messages)>,
@@ -168,8 +177,16 @@ impl MergeStream {
 		merge: Box<MergeFn>,
 		cel: CelExecWrapper,
 		failure_mode: FailureMode,
+		fail_on_discovery_rejection: bool,
 	) -> Self {
-		Self::new_internal(streams, req_id, Some(merge), Some(cel), failure_mode)
+		Self::new_internal(
+			streams,
+			req_id,
+			Some(merge),
+			Some(cel),
+			failure_mode,
+			fail_on_discovery_rejection,
+		)
 	}
 	fn new_internal(
 		streams: Vec<(Strng, Messages)>,
@@ -177,6 +194,7 @@ impl MergeStream {
 		merge: Option<Box<MergeFn>>,
 		cel: Option<CelExecWrapper>,
 		failure_mode: FailureMode,
+		fail_on_discovery_rejection: bool,
 	) -> Self {
 		let terminal_messages = streams.iter().map(|_| None).collect::<Vec<_>>();
 		Self {
@@ -187,6 +205,7 @@ impl MergeStream {
 			merge,
 			cel,
 			failure_mode,
+			fail_on_discovery_rejection,
 			first_failure: None,
 		}
 	}
@@ -239,7 +258,12 @@ impl Stream for MergeStream {
 							// This stream is done, never look at it again
 						},
 						Ok(ServerJsonRpcMessage::Error(e)) => {
-							if self.failure_mode == FailureMode::FailOpen {
+							let discovery_rejection = self.fail_on_discovery_rejection
+								&& matches!(
+									e.error.code,
+									ErrorCode::METHOD_NOT_FOUND | ErrorCode::UNSUPPORTED_PROTOCOL_VERSION
+								);
+							if self.failure_mode == FailureMode::FailOpen && !discovery_rejection {
 								warn!(
 									"upstream JSON-RPC error, skipping (failure_mode=FailOpen): {:?}",
 									e

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -768,7 +768,24 @@ impl TestBind {
 		servers: Vec<(&str, SocketAddr, bool)>,
 		stateful: bool,
 	) -> Self {
-		self.with_multiplex_mcp_backend_policies(name, servers, stateful, vec![])
+		self.with_multiplex_mcp_backend_failure_mode(name, servers, stateful, FailureMode::FailClosed)
+	}
+
+	pub fn with_multiplex_mcp_backend_failure_mode(
+		self,
+		name: &str,
+		servers: Vec<(&str, SocketAddr, bool)>,
+		stateful: bool,
+		failure_mode: FailureMode,
+	) -> Self {
+		self.with_multiplex_mcp_backend_options(
+			name,
+			servers,
+			stateful,
+			vec![],
+			Default::default(),
+			failure_mode,
+		)
 	}
 
 	pub fn with_multiplex_mcp_backend_policies(
@@ -795,6 +812,25 @@ impl TestBind {
 		policies: Vec<BackendTrafficPolicy>,
 		prefix_mode: crate::types::agent::McpPrefixMode,
 	) -> Self {
+		self.with_multiplex_mcp_backend_options(
+			name,
+			servers,
+			stateful,
+			policies,
+			prefix_mode,
+			FailureMode::FailClosed,
+		)
+	}
+
+	fn with_multiplex_mcp_backend_options(
+		self,
+		name: &str,
+		servers: Vec<(&str, SocketAddr, bool)>,
+		stateful: bool,
+		policies: Vec<BackendTrafficPolicy>,
+		prefix_mode: crate::types::agent::McpPrefixMode,
+		failure_mode: FailureMode,
+	) -> Self {
 		let b = Backend::MCP(
 			ResourceName::new(name.into(), "".into()),
 			McpBackend {
@@ -820,7 +856,7 @@ impl TestBind {
 					.collect_vec(),
 				stateful,
 				prefix_mode,
-				failure_mode: FailureMode::FailClosed,
+				failure_mode,
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
 			},
 		);


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/3004

Without this, a MCP client that is legacy would return an error. With
failOpen, we would silently ignore this and not trigger the downgrade to
the older version.

Signed-off-by: John Howard <john.howard@solo.io>
