### PR TITLE
controller: write InferencePool status for pools referenced via AgentgatewayModel

### DIFF
--- a/controller/pkg/agentgateway/translator/golden_test.go
+++ b/controller/pkg/agentgateway/translator/golden_test.go
@@ -64,7 +64,7 @@ func TestRouteCollection(t *testing.T) {
 func TestModels(t *testing.T) {
 	testutils.RunForDirectory(t, "testdata/models", func(t *testing.T, ctx plugins.PolicyCtx) (any, []ir.AgwResource) {
 		ctx.Collections.Settings.EnableAgentgatewayModels = true
-		sq, ri := testutils.Syncer(t, ctx, "Gateway", "AgentgatewayModel", "HTTPRoute")
+		sq, ri := testutils.Syncer(t, ctx, "Gateway", "AgentgatewayModel", "HTTPRoute", "InferencePool")
 		r := ri.Outputs.Resources.List()
 		return sq.Dump(), slices.SortBy(r, func(a ir.AgwResource) string {
 			return a.ResourceName()

--- a/controller/pkg/agentgateway/translator/model_collections.go
+++ b/controller/pkg/agentgateway/translator/model_collections.go
@@ -11,6 +11,7 @@ import (
 	"istio.io/istio/pkg/config"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/util/sets"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -33,7 +34,7 @@ func AgwModelCollection(
 	models krt.Collection[*agentgateway.AgentgatewayModel],
 	inputs RouteContextInputs,
 	krtopts krtutil.KrtOptions,
-) (krt.Collection[agwir.AgwResource], krt.Collection[*plugins.RouteAttachment]) {
+) (krt.Collection[agwir.AgwResource], krt.Collection[*plugins.RouteAttachment], krt.Collection[*utils.AncestorBackend]) {
 	modelStatus, modelResources := krt.NewStatusManyCollection(models, func(krtctx krt.HandlerContext, obj *agentgateway.AgentgatewayModel) (*agentgateway.AgentgatewayModelStatus, []agwir.AgwResource) {
 		ctx := inputs.WithCtx(krtctx)
 		rm := reports.NewReportMap()
@@ -52,7 +53,56 @@ func AgwModelCollection(
 	status.RegisterStatus(queue, modelStatus, GetStatus)
 
 	attachments := gatewayRouteAttachmentCollection(inputs, models, wellknown.AgentgatewayModelGVK, krtopts)
-	return modelResources, attachments
+	ancestors := krt.NewManyCollection(models, func(krtctx krt.HandlerContext, obj *agentgateway.AgentgatewayModel) []*utils.AncestorBackend {
+		return extractModelAncestorBackends(inputs.WithCtx(krtctx), obj)
+	}, krtopts.ToOptions("translator/ModelAncestorBackends")...)
+	return modelResources, attachments, ancestors
+}
+
+// extractModelAncestorBackends mirrors extractAncestorBackends for AgentgatewayModels, so
+// backends referenced only by a model (spec.custom.backendRef) still resolve to their
+// Gateways in the reference index.
+func extractModelAncestorBackends(ctx RouteContext, model *agentgateway.AgentgatewayModel) []*utils.AncestorBackend {
+	custom := model.Spec.Custom
+	if custom == nil || custom.BackendRef == nil {
+		return nil
+	}
+	source := utils.TypedNamespacedName{
+		NamespacedName: types.NamespacedName{
+			Namespace: model.Namespace,
+			Name:      model.Name,
+		},
+		Kind: wellknown.AgentgatewayModelGVK.Kind,
+	}
+	gateways := sets.Set[types.NamespacedName]{}
+	for _, parent := range FilteredReferences(extractModelParentReferenceInfo(ctx, model)) {
+		gateways.Insert(parent.ParentGateway)
+	}
+	kind := wellknown.ServiceKind
+	if custom.BackendRef.Kind != nil {
+		kind = *custom.BackendRef.Kind
+	}
+	backend := utils.TypedNamespacedName{
+		NamespacedName: types.NamespacedName{
+			// backendRef may target only namespace-local resources.
+			Namespace: model.Namespace,
+			Name:      custom.BackendRef.Name,
+		},
+		Kind: kind,
+	}
+	gtw := gateways.UnsortedList()
+	slices.SortFunc(gtw, func(a, b types.NamespacedName) int {
+		return strings.Compare(a.String(), b.String())
+	})
+	res := make([]*utils.AncestorBackend, 0, len(gtw))
+	for _, gw := range gtw {
+		res = append(res, &utils.AncestorBackend{
+			Gateway: gw,
+			Backend: backend,
+			Source:  source,
+		})
+	}
+	return res
 }
 
 // extractModelParentReferenceInfo resolves an HTTPRoute parent to that route's

--- a/controller/pkg/agentgateway/translator/testdata/models/custom-inferencepool.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/models/custom-inferencepool.yaml
@@ -1,0 +1,263 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: llm-pool
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - name: llm
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      kinds:
+      - group: agentgateway.dev
+        kind: AgentgatewayModel
+      namespaces:
+        from: Same
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-pool-endpoint-picker
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9002
+    targetPort: 9002
+  selector:
+    app: llama
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: llama-pool
+  namespace: default
+spec:
+  endpointPickerRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: llama-pool-endpoint-picker
+    port:
+      number: 9002
+  selector:
+    matchLabels:
+      app: llama
+  targetPorts:
+  - number: 8000
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: llama
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: llm-pool
+    sectionName: llm
+  provider: Custom
+  custom:
+    backendRef:
+      group: inference.networking.k8s.io
+      kind: InferencePool
+      name: llama-pool
+    formats:
+    - type: Completions
+
+---
+# Output
+output:
+- gateway:
+    Name: llm-pool
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - custom:
+              formats:
+              - format: COMPLETIONS
+            name: backend
+            providerBackend:
+              port: 8000
+              service:
+                hostname: llama-pool.default.inference.cluster.local
+                namespace: default
+      key: default/llama/backend.llm
+      name:
+        name: llama
+        namespace: default
+- gateway:
+    Name: llm-pool
+    Namespace: default
+  resource:
+    bind:
+      key: 80/default/llm-pool
+      port: 80
+- gateway:
+    Name: llm-pool
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 80/default/llm-pool
+      key: default/llm-pool.llm
+      name:
+        gatewayName: llm-pool
+        gatewayNamespace: default
+        listenerName: llm
+      protocol: HTTP
+- gateway:
+    Name: llm-pool
+    Namespace: default
+  resource:
+    modelRoute:
+      concreteModel:
+        backend:
+          backend: default/llama/backend.llm
+      key: default/llama.llm
+      listenerKey: default/llm-pool.llm
+      match:
+        model: llama
+- gateway:
+    Name: llm-pool
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker:
+            port: 9002
+            service:
+              hostname: llama-pool-endpoint-picker.default.svc.cluster.local
+              namespace: default
+          failureMode: FAIL_CLOSED
+      key: default/llama-pool:inference
+      name:
+        kind: InferencePool
+        name: llama-pool
+        namespace: default
+      target:
+        service:
+          hostname: llama-pool.default.inference.cluster.local
+          namespace: default
+- gateway:
+    Name: llm-pool
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          verification: INSECURE_ALL
+      key: default/llama-pool:inferencetls
+      name:
+        kind: InferencePool
+        name: llama-pool
+        namespace: default
+      target:
+        service:
+          hostname: llama-pool-endpoint-picker.default.svc.cluster.local
+          namespace: default
+          port: 9002
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayModel
+  metadata:
+    name: llama
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: Successfully accepted AgentgatewayModel
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: ""
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: llm-pool
+        namespace: default
+        sectionName: llm
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: llama-pool
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: All InferencePool references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: llm-pool
+        namespace: default
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: llm-pool
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: llm
+      supportedKinds:
+      - group: agentgateway.dev
+        kind: AgentgatewayModel

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -491,9 +491,10 @@ func (s *Syncer) buildAgwResources(
 	baseAgwRoutes, routeAttachments, ancestorBackends := translator.AgwRouteCollection(s.statusCollections, s.agwCollections.HTTPRoutes, s.agwCollections.GRPCRoutes, s.agwCollections.TCPRoutes, s.agwCollections.TLSRoutes, routeInputs, krtopts)
 	routeCollections := []krt.Collection[agwir.AgwResource]{baseAgwRoutes}
 	if s.agwCollections.Settings.EnableAgentgatewayModels {
-		modelResources, modelAttachments := translator.AgwModelCollection(s.statusCollections, s.agwCollections.Models, routeInputs, krtopts)
+		modelResources, modelAttachments, modelAncestors := translator.AgwModelCollection(s.statusCollections, s.agwCollections.Models, routeInputs, krtopts)
 		routeAttachments = krt.JoinCollection([]krt.Collection[*plugins.RouteAttachment]{routeAttachments, modelAttachments}, krtopts.ToOptions("translator/RouteAttachmentsWithModels")...)
 		routeCollections = append(routeCollections, modelResources)
+		ancestorBackends = krt.JoinCollection([]krt.Collection[*utils.AncestorBackend]{ancestorBackends, modelAncestors}, krtopts.ToOptions("translator/AncestorBackendsWithModels")...)
 	}
 	if s.agwPlugins.AddResourceExtension != nil {
 		if s.agwPlugins.AddResourceExtension.Routes != nil {


### PR DESCRIPTION
## Summary

An `InferencePool` referenced only through
`AgentgatewayModel.spec.custom.backendRef` never receives a `status.parents`
entry. Consumers that require an `Accepted=True` parent condition, such as
KServe's `LLMInferenceService` readiness check, therefore remain in
`WaitingForGateway`.

For `InferencePool` targets, the Gateway lookup is backed by the
`AncestorBackend` index, whose entries were populated only from route
(`HTTPRoute`, `GRPCRoute`, `TLSRoute`, `TCPRoute`) backend references;
`AgwModelCollection` contributed none, so `LookupGatewaysForBackend` returned
an empty set for model-referenced pools.

This PR makes models contribute to the same index:

1. `AgwModelCollection` emits `AncestorBackend` entries for
   `spec.custom.backendRef`, one per attached Gateway, mirroring
   `extractAncestorBackends` for routes.
2. When `EnableAgentgatewayModels` is enabled, the syncer joins the
   model-derived entries into `ancestorBackends` before building the ancestors
   index.

The existing `buildInferencePoolStatus` logic then writes Gateway-kind parent
references with `Accepted=True`, using the same status shape as pools
referenced by an `HTTPRoute`.

## Root cause

On `main`, the relevant status path is:

```text
inference_plugin.go: inferencePoolAttachedGateways()
  └─ ReferenceIndex.LookupGatewaysForBackend(kind=InferencePool)
       └─ attachment lookup uses the Ancestors index
            └─ entries come only from route backendRefs
                 (extractAncestorBackends in route_collections.go)
```

Because `AgentgatewayModel` did not contribute entries to this index,
`attachedGateways` was empty, `desiredInferencePoolParentRefs` returned an
empty list, and `status.parents` remained empty.

A golden fixture (Gateway, EPP Service, InferencePool, and an
`AgentgatewayModel` with a Custom provider referencing the pool) demonstrates
the change:

```yaml
# Before: no status.parents entry

# After:
status:
  parents:
  - conditions:
    - message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
      reason: Accepted
      status: "True"
      type: Accepted
    controllerName: agentgateway.dev/agentgateway
    parentRef: { group: gateway.networking.k8s.io, kind: Gateway, name: llm-pool }
```

PR #2794 fixed the adjacent `enqueueStatus unknown external type` warning for
`AgentgatewayModel`, but did not populate the referenced pool's `Accepted`
condition.

## Behavior changes

- Pools referenced through `AgentgatewayModel.spec.custom.backendRef` now
  report Gateway-kind parent references with `Accepted` and `ResolvedRefs`
  conditions, matching the shape used for route-referenced pools.
- Service-kind `custom.backendRef` targets are indexed as well, consistent
  with route backend reference handling.
- Unchanged: parents identify Gateways (not `AgentgatewayModel` resources),
  route-derived status is untouched, and model-derived entries are gated by
  `EnableAgentgatewayModels`.

Known limitation: indirect virtual-model → concrete-model → InferencePool
references are not propagated; only Gateways directly attached to the concrete
model are credited to its pool.

## Testing

- Added the golden fixture
  `translator/testdata/models/custom-inferencepool.yaml` and included
  `InferencePool` in the status captured by `TestModels`.
- `go test ./pkg/agentgateway/translator/ -run TestModels -count=1` passes,
  with stable golden output after refresh and rerun.
- Reverting the implementation while retaining the fixture causes the test to
  fail because the expected `status.parents` entry is absent.
- `go build ./...` passes; `gofmt` produces no diff; `go vet ./...` reports
  only one pre-existing warning (`pkg/syncer/service.go`), also reproducible
  on unmodified `main`.

Fixes #2818