### PR TITLE
fix: reconcile listener port swaps dynamically

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -136,18 +136,28 @@ pub struct Gateway {
 }
 
 enum ActiveBind {
-	Task(AbortHandle),
-	PerCore(watch::Sender<()>),
+	Task(AbortHandle, watch::Sender<Arc<crate::types::agent::Bind>>),
+	PerCore(
+		watch::Sender<()>,
+		watch::Sender<Arc<crate::types::agent::Bind>>,
+	),
 }
 
 impl ActiveBind {
 	fn stop(self) {
 		match self {
-			Self::Task(handle) => handle.abort(),
-			Self::PerCore(stop) => {
+			Self::Task(handle, _) => handle.abort(),
+			Self::PerCore(stop, _) => {
 				let _ = stop.send(());
 			},
 		}
+	}
+
+	fn update(&self, bind: crate::types::agent::Bind) {
+		let config = match self {
+			Self::Task(_, config) | Self::PerCore(_, config) => config,
+		};
+		config.send_replace(Arc::new(bind));
 	}
 }
 
@@ -168,6 +178,12 @@ impl Gateway {
 		let mut handle_bind = |js: &mut JoinSet<anyhow::Result<()>>, b: BindEvent| {
 			let (bind_key, bind, listeners) = match b {
 				BindEvent::Add(bind, listeners) => (bind.key.clone(), bind, listeners),
+				BindEvent::Update(bind) => {
+					if let Some(active) = active.get(&bind.key) {
+						active.update(bind);
+					}
+					return;
+				},
 				BindEvent::Remove(bind_key) => {
 					if let Some(h) = active.remove(&bind_key) {
 						h.stop();
@@ -178,22 +194,23 @@ impl Gateway {
 			if let Some(h) = active.remove(&bind_key) {
 				h.stop();
 			}
+			let (config, config_rx) = watch::channel(Arc::new(bind));
 
-			debug!("add bind {}", bind.address);
+			debug!("add bind {}", config.borrow().address);
 			match listeners {
 				BindListeners::Single(listener) => {
 					let task = js.spawn(
-						Self::run_bind(self.pi.clone(), subdrain.clone(), Arc::new(bind), listener)
+						Self::run_bind(self.pi.clone(), subdrain.clone(), config_rx, listener)
 							.in_current_span(),
 					);
-					active.insert(bind_key, ActiveBind::Task(task));
+					active.insert(bind_key, ActiveBind::Task(task, config));
 				},
 				BindListeners::PerCore(listeners) => {
 					let (stop, stop_rx) = watch::channel(());
 					for (core_id, listener) in listeners {
 						let subdrain = subdrain.clone();
 						let pi = self.pi.clone();
-						let bind = bind.clone();
+						let config_rx = config_rx.clone();
 						let mut stop_rx = stop_rx.clone();
 						std::thread::spawn(move || {
 							let res = core_affinity::set_for_current(core_id);
@@ -207,13 +224,13 @@ impl Gateway {
 								.block_on(async {
 									tokio::select! {
 										_ = stop_rx.changed() => {},
-										_ = Self::run_bind(pi, subdrain, Arc::new(bind), listener)
+										_ = Self::run_bind(pi, subdrain, config_rx, listener)
 											.in_current_span() => {},
 									}
 								})
 						});
 					}
-					active.insert(bind_key, ActiveBind::PerCore(stop));
+					active.insert(bind_key, ActiveBind::PerCore(stop, config));
 				},
 			}
 		};
@@ -242,14 +259,12 @@ impl Gateway {
 	pub(super) async fn run_bind(
 		pi: Arc<ProxyInputs>,
 		drain: DrainWatcher,
-		bind: Arc<crate::types::agent::Bind>,
+		bind_config: watch::Receiver<Arc<crate::types::agent::Bind>>,
 		listener: std::net::TcpListener,
 	) -> anyhow::Result<()> {
 		let min_deadline = pi.cfg.termination_min_deadline;
 		let max_deadline = pi.cfg.termination_max_deadline;
-		let name = bind.key.clone();
-		let bind_protocol = bind.protocol;
-		let tunnel_protocol = bind.tunnel_protocol;
+		let name = bind_config.borrow().key.clone();
 		let pi = if pi.cfg.threading_mode == crate::ThreadingMode::ThreadPerCore {
 			let mut pi = Arc::unwrap_or_clone(pi);
 			let client = client::Client::new(
@@ -301,14 +316,16 @@ impl Gateway {
 				let start = Instant::now();
 				let mut force_shutdown = force_shutdown.clone();
 				let name = name.clone();
+				let bind_config = bind_config.clone();
 				tokio::spawn(telemetry::connection_scope(async move {
+					let bind = bind_config.borrow().clone();
 					debug!(bind=?name, "connection started");
 					tokio::select! {
 						// We took too long; shutdown now.
 						_ = force_shutdown.changed() => {
 							info!(bind=?name, "connection forcefully terminated");
 						}
-						_ = Self::handle_tunnel(name.clone(), bind_protocol, tunnel_protocol, stream, pi, drain) => {}
+						_ = Self::handle_tunnel(name.clone(), bind.protocol, bind.tunnel_protocol, stream, pi, drain) => {}
 					}
 					debug!(bind=?name, dur=?start.elapsed(), "connection completed");
 				}));

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1261,7 +1261,7 @@ impl HTTPProxy {
 
 	fn detect_misdirected(
 		log: &RequestLog,
-		bind: &Bind,
+		bind: &BindSnapshot,
 		req: &Request,
 		selected_listener: &Listener,
 	) -> Result<(), ProxyError> {
@@ -4359,19 +4359,21 @@ mod route_chain_tests {
 			.unwrap()
 	}
 
-	fn bind() -> Bind {
-		Bind {
-			key: proxymock::BIND_KEY,
-			address: "127.0.0.1:0".parse().unwrap(),
-			listeners: ListenerSet::from_list([Listener {
+	fn bind() -> BindSnapshot {
+		BindSnapshot {
+			bind: Arc::new(Bind {
+				key: proxymock::BIND_KEY,
+				address: "127.0.0.1:0".parse().unwrap(),
+				protocol: BindProtocol::http,
+				tunnel_protocol: Default::default(),
+				mode: Default::default(),
+			}),
+			listeners: Arc::new(ListenerSet::from_list([Listener {
 				key: proxymock::LISTENER_KEY,
 				name: Default::default(),
 				hostname: Default::default(),
 				protocol: ListenerProtocol::HTTP,
-			}]),
-			protocol: BindProtocol::http,
-			tunnel_protocol: Default::default(),
-			mode: Default::default(),
+			}])),
 		}
 	}
 

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -24,10 +24,10 @@ use crate::proxy::httpproxy::PolicyClient;
 use crate::store::{BackendPolicy, HasExpressions, PolicyExpressions, RequestPolicy};
 use crate::types::agent::{
 	A2aPolicy, Backend, BackendKey, BackendTargetRef, BackendTrafficPolicy, BackendWithPolicies,
-	Bind, BindKey, FrontendPolicy, JwtAuthentication, Listener, ListenerKey, ListenerName,
-	McpAuthentication, PolicyInheritance, PolicyKey, PolicyTarget, Route, RouteBackendReference,
-	RouteGroupKey, RouteKey, RouteMatch, RouteName, RouteSet, TCPRoute, TCPRouteSet, TargetedPolicy,
-	TrafficPolicy,
+	Bind, BindKey, BindSnapshot, FrontendPolicy, JwtAuthentication, Listener, ListenerKey,
+	ListenerName, ListenerSet, McpAuthentication, PolicyInheritance, PolicyKey, PolicyTarget, Route,
+	RouteBackendReference, RouteGroupKey, RouteKey, RouteMatch, RouteName, RouteSet, TCPRoute,
+	TCPRouteSet, TargetedPolicy, TrafficPolicy,
 };
 use crate::types::agent_xds::Diagnostics;
 use crate::types::discovery::NamespacedHostname;
@@ -102,8 +102,7 @@ pub struct Store {
 	model_routes: HashMap<RouteKey, (ListenerKey, agent::ModelRoute)>,
 	model_routers: HashMap<RouteKey, BackendKey>,
 
-	// Listeners we got before a Bind arrived
-	pending_listeners: HashMap<BindKey, HashMap<ListenerKey, Listener>>,
+	listeners: HashMap<BindKey, Arc<ListenerSet>>,
 	http_routes: HbHashMap<RouteTarget, Arc<RouteSet>>,
 	tcp_routes: HbHashMap<RouteTarget, Arc<TCPRouteSet>>,
 	listener_change_tx: watch::Sender<u64>,
@@ -116,6 +115,7 @@ pub struct Store {
 #[derive(Debug)]
 pub enum BindEvent {
 	Add(Bind, BindListeners),
+	Update(Bind),
 	Remove(BindKey),
 }
 
@@ -659,7 +659,7 @@ impl Store {
 			backends: Default::default(),
 			model_routes: Default::default(),
 			model_routers: Default::default(),
-			pending_listeners: Default::default(),
+			listeners: Default::default(),
 			http_routes: Default::default(),
 			tcp_routes: Default::default(),
 			listener_change_tx,
@@ -704,9 +704,9 @@ impl Store {
 
 	pub fn get_bind_listener(&self, bind: &BindKey, listener: &ListenerKey) -> Option<Arc<Listener>> {
 		self
-			.binds
+			.listeners
 			.get(bind)
-			.and_then(|bind| bind.listeners.inner.get(listener).cloned())
+			.and_then(|listeners| listeners.inner.get(listener).cloned())
 	}
 
 	fn notify_listener_changed(&self) {
@@ -715,26 +715,12 @@ impl Store {
 			.send_modify(|epoch| *epoch = epoch.saturating_add(1));
 	}
 
-	fn bind_listener_changed(old: &Bind, new: &Bind) -> bool {
-		for new_listener in new.listeners.iter() {
-			let Some(old_listener) = old.listeners.get(&new_listener.key) else {
-				// If a new listener is added, no need to notify
-				continue;
-			};
-			if old_listener != new_listener {
-				return true;
-			}
-		}
-		for old_listener in old.listeners.iter() {
-			let Some(new_listener) = new.listeners.get(&old_listener.key) else {
-				// If an old listener is removed, we do need to notify!
-				return true;
-			};
-			if old_listener != new_listener {
-				return true;
-			}
-		}
-		false
+	fn serving_listener_changed(old: &ListenerSet, new: &ListenerSet) -> bool {
+		new.iter().any(|listener| {
+			old
+				.get(&listener.key)
+				.is_some_and(|old_listener| old_listener != listener)
+		}) || old.iter().any(|listener| !new.contains(&listener.key))
 	}
 
 	fn insert_http_route_target(&mut self, target: RouteTarget, route: Route) {
@@ -892,16 +878,6 @@ impl Store {
 		debug!(bind=%bind.key, "insert bind");
 		let old_bind = self.binds.get(&key).cloned();
 
-		for (_, listener) in self
-			.pending_listeners
-			.remove(&bind.key)
-			.into_iter()
-			.flatten()
-		{
-			debug!("adding pending listener {} to {}", listener.key, bind.key);
-			bind.listeners.insert(listener);
-		}
-
 		// Capture (rather than swallow) any OS bind failure so callers can decide whether it
 		// is fatal. The bind is still recorded below so routing lookups (find_bind, etc.)
 		// remain consistent regardless of the caller's error handling.
@@ -916,6 +892,12 @@ impl Store {
 		let address_changed = old_bind
 			.as_deref()
 			.is_some_and(|old| old.address != bind.address);
+		let active_config_changed = old_bind.as_deref().is_some_and(|old| {
+			old.mode == agent::BindMode::Standard
+				&& bind.mode == agent::BindMode::Standard
+				&& !address_changed
+				&& old != &bind
+		});
 
 		// A bind's key is stable across mode changes. Explicitly stop the accept loop when
 		// an existing bind becomes internal; merely replacing the stored Bind leaves the
@@ -951,14 +933,11 @@ impl Store {
 				},
 			}
 		};
-		if let Some(old_bind) = old_bind.as_deref()
-			&& Self::bind_listener_changed(old_bind, &bind)
-		{
-			self.notify_listener_changed();
-		}
 		self.binds.insert(key.clone(), Arc::new(bind.clone()));
 		if let Some(listeners) = listeners {
 			let _ = self.tx.send(BindEvent::Add(bind, listeners));
+		} else if active_config_changed {
+			let _ = self.tx.send(BindEvent::Update(bind));
 		}
 		if let Some(err) = bind_error {
 			return Err(err.context(format!("bind {key}")));
@@ -1465,11 +1444,16 @@ impl Store {
 	pub fn all_access_log_policies(&self) -> Vec<Arc<crate::types::agent::AccessLogPolicy>> {
 		self
 			.binds
-			.values()
-			.flat_map(|bind| {
-				bind.listeners.iter().map(|listener| {
-					self.listener_frontend_policies(&listener.name, Some(bind.address.port()), None)
-				})
+			.iter()
+			.flat_map(|(bind_key, bind)| {
+				self
+					.listeners
+					.get(bind_key)
+					.into_iter()
+					.flat_map(|listeners| listeners.iter())
+					.map(|listener| {
+						self.listener_frontend_policies(&listener.name, Some(bind.address.port()), None)
+					})
 			})
 			.filter_map(|fp| fp.access_log_otlp)
 			.unique_by(|p| Arc::as_ptr(p) as usize)
@@ -1552,8 +1536,17 @@ impl Store {
 		pol
 	}
 
-	pub fn bind(&self, bind: &BindKey) -> Option<Arc<Bind>> {
-		self.binds.get(bind).cloned()
+	fn bind_snapshot(&self, bind: Arc<Bind>) -> BindSnapshot {
+		let listeners = self.listeners.get(&bind.key).cloned().unwrap_or_default();
+		BindSnapshot { bind, listeners }
+	}
+
+	pub fn bind(&self, bind: &BindKey) -> Option<BindSnapshot> {
+		self
+			.binds
+			.get(bind)
+			.cloned()
+			.map(|bind| self.bind_snapshot(bind))
 	}
 
 	pub fn bind_addresses(&self) -> Vec<std::net::SocketAddr> {
@@ -1562,7 +1555,7 @@ impl Store {
 
 	/// find_bind looks up a bind by address. Typically, this is done by the kernel for us, but in some cases
 	/// we do userspace routing to a bind.
-	pub fn find_bind(&self, want: SocketAddr) -> Option<Arc<Bind>> {
+	pub fn find_bind(&self, want: SocketAddr) -> Option<BindSnapshot> {
 		self
 			.binds
 			.values()
@@ -1575,6 +1568,7 @@ impl Store {
 				}
 			})
 			.cloned()
+			.map(|bind| self.bind_snapshot(bind))
 	}
 
 	/// Finds a wildcard-address bind by port.
@@ -1582,12 +1576,13 @@ impl Store {
 	/// This is used when a CONNECT authority contains a hostname rather than an IP address. Since
 	/// the hostname is not resolved here, it must not be allowed to select a bind scoped to a
 	/// concrete address (for example, a loopback-only listener) merely because the ports match.
-	pub fn find_bind_by_port(&self, port: u16) -> Option<Arc<Bind>> {
+	pub fn find_bind_by_port(&self, port: u16) -> Option<BindSnapshot> {
 		self
 			.binds
 			.values()
 			.find(|b| b.address.ip().is_unspecified() && b.address.port() == port)
 			.cloned()
+			.map(|bind| self.bind_snapshot(bind))
 	}
 
 	/// find_wildcard_bind returns the internal wildcard bind, if one is configured. This is the
@@ -1597,13 +1592,14 @@ impl Store {
 	/// Local config enforces at most one wildcard bind, but other sources (e.g. XDS) could supply
 	/// several. Select the lowest key so the choice is deterministic rather than dependent on
 	/// HashMap iteration order.
-	pub fn find_wildcard_bind(&self) -> Option<Arc<Bind>> {
+	pub fn find_wildcard_bind(&self) -> Option<BindSnapshot> {
 		self
 			.binds
 			.values()
 			.filter(|b| b.is_wildcard())
 			.min_by(|a, b| a.key.cmp(&b.key))
 			.cloned()
+			.map(|bind| self.bind_snapshot(bind))
 	}
 
 	pub fn all_policies(&self) -> Vec<Arc<TargetedPolicy>> {
@@ -1654,20 +1650,16 @@ impl Store {
         fields(listener),
     )]
 	pub fn remove_listener(&mut self, listener: ListenerKey) {
-		let Some((bind_key, bind)) = self.binds.iter().find_map(|(bind_key, bind)| {
-			bind
-				.listeners
-				.contains(&listener)
-				.then(|| (bind_key.clone(), bind.clone()))
-		}) else {
-			return;
-		};
-		let mut bind = Arc::unwrap_or_clone(bind);
-		bind.listeners.remove(&listener);
-		// Removing a listener never opens a new socket (the bind already exists), so this
-		// cannot fail on bind; log defensively rather than propagate.
-		if let Err(err) = self.upsert_bind(bind_key, bind) {
-			warn!(error=%err, "failed to update bind after listener removal");
+		let binds = &self.binds;
+		let mut serving_listener_changed = false;
+		self.listeners.retain(|bind_key, listeners| {
+			if Arc::make_mut(listeners).remove(&listener).is_some() && binds.contains_key(bind_key) {
+				serving_listener_changed = true;
+			}
+			!listeners.inner.is_empty()
+		});
+		if serving_listener_changed {
+			self.notify_listener_changed();
 		}
 	}
 
@@ -1754,6 +1746,7 @@ impl Store {
     )]
 	pub fn insert_bind(&mut self, bind: Bind) {
 		let key = bind.key.clone();
+		self.listeners.entry(key.clone()).or_default();
 		// XDS-delivered binds must not crash the proxy on a bind failure: a bad dynamic config
 		// should be rejected/logged, not fatal. Static local config uses `sync_local`, which
 		// surfaces the error so startup can exit(1) (see issue #87).
@@ -1789,20 +1782,29 @@ impl Store {
 
 	pub fn insert_listener(&mut self, lis: Listener, bind_name: BindKey) {
 		debug!(listener=%lis.key,bind=%bind_name, "insert listener");
-		if let Some(b) = self.binds.get(&bind_name) {
-			let mut bind = Arc::unwrap_or_clone(b.clone());
-			bind.listeners.remove(&lis.key);
-			bind.listeners.insert(lis);
-			if let Err(err) = self.upsert_bind(bind_name.clone(), bind) {
-				warn!(bind=%bind_name, error=%err, "failed to start bind listener");
+		let listener_key = lis.key.clone();
+		let binds = &self.binds;
+		let mut serving_listener_changed = false;
+		self.listeners.retain(|key, listeners| {
+			if *key != bind_name
+				&& Arc::make_mut(listeners).remove(&listener_key).is_some()
+				&& binds.contains_key(key)
+			{
+				serving_listener_changed = true;
 			}
-		} else {
-			debug!("no bind found, keeping listener pending");
-			self
-				.pending_listeners
-				.entry(bind_name)
-				.or_default()
-				.insert(lis.key.clone(), lis);
+			!listeners.inner.is_empty()
+		});
+		let listeners = self.listeners.entry(bind_name.clone()).or_default();
+		if listeners
+			.get(&listener_key)
+			.is_some_and(|current| current != &lis)
+			&& self.binds.contains_key(&bind_name)
+		{
+			serving_listener_changed = true;
+		}
+		Arc::make_mut(listeners).insert(lis);
+		if serving_listener_changed {
+			self.notify_listener_changed();
 		}
 	}
 
@@ -1951,13 +1953,7 @@ impl Store {
 	}
 
 	fn insert_xds_bind(&mut self, raw: XdsBind, diagnostics: &mut Diagnostics) -> anyhow::Result<()> {
-		let mut bind = Bind::from_xds(&raw, self.ipv6_enabled, diagnostics)?;
-		// If XDS server pushes the same bind twice (which it shouldn't really do, but oh well),
-		// we need to copy the listeners over.
-		if let Some(old) = self.binds.get(&bind.key) {
-			debug!("bind update, copy old listeners over");
-			bind.listeners = Arc::unwrap_or_clone(old.clone()).listeners;
-		}
+		let bind = Bind::from_xds(&raw, self.ipv6_enabled, diagnostics)?;
 		self.insert_bind(bind);
 		Ok(())
 	}
@@ -2116,11 +2112,13 @@ impl StoreUpdater {
 			.binds
 			.iter()
 			.sorted_by_key(|k| k.0)
-			.map(|(_, bind)| DumpBind {
+			.map(|(bind_key, bind)| DumpBind {
 				bind: bind.clone(),
-				listeners: bind
+				listeners: store
 					.listeners
-					.iter()
+					.get(bind_key)
+					.into_iter()
+					.flat_map(|listeners| listeners.iter())
 					.map(|listener| {
 						(
 							listener.key.clone(),
@@ -2193,7 +2191,7 @@ impl StoreUpdater {
 	#[allow(clippy::too_many_arguments)]
 	pub fn sync_local(
 		&self,
-		binds: Vec<Bind>,
+		binds: Vec<BindSnapshot>,
 		listener_routes: Vec<(ListenerKey, Vec<Route>)>,
 		listener_tcp_routes: Vec<(ListenerKey, Vec<TCPRoute>)>,
 		policies: Vec<TargetedPolicy>,
@@ -2223,11 +2221,21 @@ impl StoreUpdater {
 		// not re-opened, and a reload that adds a new port after startup must not silently
 		// serve nothing on that bind (issue #87).
 		let mut bind_errors = Vec::new();
-		for b in binds {
+		for snapshot in binds {
+			let BindSnapshot { bind, listeners } = snapshot;
+			let b = Arc::unwrap_or_clone(bind);
 			let is_new_bind = !prev_bind_keys.contains(&b.key);
 			old_binds.remove(&b.key);
 			next_state.binds.insert(b.key.clone());
 			let key = b.key.clone();
+			let listener_changed = s
+				.listeners
+				.get(&key)
+				.is_some_and(|old| Store::serving_listener_changed(old, &listeners));
+			s.listeners.insert(key.clone(), listeners);
+			if listener_changed && s.binds.contains_key(&key) {
+				s.notify_listener_changed();
+			}
 			if let Err(err) = s.upsert_bind(key, b)
 				&& is_new_bind
 			{
@@ -2267,6 +2275,7 @@ impl StoreUpdater {
 			}
 		}
 		for remaining_bind in old_binds {
+			s.listeners.remove(&remaining_bind);
 			s.remove_bind(remaining_bind);
 		}
 		for remaining_route in old_routes {
@@ -2394,7 +2403,6 @@ mod tests {
 			protocol: BindProtocol::http,
 			tunnel_protocol: TunnelProtocol::Direct,
 			mode: agent::BindMode::Standard,
-			listeners: ListenerSet::default(),
 		};
 
 		store.insert_bind(bind.clone());
@@ -2429,6 +2437,150 @@ mod tests {
 			matches!(events.next().await, Some(BindEvent::Add(updated, _)) if updated.address == bind.address),
 			"changing a standard bind's address should open its new listener"
 		);
+	}
+
+	#[test]
+	fn moving_listener_before_binds_arrive_keeps_only_latest_assignment() {
+		let listener_key = strng::literal!("gw.http");
+		let listener = Listener {
+			key: listener_key.clone(),
+			name: ListenerName {
+				gateway_name: strng::literal!("gw"),
+				gateway_namespace: strng::literal!("ns"),
+				listener_name: strng::literal!("http"),
+				listener_set: None,
+			},
+			hostname: strng::EMPTY,
+			protocol: ListenerProtocol::HTTP,
+		};
+		let old_bind = strng::literal!("8080/ns/gw");
+		let new_bind = strng::literal!("8443/ns/gw");
+		let mut store = Store::with_ipv6_enabled(true);
+
+		store.insert_listener(listener.clone(), old_bind.clone());
+		store.insert_listener(listener, new_bind.clone());
+		store.insert_bind(Bind {
+			key: old_bind.clone(),
+			address: "[::]:8080".parse().unwrap(),
+			protocol: BindProtocol::http,
+			tunnel_protocol: TunnelProtocol::Direct,
+			mode: agent::BindMode::Internal,
+		});
+		store.insert_bind(Bind {
+			key: new_bind.clone(),
+			address: "[::]:8443".parse().unwrap(),
+			protocol: BindProtocol::http,
+			tunnel_protocol: TunnelProtocol::Direct,
+			mode: agent::BindMode::Internal,
+		});
+
+		assert!(
+			!store
+				.bind(&old_bind)
+				.unwrap()
+				.listeners
+				.contains(&listener_key)
+		);
+		assert!(
+			store
+				.bind(&new_bind)
+				.unwrap()
+				.listeners
+				.contains(&listener_key)
+		);
+	}
+
+	#[tokio::test]
+	async fn swapping_listener_ports_updates_bind_protocols_and_assignments() {
+		let first_probe = StdTcpListener::bind("127.0.0.1:0").expect("reserve an available port");
+		let first_address = first_probe.local_addr().expect("probe has an address");
+		let second_probe = StdTcpListener::bind("127.0.0.1:0").expect("reserve an available port");
+		let second_address = second_probe.local_addr().expect("probe has an address");
+		drop((first_probe, second_probe));
+
+		let http_key = strng::literal!("gw.http");
+		let tls_key = strng::literal!("gw.https-public");
+		let http_listener = Listener {
+			key: http_key.clone(),
+			name: ListenerName {
+				gateway_name: strng::literal!("gw"),
+				gateway_namespace: strng::literal!("ns"),
+				listener_name: strng::literal!("http"),
+				listener_set: None,
+			},
+			hostname: strng::EMPTY,
+			protocol: ListenerProtocol::HTTP,
+		};
+		let tls_listener = Listener {
+			key: tls_key.clone(),
+			name: ListenerName {
+				gateway_name: strng::literal!("gw"),
+				gateway_namespace: strng::literal!("ns"),
+				listener_name: strng::literal!("https-public"),
+				listener_set: None,
+			},
+			hostname: strng::EMPTY,
+			protocol: ListenerProtocol::TLS(None),
+		};
+		let bind_8080 = strng::literal!("8080/ns/gw");
+		let bind_8443 = strng::literal!("8443/ns/gw");
+		let mut store = Store::with_ipv6_enabled(true);
+		let mut events = store.subscribe();
+
+		let mut first_bind = Bind {
+			key: bind_8080.clone(),
+			address: first_address,
+			protocol: BindProtocol::http,
+			tunnel_protocol: TunnelProtocol::Direct,
+			mode: agent::BindMode::Standard,
+		};
+		let mut second_bind = Bind {
+			key: bind_8443.clone(),
+			address: second_address,
+			protocol: BindProtocol::tls,
+			tunnel_protocol: TunnelProtocol::Direct,
+			mode: agent::BindMode::Standard,
+		};
+
+		store.insert_bind(first_bind.clone());
+		assert!(matches!(events.next().await, Some(BindEvent::Add(_, _))));
+		store.insert_bind(second_bind.clone());
+		assert!(matches!(events.next().await, Some(BindEvent::Add(_, _))));
+		store.insert_listener(http_listener.clone(), bind_8080.clone());
+		store.insert_listener(tls_listener.clone(), bind_8443.clone());
+
+		// Both bind resources still exist during a port swap, so xDS updates the
+		// protocols and listeners in place rather than deleting either old bind first.
+		first_bind.protocol = BindProtocol::tls;
+		store.insert_bind(first_bind);
+		assert!(
+			matches!(events.next().await, Some(BindEvent::Update(updated)) if updated.key == bind_8080 && updated.protocol == BindProtocol::tls),
+			"the existing accept loop must receive the new TLS protocol"
+		);
+		second_bind.protocol = BindProtocol::http;
+		store.insert_bind(second_bind);
+		assert!(
+			matches!(events.next().await, Some(BindEvent::Update(updated)) if updated.key == bind_8443 && updated.protocol == BindProtocol::http),
+			"the existing accept loop must receive the new HTTP protocol"
+		);
+		store.insert_listener(http_listener, bind_8443.clone());
+		store.insert_listener(tls_listener, bind_8080.clone());
+
+		let bind_8080 = store.bind(&bind_8080).unwrap();
+		assert_eq!(
+			bind_8080.listeners.inner.len(),
+			1,
+			"the old HTTP listener must be removed when it moves to another bind"
+		);
+		assert!(bind_8080.listeners.contains(&tls_key));
+
+		let bind_8443 = store.bind(&bind_8443).unwrap();
+		assert_eq!(
+			bind_8443.listeners.inner.len(),
+			1,
+			"the old TLS listener must be removed when it moves to another bind"
+		);
+		assert!(bind_8443.listeners.contains(&http_key));
 	}
 
 	fn route(name: &'static str, namespace: &'static str, kind: Option<&'static str>) -> RouteName {
@@ -2916,13 +3068,15 @@ mod tests {
 	#[test]
 	fn dump_includes_listener_routes() {
 		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(true))));
-		let bind = Bind {
-			key: strng::literal!("bind"),
-			address: "127.0.0.1:0".parse().unwrap(),
-			protocol: BindProtocol::http,
-			tunnel_protocol: TunnelProtocol::Direct,
-			mode: agent::BindMode::Standard,
-			listeners: ListenerSet::from_list([Listener {
+		let bind = BindSnapshot {
+			bind: Arc::new(Bind {
+				key: strng::literal!("bind"),
+				address: "127.0.0.1:0".parse().unwrap(),
+				protocol: BindProtocol::http,
+				tunnel_protocol: TunnelProtocol::Direct,
+				mode: agent::BindMode::Standard,
+			}),
+			listeners: Arc::new(ListenerSet::from_list([Listener {
 				key: strng::literal!("listener"),
 				name: ListenerName {
 					gateway_name: strng::literal!("gw"),
@@ -2932,7 +3086,7 @@ mod tests {
 				},
 				hostname: strng::literal!("example.com"),
 				protocol: ListenerProtocol::HTTP,
-			}]),
+			}])),
 		};
 		let route = Route {
 			key: strng::literal!("route"),
@@ -2953,7 +3107,10 @@ mod tests {
 
 		{
 			let mut store = updater.write();
-			store.insert_bind(bind);
+			store.insert_bind(Arc::unwrap_or_clone(bind.bind));
+			for listener in bind.listeners.iter() {
+				store.insert_listener(listener.clone(), strng::literal!("bind"));
+			}
 			store.insert_route(route, strng::literal!("listener"));
 		}
 
@@ -2971,14 +3128,16 @@ mod tests {
 		);
 	}
 
-	fn standard_bind(address: std::net::SocketAddr) -> Bind {
-		Bind {
-			key: strng::literal!("bind"),
-			address,
-			protocol: BindProtocol::http,
-			tunnel_protocol: TunnelProtocol::Direct,
-			mode: agent::BindMode::Standard,
-			listeners: ListenerSet::from_list([Listener {
+	fn standard_bind(address: std::net::SocketAddr) -> BindSnapshot {
+		BindSnapshot {
+			bind: Arc::new(Bind {
+				key: strng::literal!("bind"),
+				address,
+				protocol: BindProtocol::http,
+				tunnel_protocol: TunnelProtocol::Direct,
+				mode: agent::BindMode::Standard,
+			}),
+			listeners: Arc::new(ListenerSet::from_list([Listener {
 				key: strng::literal!("listener"),
 				name: ListenerName {
 					gateway_name: strng::literal!("gw"),
@@ -2988,7 +3147,7 @@ mod tests {
 				},
 				hostname: strng::literal!("example.com"),
 				protocol: ListenerProtocol::HTTP,
-			}]),
+			}])),
 		}
 	}
 
@@ -3021,7 +3180,7 @@ mod tests {
 	#[test]
 	fn sync_local_bind_success_returns_ok() {
 		let updater = StoreUpdater::new(Arc::new(RwLock::new(Store::with_ipv6_enabled(false))));
-		updater
+		let prev = updater
 			.sync_local(
 				vec![standard_bind("127.0.0.1:0".parse().unwrap())],
 				vec![],
@@ -3032,6 +3191,14 @@ mod tests {
 				Default::default(),
 			)
 			.expect("bind on an ephemeral port should succeed");
+
+		updater
+			.sync_local(vec![], vec![], vec![], vec![], vec![], vec![], prev)
+			.expect("removing the bind should succeed");
+		assert!(
+			updater.read().listeners.is_empty(),
+			"local bind removal must also remove its listeners"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -37,11 +37,11 @@ use crate::transport::stream::{Socket, TCPConnectionInfo};
 use crate::transport::tls;
 use crate::types::agent::{
 	Backend, BackendReference, BackendTarget, BackendTrafficPolicy, BackendWithPolicies, Bind,
-	BindKey, BindProtocol, FrontendPolicy, Listener, ListenerProtocol, ListenerSet, ListenerTarget,
-	McpBackend, McpTarget, McpTargetSpec, PathMatch, PolicyInheritance, PolicyPhase, PolicyTarget,
-	ResourceName, Route, RouteBackendReference, RouteMatch, RouteName, SimpleBackendReference,
-	SseTargetSpec, StreamableHTTPTargetSpec, TCPRoute, TCPRouteBackendReference, Target,
-	TargetedPolicy,
+	BindKey, BindProtocol, BindSnapshot, FrontendPolicy, Listener, ListenerProtocol, ListenerSet,
+	ListenerTarget, McpBackend, McpTarget, McpTargetSpec, PathMatch, PolicyInheritance, PolicyPhase,
+	PolicyTarget, ResourceName, Route, RouteBackendReference, RouteMatch, RouteName,
+	SimpleBackendReference, SseTargetSpec, StreamableHTTPTargetSpec, TCPRoute,
+	TCPRouteBackendReference, Target, TargetedPolicy,
 };
 use crate::types::loadbalancer::EndpointSet;
 use crate::types::local::LocalNamedAIProvider;
@@ -292,28 +292,35 @@ pub fn basic_named_tcp_route(target: Strng) -> TCPRoute {
 pub const BIND_KEY: Strng = strng::literal!("bind");
 pub const LISTENER_KEY: Strng = strng::literal!("listener");
 
-pub fn simple_bind() -> Bind {
-	Bind {
-		key: BIND_KEY,
-		// not really used
-		address: "127.0.0.1:0".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
+pub fn simple_bind() -> BindSnapshot {
+	BindSnapshot {
+		bind: Arc::new(Bind {
+			key: BIND_KEY,
+			// not really used
+			address: "127.0.0.1:0".parse().unwrap(),
+			protocol: BindProtocol::http,
+			tunnel_protocol: Default::default(),
+			mode: Default::default(),
+		}),
+		listeners: Arc::new(ListenerSet::from_list([Listener {
 			key: LISTENER_KEY,
 			name: Default::default(),
 			hostname: Default::default(),
 			protocol: ListenerProtocol::HTTP,
-		}]),
-		protocol: BindProtocol::http,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
+		}])),
 	}
 }
 
-pub fn waypoint_bind(protocol: ListenerProtocol) -> Bind {
-	Bind {
-		key: BIND_KEY,
-		address: "127.0.0.1:15008".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
+pub fn waypoint_bind(protocol: ListenerProtocol) -> BindSnapshot {
+	BindSnapshot {
+		bind: Arc::new(Bind {
+			key: BIND_KEY,
+			address: "127.0.0.1:15008".parse().unwrap(),
+			protocol: BindProtocol::http,
+			tunnel_protocol: Default::default(),
+			mode: Default::default(),
+		}),
+		listeners: Arc::new(ListenerSet::from_list([Listener {
 			key: LISTENER_KEY,
 			name: crate::types::agent::ListenerName {
 				gateway_name: strng::literal!("default"),
@@ -323,27 +330,26 @@ pub fn waypoint_bind(protocol: ListenerProtocol) -> Bind {
 			},
 			hostname: Default::default(),
 			protocol,
-		}]),
-		protocol: BindProtocol::http,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
+		}])),
 	}
 }
 
-pub fn simple_tcp_bind() -> Bind {
-	Bind {
-		key: BIND_KEY,
-		// not really used
-		address: "127.0.0.1:0".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
+pub fn simple_tcp_bind() -> BindSnapshot {
+	BindSnapshot {
+		bind: Arc::new(Bind {
+			key: BIND_KEY,
+			// not really used
+			address: "127.0.0.1:0".parse().unwrap(),
+			protocol: BindProtocol::tcp,
+			tunnel_protocol: Default::default(),
+			mode: Default::default(),
+		}),
+		listeners: Arc::new(ListenerSet::from_list([Listener {
 			key: LISTENER_KEY,
 			name: Default::default(),
 			hostname: Default::default(),
 			protocol: ListenerProtocol::TCP,
-		}]),
-		protocol: BindProtocol::tcp,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
+		}])),
 	}
 }
 
@@ -465,9 +471,13 @@ impl tower::Service<Uri> for MemoryConnector {
 }
 
 impl TestBind {
-	pub fn with_bind(self, bind: Bind) -> Self {
+	pub fn with_bind(self, snapshot: BindSnapshot) -> Self {
 		let mut binds = self.pi.stores.binds.write();
-		binds.insert_bind(bind);
+		let bind_key = snapshot.key.clone();
+		for listener in snapshot.listeners.iter() {
+			binds.insert_listener(listener.clone(), bind_key.clone());
+		}
+		binds.insert_bind(Arc::unwrap_or_clone(snapshot.bind));
 		drop(binds);
 		self
 	}

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -19,6 +19,7 @@ use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use rustls::server::danger::ClientCertVerifier;
 use rustls_pki_types::pem::{PemObject, SectionKind};
 use secrecy::SecretString;
+use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 use serde_json::Value;
 
@@ -42,6 +43,7 @@ use crate::types::{agent, backend, frontend};
 use crate::{apply, *};
 
 #[apply(schema_ser_schema!)]
+#[derive(Eq, PartialEq)]
 pub struct Bind {
 	pub key: BindKey,
 	pub address: SocketAddr,
@@ -51,7 +53,6 @@ pub struct Bind {
 	/// `standard` (default) binds the `address`; `internal` does not bind a socket and is only
 	/// reachable via in-process routing (e.g. CONNECT tunnel re-entry by other listeners).
 	pub mode: BindMode,
-	pub listeners: ListenerSet,
 }
 
 impl Bind {
@@ -59,6 +60,53 @@ impl Bind {
 	/// it handles CONNECT re-entry for any destination port that no other bind matches by port.
 	pub fn is_wildcard(&self) -> bool {
 		self.mode == BindMode::Internal && self.address.port() == 0
+	}
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct BindSnapshot {
+	#[cfg_attr(feature = "schema", schemars(flatten))]
+	pub bind: Arc<Bind>,
+	pub listeners: Arc<ListenerSet>,
+}
+
+impl Serialize for BindSnapshot {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		let mut snapshot = serializer.serialize_struct("BindSnapshot", 6)?;
+		snapshot.serialize_field("key", &self.key)?;
+		snapshot.serialize_field("address", &self.address)?;
+		snapshot.serialize_field("protocol", &self.protocol)?;
+		snapshot.serialize_field("tunnelProtocol", &self.tunnel_protocol)?;
+		snapshot.serialize_field("mode", &self.mode)?;
+		snapshot.serialize_field("listeners", &self.listeners)?;
+		snapshot.end()
+	}
+}
+
+impl BindSnapshot {
+	pub fn new(bind: Bind, listeners: ListenerSet) -> Self {
+		Self {
+			bind: Arc::new(bind),
+			listeners: Arc::new(listeners),
+		}
+	}
+}
+
+impl std::ops::Deref for BindSnapshot {
+	type Target = Bind;
+
+	fn deref(&self) -> &Self::Target {
+		&self.bind
+	}
+}
+
+impl std::ops::DerefMut for BindSnapshot {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		Arc::make_mut(&mut self.bind)
 	}
 }
 
@@ -1831,7 +1879,7 @@ pub struct OpenAPITarget {
 	pub schema: Arc<OpenAPI>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(
 	feature = "schema",

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1439,7 +1439,6 @@ impl Bind {
 		Ok(Self {
 			key: s.key.clone().into(),
 			address,
-			listeners: Default::default(),
 			protocol: match proto::agent::bind::Protocol::try_from(s.protocol)? {
 				proto::agent::bind::Protocol::Http => BindProtocol::http,
 				proto::agent::bind::Protocol::Tcp => BindProtocol::tcp,

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -26,7 +26,7 @@ use crate::mcp::{FailureMode, McpAuthorization};
 use crate::store::{LocalWorkload, RequestPolicy};
 use crate::types::agent::{
 	A2aPolicy, Authorization, Backend, BackendKey, BackendReference, BackendTrafficPolicy,
-	BackendWithPolicies, Bind, BindMode, BindProtocol, FrontendPolicy, HeaderMatch,
+	BackendWithPolicies, Bind, BindMode, BindProtocol, BindSnapshot, FrontendPolicy, HeaderMatch,
 	JwtAuthentication, Listener, ListenerKey, ListenerName, ListenerProtocol, ListenerSet,
 	ListenerTarget, LocalMcpAuthentication, McpAuthentication, McpBackend, McpPrefixMode, McpTarget,
 	McpTargetName, McpTargetSpec, OpenAPITarget, PathMatch, PolicyPhase, PolicyTarget, PolicyType,
@@ -303,7 +303,7 @@ fn parse_deprecated_tracing_endpoint(endpoint: &str) -> anyhow::Result<(Target, 
 pub struct NormalizedLocalConfig {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub model_catalog: Option<Vec<crate::ModelCatalogSource>>,
-	pub binds: Vec<Bind>,
+	pub binds: Vec<BindSnapshot>,
 	pub listener_routes: Vec<(ListenerKey, Vec<Route>)>,
 	pub listener_tcp_routes: Vec<(ListenerKey, Vec<TCPRoute>)>,
 	pub policies: Vec<TargetedPolicy>,
@@ -2962,13 +2962,15 @@ async fn convert(
 			// Windows and IPv6 don't mix well apparently?
 			SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), bind_port)
 		};
-		let b = Bind {
-			key: bind_name,
-			address: sockaddr,
-			protocol: detect_bind_protocol(&ls),
-			listeners: ls,
-			tunnel_protocol: b.tunnel_protocol,
-			mode: b.mode,
+		let b = BindSnapshot {
+			bind: Arc::new(Bind {
+				key: bind_name,
+				address: sockaddr,
+				protocol: detect_bind_protocol(&ls),
+				tunnel_protocol: b.tunnel_protocol,
+				mode: b.mode,
+			}),
+			listeners: Arc::new(ls),
 		};
 		all_binds.push(b)
 	}
@@ -3417,7 +3419,7 @@ async fn convert_gateways(
 	config: &crate::Config,
 	gateway: ListenerTarget,
 	gateways: IndexMap<Strng, LocalGateway>,
-	all_binds: &mut Vec<Bind>,
+	all_binds: &mut Vec<BindSnapshot>,
 	all_listener_routes: &mut Vec<(ListenerKey, Vec<Route>)>,
 	all_listener_tcp_routes: &mut Vec<(ListenerKey, Vec<TCPRoute>)>,
 	all_policies: &mut Vec<TargetedPolicy>,
@@ -3489,13 +3491,15 @@ async fn convert_gateways(
 		} else {
 			SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
 		};
-		all_binds.push(Bind {
-			key: strng::format!("bind/{port}"),
-			address: sockaddr,
-			protocol: detect_bind_protocol(&listeners),
-			listeners,
-			tunnel_protocol: TunnelProtocol::Direct,
-			mode: BindMode::Standard,
+		all_binds.push(BindSnapshot {
+			bind: Arc::new(Bind {
+				key: strng::format!("bind/{port}"),
+				address: sockaddr,
+				protocol: detect_bind_protocol(&listeners),
+				tunnel_protocol: TunnelProtocol::Direct,
+				mode: BindMode::Standard,
+			}),
+			listeners: Arc::new(listeners),
 		});
 	}
 	Ok(refs)
@@ -4099,7 +4103,7 @@ async fn convert_llm_config(
 	llm_config: LocalLLMConfig,
 	attach_policies_to_route: bool,
 ) -> anyhow::Result<(
-	Bind,
+	BindSnapshot,
 	Vec<Route>,
 	Vec<TargetedPolicy>,
 	Vec<BackendWithPolicies>,
@@ -4584,17 +4588,19 @@ async fn convert_llm_config(
 		SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
 	};
 
-	let bind = Bind {
-		key: strng::format!("bind/{}", port),
-		address: sockaddr,
-		protocol: if tls_enabled {
-			BindProtocol::tls
-		} else {
-			BindProtocol::http
-		},
-		listeners: listener_set,
-		tunnel_protocol: TunnelProtocol::Direct,
-		mode: BindMode::Standard,
+	let bind = BindSnapshot {
+		bind: Arc::new(Bind {
+			key: strng::format!("bind/{}", port),
+			address: sockaddr,
+			protocol: if tls_enabled {
+				BindProtocol::tls
+			} else {
+				BindProtocol::http
+			},
+			tunnel_protocol: TunnelProtocol::Direct,
+			mode: BindMode::Standard,
+		}),
+		listeners: Arc::new(listener_set),
 	};
 
 	Ok((bind, routes, all_policies, all_backends))
@@ -4607,7 +4613,7 @@ async fn convert_mcp_config(
 	mcp_config: LocalSimpleMcpConfig,
 	shared_port: bool,
 ) -> anyhow::Result<(
-	Bind,
+	BindSnapshot,
 	Vec<Route>,
 	Vec<TargetedPolicy>,
 	Vec<BackendWithPolicies>,
@@ -4677,13 +4683,15 @@ async fn convert_mcp_config(
 		SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
 	};
 
-	let bind = Bind {
-		key: strng::format!("bind/{}", port),
-		address: sockaddr,
-		protocol: BindProtocol::http,
-		listeners: listener_set,
-		tunnel_protocol: TunnelProtocol::Direct,
-		mode: BindMode::Standard,
+	let bind = BindSnapshot {
+		bind: Arc::new(Bind {
+			key: strng::format!("bind/{}", port),
+			address: sockaddr,
+			protocol: BindProtocol::http,
+			tunnel_protocol: TunnelProtocol::Direct,
+			mode: BindMode::Standard,
+		}),
+		listeners: Arc::new(listener_set),
 	};
 
 	let backends = LocalBackend::MCP(backend)

--- a/crates/agentgateway/tests/common/mod.rs
+++ b/crates/agentgateway/tests/common/mod.rs
@@ -19,7 +19,7 @@ pub mod prelude {
 	pub use agentgateway::read_body;
 	pub use agentgateway::test_helpers::proxymock::*;
 	pub use agentgateway::types::agent::{
-		Backend, BackendTrafficPolicy, BackendWithPolicies, Bind, BindProtocol, Listener,
+		Backend, BackendTrafficPolicy, BackendWithPolicies, Bind, BindProtocol, BindSnapshot, Listener,
 		ListenerProtocol, ListenerSet, PathMatch, ResourceName, Route, RouteMatch,
 		SimpleBackendReference, Target,
 	};

--- a/crates/agentgateway/tests/tests/auto_protocol.rs
+++ b/crates/agentgateway/tests/tests/auto_protocol.rs
@@ -3,24 +3,30 @@ use agentgateway::types::agent::{Bind, BindProtocol, Listener, ListenerProtocol,
 use crate::common::prelude::*;
 use crate::tests::tls::{https_bind, test_server_tls_config};
 
+fn auto_bind(listeners: ListenerSet) -> BindSnapshot {
+	BindSnapshot::new(
+		Bind {
+			key: BIND_KEY,
+			address: "127.0.0.1:0".parse().unwrap(),
+			protocol: BindProtocol::auto,
+			tunnel_protocol: Default::default(),
+			mode: Default::default(),
+		},
+		listeners,
+	)
+}
+
 /// BindProtocol::auto should detect plaintext HTTP and proxy it successfully.
 #[tokio::test]
 async fn auto_protocol_plaintext_http() {
 	let mock = simple_mock().await;
 	let route = basic_route(*mock.address());
-	let bind = Bind {
-		key: BIND_KEY,
-		address: "127.0.0.1:0".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
-			key: LISTENER_KEY,
-			name: Default::default(),
-			hostname: Default::default(),
-			protocol: ListenerProtocol::HTTP,
-		}]),
-		protocol: BindProtocol::auto,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
-	};
+	let bind = auto_bind(ListenerSet::from_list([Listener {
+		key: LISTENER_KEY,
+		name: Default::default(),
+		hostname: Default::default(),
+		protocol: ListenerProtocol::HTTP,
+	}]));
 
 	let t = setup_proxy_test("{}")
 		.unwrap()
@@ -107,19 +113,12 @@ async fn auto_protocol_plaintext_rejected_for_https_only() {
 async fn auto_protocol_tls_rejected_for_http_only() {
 	let mock = simple_mock().await;
 	let route = basic_route(*mock.address());
-	let bind = Bind {
-		key: BIND_KEY,
-		address: "127.0.0.1:0".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
-			key: LISTENER_KEY,
-			name: Default::default(),
-			hostname: Default::default(),
-			protocol: ListenerProtocol::HTTP,
-		}]),
-		protocol: BindProtocol::auto,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
-	};
+	let bind = auto_bind(ListenerSet::from_list([Listener {
+		key: LISTENER_KEY,
+		name: Default::default(),
+		hostname: Default::default(),
+		protocol: ListenerProtocol::HTTP,
+	}]));
 
 	let t = setup_proxy_test("{}")
 		.unwrap()
@@ -143,27 +142,20 @@ async fn auto_protocol_mixed_listeners() {
 	let mock = simple_mock().await;
 	let route = basic_route(*mock.address());
 	let route2 = basic_route(*mock.address());
-	let bind = Bind {
-		key: BIND_KEY,
-		address: "127.0.0.1:0".parse().unwrap(),
-		listeners: ListenerSet::from_list([
-			Listener {
-				key: strng::new("http-listener"),
-				name: Default::default(),
-				hostname: strng::new("http.local"),
-				protocol: ListenerProtocol::HTTP,
-			},
-			Listener {
-				key: strng::new("https-listener"),
-				name: Default::default(),
-				hostname: strng::new("*.example.com"),
-				protocol: ListenerProtocol::HTTPS(test_server_tls_config()),
-			},
-		]),
-		protocol: BindProtocol::auto,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
-	};
+	let bind = auto_bind(ListenerSet::from_list([
+		Listener {
+			key: strng::new("http-listener"),
+			name: Default::default(),
+			hostname: strng::new("http.local"),
+			protocol: ListenerProtocol::HTTP,
+		},
+		Listener {
+			key: strng::new("https-listener"),
+			name: Default::default(),
+			hostname: strng::new("*.example.com"),
+			protocol: ListenerProtocol::HTTPS(test_server_tls_config()),
+		},
+	]));
 
 	let t = setup_proxy_test("{}")
 		.unwrap()
@@ -209,19 +201,12 @@ async fn auto_protocol_mixed_listeners() {
 async fn auto_protocol_peek_timeout() {
 	let mock = simple_mock().await;
 	let route = basic_route(*mock.address());
-	let bind = Bind {
-		key: BIND_KEY,
-		address: "127.0.0.1:0".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
-			key: LISTENER_KEY,
-			name: Default::default(),
-			hostname: Default::default(),
-			protocol: ListenerProtocol::HTTP,
-		}]),
-		protocol: BindProtocol::auto,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
-	};
+	let bind = auto_bind(ListenerSet::from_list([Listener {
+		key: LISTENER_KEY,
+		name: Default::default(),
+		hostname: Default::default(),
+		protocol: ListenerProtocol::HTTP,
+	}]));
 
 	let t = setup_proxy_test("{}")
 		.unwrap()

--- a/crates/agentgateway/tests/tests/connect.rs
+++ b/crates/agentgateway/tests/tests/connect.rs
@@ -496,19 +496,21 @@ async fn connect_tunnel_terminates_outer_tls() {
 
 		// OUTER bind: HTTPS Static cert + tunnelProtocol Connect. The fix terminates
 		// this outer TLS before serving CONNECT.
-		let outer = Bind {
-			key: strng::literal!("outer"),
-			address: "127.0.0.1:15011".parse().unwrap(),
-			listeners: ListenerSet::from_list([Listener {
-				key: LISTENER_KEY,
+		let outer = BindSnapshot::new(
+			Bind {
+				key: strng::literal!("outer"),
+				address: "127.0.0.1:15011".parse().unwrap(),
+				protocol: BindProtocol::tls,
+				tunnel_protocol: TunnelProtocol::Connect,
+				mode: Default::default(),
+			},
+			ListenerSet::from_list([Listener {
+				key: strng::literal!("outer-listener"),
 				name: Default::default(),
 				hostname: strng::new("*.example.com"),
 				protocol: ListenerProtocol::HTTPS(test_server_tls_config()),
 			}]),
-			protocol: BindProtocol::tls,
-			tunnel_protocol: TunnelProtocol::Connect,
-			mode: Default::default(),
-		};
+		);
 
 		// INNER plain bind, re-entered by the CONNECT authority port.
 		let mut inner = simple_bind();
@@ -1008,19 +1010,21 @@ async fn connect_tunnel_dynamic_ca_obo_dynamic_backend() {
 	outer.address = "127.0.0.1:15010".parse().unwrap();
 	outer.tunnel_protocol = TunnelProtocol::Connect;
 	// Inner bind terminates TLS with the dynamic CA (empty hostname = match any SNI).
-	let inner = Bind {
-		key: BIND_KEY,
-		address: "0.0.0.0:18082".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
+	let inner = BindSnapshot::new(
+		Bind {
+			key: BIND_KEY,
+			address: "0.0.0.0:18082".parse().unwrap(),
+			protocol: BindProtocol::tls,
+			tunnel_protocol: Default::default(),
+			mode: Default::default(),
+		},
+		ListenerSet::from_list([Listener {
 			key: LISTENER_KEY,
 			name: Default::default(),
 			hostname: Default::default(),
 			protocol: ListenerProtocol::HTTPS(tls_config),
 		}]),
-		protocol: BindProtocol::tls,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
-	};
+	);
 
 	// `dynamic: {}` backend: the upstream is resolved from the decrypted request's
 	// Host/authority (DFP), proven on direct requests by `dfp_uses_host_port`.

--- a/crates/agentgateway/tests/tests/dfp.rs
+++ b/crates/agentgateway/tests/tests/dfp.rs
@@ -37,20 +37,22 @@ fn setup_dfp_https() -> (TestBind, MemoryClient) {
 
 	let route = basic_named_route("/dynamic".into());
 
-	let bind = Bind {
-		key: BIND_KEY,
-		// not really used
-		address: "127.0.0.1:0".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
+	let bind = BindSnapshot::new(
+		Bind {
+			key: BIND_KEY,
+			// not really used
+			address: "127.0.0.1:0".parse().unwrap(),
+			protocol: BindProtocol::tls,
+			tunnel_protocol: Default::default(),
+			mode: Default::default(),
+		},
+		ListenerSet::from_list([Listener {
 			key: LISTENER_KEY,
 			name: Default::default(),
 			hostname: Default::default(),
 			protocol: ListenerProtocol::HTTPS(test_server_tls_config()),
 		}]),
-		protocol: BindProtocol::tls,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
-	};
+	);
 
 	let t = setup_proxy_test("{}").unwrap();
 	let pi = t.inputs();

--- a/crates/agentgateway/tests/tests/tls.rs
+++ b/crates/agentgateway/tests/tests/tls.rs
@@ -19,20 +19,22 @@ pub(in crate::tests) fn test_server_tls_config() -> agentgateway::types::agent::
 	.expect("test server tls config")
 }
 
-pub(in crate::tests) fn https_bind() -> Bind {
-	Bind {
-		key: BIND_KEY,
-		address: "127.0.0.1:0".parse().unwrap(),
-		listeners: ListenerSet::from_list([Listener {
+pub(in crate::tests) fn https_bind() -> BindSnapshot {
+	BindSnapshot::new(
+		Bind {
+			key: BIND_KEY,
+			address: "127.0.0.1:0".parse().unwrap(),
+			protocol: BindProtocol::tls,
+			tunnel_protocol: Default::default(),
+			mode: Default::default(),
+		},
+		ListenerSet::from_list([Listener {
 			key: LISTENER_KEY,
 			name: Default::default(),
 			hostname: strng::new("*.example.com"),
 			protocol: ListenerProtocol::HTTPS(test_server_tls_config()),
 		}]),
-		protocol: BindProtocol::tls,
-		tunnel_protocol: Default::default(),
-		mode: Default::default(),
-	}
+	)
 }
 
 async fn serve_https_http1_connection(

--- a/schema/admin.json
+++ b/schema/admin.json
@@ -79,7 +79,6 @@
         "protocol",
         "tunnelProtocol",
         "mode",
-        "listeners",
         "listeners"
       ]
     },
@@ -124,7 +123,7 @@
         }
       ]
     },
-    "Listener": {
+    "DumpListener": {
       "type": "object",
       "properties": {
         "key": {
@@ -155,6 +154,24 @@
         },
         "protocol": {
           "$ref": "#/$defs/ListenerProtocol"
+        },
+        "routes": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/Route"
+          }
+        },
+        "tcpRoutes": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/TCPRoute"
+          }
         }
       },
       "additionalProperties": false,
@@ -240,67 +257,6 @@
     },
     "ServerTLSConfig": {
       "type": "null"
-    },
-    "DumpListener": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string"
-        },
-        "gatewayName": {
-          "type": "string"
-        },
-        "gatewayNamespace": {
-          "type": "string"
-        },
-        "listenerName": {
-          "type": "string"
-        },
-        "listenerSet": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ResourceName"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "hostname": {
-          "description": "Can be a wildcard",
-          "type": "string"
-        },
-        "protocol": {
-          "$ref": "#/$defs/ListenerProtocol"
-        },
-        "routes": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/$defs/Route"
-          }
-        },
-        "tcpRoutes": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/$defs/TCPRoute"
-          }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "key",
-        "gatewayName",
-        "gatewayNamespace",
-        "listenerName",
-        "hostname",
-        "protocol"
-      ]
     },
     "Route": {
       "type": "object",


### PR DESCRIPTION
Store listeners independently from binds so listener moves replace their previous assignment even when both bind resources remain present. Join them as a BindSnapshot at lookup time, preserving a consistent view for in-flight requests without duplicating listener ownership.

Propagate same-address bind protocol changes to active accept loops so new connections use the updated HTTP/TLS mode without reopening the socket. This prevents colliding Gateway listener port swaps from merging stale listeners or continuing to serve the protocol captured at startup.

Signed-off-by: John Howard <john.howard@solo.io>
