### PR TITLE
fix(llm): classify proxy errors by phase

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -2055,7 +2055,7 @@ impl AIProvider {
 		let (encoding, bytes) =
 			http::compression::to_bytes_with_decompression(body, ce.as_ref(), buffer_limit)
 				.await
-				.map_err(|e| map_compression_error(e, &parts.headers))?;
+				.map_err(|e| map_response_compression_error(e, &parts.headers))?;
 
 		// Snapshot decompressed bytes for CEL response.body access before re-compression,
 		// so maybe_buffer_response_body can skip decompression entirely.
@@ -2337,7 +2337,7 @@ impl AIProvider {
 		let body = dtrace::TracingBody::maybe_wrap("llm raw response", body, buffer);
 		let ce = parts.headers.typed_get::<ContentEncoding>();
 		let (body, decompressed_encoding) = http::compression::decompress_body(body, ce.as_ref())
-			.map_err(|e| map_compression_error(e, &parts.headers))?;
+			.map_err(|e| map_response_compression_error(e, &parts.headers))?;
 
 		// Strip encoding headers after successful decompression
 		if decompressed_encoding.is_some() {
@@ -2453,7 +2453,7 @@ impl AIProvider {
 			match http::compression::to_bytes_with_decompression(body, ce.as_ref(), buffer).await {
 				Ok(v) => v,
 				Err(http::compression::Error::LimitExceeded) => return Err(AIError::RequestTooLarge),
-				Err(e) => return Err(map_compression_error(e, &parts.headers)),
+				Err(e) => return Err(map_request_compression_error(e, &parts.headers)),
 			};
 		// Strip encoding headers now that the body is plaintext so downstream
 		// translation/marshalling and upstream forwarding see a consistent body.
@@ -2592,17 +2592,36 @@ fn bedrock_tool_name_map(req: &LLMRequest) -> Option<&conversion::bedrock::Bedro
 	}
 }
 
-fn map_compression_error(e: http::compression::Error, headers: &::http::HeaderMap) -> AIError {
+fn unsupported_encoding(headers: &::http::HeaderMap) -> AIError {
+	AIError::UnsupportedEncoding(strng::new(
+		headers
+			.get(header::CONTENT_ENCODING)
+			.and_then(|v| v.to_str().ok())
+			.unwrap_or("unknown"),
+	))
+}
+
+fn map_request_compression_error(
+	e: http::compression::Error,
+	headers: &::http::HeaderMap,
+) -> AIError {
 	match e {
-		http::compression::Error::UnsupportedEncoding => AIError::UnsupportedEncoding(strng::new(
-			headers
-				.get(header::CONTENT_ENCODING)
-				.and_then(|v| v.to_str().ok())
-				.unwrap_or("unknown"),
-		)),
+		http::compression::Error::UnsupportedEncoding => unsupported_encoding(headers),
 		http::compression::Error::LimitExceeded => AIError::ResponseTooLarge,
 		http::compression::Error::Io(e) => AIError::Encoding(axum_core::Error::new(e)),
 		http::compression::Error::Body(e) => AIError::Encoding(e),
+	}
+}
+
+fn map_response_compression_error(
+	e: http::compression::Error,
+	headers: &::http::HeaderMap,
+) -> AIError {
+	match e {
+		http::compression::Error::UnsupportedEncoding => unsupported_encoding(headers),
+		http::compression::Error::LimitExceeded => AIError::ResponseTooLarge,
+		http::compression::Error::Io(e) => AIError::ResponseDecoding(axum_core::Error::new(e)),
+		http::compression::Error::Body(e) => AIError::ResponseDecoding(e),
 	}
 }
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2351,7 +2351,7 @@ async fn make_backend_call(
 							&mut log,
 						))
 						.await
-						.map_err(ProxyError::AI)?,
+						.map_err(ProxyError::AIRequest)?,
 						RouteType::Messages => Box::pin(llm.provider.process_messages_request(
 							&backend_info,
 							llm_request_policies.llm.as_deref(),
@@ -2360,7 +2360,7 @@ async fn make_backend_call(
 							&mut log,
 						))
 						.await
-						.map_err(ProxyError::AI)?,
+						.map_err(ProxyError::AIRequest)?,
 						RouteType::Responses => Box::pin(llm.provider.process_responses_request(
 							&backend_info,
 							llm_request_policies.llm.as_deref(),
@@ -2369,7 +2369,7 @@ async fn make_backend_call(
 							&mut log,
 						))
 						.await
-						.map_err(ProxyError::AI)?,
+						.map_err(ProxyError::AIRequest)?,
 						RouteType::Embeddings => Box::pin(llm.provider.process_embeddings_request(
 							&backend_info,
 							llm_request_policies.llm.as_deref(),
@@ -2378,7 +2378,7 @@ async fn make_backend_call(
 							&mut log,
 						))
 						.await
-						.map_err(ProxyError::AI)?,
+						.map_err(ProxyError::AIRequest)?,
 						RouteType::Rerank => Box::pin(llm.provider.process_rerank_request(
 							&backend_info,
 							llm_request_policies.llm.as_deref(),
@@ -2387,7 +2387,7 @@ async fn make_backend_call(
 							&mut log,
 						))
 						.await
-						.map_err(ProxyError::AI)?,
+						.map_err(ProxyError::AIRequest)?,
 						RouteType::AnthropicTokenCount => Box::pin(llm.provider.process_count_tokens_request(
 							&backend_info,
 							req,
@@ -2395,7 +2395,7 @@ async fn make_backend_call(
 							&mut log,
 						))
 						.await
-						.map_err(ProxyError::AI)?,
+						.map_err(ProxyError::AIRequest)?,
 						RouteType::Detect => Box::pin(llm.provider.process_detect_request(
 							&backend_info,
 							llm_request_policies.llm.as_deref(),
@@ -2403,7 +2403,7 @@ async fn make_backend_call(
 							&mut log,
 						))
 						.await
-						.map_err(ProxyError::AI)?,
+						.map_err(ProxyError::AIRequest)?,
 						_ => unreachable!(),
 					};
 					let (mut req, llm_request, upstream_route_type) = match r {
@@ -2681,7 +2681,7 @@ async fn make_backend_call(
 				.assert_size::<{ 4 * 1024 }>(),
 		)
 		.await
-		.map_err(ProxyError::AI)?
+		.map_err(ProxyError::AIResponse)?
 	} else {
 		resp
 	};

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -54,12 +54,13 @@ impl ProxyResponse {
 			| ProxyError::MethodNotAllowed
 			| ProxyError::ProcessingString(_)
 			| ProxyError::Processing(_)
-			| ProxyError::AI(_)
 			| ProxyError::RouteCycleDetected
 			| ProxyError::Body(_)
 			| ProxyError::Http(_)
 			| ProxyError::BackendUnsupportedMirror
 			| ProxyError::FilterError(_) => ProxyResponseReason::Internal,
+			ProxyError::AIRequest(error) => classify_ai_request(error).reason,
+			ProxyError::AIResponse(error) => classify_ai_response(error).reason,
 			ProxyError::JwtAuthenticationFailure(_) => ProxyResponseReason::JwtAuth,
 			ProxyError::OidcFailure(_) => ProxyResponseReason::Oidc,
 			ProxyError::McpJwtAuthenticationFailure(_, _) => ProxyResponseReason::JwtAuth,
@@ -104,6 +105,8 @@ pub enum ProxyResponseReason {
 	NoHealthyBackend,
 	/// Some internal error in processing occurred
 	Internal,
+	/// The client supplied an invalid request
+	InvalidRequest,
 	/// JWT authentication failed
 	JwtAuth,
 	/// OIDC processing failed
@@ -196,8 +199,10 @@ pub enum ProxyError {
 	RequestTimeout,
 	#[error("processing failed: {0}")]
 	Processing(anyhow::Error),
-	#[error(transparent)]
-	AI(#[from] llm::AIError),
+	#[error("failed to process LLM request: {0}")]
+	AIRequest(llm::AIError),
+	#[error("failed to process LLM response: {0}")]
+	AIResponse(llm::AIError),
 	#[error("invalid http: {0}")]
 	Http(#[from] ::http::Error),
 	#[error("ext_proc failed: {0}")]
@@ -225,6 +230,85 @@ pub enum ProxyError {
 	UpgradeFailed(Option<HeaderValue>, Option<HeaderValue>),
 	#[error("mcp: {0}")]
 	MCP(mcp::Error),
+}
+
+struct AIErrorClassification {
+	status: StatusCode,
+	reason: ProxyResponseReason,
+}
+
+fn classify_ai_request(error: &llm::AIError) -> AIErrorClassification {
+	match error {
+		llm::AIError::MissingField(_)
+		| llm::AIError::MessageNotFound
+		| llm::AIError::StreamingUnsupported
+		| llm::AIError::UnsupportedModel
+		| llm::AIError::UnsupportedContent
+		| llm::AIError::UnsupportedConversion(_)
+		| llm::AIError::RequestParsing(_) => AIErrorClassification {
+			status: StatusCode::BAD_REQUEST,
+			reason: ProxyResponseReason::InvalidRequest,
+		},
+		llm::AIError::ModelNotFound => AIErrorClassification {
+			status: StatusCode::NOT_FOUND,
+			reason: ProxyResponseReason::InvalidRequest,
+		},
+		llm::AIError::RequestTooLarge => AIErrorClassification {
+			status: StatusCode::PAYLOAD_TOO_LARGE,
+			reason: ProxyResponseReason::InvalidRequest,
+		},
+		llm::AIError::UnsupportedEncoding(_) => AIErrorClassification {
+			status: StatusCode::UNSUPPORTED_MEDIA_TYPE,
+			reason: ProxyResponseReason::InvalidRequest,
+		},
+		llm::AIError::RequestMarshal(_)
+		| llm::AIError::ResponseParsing(_)
+		| llm::AIError::IncompleteResponse
+		| llm::AIError::InvalidResponse(_)
+		| llm::AIError::ResponseMarshal(_)
+		| llm::AIError::ResponseTooLarge
+		| llm::AIError::PromptWebhookError
+		| llm::AIError::ResponseDecoding(_)
+		| llm::AIError::Encoding(_)
+		| llm::AIError::JoinError(_) => AIErrorClassification {
+			status: StatusCode::SERVICE_UNAVAILABLE,
+			reason: ProxyResponseReason::Internal,
+		},
+	}
+}
+
+fn classify_ai_response(error: &llm::AIError) -> AIErrorClassification {
+	match error {
+		llm::AIError::ResponseParsing(_)
+		| llm::AIError::IncompleteResponse
+		| llm::AIError::InvalidResponse(_)
+		| llm::AIError::ResponseTooLarge
+		| llm::AIError::UnsupportedEncoding(_)
+		| llm::AIError::UnsupportedConversion(_)
+		| llm::AIError::UnsupportedContent
+		| llm::AIError::ResponseDecoding(_) => AIErrorClassification {
+			status: StatusCode::BAD_GATEWAY,
+			reason: ProxyResponseReason::UpstreamFailure,
+		},
+		llm::AIError::PromptWebhookError => AIErrorClassification {
+			status: StatusCode::SERVICE_UNAVAILABLE,
+			reason: ProxyResponseReason::Internal,
+		},
+		llm::AIError::MissingField(_)
+		| llm::AIError::ModelNotFound
+		| llm::AIError::MessageNotFound
+		| llm::AIError::StreamingUnsupported
+		| llm::AIError::UnsupportedModel
+		| llm::AIError::RequestTooLarge
+		| llm::AIError::RequestParsing(_)
+		| llm::AIError::RequestMarshal(_)
+		| llm::AIError::ResponseMarshal(_)
+		| llm::AIError::Encoding(_)
+		| llm::AIError::JoinError(_) => AIErrorClassification {
+			status: StatusCode::INTERNAL_SERVER_ERROR,
+			reason: ProxyResponseReason::Internal,
+		},
+	}
 }
 
 impl ProxyError {
@@ -293,27 +377,8 @@ impl ProxyError {
 
 			ProxyError::RequestTimeout => StatusCode::GATEWAY_TIMEOUT,
 			ProxyError::Processing(_) => StatusCode::SERVICE_UNAVAILABLE,
-			ProxyError::AI(ref error) => match error {
-				llm::AIError::MissingField(_)
-				| llm::AIError::MessageNotFound
-				| llm::AIError::StreamingUnsupported
-				| llm::AIError::UnsupportedModel
-				| llm::AIError::UnsupportedContent
-				| llm::AIError::UnsupportedConversion(_)
-				| llm::AIError::RequestParsing(_) => StatusCode::BAD_REQUEST,
-				llm::AIError::ModelNotFound => StatusCode::NOT_FOUND,
-				llm::AIError::RequestTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
-				llm::AIError::UnsupportedEncoding(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
-				llm::AIError::RequestMarshal(_)
-				| llm::AIError::ResponseParsing(_)
-				| llm::AIError::IncompleteResponse
-				| llm::AIError::InvalidResponse(_)
-				| llm::AIError::ResponseMarshal(_)
-				| llm::AIError::ResponseTooLarge
-				| llm::AIError::PromptWebhookError
-				| llm::AIError::Encoding(_)
-				| llm::AIError::JoinError(_) => StatusCode::SERVICE_UNAVAILABLE,
-			},
+			ProxyError::AIRequest(ref error) => classify_ai_request(error).status,
+			ProxyError::AIResponse(ref error) => classify_ai_response(error).status,
 			ProxyError::Http(_) => StatusCode::SERVICE_UNAVAILABLE,
 			ProxyError::Body(_) => StatusCode::SERVICE_UNAVAILABLE,
 			ProxyError::ProcessingString(_) => StatusCode::SERVICE_UNAVAILABLE,
@@ -552,6 +617,83 @@ pub fn resolve_simple_backend_with_policies(
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	fn assert_ai_error_mapping(
+		make_error: impl Fn() -> ProxyError,
+		expected_status: StatusCode,
+		expected_reason: ProxyResponseReason,
+	) {
+		assert_eq!(
+			ProxyResponse::Error(make_error()).as_reason(),
+			expected_reason
+		);
+		assert_eq!(
+			make_error().into_response_with_grpc(false).status(),
+			expected_status
+		);
+	}
+
+	#[test]
+	fn ai_error_status_and_reason_depend_on_processing_phase() {
+		assert_ai_error_mapping(
+			|| ProxyError::AIRequest(llm::AIError::UnsupportedEncoding("snappy".into())),
+			StatusCode::UNSUPPORTED_MEDIA_TYPE,
+			ProxyResponseReason::InvalidRequest,
+		);
+		assert_ai_error_mapping(
+			|| ProxyError::AIResponse(llm::AIError::UnsupportedEncoding("snappy".into())),
+			StatusCode::BAD_GATEWAY,
+			ProxyResponseReason::UpstreamFailure,
+		);
+		assert_ai_error_mapping(
+			|| ProxyError::AIRequest(llm::AIError::UnsupportedConversion("request".into())),
+			StatusCode::BAD_REQUEST,
+			ProxyResponseReason::InvalidRequest,
+		);
+		assert_ai_error_mapping(
+			|| ProxyError::AIResponse(llm::AIError::UnsupportedConversion("response".into())),
+			StatusCode::BAD_GATEWAY,
+			ProxyResponseReason::UpstreamFailure,
+		);
+		assert_ai_error_mapping(
+			|| ProxyError::AIRequest(llm::AIError::MessageNotFound),
+			StatusCode::BAD_REQUEST,
+			ProxyResponseReason::InvalidRequest,
+		);
+		assert_ai_error_mapping(
+			|| ProxyError::AIResponse(llm::AIError::MessageNotFound),
+			StatusCode::INTERNAL_SERVER_ERROR,
+			ProxyResponseReason::Internal,
+		);
+		assert_ai_error_mapping(
+			|| ProxyError::AIRequest(llm::AIError::StreamingUnsupported),
+			StatusCode::BAD_REQUEST,
+			ProxyResponseReason::InvalidRequest,
+		);
+		assert_ai_error_mapping(
+			|| ProxyError::AIResponse(llm::AIError::StreamingUnsupported),
+			StatusCode::INTERNAL_SERVER_ERROR,
+			ProxyResponseReason::Internal,
+		);
+		assert_ai_error_mapping(
+			|| {
+				ProxyError::AIResponse(llm::AIError::ResponseDecoding(axum_core::Error::new(
+					std::io::Error::other("decode"),
+				)))
+			},
+			StatusCode::BAD_GATEWAY,
+			ProxyResponseReason::UpstreamFailure,
+		);
+		assert_ai_error_mapping(
+			|| {
+				ProxyError::AIResponse(llm::AIError::Encoding(axum_core::Error::new(
+					std::io::Error::other("encode"),
+				)))
+			},
+			StatusCode::INTERNAL_SERVER_ERROR,
+			ProxyResponseReason::Internal,
+		);
+	}
 
 	#[test]
 	fn grpc_error_response_maps_http_status_to_grpc_status() {

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -708,6 +708,49 @@ async fn llm_custom_provider_rejects_unsupported_format_before_upstream_call() {
 	assert_eq!(requests.len(), 0);
 }
 
+#[tokio::test]
+async fn llm_rejects_unsupported_request_encoding_as_client_error() {
+	let mock = body_mock(include_bytes!(
+		"../../../llm/src/tests/response/completions/basic.json"
+	))
+	.await;
+	let (mock, _bind, io) =
+		setup_custom_llm_provider_backend_mock(mock, vec![custom::ProviderFormat::Completions]);
+
+	let res = send_completions_with_model(
+		io,
+		"replaceme",
+		&[(header::CONTENT_ENCODING.as_str(), "snappy")],
+	)
+	.await;
+	assert_eq!(res.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 0);
+}
+
+#[tokio::test]
+async fn llm_maps_unsupported_upstream_response_encoding_to_bad_gateway() {
+	let response_body = include_bytes!("../../../llm/src/tests/response/completions/basic.json");
+	let mock = MockServer::start().await;
+	Mock::given(wiremock::matchers::path_regex("/.*"))
+		.respond_with(
+			ResponseTemplate::new(StatusCode::OK.as_u16())
+				.insert_header(header::CONTENT_ENCODING.as_str(), "snappy")
+				.set_body_raw(response_body, "application/json"),
+		)
+		.mount(&mock)
+		.await;
+	let (_mock, _bind, io) =
+		setup_custom_llm_provider_backend_mock(mock, vec![custom::ProviderFormat::Completions]);
+
+	let res = send_completions_with_model(io, "replaceme", &[]).await;
+	assert_eq!(res.status(), StatusCode::BAD_GATEWAY);
+}
+
 async fn recv_rate_limit_request(
 	requests: &mut mpsc::UnboundedReceiver<
 		agentgateway::http::remoteratelimit::proto::RateLimitRequest,

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -407,6 +407,8 @@ pub enum AIError {
 	ResponseMarshal(serde_json::Error),
 	#[error("unsupported content encoding: {0}")]
 	UnsupportedEncoding(Strng),
+	#[error("failed to decode response: {0}")]
+	ResponseDecoding(axum_core::Error),
 	#[error("failed to encode response: {0}")]
 	Encoding(axum_core::Error),
 	#[error("error computing tokens")]


### PR DESCRIPTION
Fixes #2854

## What

Preserves whether an `AIError` occurred while processing the client request or the upstream response.

- Splits `ProxyError::AI` into `AIRequest` and `AIResponse`
- Classifies HTTP Status and telemetry reason by both error type and processing phase
- Keeps client errors in the appropriate 4xx class
- Maps malformed or unsupported upstream responses to `502 Bad Gateway`
- Distinguishes upstream response decoding failures from gateway response encoding failures
- Adds `InvalidRequest` observability classification
- Defines phase-specific behavior for ambiguous errors, including `MessageNotFound` and `StreamingUnsupported`

Key behavior:
- Request `UnsupportedEncoding` → 415
- Response `UnsupportedEncoding` → 502
- Request `UnsupportedConversion` → 400
- Response `UnsupportedConversion` → 502
- Response decoding failure → 502 / `UpstreamFailure`
- Gateway response encoding failure → 500 / `Internal`

## Testing

Added focused phase-classification tests and integration coverage for unsupported request and upstream response encodings.

Validated with focused units, LLM integration tests, and Clippy.

### AI assistance
I used non-trivial AI assistance while implementing and testing this change. I reviewed and verified the resulting code, understand the changes, and take full ownership of the contribution.
