### PR TITLE
fix: keep /api/config and /api/config/effective truthful after a rejected reload

### DIFF
--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -95,6 +95,7 @@ pub async fn run(
 	let model_catalog = crate::llm::cost::ModelCatalog::new(model_catalog_sources).await?;
 
 	let (xds_tx, xds_rx) = tokio::sync::watch::channel(());
+	let config_reload_status = Arc::new(state_manager::ConfigReloadStatus::default());
 	let state_mgr = state_manager::StateManager::new(
 		config.clone(),
 		control_client.clone(),
@@ -102,6 +103,7 @@ pub async fn run(
 		xds_tx,
 		config_resource_store.clone(),
 		model_catalog.clone(),
+		config_reload_status.clone(),
 	)
 	.await?;
 	let stores = state_mgr.stores();
@@ -127,6 +129,7 @@ pub async fn run(
 		shutdown.trigger(),
 		drain_rx.clone(),
 		data_plane_handle.clone(),
+		config_reload_status,
 	)
 	.await
 	.context("admin server starts")?;

--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -79,6 +79,7 @@ struct AdminState {
 	shutdown_trigger: signal::ShutdownTrigger,
 	#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 	dataplane_handle: Handle,
+	config_reload_status: Arc<crate::state_manager::ConfigReloadStatus>,
 }
 
 pub struct Service {
@@ -130,6 +131,7 @@ impl Service {
 		shutdown_trigger: signal::ShutdownTrigger,
 		drain_rx: DrainWatcher,
 		dataplane_handle: Handle,
+		config_reload_status: Arc<crate::state_manager::ConfigReloadStatus>,
 	) -> anyhow::Result<Self> {
 		let state = Arc::new(AdminState {
 			config,
@@ -139,6 +141,7 @@ impl Service {
 			resource_manager,
 			shutdown_trigger,
 			dataplane_handle,
+			config_reload_status,
 		});
 		let service = AdminService {
 			router: admin_router(state.clone()),
@@ -200,6 +203,7 @@ fn admin_router(state: Arc<AdminState>) -> Router {
 			state.model_catalog.clone(),
 			state.config_resource_store.clone(),
 			state.resource_manager.clone(),
+			state.config_reload_status.clone(),
 		))
 	} else {
 		router.route("/", get(handle_dashboard))

--- a/crates/agentgateway/src/management/admin_tests.rs
+++ b/crates/agentgateway/src/management/admin_tests.rs
@@ -23,6 +23,7 @@ async fn spawn_admin(cfg: &str) -> (SocketAddr, agent_core::drain::DrainTrigger)
 		shutdown.trigger(),
 		drain_rx,
 		Handle::current(),
+		Arc::new(crate::state_manager::ConfigReloadStatus::default()),
 	)
 	.await
 	.expect("admin server should bind");

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 
 use agent_core::prelude::*;
 use agent_core::readiness;
+use arc_swap::ArcSwapOption;
+use chrono::{DateTime, Utc};
 
 use crate::client::Client;
 use crate::store::Stores;
@@ -11,6 +13,51 @@ use crate::types::discovery::SelfIdentitySource;
 use crate::types::proto::agent::Resource as ADPResource;
 use crate::types::proto::workload::Address as XdsAddress;
 use crate::{ConfigSource, ConfigStoreMode, client, config_store, control, store};
+
+#[derive(Debug)]
+pub struct AppliedConfig {
+	pub content: String,
+	pub applied_at: DateTime<Utc>,
+}
+
+#[derive(Debug)]
+pub struct ReloadError {
+	pub message: String,
+	pub occurred_at: DateTime<Utc>,
+}
+
+/// Tracks the outcome of the local config reload pipeline so API consumers can distinguish
+/// the currently-applied config from a rejected on-disk edit.
+#[derive(Debug, Default)]
+pub struct ConfigReloadStatus {
+	applied: ArcSwapOption<AppliedConfig>,
+	last_error: ArcSwapOption<ReloadError>,
+}
+
+impl ConfigReloadStatus {
+	fn record_applied(&self, content: String) {
+		self.applied.store(Some(Arc::new(AppliedConfig {
+			content,
+			applied_at: Utc::now(),
+		})));
+		self.last_error.store(None);
+	}
+
+	fn record_error(&self, message: String) {
+		self.last_error.store(Some(Arc::new(ReloadError {
+			message,
+			occurred_at: Utc::now(),
+		})));
+	}
+
+	pub fn applied(&self) -> Option<Arc<AppliedConfig>> {
+		self.applied.load_full()
+	}
+
+	pub fn last_error(&self) -> Option<Arc<ReloadError>> {
+		self.last_error.load_full()
+	}
+}
 
 #[derive(serde::Serialize)]
 pub struct StateManager {
@@ -38,6 +85,7 @@ impl StateManager {
 		awaiting_ready: tokio::sync::watch::Sender<()>,
 		config_resource_store: Option<config_store::ConfigResourceStore>,
 		model_catalog: Arc<crate::llm::cost::ModelCatalog>,
+		reload_status: Arc<ConfigReloadStatus>,
 	) -> anyhow::Result<Self> {
 		let xds = &config.xds;
 		let stores = Stores::new_with_dynamic_ca_cert_cache(
@@ -85,6 +133,7 @@ impl StateManager {
 					port: None,
 				},
 				metrics: config_metrics,
+				reload_status,
 			};
 			Box::pin(local_client.run()).await?;
 		}
@@ -123,6 +172,7 @@ pub struct LocalClient {
 	pub resource_manager: crate::resource_manager::ResourceManager,
 	pub gateway: ListenerTarget,
 	pub metrics: Arc<agent_xds::Metrics>,
+	pub reload_status: Arc<ConfigReloadStatus>,
 }
 
 impl LocalClient {
@@ -269,6 +319,8 @@ impl LocalClient {
 				.sync_local(config.services, config.workloads, prev.discovery)?;
 		let next_binds = bind_result?;
 
+		self.reload_status.record_applied(config_content);
+
 		Ok(PreviousState {
 			binds: next_binds,
 			discovery: next_discovery,
@@ -295,6 +347,7 @@ impl LocalClient {
 			Err(e) => {
 				self.metrics.config_synchronized.set(0);
 				error!("Failed to reload config: {}", e);
+				self.reload_status.record_error(e.to_string());
 				prev
 			},
 		}
@@ -607,6 +660,7 @@ frontendPolicies:
 			resource_manager,
 			gateway: config.gateway(),
 			metrics,
+			reload_status: Arc::new(ConfigReloadStatus::default()),
 		};
 
 		local_client.run().await.unwrap();

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -37,6 +37,7 @@ struct App {
 	config_resource_store: Option<ConfigResourceStore>,
 	resource_manager: crate::resource_manager::ResourceManager,
 	model_catalog: Arc<ModelCatalog>,
+	reload_status: Arc<crate::state_manager::ConfigReloadStatus>,
 }
 
 impl App {
@@ -84,6 +85,7 @@ pub fn router(
 	model_catalog: Arc<ModelCatalog>,
 	config_resource_store: Option<ConfigResourceStore>,
 	resource_manager: crate::resource_manager::ResourceManager,
+	reload_status: Arc<crate::state_manager::ConfigReloadStatus>,
 ) -> Router {
 	let ui_service = tower::service_fn(move |req| serve_ui_asset(req, &ASSETS_DIR));
 	Router::new()
@@ -91,6 +93,7 @@ pub fn router(
 		.route("/api/runtime", get(get_runtime))
 		.route("/api/config", get(get_config).post(write_config))
 		.route("/api/config/effective", get(get_effective_config))
+		.route("/api/config/status", get(get_config_status))
 		.route("/api/config/resources", get(list_config_resources))
 		.route(
 			"/api/config/resources/{kind}",
@@ -116,6 +119,7 @@ pub fn router(
 			config_resource_store,
 			resource_manager,
 			model_catalog,
+			reload_status,
 		})
 }
 
@@ -293,7 +297,7 @@ async fn get_config(State(app): State<App>) -> Result<Json<Value>, ErrorResponse
 }
 
 async fn get_effective_config(State(app): State<App>) -> Result<Json<Value>, ErrorResponse> {
-	let base = app.cfg()?.read_to_string().await?;
+	let base = current_config_content(&app).await?;
 	let config = if app.state.storage.mode == ConfigStoreMode::Hybrid {
 		let resources = app
 			.config_resource_store()?
@@ -306,6 +310,36 @@ async fn get_effective_config(State(app): State<App>) -> Result<Json<Value>, Err
 	};
 	let value = yamlviajson::from_str(&config).map_err(ErrorResponse::Anyhow)?;
 	Ok(Json(value))
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigReloadStatusResponse {
+	applied_at: Option<chrono::DateTime<Utc>>,
+	last_error: Option<ConfigReloadErrorResponse>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConfigReloadErrorResponse {
+	message: String,
+	occurred_at: chrono::DateTime<Utc>,
+}
+
+async fn get_config_status(State(app): State<App>) -> Json<ConfigReloadStatusResponse> {
+	Json(ConfigReloadStatusResponse {
+		applied_at: app
+			.reload_status
+			.applied()
+			.map(|applied| applied.applied_at),
+		last_error: app
+			.reload_status
+			.last_error()
+			.map(|error| ConfigReloadErrorResponse {
+				message: error.message.clone(),
+				occurred_at: error.occurred_at,
+			}),
+	})
 }
 
 async fn write_config(
@@ -388,8 +422,21 @@ async fn list_stored_config_resources(
 	Ok(ConfigResourcesResponse { resources }.into())
 }
 
+/// The config content currently in effect: the last successfully-applied reload when one
+/// exists, falling back to a fresh disk read for xds mode or before the first reload completes.
+async fn current_config_content(app: &App) -> Result<String, ErrorResponse> {
+	match app.reload_status.applied() {
+		Some(applied) => Ok(applied.content.clone()),
+		None => app
+			.cfg()?
+			.read_to_string()
+			.await
+			.map_err(ErrorResponse::Anyhow),
+	}
+}
+
 async fn read_file_config(app: &App) -> Result<Value, ErrorResponse> {
-	let config = app.cfg()?.read_to_string().await?;
+	let config = current_config_content(app).await?;
 	yamlviajson::from_str(&config).map_err(ErrorResponse::Anyhow)
 }
 
@@ -914,6 +961,7 @@ mod tests {
 			resource_manager: crate::resource_manager::ResourceManager::new(client)
 				.expect("resource manager"),
 			model_catalog: Arc::new(crate::llm::cost::ModelCatalog::default()),
+			reload_status: Arc::new(crate::state_manager::ConfigReloadStatus::default()),
 		}
 	}
 

--- a/crates/agentgateway/tests/common/gateway.rs
+++ b/crates/agentgateway/tests/common/gateway.rs
@@ -35,6 +35,8 @@ pub struct AgentGateway {
 	// Used to store temp dirs so they are dropped when the test completes
 	pub _temp_dirs: Vec<TempDir>,
 	port: u16,
+	#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+	config_path: PathBuf,
 	task: tokio::task::JoinHandle<()>,
 	client: Client<HttpConnector, Body>,
 	shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
@@ -64,17 +66,20 @@ impl AgentGateway {
 
 		let js = serde_json::to_string(&js).unwrap();
 		let mut temp_dirs = Vec::new();
-		let (temp, config) = create_temp_config_file(&js).await?;
+		let (temp, config_path) = create_temp_config_file(&js).await?;
 		temp_dirs.push(temp);
 		info!("starting agent...");
 
 		let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
 		let (port_tx, port_rx) = tokio::sync::oneshot::channel::<u16>();
-
+		let config_path_for_task = config_path.clone();
 		let task = tokio::task::spawn(async move {
 			let config = Arc::new(
-				agentgateway::config::parse_config(js, Some(agentgateway::ConfigSource::File(config)))
-					.unwrap(),
+				agentgateway::config::parse_config(
+					js,
+					Some(agentgateway::ConfigSource::File(config_path_for_task)),
+				)
+				.unwrap(),
 			);
 			let config_resource_store = if config.storage.mode == agentgateway::ConfigStoreMode::Hybrid {
 				Some(
@@ -118,6 +123,7 @@ impl AgentGateway {
 		Ok(Self {
 			_temp_dirs: temp_dirs,
 			port,
+			config_path,
 			task,
 			client,
 			shutdown_tx: Some(shutdown_tx),
@@ -171,6 +177,11 @@ impl AgentGateway {
 
 	pub fn port(&self) -> u16 {
 		self.port
+	}
+
+	#[cfg_attr(not(feature = "ui"), allow(dead_code))]
+	pub fn config_path(&self) -> &std::path::Path {
+		&self.config_path
 	}
 }
 

--- a/crates/agentgateway/tests/tests/config_reload_status.rs
+++ b/crates/agentgateway/tests/tests/config_reload_status.rs
@@ -1,0 +1,73 @@
+use std::time::{Duration, Instant};
+
+use http::{Method, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::Value;
+
+use crate::common::gateway::AgentGateway;
+
+const VALID_CONFIG: &str =
+	"config: {}\ngateways:\n  default:\n    port: $PORT\nui:\n  gateways: default\n";
+
+#[tokio::test]
+async fn rejected_reload_preserves_last_applied_config() -> anyhow::Result<()> {
+	let gateway = AgentGateway::new(VALID_CONFIG).await?;
+
+	let original_config = get_json(&gateway, "http://localhost/api/config").await?;
+	let original_effective = get_json(&gateway, "http://localhost/api/config/effective").await?;
+
+	let status = get_json(&gateway, "http://localhost/api/config/status").await?;
+	anyhow::ensure!(
+		status["lastError"].is_null(),
+		"expected no reload error before corrupting the config: {status}"
+	);
+
+	tokio::fs::write(gateway.config_path(), "totallyBogusKey: true\n").await?;
+
+	let status = wait_for_reload_error(&gateway).await?;
+	anyhow::ensure!(
+		status["lastError"]["message"]
+			.as_str()
+			.is_some_and(|message| message.contains("unknown field")),
+		"expected reload error to mention the unknown field: {status}"
+	);
+
+	let config_after = get_json(&gateway, "http://localhost/api/config").await?;
+	let effective_after = get_json(&gateway, "http://localhost/api/config/effective").await?;
+	anyhow::ensure!(
+		config_after == original_config,
+		"GET /api/config should still return the last-applied config: got {config_after}, want {original_config}"
+	);
+	anyhow::ensure!(
+		effective_after == original_effective,
+		"GET /api/config/effective should still return the last-applied config: got {effective_after}, want {original_effective}"
+	);
+
+	Ok(())
+}
+
+async fn get_json(gateway: &AgentGateway, url: &str) -> anyhow::Result<Value> {
+	let response = gateway.send_request(Method::GET, url).await;
+	anyhow::ensure!(
+		response.status() == StatusCode::OK,
+		"GET {url} failed: {}",
+		response.status()
+	);
+	let body = response.into_body().collect().await?.to_bytes();
+	Ok(serde_json::from_slice(&body)?)
+}
+
+async fn wait_for_reload_error(gateway: &AgentGateway) -> anyhow::Result<Value> {
+	let deadline = Instant::now() + Duration::from_secs(5);
+	loop {
+		let status = get_json(gateway, "http://localhost/api/config/status").await?;
+		if !status["lastError"].is_null() {
+			return Ok(status);
+		}
+		anyhow::ensure!(
+			Instant::now() < deadline,
+			"timed out waiting for a reload error to be recorded: {status}"
+		);
+		tokio::time::sleep(Duration::from_millis(50)).await;
+	}
+}

--- a/crates/agentgateway/tests/tests/mod.rs
+++ b/crates/agentgateway/tests/tests/mod.rs
@@ -2,6 +2,8 @@ mod auth;
 mod auto_protocol;
 mod basic;
 #[cfg(feature = "ui")]
+mod config_reload_status;
+#[cfg(feature = "ui")]
 mod config_store;
 mod connect;
 mod cors;


### PR DESCRIPTION
Fixes #3029

## Problem

After a failed hot-reload the gateway correctly keeps serving the last-good config, but `GET /api/config` and `GET /api/config/effective` re-read the file from disk, so they return the **rejected** content. Nothing in the API tells a client that the config on disk was refused, so the dashboard and any automation happily show config that is not running.

## Change

- `ConfigReloadStatus` (`state_manager.rs`) holds the last successfully-applied config content and the last reload error, using the same `arc_swap` pattern as `ModelCatalog`. One instance is created in `app::run()` and shared with `LocalClient` and the admin/UI router.
- `LocalClient::reload_config` records the applied content on success (clearing any previous error); the existing `Err` arm of `reload_config_after_change` records the error next to the `error!` log it already emits.
- `get_config` and `get_effective_config` now serve the applied snapshot, falling back to a disk read only when no snapshot exists yet (xds mode, or before the first reload).
- New `GET /api/config/status` returns `{appliedAt, lastError: {message, occurredAt} | null}`, which is the "surface the last reload error" half of the issue. It needs no admin allowlist change: the existing `PathPrefix("/api/config")` entry already covers it.

## Testing

- New integration test `rejected_reload_preserves_last_applied_config` (`tests/tests/config_reload_status.rs`): boots a valid config, writes `totallyBogusKey: true` to the config file, polls `/api/config/status` until the rejection is recorded, then asserts both `/api/config` and `/api/config/effective` still return the original config and the error mentions the unknown field. It gates on an observed rejected reload, so it cannot pass without a reload having actually failed. The test needed a `config_path()` accessor on the test harness.
- `make lint` and `make test` pass. The new test lives beside the existing `config_store.rs` tests and, like them, requires `--features ui`, so it runs under `cargo test --features ui` rather than plain `make test`.
- Manual run of the issue's own reproduction against the built binary:

  | step | `/api/config` | `/api/config/status` |
  |---|---|---|
  | valid config | shows the config | `lastError: null` |
  | `totallyBogusKey` added | unchanged, still the applied config | `lastError.message: "unknown field `totallyBogusKey`, expected one of ..."` |
  | file fixed again | shows the new config | `lastError: null`, new `appliedAt` |

## Note for reviewers

After a successful `POST /api/config`, a `GET` can briefly return the previous snapshot until the file watcher fires (~250ms debounce). That window is new, and I kept it deliberately: the alternative is to optimistically record content that a later reload might still reject, which would reintroduce exactly the untruthfulness this PR removes. Happy to change it if you would rather have the write path publish the snapshot itself.