### PR TITLE
feat(llm): expose model and provider to prompt-guard webhook CEL

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1729,8 +1729,31 @@ impl AIProvider {
 				let http_headers = &parts.headers;
 				let claims = parts.extensions.get::<Claims>().cloned();
 				let original = log.as_ref().and_then(|l| l.request_snapshot.clone());
+				let request_model = req
+					.model()
+					.clone()
+					.map(strng::new)
+					.unwrap_or_default();
+				let llm_ctx = Box::new(crate::cel::LLMContext::from(LLMRequest {
+					input_tokens: None,
+					input_format: original_format,
+					cache_convention: CacheTokenConvention::pending(),
+					request_model,
+					provider: self.provider(),
+					streaming: false,
+					params: LLMRequestParams::default(),
+					prompt: None,
+					provider_state: None,
+				}));
 				if let Some((response, guardrail)) = p
-					.apply_prompt_guard(backend_info, req, http_headers, claims, original.as_deref())
+					.apply_prompt_guard(
+						backend_info,
+						req,
+						http_headers,
+						claims,
+						original.as_deref(),
+						Some(&llm_ctx),
+					)
 					.await
 					.map_err(|e| {
 						warn!("failed to call prompt guard webhook: {e}");
@@ -1993,14 +2016,20 @@ impl AIProvider {
 			let mut resp = self.translate_chat_or_detect_response(&req, &bytes)?;
 			let prompt_guard_headers =
 				response_prompt_guard_headers(&parts.headers, rate_limit.request_traceparent.as_ref());
+			let llm_ctx = Box::new(crate::cel::LLMContext::from_llm_info(
+				LLMInfo::new(req.clone(), resp.to_llm_response(log_content)),
+				model_catalog,
+			));
 
-			// Apply response prompt guard
+			// Apply response prompt guard with LLM CEL context already populated
+			// (model/provider/responseModel), so webhook header expressions can use them.
 			if let Some(dr) = Policy::apply_response_prompt_guard(
 				&client,
 				resp.as_mut(),
 				&prompt_guard_headers,
 				&rate_limit.prompt_guard,
 				req_snapshot.as_deref(),
+				Some(&llm_ctx),
 			)
 			.await
 			.map_err(|e| {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -1729,11 +1729,7 @@ impl AIProvider {
 				let http_headers = &parts.headers;
 				let claims = parts.extensions.get::<Claims>().cloned();
 				let original = log.as_ref().and_then(|l| l.request_snapshot.clone());
-				let request_model = req
-					.model()
-					.clone()
-					.map(strng::new)
-					.unwrap_or_default();
+				let request_model = req.model().clone().map(strng::new).unwrap_or_default();
 				let llm_ctx = Box::new(crate::cel::LLMContext::from(LLMRequest {
 					input_tokens: None,
 					input_format: original_format,

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -476,6 +476,7 @@ impl PromptGuard {
 				client,
 				claims.clone(),
 				original,
+				None,
 			)
 			.await
 			{
@@ -556,7 +557,7 @@ impl PromptGuard {
 			content: window.to_string(),
 		};
 		let (action, rejection) =
-			Policy::apply_single_response_guard(guard, &mut resp, http_headers, client, original).await?;
+			Policy::apply_single_response_guard(guard, &mut resp, http_headers, client, original, None).await?;
 		match rejection {
 			Some(rejected) => {
 				let body = rejected.into_body().collect().await?.to_bytes();
@@ -836,6 +837,7 @@ impl Policy {
 		http_headers: &HeaderMap,
 		claims: Option<Claims>,
 		original: Option<&cel::RequestSnapshot>,
+		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<Option<(Response, &'static str)>> {
 		let client = PolicyClient::new(backend_info.inputs.clone());
 		for g in self
@@ -844,9 +846,16 @@ impl Policy {
 			.iter()
 			.flat_map(|g| g.request.iter())
 		{
-			let (action, rejection) =
-				Self::apply_single_request_guard(g, req, http_headers, &client, claims.clone(), original)
-					.await?;
+			let (action, rejection) = Self::apply_single_request_guard(
+				g,
+				req,
+				http_headers,
+				&client,
+				claims.clone(),
+				original,
+				llm,
+			)
+			.await?;
 			Self::record_guardrail_trip(&client, GuardrailPhase::Request, action);
 			if let Some(res) = rejection {
 				return Ok(Some((res, g.kind.name())));
@@ -864,10 +873,18 @@ impl Policy {
 		client: &PolicyClient,
 		claims: Option<Claims>,
 		original: Option<&cel::RequestSnapshot>,
+		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<(GuardrailAction, Option<Response>)> {
-		let outcome =
-			Self::evaluate_single_request_guard(guard, req, http_headers, client, claims, original)
-				.await?;
+		let outcome = Self::evaluate_single_request_guard(
+			guard,
+			req,
+			http_headers,
+			client,
+			claims,
+			original,
+			llm,
+		)
+		.await?;
 		Self::apply_request_guard_outcome(outcome, req)
 	}
 
@@ -878,11 +895,12 @@ impl Policy {
 		client: &PolicyClient,
 		claims: Option<Claims>,
 		original: Option<&cel::RequestSnapshot>,
+		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<GuardrailOutcome<RequestGuardMutation>> {
 		match &guard.kind {
 			RequestGuardKind::Regex(rg) => Ok(Self::evaluate_regex_request(req, rg, &guard.rejection)),
 			RequestGuardKind::Webhook(wh) => {
-				Self::evaluate_webhook_request(req, http_headers, client, wh, original).await
+				Self::evaluate_webhook_request(req, http_headers, client, wh, original, llm).await
 			},
 			RequestGuardKind::OpenAIModeration(m) => {
 				Self::evaluate_moderation(req, claims, client, m, &guard.rejection).await
@@ -1173,6 +1191,7 @@ impl Policy {
 		client: &PolicyClient,
 		webhook: &Webhook,
 		original: Option<&cel::RequestSnapshot>,
+		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<GuardrailOutcome<RequestGuardMutation>> {
 		let llm_request = webhook
 			.headers
@@ -1180,7 +1199,7 @@ impl Policy {
 			.any(|(_, expression)| expression.needs_llm_request())
 			.then(|| req.to_value())
 			.transpose()?;
-		let context = webhook::EvaluationContext::new(original, llm_request.as_ref());
+		let context = webhook::EvaluationContext::new(original, llm_request.as_ref()).with_llm(llm);
 		let messages = req.get_messages();
 		let headers = Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
 		let whr = match webhook::send_request(client, webhook, context, &headers, messages).await {
@@ -1241,13 +1260,14 @@ impl Policy {
 		client: &PolicyClient,
 		webhook: &Webhook,
 		original: Option<&cel::RequestSnapshot>,
+		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<GuardrailOutcome<ResponseGuardMutation>> {
 		let messages = resp.to_webhook_choices();
 		let headers = Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
 		let whr = match webhook::send_response(
 			client,
 			webhook,
-			webhook::EvaluationContext::new(original, None),
+			webhook::EvaluationContext::new(original, None).with_llm(llm),
 			&headers,
 			messages,
 		)
@@ -1427,10 +1447,11 @@ impl Policy {
 		http_headers: &HeaderMap,
 		guards: &Vec<ResponseGuard>,
 		original: Option<&cel::RequestSnapshot>,
+		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<Option<Response>> {
 		for g in guards {
 			let (action, rejection) =
-				Self::apply_single_response_guard(g, resp, http_headers, client, original).await?;
+				Self::apply_single_response_guard(g, resp, http_headers, client, original, llm).await?;
 			Self::record_guardrail_trip(client, GuardrailPhase::Response, action);
 			if let Some(res) = rejection {
 				return Ok(Some(res));
@@ -1445,9 +1466,10 @@ impl Policy {
 		http_headers: &HeaderMap,
 		client: &PolicyClient,
 		original: Option<&cel::RequestSnapshot>,
+		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<(GuardrailAction, Option<Response>)> {
 		let outcome =
-			Self::evaluate_single_response_guard(guard, resp, http_headers, client, original).await?;
+			Self::evaluate_single_response_guard(guard, resp, http_headers, client, original, llm).await?;
 		Self::apply_response_guard_outcome(outcome, resp)
 	}
 
@@ -1457,11 +1479,12 @@ impl Policy {
 		http_headers: &HeaderMap,
 		client: &PolicyClient,
 		original: Option<&cel::RequestSnapshot>,
+		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<GuardrailOutcome<ResponseGuardMutation>> {
 		match &guard.kind {
 			ResponseGuardKind::Regex(rg) => Ok(Self::evaluate_regex_response(resp, rg, &guard.rejection)),
 			ResponseGuardKind::Webhook(wh) => {
-				Self::evaluate_webhook_response(resp, http_headers, client, wh, original).await
+				Self::evaluate_webhook_response(resp, http_headers, client, wh, original, llm).await
 			},
 			ResponseGuardKind::BedrockGuardrails(bg) => {
 				Self::evaluate_bedrock_guardrails_response(resp, None, client, bg, &guard.rejection).await

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -557,7 +557,8 @@ impl PromptGuard {
 			content: window.to_string(),
 		};
 		let (action, rejection) =
-			Policy::apply_single_response_guard(guard, &mut resp, http_headers, client, original, None).await?;
+			Policy::apply_single_response_guard(guard, &mut resp, http_headers, client, original, None)
+				.await?;
 		match rejection {
 			Some(rejected) => {
 				let body = rejected.into_body().collect().await?.to_bytes();
@@ -875,16 +876,9 @@ impl Policy {
 		original: Option<&cel::RequestSnapshot>,
 		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<(GuardrailAction, Option<Response>)> {
-		let outcome = Self::evaluate_single_request_guard(
-			guard,
-			req,
-			http_headers,
-			client,
-			claims,
-			original,
-			llm,
-		)
-		.await?;
+		let outcome =
+			Self::evaluate_single_request_guard(guard, req, http_headers, client, claims, original, llm)
+				.await?;
 		Self::apply_request_guard_outcome(outcome, req)
 	}
 
@@ -1469,7 +1463,8 @@ impl Policy {
 		llm: Option<&cel::LLMContext>,
 	) -> anyhow::Result<(GuardrailAction, Option<Response>)> {
 		let outcome =
-			Self::evaluate_single_response_guard(guard, resp, http_headers, client, original, llm).await?;
+			Self::evaluate_single_response_guard(guard, resp, http_headers, client, original, llm)
+				.await?;
 		Self::apply_response_guard_outcome(outcome, resp)
 	}
 

--- a/crates/agentgateway/src/llm/policy/webhook.rs
+++ b/crates/agentgateway/src/llm/policy/webhook.rs
@@ -17,6 +17,7 @@ const RESPONSE_PATH: &str = "response";
 pub(super) struct EvaluationContext<'a> {
 	request: Option<&'a RequestSnapshot>,
 	llm_request: Option<&'a serde_json::Value>,
+	llm: Option<&'a cel::LLMContext>,
 }
 
 impl<'a> EvaluationContext<'a> {
@@ -27,14 +28,24 @@ impl<'a> EvaluationContext<'a> {
 		Self {
 			request,
 			llm_request,
+			llm: None,
 		}
 	}
 
+	pub(super) fn with_llm(mut self, llm: Option<&'a cel::LLMContext>) -> Self {
+		self.llm = llm;
+		self
+	}
+
 	fn executor(self) -> cel::Executor<'a> {
-		match self.llm_request {
+		let mut exec = match self.llm_request {
 			Some(llm_request) => cel::Executor::new_llm(self.request, llm_request),
 			None => cel::Executor::new_request_snapshot(self.request),
+		};
+		if let Some(llm) = self.llm {
+			exec.llm = cel::ExtensionOrDirect::Direct(Some(llm));
 		}
+		exec
 	}
 }
 
@@ -484,5 +495,85 @@ mod tests {
 		assert_eq!(req.uri().path(), "/prefixed/request");
 		// ...but context-dependent ones are skipped.
 		assert!(req.headers().get("x-user").is_none());
+	}
+
+	fn llm_ctx() -> crate::cel::LLMContext {
+		crate::cel::LLMContext::from_llm_info(
+			crate::llm::LLMInfo::new(
+				crate::llm::LLMRequest {
+					input_tokens: None,
+					input_format: crate::llm::InputFormat::Completions,
+					cache_convention: crate::llm::CacheTokenConvention::pending(),
+					request_model: "gpt-4o-mini".into(),
+					provider: "openai".into(),
+					streaming: false,
+					params: Default::default(),
+					prompt: None,
+					provider_state: None,
+				},
+				crate::llm::LLMResponse {
+					provider_model: Some("gpt-4o-mini-2024-07-18".into()),
+					..Default::default()
+				},
+			),
+			None,
+		)
+	}
+
+	#[test]
+	fn request_webhook_headers_see_llm_model_and_provider() {
+		let wh = webhook(Vec::from([
+			(
+				HeaderOrPseudo::Header(::http::HeaderName::from_static("x-llm-model")),
+				expr("llm.requestModel"),
+			),
+			(
+				HeaderOrPseudo::Header(::http::HeaderName::from_static("x-llm-provider")),
+				expr("llm.provider"),
+			),
+		]));
+		let llm = llm_ctx();
+		let req = build_request_for_request(
+			&wh,
+			EvaluationContext::new(None, None).with_llm(Some(&llm)),
+			&HeaderMap::new(),
+			vec![],
+		)
+		.unwrap();
+		assert_eq!(req.headers().get("x-llm-model").unwrap(), "gpt-4o-mini");
+		assert_eq!(req.headers().get("x-llm-provider").unwrap(), "openai");
+	}
+
+	#[test]
+	fn response_webhook_headers_see_response_model() {
+		let wh = webhook(Vec::from([
+			(
+				HeaderOrPseudo::Header(::http::HeaderName::from_static("x-llm-model")),
+				expr("llm.requestModel"),
+			),
+			(
+				HeaderOrPseudo::Header(::http::HeaderName::from_static("x-response-model")),
+				expr("llm.responseModel"),
+			),
+			(
+				HeaderOrPseudo::Header(::http::HeaderName::from_static("x-llm-provider")),
+				expr("llm.provider"),
+			),
+		]));
+		let llm = llm_ctx();
+		let req = build_request_for_response(
+			&wh,
+			EvaluationContext::new(None, None).with_llm(Some(&llm)),
+			&HeaderMap::new(),
+			vec![],
+		)
+		.unwrap();
+		assert_eq!(req.headers().get("x-llm-model").unwrap(), "gpt-4o-mini");
+		assert_eq!(
+			req.headers().get("x-response-model").unwrap(),
+			"gpt-4o-mini-2024-07-18"
+		);
+		assert_eq!(req.headers().get("x-llm-provider").unwrap(), "openai");
+		assert_eq!(req.uri().path(), "/response");
 	}
 }


### PR DESCRIPTION
## Summary
- Build LLM CEL context before request and response prompt-guard webhooks run.
- Header expressions can use `llm.requestModel`, `llm.provider`, and `llm.responseModel` on both phases (responseModel is the provider-reported model).
- `forwardHeaderMatches` is unchanged; this is the CEL path from #2505.

Fixes #2505

## Test plan
- [x] Request webhook headers resolve `llm.requestModel` / `llm.provider`
- [x] Response webhook headers resolve `llm.responseModel` plus request model/provider
- [x] Existing webhook CEL tests still pass (9/9)

```text
$ cargo test -p agentgateway --lib llm::policy::webhook::tests -- --nocapture
test llm::policy::webhook::tests::default_paths_are_preserved ... ok
test llm::policy::webhook::tests::response_webhook_headers_see_response_model ... ok
test llm::policy::webhook::tests::request_webhook_headers_see_llm_model_and_provider ... ok
test llm::policy::webhook::tests::jwt_claims_available_in_expressions ... ok
test llm::policy::webhook::tests::claims_are_not_attached_to_the_outgoing_request ... ok
test llm::policy::webhook::tests::path_pseudo_header_overrides_default_path ... ok
test llm::policy::webhook::tests::expressions_see_the_original_request ... ok
test llm::policy::webhook::tests::no_snapshot_degrades_gracefully ... ok
test llm::policy::webhook::tests::failed_expression_removes_header_and_keeps_path ... ok
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 1718 filtered out
```
