### PR TITLE
feat(mcp): opt-in DNS rebinding protection for localhost Host/Origin

### DIFF
--- a/crates/agentgateway/src/mcp/dns_rebinding.rs
+++ b/crates/agentgateway/src/mcp/dns_rebinding.rs
@@ -21,80 +21,60 @@ pub fn reject_non_localhost(req: &Request) -> Option<Response> {
 	Some(response)
 }
 
-fn is_localhost_request(req: &Request) -> bool {
-	let origin = req
-		.headers()
-		.get(header::ORIGIN)
-		.and_then(|v| v.to_str().ok())
-		.filter(|o| *o != "null");
-	if let Some(origin) = origin
-		&& !is_localhost_origin(origin)
-	{
+pub(super) fn is_localhost_request(req: &Request) -> bool {
+	if !has_localhost_authority(req) {
 		return false;
 	}
 
-	if let Some(host) = request_host(req) {
-		return is_localhost_host(host);
+	let mut origins = req.headers().get_all(header::ORIGIN).iter();
+	let Some(origin) = origins.next() else {
+		// Non-browser and same-origin requests may omit Origin.
+		return true;
+	};
+	// Origin is a singleton header. Reject duplicates rather than validating only
+	// the first value and accidentally ignoring a conflicting one.
+	if origins.next().is_some() {
+		return false;
 	}
-
-	// No Host: accept only when Origin already proved localhost.
-	origin.is_some_and(is_localhost_origin)
+	origin.to_str().ok().is_some_and(is_localhost_origin)
 }
 
-fn request_host(req: &Request) -> Option<&str> {
-	req
-		.headers()
-		.get(header::HOST)
-		.and_then(|v| v.to_str().ok())
-		.or_else(|| req.uri().host())
+fn has_localhost_authority(req: &Request) -> bool {
+	// Inbound HTTP/1 Host is normalized into the URI authority before routing;
+	// HTTP/2 already carries it as :authority. Keep that normalized value as the
+	// sole source of truth.
+	req.uri().host().is_some_and(is_localhost_host)
 }
 
 fn is_localhost_origin(origin: &str) -> bool {
-	let Some(rest) = origin
-		.strip_prefix("http://")
-		.or_else(|| origin.strip_prefix("https://"))
-	else {
+	// `null` is a real browser Origin for opaque origins, not an absent header.
+	// It is deliberately rejected by this localhost-only policy.
+	let Ok(origin) = url::Url::parse(origin.trim()) else {
 		return false;
 	};
-	let host = rest.split('/').next().unwrap_or(rest);
-	is_localhost_host(host)
+	matches!(origin.scheme(), "http" | "https")
+		&& origin.username().is_empty()
+		&& origin.password().is_none()
+		&& origin.path() == "/"
+		&& origin.query().is_none()
+		&& origin.fragment().is_none()
+		&& origin.host_str().is_some_and(is_localhost_host)
 }
 
 fn is_localhost_host(host: &str) -> bool {
-	let host = strip_port(host.trim());
-	let host = host
-		.strip_prefix('[')
-		.and_then(|h| h.strip_suffix(']'))
-		.unwrap_or(host);
+	let host = host.trim_matches(['[', ']']);
 	host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
-}
-
-/// Strip a trailing `:port`, keeping IPv6 bracket form (`[::1]:8080` → `[::1]`).
-fn strip_port(host: &str) -> &str {
-	if let Some(rest) = host.strip_prefix('[')
-		&& let Some(end) = rest.find(']')
-	{
-		// `end` is relative to `rest`; include the leading '[' and trailing ']'.
-		return &host[..=end + 1];
-	}
-	if let Some((name, port)) = host.rsplit_once(':')
-		&& !port.is_empty()
-		&& port.bytes().all(|b| b.is_ascii_digit())
-	{
-		return name;
-	}
-	host
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 
-	fn req(host: Option<&str>, origin: Option<&str>) -> Request {
-		let mut b = ::http::Request::builder().method("POST").uri("http://127.0.0.1:8080/mcp");
-		if let Some(host) = host {
-			b = b.header(header::HOST, host);
-		}
+	fn req(authority: Option<&str>, origin: Option<&str>) -> Request {
+		let uri = authority
+			.map(|authority| format!("http://{authority}/mcp"))
+			.unwrap_or_else(|| "/mcp".to_string());
+		let mut b = ::http::Request::builder().method("POST").uri(uri);
 		if let Some(origin) = origin {
 			b = b.header(header::ORIGIN, origin);
 		}
@@ -103,12 +83,15 @@ mod tests {
 
 	#[test]
 	fn accepts_localhost_hosts() {
-		for host in ["localhost", "localhost:8080", "127.0.0.1", "127.0.0.1:9", "[::1]", "[::1]:8080"]
-		{
-			assert!(
-				is_localhost_request(&req(Some(host), None)),
-				"host {host}"
-			);
+		for host in [
+			"localhost",
+			"localhost:8080",
+			"127.0.0.1",
+			"127.0.0.1:9",
+			"[::1]",
+			"[::1]:8080",
+		] {
+			assert!(is_localhost_request(&req(Some(host), None)), "host {host}");
 		}
 	}
 
@@ -116,6 +99,7 @@ mod tests {
 	fn rejects_non_localhost_host() {
 		assert!(!is_localhost_request(&req(Some("evil.com"), None)));
 		assert!(!is_localhost_request(&req(Some("evil.com:443"), None)));
+		assert!(!is_localhost_request(&req(None, None)));
 	}
 
 	#[test]
@@ -133,9 +117,37 @@ mod tests {
 			Some("http://localhost:8080")
 		)));
 		assert!(is_localhost_request(&req(
-			None,
+			Some("127.0.0.1"),
 			Some("http://127.0.0.1")
 		)));
+	}
+
+	#[test]
+	fn rejects_null_and_malformed_origins() {
+		for origin in [
+			"null",
+			"http://[::1].evil.example",
+			"http://[::1]garbage",
+			"http://localhost/path",
+			"ftp://localhost",
+		] {
+			assert!(
+				!is_localhost_request(&req(Some("localhost"), Some(origin))),
+				"origin {origin}"
+			);
+		}
+	}
+
+	#[test]
+	fn rejects_duplicate_origins() {
+		let request = ::http::Request::builder()
+			.method("POST")
+			.uri("http://localhost/mcp")
+			.header(header::ORIGIN, "http://localhost")
+			.header(header::ORIGIN, "http://evil.example")
+			.body(crate::http::Body::empty())
+			.unwrap();
+		assert!(!is_localhost_request(&request));
 	}
 
 	#[test]

--- a/crates/agentgateway/src/mcp/dns_rebinding.rs
+++ b/crates/agentgateway/src/mcp/dns_rebinding.rs
@@ -1,0 +1,147 @@
+use ::http::{StatusCode, header};
+
+use crate::http::{Request, Response};
+
+/// Opt-in DNS rebinding protection for MCP servers (see #1855).
+///
+/// The MCP spec requires localhost servers to reject non-localhost `Host` /
+/// `Origin` headers. agentgateway is typically not a browser-facing localhost
+/// server, so this is off by default.
+pub fn reject_non_localhost(req: &Request) -> Option<Response> {
+	if is_localhost_request(req) {
+		return None;
+	}
+	let response = ::http::Response::builder()
+		.status(StatusCode::FORBIDDEN)
+		.header(header::CONTENT_TYPE, "text/plain")
+		.body(crate::http::Body::from(
+			"MCP DNS rebinding protection: Host/Origin must be localhost, 127.0.0.1, or [::1]",
+		))
+		.expect("valid response");
+	Some(response)
+}
+
+fn is_localhost_request(req: &Request) -> bool {
+	let origin = req
+		.headers()
+		.get(header::ORIGIN)
+		.and_then(|v| v.to_str().ok())
+		.filter(|o| *o != "null");
+	if let Some(origin) = origin
+		&& !is_localhost_origin(origin)
+	{
+		return false;
+	}
+
+	if let Some(host) = request_host(req) {
+		return is_localhost_host(host);
+	}
+
+	// No Host: accept only when Origin already proved localhost.
+	origin.is_some_and(is_localhost_origin)
+}
+
+fn request_host(req: &Request) -> Option<&str> {
+	req
+		.headers()
+		.get(header::HOST)
+		.and_then(|v| v.to_str().ok())
+		.or_else(|| req.uri().host())
+}
+
+fn is_localhost_origin(origin: &str) -> bool {
+	let Some(rest) = origin
+		.strip_prefix("http://")
+		.or_else(|| origin.strip_prefix("https://"))
+	else {
+		return false;
+	};
+	let host = rest.split('/').next().unwrap_or(rest);
+	is_localhost_host(host)
+}
+
+fn is_localhost_host(host: &str) -> bool {
+	let host = strip_port(host.trim());
+	let host = host
+		.strip_prefix('[')
+		.and_then(|h| h.strip_suffix(']'))
+		.unwrap_or(host);
+	host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
+}
+
+/// Strip a trailing `:port`, keeping IPv6 bracket form (`[::1]:8080` → `[::1]`).
+fn strip_port(host: &str) -> &str {
+	if let Some(rest) = host.strip_prefix('[')
+		&& let Some(end) = rest.find(']')
+	{
+		// `end` is relative to `rest`; include the leading '[' and trailing ']'.
+		return &host[..=end + 1];
+	}
+	if let Some((name, port)) = host.rsplit_once(':')
+		&& !port.is_empty()
+		&& port.bytes().all(|b| b.is_ascii_digit())
+	{
+		return name;
+	}
+	host
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn req(host: Option<&str>, origin: Option<&str>) -> Request {
+		let mut b = ::http::Request::builder().method("POST").uri("http://127.0.0.1:8080/mcp");
+		if let Some(host) = host {
+			b = b.header(header::HOST, host);
+		}
+		if let Some(origin) = origin {
+			b = b.header(header::ORIGIN, origin);
+		}
+		b.body(crate::http::Body::empty()).unwrap()
+	}
+
+	#[test]
+	fn accepts_localhost_hosts() {
+		for host in ["localhost", "localhost:8080", "127.0.0.1", "127.0.0.1:9", "[::1]", "[::1]:8080"]
+		{
+			assert!(
+				is_localhost_request(&req(Some(host), None)),
+				"host {host}"
+			);
+		}
+	}
+
+	#[test]
+	fn rejects_non_localhost_host() {
+		assert!(!is_localhost_request(&req(Some("evil.com"), None)));
+		assert!(!is_localhost_request(&req(Some("evil.com:443"), None)));
+	}
+
+	#[test]
+	fn rejects_non_localhost_origin_even_with_localhost_host() {
+		assert!(!is_localhost_request(&req(
+			Some("127.0.0.1:8080"),
+			Some("http://evil.com")
+		)));
+	}
+
+	#[test]
+	fn accepts_localhost_origin() {
+		assert!(is_localhost_request(&req(
+			Some("127.0.0.1:8080"),
+			Some("http://localhost:8080")
+		)));
+		assert!(is_localhost_request(&req(
+			None,
+			Some("http://127.0.0.1")
+		)));
+	}
+
+	#[test]
+	fn reject_non_localhost_builds_403() {
+		let resp = reject_non_localhost(&req(Some("evil.com"), None)).expect("rejected");
+		assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+		assert!(reject_non_localhost(&req(Some("localhost"), None)).is_none());
+	}
+}

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1708,6 +1708,26 @@ async fn dns_rebinding_protection_rejects_non_localhost_origin() {
 		.unwrap();
 	assert_eq!(forbidden.status(), reqwest::StatusCode::FORBIDDEN);
 
+	let null_origin = mcp_json_post(&client, &url, &mcp_initialize_body())
+		.header("Origin", "null")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(null_origin.status(), reqwest::StatusCode::FORBIDDEN);
+
+	// Well-known GETs normally bypass the MCP service and pass directly to the
+	// upstream. DNS rebinding validation must still run before that fast path.
+	let forbidden_well_known = client
+		.get(format!("http://{io}/.well-known/oauth-protected-resource"))
+		.header("Origin", "http://evil.example")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(
+		forbidden_well_known.status(),
+		reqwest::StatusCode::FORBIDDEN
+	);
+
 	let allowed = mcp_json_post(&client, &url, &mcp_initialize_body())
 		.header("Origin", format!("http://127.0.0.1:{}", io.port()))
 		.send()

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1662,6 +1662,88 @@ fn mcp_json_post<'a>(
 		.json(body)
 }
 
+fn mcp_initialize_body() -> serde_json::Value {
+	serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "initialize",
+		"params": {
+			"protocolVersion": "2025-06-18",
+			"capabilities": {},
+			"clientInfo": {"name": "test-client", "version": "0.0.1"}
+		}
+	})
+}
+
+#[tokio::test]
+async fn dns_rebinding_protection_off_allows_non_localhost_origin() {
+	let mock = mock_streamable_http_server(true).await;
+	let (_bind, io) = setup_proxy(&mock, true, false).await;
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+	let resp = mcp_json_post(&client, &url, &mcp_initialize_body())
+		.header("Origin", "http://evil.example")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn dns_rebinding_protection_rejects_non_localhost_origin() {
+	let mock = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend_dns_rebinding_protection(mock.addr, true, false)
+		.with_bind(simple_bind())
+		.with_route(basic_route(mock.addr));
+	let io = t.serve_real_listener(BIND_KEY).await;
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+
+	let forbidden = mcp_json_post(&client, &url, &mcp_initialize_body())
+		.header("Origin", "http://evil.example")
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(forbidden.status(), reqwest::StatusCode::FORBIDDEN);
+
+	let allowed = mcp_json_post(&client, &url, &mcp_initialize_body())
+		.header("Origin", format!("http://127.0.0.1:{}", io.port()))
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(allowed.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn dns_rebinding_protection_rejects_non_localhost_host() {
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+	let mock = mock_streamable_http_server(true).await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend_dns_rebinding_protection(mock.addr, true, false)
+		.with_bind(simple_bind())
+		.with_route(basic_route(mock.addr));
+	let io = t.serve_real_listener(BIND_KEY).await;
+
+	let mut stream = tokio::net::TcpStream::connect(io).await.unwrap();
+	let body = mcp_initialize_body().to_string();
+	let req = format!(
+		"POST /mcp HTTP/1.1\r\nHost: evil.example\r\nContent-Type: application/json\r\nAccept: application/json, text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+		body.len()
+	);
+	stream.write_all(req.as_bytes()).await.unwrap();
+	let mut buf = Vec::new();
+	stream.read_to_end(&mut buf).await.unwrap();
+	let text = String::from_utf8_lossy(&buf);
+	assert!(
+		text.starts_with("HTTP/1.1 403"),
+		"expected 403 for Host: evil.example, got: {text}"
+	);
+}
+
 #[tokio::test]
 async fn streamable_http_downstream_sse_frames_include_message_event() {
 	use wiremock::{Mock, ResponseTemplate};
@@ -3683,6 +3765,7 @@ async fn setup_proxy_policies_with_target(
 			legacy_sse,
 			policies,
 			target_policies,
+			false,
 		)
 		.with_bind(simple_bind())
 		.with_route(basic_route(mock.addr));

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -1,5 +1,6 @@
 mod apps;
 pub(crate) mod auth;
+pub(crate) mod dns_rebinding;
 pub(crate) mod guardrails;
 mod handler;
 mod mergestream;

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -124,6 +124,12 @@ impl App {
 		let tracer = log.span_writer();
 		req.extensions_mut().insert(tracer);
 
+		if backend.dns_rebinding_protection
+			&& let Some(resp) = mcp::dns_rebinding::reject_non_localhost(&req)
+		{
+			return Ok(resp);
+		}
+
 		authorization_policies.register(log.cel.ctx());
 		log.cel.ctx().maybe_buffer_request_body(&mut req).await;
 

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -40,6 +40,11 @@ impl App {
 		backend: &McpBackend,
 		req: &Request,
 	) -> Option<SimpleBackendReference> {
+		// Invalid well-known requests must not bypass the validation in `serve`
+		// through the direct upstream passthrough path.
+		if backend.dns_rebinding_protection && !mcp::dns_rebinding::is_localhost_request(req) {
+			return None;
+		}
 		if backend.targets.len() != 1 {
 			return None;
 		}

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -1556,6 +1556,7 @@ async fn test_openapi_from_url() {
 		stateful_mode: McpStatefulMode::Stateful,
 		prefix_mode: None,
 		failure_mode: None,
+		dns_rebinding_protection: false,
 	});
 
 	// Convert to runtime backends

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -699,7 +699,16 @@ impl TestBind {
 		legacy_sse: bool,
 		policies: Vec<BackendTrafficPolicy>,
 	) -> Self {
-		self.with_mcp_backend_and_target_policies(b, stateful, legacy_sse, policies, vec![])
+		self.with_mcp_backend_and_target_policies(b, stateful, legacy_sse, policies, vec![], false)
+	}
+
+	pub fn with_mcp_backend_dns_rebinding_protection(
+		self,
+		b: SocketAddr,
+		stateful: bool,
+		legacy_sse: bool,
+	) -> Self {
+		self.with_mcp_backend_and_target_policies(b, stateful, legacy_sse, vec![], vec![], true)
 	}
 
 	// Like `with_mcp_backend_policies`, but also attaches `target_policies` to the
@@ -713,6 +722,7 @@ impl TestBind {
 		legacy_sse: bool,
 		policies: Vec<BackendTrafficPolicy>,
 		target_policies: Vec<BackendTrafficPolicy>,
+		dns_rebinding_protection: bool,
 	) -> Self {
 		let opb = Backend::Opaque(
 			ResourceName::new(strng::format!("basic-{}", b), "".into()),
@@ -740,6 +750,7 @@ impl TestBind {
 				prefix_mode: Default::default(),
 				failure_mode: FailureMode::FailClosed,
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
+				dns_rebinding_protection,
 			},
 		);
 		{
@@ -858,6 +869,7 @@ impl TestBind {
 				prefix_mode,
 				failure_mode,
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
+				dns_rebinding_protection: false,
 			},
 		);
 		{

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1734,6 +1734,11 @@ pub struct McpBackend {
 	#[serde(with = "crate::serdes::serde_dur")]
 	#[cfg_attr(feature = "schema", schemars(with = "String"))]
 	pub session_idle_ttl: Duration,
+	/// When true, reject MCP requests whose Host/Origin is not localhost
+	/// (`localhost`, `127.0.0.1`, `[::1]`, with optional port). Off by default:
+	/// agentgateway is typically not a browser-facing localhost MCP server.
+	#[serde(default)]
+	pub dns_rebinding_protection: bool,
 }
 
 impl McpBackend {

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1737,7 +1737,7 @@ pub struct McpBackend {
 	/// When true, reject MCP requests whose Host/Origin is not localhost
 	/// (`localhost`, `127.0.0.1`, `[::1]`, with optional port). Off by default:
 	/// agentgateway is typically not a browser-facing localhost MCP server.
-	#[serde(default)]
+	#[serde(default, skip_serializing_if = "crate::serdes::is_default")]
 	pub dns_rebinding_protection: bool,
 }
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2002,6 +2002,7 @@ pub(crate) fn backend_with_policies_from_proto(
 					proto::agent::mcp_backend::FailureMode::FailClosed => FailureMode::FailClosed,
 				},
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
+				dns_rebinding_protection: false,
 			},
 		),
 		Some(backend::Kind::Guardrail(_)) => {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1721,6 +1721,7 @@ impl LocalBackend {
 					prefix_mode: tgt.prefix_mode.unwrap_or_default(),
 					failure_mode: tgt.failure_mode.unwrap_or_default(),
 					session_idle_ttl: mcp_session_ttl,
+					dns_rebinding_protection: tgt.dns_rebinding_protection,
 				};
 				backends.push(Backend::MCP(name, m).into());
 				backends
@@ -1787,6 +1788,10 @@ pub struct LocalMcpBackend {
 	/// Defaults to `failClosed`.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub failure_mode: Option<FailureMode>,
+	/// Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).
+	/// Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.
+	#[serde(default)]
+	pub dns_rebinding_protection: bool,
 }
 
 #[apply(schema_de!)]

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1790,7 +1790,7 @@ pub struct LocalMcpBackend {
 	pub failure_mode: Option<FailureMode>,
 	/// Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).
 	/// Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.
-	#[serde(default)]
+	#[serde(default, skip_serializing_if = "crate::serdes::is_default")]
 	pub dns_rebinding_protection: bool,
 }
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -7566,6 +7566,11 @@
               "type": "null"
             }
           ]
+        },
+        "dnsRebindingProtection": {
+          "description": "Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).\nOff by default; see https://github.com/agentgateway/agentgateway/issues/1855.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false,
@@ -11731,6 +11736,11 @@
               "type": "null"
             }
           ]
+        },
+        "dnsRebindingProtection": {
+          "description": "Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).\nOff by default; see https://github.com/agentgateway/agentgateway/issues/1855.",
+          "type": "boolean",
+          "default": false
         },
         "policies": {
           "description": "Policies applied to MCP requests.",

--- a/schema/config.json
+++ b/schema/config.json
@@ -7569,8 +7569,7 @@
         },
         "dnsRebindingProtection": {
           "description": "Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).\nOff by default; see https://github.com/agentgateway/agentgateway/issues/1855.",
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -11739,8 +11738,7 @@
         },
         "dnsRebindingProtection": {
           "description": "Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).\nOff by default; see https://github.com/agentgateway/agentgateway/issues/1855.",
-          "type": "boolean",
-          "default": false
+          "type": "boolean"
         },
         "policies": {
           "description": "Policies applied to MCP requests.",

--- a/schema/config.md
+++ b/schema/config.md
@@ -5305,6 +5305,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`binds[].listeners[].routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
 |`binds[].listeners[].routes[].backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`binds[].listeners[].routes[].backends[].mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
 |`binds[].listeners[].routes[].backends[].ai`|object||
 |`binds[].listeners[].routes[].backends[].ai.name`|string|Name identifying this provider, referenced by `llm.models[].provider`.|
 |`binds[].listeners[].routes[].backends[].ai.provider`|object|The upstream LLM provider type and its configuration.<br>Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -23161,6 +23162,7 @@
 |`backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
 |`backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`backends[].mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
 |`backends[].ai`|object||
 |`backends[].ai.name`|string|Name identifying this provider, referenced by `llm.models[].provider`.|
 |`backends[].ai.provider`|object|The upstream LLM provider type and its configuration.<br>Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -38247,6 +38249,7 @@
 |`routeGroups[].routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`routeGroups[].routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
 |`routeGroups[].routes[].backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`routeGroups[].routes[].backends[].mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
 |`routeGroups[].routes[].backends[].ai`|object||
 |`routeGroups[].routes[].backends[].ai.name`|string|Name identifying this provider, referenced by `llm.models[].provider`.|
 |`routeGroups[].routes[].backends[].ai.provider`|object|The upstream LLM provider type and its configuration.<br>Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -55913,6 +55916,7 @@
 |`routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
 |`routes[].backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`routes[].backends[].mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
 |`routes[].backends[].ai`|object||
 |`routes[].backends[].ai.name`|string|Name identifying this provider, referenced by `llm.models[].provider`.|
 |`routes[].backends[].ai.provider`|object|The upstream LLM provider type and its configuration.<br>Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -73350,6 +73354,7 @@
 |`mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
 |`mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
+|`mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
 |`mcp.policies`|object|Policies applied to MCP requests.|
 |`mcp.policies.requestHeaderModifier`|object|Modify request headers before forwarding.|
 |`mcp.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|


### PR DESCRIPTION
## Summary
- Opt-in `dnsRebindingProtection` on MCP backends (default off), as requested in #1855.
- When enabled, Host/Origin must be `localhost`, `127.0.0.1`, or `[::1]` (optional port); otherwise the gateway returns 403.
- Off by default so typical proxy deployments are unchanged.

Fixes #1855

## Test plan
- [x] Unit tests for Host/Origin localhost parsing
- [x] E2E: protection off still allows `Origin: http://evil.example`
- [x] E2E: protection on rejects non-localhost Origin (403) and allows localhost Origin (200)
- [x] E2E: raw HTTP `Host: evil.example` returns 403

```text
$ cargo test -p agentgateway --lib dns_rebinding -- --nocapture
test mcp::dns_rebinding::tests::rejects_non_localhost_origin_even_with_localhost_host ... ok
test mcp::dns_rebinding::tests::rejects_non_localhost_host ... ok
test mcp::dns_rebinding::tests::accepts_localhost_origin ... ok
test mcp::dns_rebinding::tests::accepts_localhost_hosts ... ok
test mcp::dns_rebinding::tests::reject_non_localhost_builds_403 ... ok
test mcp::tests::dns_rebinding_protection_rejects_non_localhost_host ... ok
test mcp::tests::dns_rebinding_protection_off_allows_non_localhost_origin ... ok
test mcp::tests::dns_rebinding_protection_rejects_non_localhost_origin ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 1725 filtered out
```
