### PR TITLE
bedrock: guardrail mutates in place preserving original structure

### DIFF
--- a/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::http::auth::{AwsAuth, BackendAuthKind};
 use crate::http::jwt::Claims;
-use crate::llm::RequestType;
 use crate::llm::bedrock::AwsRegion;
 use crate::llm::policy::{BedrockGuardrails, with_default_timeout};
 use crate::proxy::httpproxy::PolicyClient;
@@ -74,38 +73,46 @@ pub struct ApplyGuardrailResponse {
 }
 
 impl ApplyGuardrailResponse {
+	/// Returns true if the guardrail intervened at all
+	pub fn is_intervened(&self) -> bool {
+		self.action == GuardrailAction::GuardrailIntervened
+	}
+
 	/// Returns true if the guardrail blocked content
 	pub fn is_blocked(&self) -> bool {
-		self.action == GuardrailAction::GuardrailIntervened && self.has_blocked_assessment()
+		self.is_intervened() && self.has_assessment_action("BLOCKED")
 	}
 
-	/// Returns true if the guardrail anonymized/masked content
+	/// Returns true if the guardrail anonymized/masked content without blocking.
 	pub fn is_anonymized(&self) -> bool {
-		self.action == GuardrailAction::GuardrailIntervened && !self.has_blocked_assessment()
+		self.is_intervened()
+			&& !self.has_assessment_action("BLOCKED")
+			&& self.has_assessment_action("ANONYMIZED")
 	}
 
-	/// Returns the masked output texts
-	pub fn output_texts(&self) -> Vec<String> {
-		self.outputs.iter().map(|o| o.text.clone()).collect()
+	pub fn into_output_texts(self) -> Vec<String> {
+		self.outputs.into_iter().map(|o| o.text).collect()
 	}
 
-	/// Check if any assessment contains a BLOCKED action
-	fn has_blocked_assessment(&self) -> bool {
-		self.assessments.iter().any(Self::value_contains_blocked)
+	fn has_assessment_action(&self, action: &str) -> bool {
+		self
+			.assessments
+			.iter()
+			.any(|a| Self::value_contains_action(a, action))
 	}
 
-	/// Search for "action": "BLOCKED" in JSON value
-	fn value_contains_blocked(value: &serde_json::Value) -> bool {
+	/// Search for `"action": "<action>"` in JSON value
+	fn value_contains_action(value: &serde_json::Value, action: &str) -> bool {
 		match value {
 			serde_json::Value::Object(map) => {
-				if let Some(serde_json::Value::String(action)) = map.get("action")
-					&& action == "BLOCKED"
+				if let Some(serde_json::Value::String(a)) = map.get("action")
+					&& a == action
 				{
 					return true;
 				}
-				map.values().any(Self::value_contains_blocked)
+				map.values().any(|v| Self::value_contains_action(v, action))
 			},
-			serde_json::Value::Array(arr) => arr.iter().any(Self::value_contains_blocked),
+			serde_json::Value::Array(arr) => arr.iter().any(|v| Self::value_contains_action(v, action)),
 			_ => false,
 		}
 	}
@@ -132,35 +139,9 @@ impl BedrockGuardrails {
 	}
 }
 
-/// Send a request to the Bedrock Guardrails ApplyGuardrail API for request content
-pub async fn send_request(
-	req: &mut dyn RequestType,
-	claims: Option<Claims>,
-	client: &PolicyClient,
-	guardrails: &BedrockGuardrails,
-) -> anyhow::Result<ApplyGuardrailResponse> {
-	let content = req
-		.get_messages()
-		.into_iter()
-		.map(|m| GuardrailContentBlock {
-			text: GuardrailTextBlock {
-				text: m.content.to_string(),
-			},
-		})
-		.collect_vec();
-
-	send_guardrail_request(
-		client,
-		claims.clone(),
-		guardrails,
-		GuardrailSource::Input,
-		content,
-	)
-	.await
-}
-
-/// Send a request to the Bedrock Guardrails ApplyGuardrail API for response content
-pub async fn send_response(
+/// Send content to the Bedrock Guardrails ApplyGuardrail API
+pub async fn send(
+	source: GuardrailSource,
 	content: Vec<String>,
 	claims: Option<Claims>,
 	client: &PolicyClient,
@@ -173,23 +154,6 @@ pub async fn send_response(
 		})
 		.collect_vec();
 
-	send_guardrail_request(
-		client,
-		claims.clone(),
-		guardrails,
-		GuardrailSource::Output,
-		content,
-	)
-	.await
-}
-
-async fn send_guardrail_request(
-	client: &PolicyClient,
-	claims: Option<Claims>,
-	guardrails: &BedrockGuardrails,
-	source: GuardrailSource,
-	content: Vec<GuardrailContentBlock>,
-) -> anyhow::Result<ApplyGuardrailResponse> {
 	let request_body = ApplyGuardrailRequest { source, content };
 	let host = strng::format!("bedrock-runtime.{}.amazonaws.com", guardrails.region);
 	let path = format!(
@@ -255,19 +219,14 @@ async fn send_guardrail_request(
 	let resp: ApplyGuardrailResponse = serde_json::from_slice(&bytes)
 		.map_err(|e| anyhow::anyhow!("Failed to parse Bedrock guardrail response: {e}"))?;
 
-	if resp.is_blocked() {
+	if resp.is_intervened() {
 		tracing::debug!(
 			guardrail_id = %guardrails.guardrail_identifier,
 			guardrail_version = %guardrails.guardrail_version,
 			source = ?source,
-			"Bedrock guardrail blocked content"
-		);
-	} else if resp.is_anonymized() {
-		tracing::debug!(
-			guardrail_id = %guardrails.guardrail_identifier,
-			guardrail_version = %guardrails.guardrail_version,
-			source = ?source,
-			"Bedrock guardrail anonymized content"
+			blocked = resp.is_blocked(),
+			anonymized = resp.is_anonymized(),
+			"Bedrock guardrail intervened"
 		);
 	}
 

--- a/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
@@ -163,7 +163,8 @@ pub async fn send(
 	let uri = format!("https://{}{}", host, path);
 
 	tracing::debug!(
-		request_body = %serde_json::to_string_pretty(&request_body).unwrap_or_default(),
+		source = ?request_body.source,
+		content_blocks = request_body.content.len(),
 		uri = %uri,
 		"Sending Bedrock guardrail request"
 	);

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -302,9 +302,26 @@ impl<Mask> From<&GuardrailOutcome<Mask>> for GuardrailAction {
 	}
 }
 
+impl<Mask> GuardrailOutcome<Mask> {
+	fn map_mask<M2>(self, f: impl FnOnce(Mask) -> M2) -> GuardrailOutcome<M2> {
+		match self {
+			GuardrailOutcome::None => GuardrailOutcome::None,
+			GuardrailOutcome::Masked(mask) => GuardrailOutcome::Masked(f(mask)),
+			GuardrailOutcome::Rejected(resp) => GuardrailOutcome::Rejected(resp),
+			GuardrailOutcome::FailOpen => GuardrailOutcome::FailOpen,
+		}
+	}
+}
+
+#[derive(Debug)]
 struct TextReplacements(Vec<Option<String>>);
 
 impl TextReplacements {
+	/// Replace every visited text, one replacement per text in visit order
+	fn replace_all(texts: Vec<String>) -> Self {
+		Self(texts.into_iter().map(Some).collect())
+	}
+
 	fn apply(self, visit_text: impl FnOnce(&mut dyn FnMut(&mut String))) {
 		let mut replacements = self.0.into_iter();
 		visit_text(&mut |text| {
@@ -922,21 +939,23 @@ impl Policy {
 		guardrails: &BedrockGuardrails,
 		rejection: &RequestRejection,
 	) -> anyhow::Result<GuardrailOutcome<RequestGuardMutation>> {
-		let resp = bedrock_guardrails::send_request(req, claims, client, guardrails).await?;
-		if resp.is_blocked() {
-			Ok(GuardrailOutcome::Rejected(rejection.as_response()))
-		} else if resp.is_anonymized() {
-			let output_texts = resp.output_texts();
-			let mut msgs = req.get_messages();
-			for (msg, text) in msgs.iter_mut().zip(output_texts) {
-				msg.content = text.into();
-			}
-			Ok(GuardrailOutcome::Masked(RequestGuardMutation::Messages(
-				msgs,
-			)))
-		} else {
-			Ok(GuardrailOutcome::None)
+		let content = Self::request_texts(req);
+		if content.is_empty() {
+			return Ok(GuardrailOutcome::None);
 		}
+		let sent_count = content.len();
+		let resp = bedrock_guardrails::send(
+			bedrock_guardrails::GuardrailSource::Input,
+			content,
+			claims,
+			client,
+			guardrails,
+		)
+		.await?;
+		Ok(
+			Self::bedrock_guardrail_outcome(resp, sent_count, rejection)
+				.map_mask(RequestGuardMutation::Texts),
+		)
 	}
 
 	async fn evaluate_bedrock_guardrails_response(
@@ -951,23 +970,44 @@ impl Policy {
 		if content.is_empty() {
 			return Ok(GuardrailOutcome::None);
 		}
+		let sent_count = content.len();
 
-		let guardrail_resp =
-			bedrock_guardrails::send_response(content, claims, client, guardrails).await?;
-		if guardrail_resp.is_blocked() {
-			Ok(GuardrailOutcome::Rejected(rejection.as_response()))
-		} else if guardrail_resp.is_anonymized() {
-			let output_texts = guardrail_resp.output_texts();
-			let mut choices = resp.to_webhook_choices();
-			for (choice, text) in choices.iter_mut().zip(output_texts) {
-				choice.message.content = text.into();
-			}
-			Ok(GuardrailOutcome::Masked(ResponseGuardMutation::Choices(
-				choices,
-			)))
-		} else {
-			Ok(GuardrailOutcome::None)
+		let guardrail_resp = bedrock_guardrails::send(
+			bedrock_guardrails::GuardrailSource::Output,
+			content,
+			claims,
+			client,
+			guardrails,
+		)
+		.await?;
+		Ok(
+			Self::bedrock_guardrail_outcome(guardrail_resp, sent_count, rejection)
+				.map_mask(ResponseGuardMutation::Texts),
+		)
+	}
+
+	/// Mask only when anonymized with one output per block sent; any other
+	/// intervention rejects (its outputs are a canned message, not masks).
+	fn bedrock_guardrail_outcome(
+		resp: bedrock_guardrails::ApplyGuardrailResponse,
+		sent_count: usize,
+		rejection: &RequestRejection,
+	) -> GuardrailOutcome<TextReplacements> {
+		if !resp.is_intervened() {
+			return GuardrailOutcome::None;
 		}
+		if resp.is_anonymized() {
+			let outputs = resp.into_output_texts();
+			if outputs.len() == sent_count {
+				return GuardrailOutcome::Masked(TextReplacements::replace_all(outputs));
+			}
+			tracing::warn!(
+				expected = sent_count,
+				got = outputs.len(),
+				"Bedrock guardrail masked output count mismatch; rejecting content"
+			);
+		}
+		GuardrailOutcome::Rejected(rejection.as_response())
 	}
 
 	async fn evaluate_google_model_armor_request(
@@ -1029,7 +1069,7 @@ impl Policy {
 		model_armor: &GoogleModelArmor,
 		rejection: &RequestRejection,
 	) -> anyhow::Result<GuardrailOutcome<ResponseGuardMutation>> {
-		let content = Self::response_texts(resp);
+		let content = Self::webhook_choice_texts(resp);
 
 		if content.is_empty() {
 			return Ok(GuardrailOutcome::None);
@@ -1051,7 +1091,7 @@ impl Policy {
 		config: &AzureContentSafety,
 		rejection: &RequestRejection,
 	) -> anyhow::Result<GuardrailOutcome<ResponseGuardMutation>> {
-		let content = Self::response_texts(resp);
+		let content = Self::webhook_choice_texts(resp);
 
 		if content.is_empty() {
 			return Ok(GuardrailOutcome::None);
@@ -1075,12 +1115,28 @@ impl Policy {
 		Ok(GuardrailOutcome::None)
 	}
 
-	fn response_texts(resp: &dyn ResponseType) -> Vec<String> {
+	/// One flattened text per choice; masking guards must use `response_texts`
+	/// instead so counts align with `visit_text_mut` order.
+	fn webhook_choice_texts(resp: &dyn ResponseType) -> Vec<String> {
 		resp
 			.to_webhook_choices()
 			.into_iter()
 			.map(|c| c.message.content.to_string())
 			.collect()
+	}
+
+	fn collect_texts(visit: impl FnOnce(&mut dyn FnMut(&mut String))) -> Vec<String> {
+		let mut texts = Vec::new();
+		visit(&mut |text| texts.push(text.clone()));
+		texts
+	}
+
+	fn request_texts(req: &mut dyn RequestType) -> Vec<String> {
+		Self::collect_texts(|f| req.visit_text_mut(f))
+	}
+
+	fn response_texts(resp: &mut dyn ResponseType) -> Vec<String> {
+		Self::collect_texts(|f| resp.visit_text_mut(f))
 	}
 
 	#[cfg(test)]

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -545,7 +545,7 @@ mod bedrock_guardrails_tests {
 		assert!(!response.is_blocked());
 		assert!(response.is_anonymized());
 		assert_eq!(
-			response.output_texts(),
+			response.into_output_texts(),
 			vec!["My name is {NAME} and my email is {EMAIL}"]
 		);
 	}
@@ -598,22 +598,274 @@ mod bedrock_guardrails_tests {
 		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
 		assert!(response.is_anonymized());
 		assert_eq!(
-			response.output_texts(),
+			response.into_output_texts(),
 			vec!["First message with {NAME}", "Second message with {EMAIL}"]
 		);
 	}
 
+	/// An intervention with no recognized assessment action (e.g. automated reasoning
+	/// findings carry no `action` field) must not be treated as maskable: its output
+	/// is a canned message, not per-block masked text.
 	#[test]
 	fn test_apply_guardrail_response_intervened_no_assessments() {
 		let json = json!({
 			"action": "GUARDRAIL_INTERVENED",
-			"outputs": [{"text": "modified content"}],
-			"assessments": []
+			"outputs": [{"text": "I can't help with that."}],
+			"assessments": [{
+				"automatedReasoningPolicy": {
+					"findings": [{"invalid": {"logicWarning": {"type": "ALWAYS_FALSE"}}}]
+				}
+			}]
 		});
 		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
 		assert!(!response.is_blocked());
-		assert!(response.is_anonymized());
+		assert!(!response.is_anonymized());
+		assert!(response.is_intervened());
 	}
+}
+
+/// Build an intervened ApplyGuardrail response from output texts and assessments JSON.
+fn bedrock_intervened(
+	outputs: &[&str],
+	assessments: serde_json::Value,
+) -> bedrock_guardrails::ApplyGuardrailResponse {
+	serde_json::from_value(serde_json::json!({
+		"action": "GUARDRAIL_INTERVENED",
+		"outputs": outputs.iter().map(|t| serde_json::json!({"text": t})).collect::<Vec<_>>(),
+		"assessments": assessments,
+	}))
+	.unwrap()
+}
+
+fn bedrock_anonymized_assessments() -> serde_json::Value {
+	serde_json::json!([{
+		"sensitiveInformationPolicy": {
+			"piiEntities": [{"action": "ANONYMIZED", "match": "x", "type": "NAME"}]
+		}
+	}])
+}
+
+/// Assert what the Bedrock guard would send, then run an anonymize verdict through
+/// the real outcome path and apply the resulting mask to the request.
+fn apply_bedrock_request_mask(req: &mut dyn RequestType, sent: &[&str], masked: &[&str]) {
+	assert_eq!(Policy::request_texts(req), sent);
+	let outcome = Policy::bedrock_guardrail_outcome(
+		bedrock_intervened(masked, bedrock_anonymized_assessments()),
+		sent.len(),
+		&RequestRejection::default(),
+	);
+	assert!(matches!(outcome, GuardrailOutcome::Masked(_)));
+	let (_, rejection) =
+		Policy::apply_request_guard_outcome(outcome.map_mask(RequestGuardMutation::Texts), req)
+			.unwrap();
+	assert!(rejection.is_none());
+}
+
+/// Same as `apply_bedrock_request_mask`, but for responses.
+fn apply_bedrock_response_mask(resp: &mut dyn ResponseType, sent: &[&str], masked: &[&str]) {
+	assert_eq!(Policy::response_texts(resp), sent);
+	let outcome = Policy::bedrock_guardrail_outcome(
+		bedrock_intervened(masked, bedrock_anonymized_assessments()),
+		sent.len(),
+		&RequestRejection::default(),
+	);
+	assert!(matches!(outcome, GuardrailOutcome::Masked(_)));
+	let (_, rejection) =
+		Policy::apply_response_guard_outcome(outcome.map_mask(ResponseGuardMutation::Texts), resp)
+			.unwrap();
+	assert!(rejection.is_none());
+}
+
+#[test]
+fn bedrock_request_mask_preserves_completions_content_parts() {
+	let mut req: crate::llm::types::completions::Request =
+		serde_json::from_value(serde_json::json!({
+			"model": "gpt-4o",
+			"messages": [{
+				"role": "user",
+				"content": [
+					{"type": "text", "text": "My name is Jane"},
+					{"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+					{"type": "text", "text": "Email jane@example.com"}
+				]
+			}]
+		}))
+		.unwrap();
+
+	apply_bedrock_request_mask(
+		&mut req,
+		&["My name is Jane", "Email jane@example.com"],
+		&["My name is {NAME}", "Email {EMAIL}"],
+	);
+
+	let value = serde_json::to_value(req).unwrap();
+	assert_eq!(
+		value["messages"][0]["content"][0]["text"],
+		"My name is {NAME}"
+	);
+	assert_eq!(
+		value["messages"][0]["content"][1]["image_url"]["url"],
+		"https://example.com/image.png"
+	);
+	assert_eq!(value["messages"][0]["content"][2]["text"], "Email {EMAIL}");
+}
+
+#[test]
+fn bedrock_request_mask_preserves_anthropic_content_parts() {
+	let mut req: crate::llm::types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "claude-sonnet-4-20250514",
+		"max_tokens": 128,
+		"system": [{"type": "text", "text": "Contact Jane", "cache_control": {"type": "ephemeral"}}],
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": "Email jane@example.com"},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AA=="}}
+			]
+		}]
+	}))
+	.unwrap();
+
+	apply_bedrock_request_mask(
+		&mut req,
+		&["Contact Jane", "Email jane@example.com"],
+		&["Contact {NAME}", "Email {EMAIL}"],
+	);
+
+	let value = serde_json::to_value(req).unwrap();
+	assert_eq!(value["system"][0]["text"], "Contact {NAME}");
+	assert_eq!(value["system"][0]["cache_control"]["type"], "ephemeral");
+	assert_eq!(value["messages"][0]["content"][0]["text"], "Email {EMAIL}");
+	assert_eq!(value["messages"][0]["content"][1]["source"]["data"], "AA==");
+}
+
+#[test]
+fn bedrock_request_mask_preserves_responses_input_items() {
+	let mut req: crate::llm::types::responses::Request = serde_json::from_value(serde_json::json!({
+		"model": "gpt-4o",
+		"instructions": "Contact Jane",
+		"input": [{
+			"role": "user",
+			"content": [
+				{"type": "input_text", "text": "Email jane@example.com"},
+				{"type": "input_image", "image_url": "https://example.com/image.png"}
+			]
+		}]
+	}))
+	.unwrap();
+
+	apply_bedrock_request_mask(
+		&mut req,
+		&["Contact Jane", "Email jane@example.com"],
+		&["Contact {NAME}", "Email {EMAIL}"],
+	);
+
+	let value = serde_json::to_value(req).unwrap();
+	assert_eq!(value["instructions"], "Contact {NAME}");
+	assert_eq!(value["input"][0]["content"][0]["text"], "Email {EMAIL}");
+	assert_eq!(
+		value["input"][0]["content"][1]["image_url"],
+		"https://example.com/image.png"
+	);
+}
+
+/// A blocked intervention returns a single canned message no matter how many blocks
+/// were sent; it must reject rather than error out or misapply the canned text.
+#[test]
+fn bedrock_blocked_intervention_with_canned_output_rejects() {
+	let resp = bedrock_intervened(
+		&["Sorry, I can't help with that."],
+		serde_json::json!([{
+			"topicPolicy": {"topics": [{"action": "BLOCKED", "name": "Finance", "type": "DENY"}]}
+		}]),
+	);
+	let outcome = Policy::bedrock_guardrail_outcome(resp, 3, &RequestRejection::default());
+	assert!(matches!(outcome, GuardrailOutcome::Rejected(_)));
+}
+
+/// Automated reasoning findings carry no `action` field; even when the output count
+/// happens to match, the canned message must not be applied as a mask.
+#[test]
+fn bedrock_unrecognized_intervention_rejects_instead_of_masking() {
+	let resp = bedrock_intervened(
+		&["I can't help with that."],
+		serde_json::json!([{
+			"automatedReasoningPolicy": {"findings": [{"impossible": {}}]}
+		}]),
+	);
+	let outcome = Policy::bedrock_guardrail_outcome(resp, 1, &RequestRejection::default());
+	assert!(matches!(outcome, GuardrailOutcome::Rejected(_)));
+}
+
+/// Masked outputs that can't be mapped one-to-one onto the sent blocks must reject
+/// rather than misalign replacements or fail the whole request.
+#[test]
+fn bedrock_masked_output_count_mismatch_rejects() {
+	let resp = bedrock_intervened(&["Email {EMAIL}"], bedrock_anonymized_assessments());
+	let outcome = Policy::bedrock_guardrail_outcome(resp, 2, &RequestRejection::default());
+	assert!(matches!(outcome, GuardrailOutcome::Rejected(_)));
+}
+
+#[test]
+fn bedrock_response_mask_preserves_choice_metadata() {
+	let mut resp: crate::llm::types::completions::Response =
+		serde_json::from_value(serde_json::json!({
+			"model": "gpt-4o",
+			"usage": null,
+			"choices": [{
+				"index": 0,
+				"finish_reason": "tool_calls",
+				"message": {
+					"role": "assistant",
+					"content": "Contact Jane",
+					"tool_calls": [{"id": "call_1", "type": "function"}]
+				}
+			}]
+		}))
+		.unwrap();
+
+	apply_bedrock_response_mask(&mut resp, &["Contact Jane"], &["Contact {NAME}"]);
+
+	let value = serde_json::to_value(resp).unwrap();
+	assert_eq!(value["choices"][0]["message"]["content"], "Contact {NAME}");
+	assert_eq!(
+		value["choices"][0]["message"]["tool_calls"][0]["id"],
+		"call_1"
+	);
+	assert_eq!(value["choices"][0]["finish_reason"], "tool_calls");
+}
+
+/// Masking rewrites the text a citation's offsets point into; stale offsets and
+/// logprobs must be dropped, while untouched parts keep theirs.
+#[test]
+fn bedrock_response_mask_clears_stale_annotation_offsets() {
+	let mut resp: crate::llm::types::responses::Response =
+		serde_json::from_value(serde_json::json!({
+			"id": "resp_01", "status": "completed", "model": "gpt-4o",
+			"output": [
+				{"type": "message", "id": "msg_01", "role": "assistant", "status": "completed", "content": [
+					{"type": "output_text", "logprobs": null, "text": "See the docs.", "annotations": [
+						{"type": "url_citation", "url": "https://example.com", "title": "Docs", "start_index": 0, "end_index": 12}
+					]},
+					{"type": "output_text", "logprobs": null, "text": "Email jane@example.com", "annotations": []}
+				]}
+			]
+		}))
+		.unwrap();
+
+	apply_bedrock_response_mask(
+		&mut resp,
+		&["See the docs.", "Email jane@example.com"],
+		&["See the docs.", "Email {EMAIL}"],
+	);
+
+	let value = serde_json::to_value(resp).unwrap();
+	let parts = &value["output"][0]["content"];
+	// untouched part keeps its citation
+	assert_eq!(parts[0]["text"], "See the docs.");
+	assert_eq!(parts[0]["annotations"][0]["url"], "https://example.com");
+	assert_eq!(parts[1]["text"], "Email {EMAIL}");
+	assert_eq!(parts[1]["annotations"], serde_json::json!([]));
 }
 
 // ============================================================================

--- a/crates/llm/src/types/responses.rs
+++ b/crates/llm/src/types/responses.rs
@@ -645,7 +645,17 @@ impl ResponseType for Response {
 			if let OutputItem::Message(msg) = o {
 				for c in &mut msg.content {
 					if let Content::OutputText(t) = c {
+						if t.annotations.is_empty() && t.logprobs.is_none() {
+							f(&mut t.text);
+							continue;
+						}
+						// offset-based metadata cannot survive a text rewrite
+						let original = t.text.clone();
 						f(&mut t.text);
+						if t.text != original {
+							t.annotations.clear();
+							t.logprobs = None;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Bedrock guardrails will now use visit_text_mut like regex does so multi-part content survives masking (don't drop tool calls, cache control, images, etc.) It also only applies the masking path when the guardrail actually anoymized...

this has some overlap with #3000 and I think it would be easier to merge that one first and rebase this to include the scopes stuff. 