### PR TITLE
feat: support MCP resource metadata on jwtAuth (RFC 9728)

### DIFF
--- a/crates/agentgateway/src/http/jwt.rs
+++ b/crates/agentgateway/src/http/jwt.rs
@@ -66,6 +66,8 @@ pub enum JwkError {
 		key_id: String,
 		curve: EllipticCurve,
 	},
+	#[error("{0}")]
+	InvalidMcpConfig(String),
 }
 
 #[derive(Clone)]
@@ -144,6 +146,10 @@ pub enum LocalJwtConfig {
 		location: AuthorizationLocation,
 		/// Trusted issuers and their signing keys.
 		providers: Vec<ProviderConfig>,
+		/// Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication
+		/// behavior on top of standard JWT validation. Requires exactly one provider and
+		/// `mode: strict`.
+		mcp: Option<LocalJwtMcpConfig>,
 	},
 	/// Validate JWTs against a single trusted token issuer.
 	Single {
@@ -162,7 +168,33 @@ pub enum LocalJwtConfig {
 		/// Claim requirements to enforce after the token signature is verified.
 		#[cfg_attr(feature = "schema", schemars(default))]
 		jwt_validation_options: JWTValidationOptions,
+		/// Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication
+		/// behavior on top of standard JWT validation. Requires `mode: strict`.
+		mcp: Option<LocalJwtMcpConfig>,
 	},
+}
+
+/// MCP OAuth resource-metadata extension for `jwtAuth`, mirroring the k8s `JWTMCPConfig` CRD.
+#[apply(schema_de!)]
+pub struct LocalJwtMcpConfig {
+	/// Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.
+	pub resource_metadata: crate::types::agent::ResourceMetadata,
+	/// Identity provider used to derive MCP authorization metadata.
+	pub provider: Option<crate::types::agent::McpIDP>,
+	/// Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway
+	/// will not proxy registration requests to the IDP and instead return this client ID.
+	pub client_id: Option<String>,
+}
+
+/// Resolved MCP OAuth extension for a `jwtAuth` policy: the sole provider's issuer/audiences
+/// plus the user-configured [`LocalJwtMcpConfig`], ready to build a runtime `McpAuthentication`.
+#[derive(Debug, Clone)]
+pub struct ResolvedJwtMcp {
+	pub issuer: String,
+	pub audiences: Vec<String>,
+	pub resource_metadata: crate::types::agent::ResourceMetadata,
+	pub provider: Option<crate::types::agent::McpIDP>,
+	pub client_id: Option<String>,
 }
 
 #[apply(schema_de!)]
@@ -172,6 +204,7 @@ struct LocalJwtMultiConfig {
 	#[serde(default)]
 	location: AuthorizationLocation,
 	providers: Vec<ProviderConfig>,
+	mcp: Option<LocalJwtMcpConfig>,
 }
 
 #[apply(schema_de!)]
@@ -185,6 +218,7 @@ struct LocalJwtSingleConfig {
 	jwks: serdes::FileInlineOrRemote,
 	#[serde(default)]
 	jwt_validation_options: JWTValidationOptions,
+	mcp: Option<LocalJwtMcpConfig>,
 }
 
 // Select the configuration shape before deserializing it so serde does not discard the
@@ -202,6 +236,7 @@ impl<'de> Deserialize<'de> for LocalJwtConfig {
 				mode: config.mode,
 				location: config.location,
 				providers: config.providers,
+				mcp: config.mcp,
 			})
 		} else {
 			let config: LocalJwtSingleConfig =
@@ -213,6 +248,7 @@ impl<'de> Deserialize<'de> for LocalJwtConfig {
 				audiences: config.audiences,
 				jwks: config.jwks,
 				jwt_validation_options: config.jwt_validation_options,
+				mcp: config.mcp,
 			})
 		}
 	}
@@ -304,13 +340,14 @@ impl LocalJwtConfig {
 	pub async fn try_into(
 		self,
 		resources: &crate::resource_manager::ResourceFetcher,
-	) -> Result<Jwt, JwkError> {
-		let (mode, authorization_location, providers_cfg) = match self {
+	) -> Result<(Jwt, Option<ResolvedJwtMcp>), JwkError> {
+		let (mode, authorization_location, providers_cfg, mcp) = match self {
 			LocalJwtConfig::Multi {
 				mode,
 				location: authorization_location,
 				providers,
-			} => (mode, authorization_location, providers),
+				mcp,
+			} => (mode, authorization_location, providers, mcp),
 			LocalJwtConfig::Single {
 				mode,
 				location: authorization_location,
@@ -318,6 +355,7 @@ impl LocalJwtConfig {
 				audiences,
 				jwks,
 				jwt_validation_options,
+				mcp,
 			} => (
 				mode,
 				authorization_location,
@@ -327,7 +365,31 @@ impl LocalJwtConfig {
 					jwks,
 					jwt_validation_options,
 				}],
+				mcp,
 			),
+		};
+
+		let resolved_mcp = match mcp {
+			Some(mcp_cfg) => {
+				let [provider] = providers_cfg.as_slice() else {
+					return Err(JwkError::InvalidMcpConfig(
+						"jwtAuth.mcp requires exactly one provider".to_string(),
+					));
+				};
+				if mode != Mode::Strict {
+					return Err(JwkError::InvalidMcpConfig(
+						"jwtAuth.mcp requires mode: strict".to_string(),
+					));
+				}
+				Some(ResolvedJwtMcp {
+					issuer: provider.issuer.clone(),
+					audiences: provider.audiences.clone().unwrap_or_default(),
+					resource_metadata: mcp_cfg.resource_metadata,
+					provider: mcp_cfg.provider,
+					client_id: mcp_cfg.client_id,
+				})
+			},
+			None => None,
 		};
 
 		let mut providers = Vec::with_capacity(providers_cfg.len());
@@ -340,11 +402,14 @@ impl LocalJwtConfig {
 			let provider = Provider::from_jwks(jwks, pc.issuer, pc.audiences, pc.jwt_validation_options)?;
 			providers.push(provider);
 		}
-		Ok(Jwt {
-			mode,
-			providers,
-			location: authorization_location,
-		})
+		Ok((
+			Jwt {
+				mode,
+				providers,
+				location: authorization_location,
+			},
+			resolved_mcp,
+		))
 	}
 }
 

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -930,12 +930,16 @@ impl TestBind {
 			.insert_route(route, LISTENER_KEY);
 	}
 	pub async fn attach_route_policy(&mut self, p: serde_json::Value) {
+		self.try_attach_route_policy(p).await.unwrap()
+	}
+	/// Like [`attach_route_policy`](Self::attach_route_policy), but surfaces policy materialization
+	/// errors (e.g. invalid `jwtAuth.mcp` config) instead of panicking.
+	pub async fn try_attach_route_policy(&mut self, p: serde_json::Value) -> anyhow::Result<()> {
 		let oidc_key = strng::format!("oidc/{}", self.policies + 1);
-		let pol: local::FilterOrPolicy = serde_json::from_value(p).unwrap();
+		let pol: local::FilterOrPolicy = serde_json::from_value(p)?;
 		let resources = crate::resource_manager::ResourceFetcher::direct(self.pi.upstream.clone());
-		let pols = local::split_policies(&resources, pol, self.pi.cfg.as_policy_context(oidc_key))
-			.await
-			.unwrap();
+		let pols =
+			local::split_policies(&resources, pol, self.pi.cfg.as_policy_context(oidc_key)).await?;
 		assert!(pols.backend_policies.is_empty());
 		for v in pols.route_policies {
 			self.policies += 1;
@@ -953,6 +957,7 @@ impl TestBind {
 				policy: (v, PolicyPhase::Route).into(),
 			});
 		}
+		Ok(())
 	}
 	pub async fn attach_gateway_policy(&mut self, p: serde_json::Value) {
 		let oidc_key = strng::format!("pol/{}", self.policies + 1);

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2981,6 +2981,7 @@ impl LocalMcpAuthentication {
 			audiences: Some(self.audiences.clone()),
 			jwks,
 			jwt_validation_options: self.jwt_validation_options.clone(),
+			mcp: None,
 		})
 	}
 
@@ -2990,7 +2991,7 @@ impl LocalMcpAuthentication {
 		resources: &crate::resource_manager::ResourceFetcher,
 	) -> anyhow::Result<McpAuthentication> {
 		let jwt_cfg = self.as_jwt()?;
-		let jwt = jwt_cfg.try_into(resources).await?;
+		let (jwt, _mcp) = jwt_cfg.try_into(resources).await?;
 		Ok(McpAuthentication {
 			issuer: self.issuer.clone(),
 			audiences: self.audiences.clone(),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -28,10 +28,10 @@ use crate::types::agent::{
 	A2aPolicy, Authorization, Backend, BackendKey, BackendReference, BackendTrafficPolicy,
 	BackendWithPolicies, Bind, BindMode, BindProtocol, FrontendPolicy, HeaderMatch,
 	JwtAuthentication, Listener, ListenerKey, ListenerName, ListenerProtocol, ListenerSet,
-	ListenerTarget, LocalMcpAuthentication, McpAuthentication, McpBackend, McpPrefixMode, McpTarget,
-	McpTargetName, McpTargetSpec, OpenAPITarget, PathMatch, PolicyPhase, PolicyTarget, PolicyType,
-	ResourceName, Route, RouteBackendReference, RouteBackendTarget, RouteGroupKey, RouteMatch,
-	RouteName, ServerTLSConfig, SimpleBackend, SimpleBackendReference,
+	ListenerTarget, LocalMcpAuthentication, McpAuthentication, McpAuthenticationMode, McpBackend,
+	McpPrefixMode, McpTarget, McpTargetName, McpTargetSpec, OpenAPITarget, PathMatch, PolicyPhase,
+	PolicyTarget, PolicyType, ResourceName, Route, RouteBackendReference, RouteBackendTarget,
+	RouteGroupKey, RouteMatch, RouteName, ServerTLSConfig, SimpleBackend, SimpleBackendReference,
 	SimpleBackendReferenceWithPolicies, SimpleBackendWithPolicies, SseTargetSpec,
 	StreamableHTTPTargetSpec, TCPRoute, TCPRouteBackendReference, Target, TargetedPolicy,
 	TracingConfig, TrafficPolicy, TunnelProtocol, TypedResourceName, validate_mcp_target_name,
@@ -5235,11 +5235,19 @@ pub(crate) async fn split_policies_for_target(
 		}
 	}
 	if let Some(p) = jwt_auth {
+		let (jwt, resolved_mcp) = p.try_into(resources).await?;
+		let mcp = resolved_mcp.map(|m| McpAuthentication {
+			issuer: m.issuer,
+			audiences: m.audiences,
+			provider: m.provider,
+			resource_metadata: m.resource_metadata,
+			jwt_validator: Arc::new(jwt.clone()),
+			mode: McpAuthenticationMode::Strict,
+			client_id: m.client_id,
+			client_secret: None,
+		});
 		route_policies.push(TrafficPolicy::JwtAuth(RequestPolicy::single(
-			JwtAuthentication {
-				jwt: p.try_into(resources).await?,
-				mcp: None,
-			},
+			JwtAuthentication { jwt, mcp },
 		)));
 	}
 	let compiled_oidc = if let Some(oidc) = oidc_config {

--- a/crates/agentgateway/tests/tests/auth.rs
+++ b/crates/agentgateway/tests/tests/auth.rs
@@ -413,6 +413,115 @@ async fn mcp_authentication_runs_in_route_policy_path() {
 }
 
 #[tokio::test]
+async fn jwt_auth_mcp_resource_metadata_challenges_and_serves_well_known_endpoint() {
+	let (_mock, mut bind, io) = basic_setup().await;
+	bind
+		.attach_route_policy(json!({
+			"jwtAuth": {
+				"mode": "strict",
+				"issuer": "https://example.com",
+				"audiences": ["test-aud"],
+				"jwks": "{\"keys\":[{\"use\":\"sig\",\"kty\":\"EC\",\"kid\":\"XhO06x8JjWH1wwkWkyeEUxsooGEWoEdidEpwyd_hmuI\",\"crv\":\"P-256\",\"alg\":\"ES256\",\"x\":\"XZHF8Em5LbpqfgewAalpSEH4Ka2I2xjcxxUt2j6-lCo\",\"y\":\"g3DFz45A7EOUMgmsNXatrXw1t-PG5xsbkxUs851RxSE\"}]}",
+				"mcp": {
+					"resourceMetadata": {
+						"resource": "https://mcp.example.com/tools",
+						"scopesSupported": ["read", "write"]
+					}
+				}
+			}
+		}))
+		.await;
+
+	let res = send_request(io.clone(), Method::GET, "http://lo").await;
+	assert_eq!(res.status(), 401);
+	let www_authenticate = res.hdr(header::WWW_AUTHENTICATE);
+	assert!(
+		www_authenticate.starts_with("Bearer resource_metadata=\""),
+		"unexpected WWW-Authenticate: {www_authenticate}"
+	);
+	assert!(
+		www_authenticate.contains("/.well-known/oauth-protected-resource"),
+		"unexpected WWW-Authenticate: {www_authenticate}"
+	);
+
+	let res = send_request(
+		io,
+		Method::GET,
+		"http://lo/.well-known/oauth-protected-resource/",
+	)
+	.await;
+	assert_eq!(res.status(), 200);
+	assert_eq!(res.hdr("content-type"), "application/json");
+	let body = res.into_body().collect().await.unwrap().to_bytes();
+	let body: Value = serde_json::from_slice(&body).unwrap();
+	assert_eq!(
+		body.get("resource"),
+		Some(&json!("https://mcp.example.com/tools")),
+		"expected the configured resource in {body}"
+	);
+	assert_eq!(
+		body.get("scopes_supported"),
+		Some(&json!(["read", "write"]))
+	);
+}
+
+#[tokio::test]
+async fn jwt_auth_mcp_requires_exactly_one_provider() {
+	let (_mock, mut bind, _io) = basic_setup().await;
+	let err = bind
+		.try_attach_route_policy(json!({
+			"jwtAuth": {
+				"mode": "strict",
+				"providers": [
+					{
+						"issuer": "https://example.com",
+						"jwks": "{\"keys\":[]}"
+					},
+					{
+						"issuer": "https://example2.com",
+						"jwks": "{\"keys\":[]}"
+					}
+				],
+				"mcp": {
+					"resourceMetadata": {}
+				}
+			}
+		}))
+		.await
+		.expect_err("multi-provider jwtAuth.mcp should be rejected");
+	assert!(
+		err
+			.to_string()
+			.contains("jwtAuth.mcp requires exactly one provider"),
+		"unexpected error: {err}"
+	);
+}
+
+#[tokio::test]
+async fn jwt_auth_mcp_requires_strict_mode() {
+	let (_mock, mut bind, _io) = basic_setup().await;
+	let err = bind
+		.try_attach_route_policy(json!({
+			"jwtAuth": {
+				"mode": "permissive",
+				"issuer": "https://example.com",
+				"jwks": "{\"keys\":[]}",
+				"mcp": {
+					"resourceMetadata": {}
+				}
+			}
+		}))
+		.await
+		.expect_err("non-strict jwtAuth.mcp should be rejected");
+	assert!(
+		err
+			.to_string()
+			.contains("jwtAuth.mcp requires mode: strict"),
+		"unexpected error: {err}"
+	);
+}
+
+#[tokio::test]
 async fn api_key() {
 	let (_mock, mut bind, io) = basic_setup().await;
 	bind

--- a/schema/config.json
+++ b/schema/config.json
@@ -5925,6 +5925,17 @@
               "items": {
                 "$ref": "#/$defs/ProviderConfig"
               }
+            },
+            "mcp": {
+              "description": "Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication\nbehavior on top of standard JWT validation. Requires exactly one provider and\n`mode: strict`.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LocalJwtMcpConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "additionalProperties": false,
@@ -5972,6 +5983,17 @@
             "jwtValidationOptions": {
               "description": "Claim requirements to enforce after the token signature is verified.",
               "$ref": "#/$defs/JWTValidationOptions"
+            },
+            "mcp": {
+              "description": "Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication\nbehavior on top of standard JWT validation. Requires `mode: strict`.",
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LocalJwtMcpConfig"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "additionalProperties": false,
@@ -6031,6 +6053,38 @@
       "required": [
         "issuer",
         "jwks"
+      ]
+    },
+    "LocalJwtMcpConfig": {
+      "description": "MCP OAuth resource-metadata extension for `jwtAuth`, mirroring the k8s `JWTMCPConfig` CRD.",
+      "type": "object",
+      "properties": {
+        "resourceMetadata": {
+          "description": "Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.",
+          "$ref": "#/$defs/ResourceMetadata"
+        },
+        "provider": {
+          "description": "Identity provider used to derive MCP authorization metadata.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/McpIDP"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "clientId": {
+          "description": "Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway\nwill not proxy registration requests to the IDP and instead return this client ID.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "resourceMetadata"
       ]
     },
     "LocalOidcConfig": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -3730,6 +3730,16 @@
 |`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwks.url`|string||
 |`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].routes[].policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.provider.auth0`|object||
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.provider.keycloak`|object||
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.provider.okta`|object||
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.provider.descope`|object||
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.provider.authentik`|object||
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.provider.entra`|object||
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`binds[].listeners[].routes[].policies.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`binds[].listeners[].routes[].policies.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`binds[].listeners[].routes[].policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -3737,6 +3747,7 @@
 |`binds[].listeners[].routes[].policies.jwtAuth.jwks.url`|string||
 |`binds[].listeners[].routes[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].routes[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`binds[].listeners[].routes[].policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`binds[].listeners[].routes[].policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
 |`binds[].listeners[].routes[].policies.oidc.issuer`|string|Issuer used for discovery and ID token validation.|
 |`binds[].listeners[].routes[].policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
@@ -15544,6 +15555,16 @@
 |`binds[].listeners[].policies.jwtAuth.providers[].jwks.url`|string||
 |`binds[].listeners[].policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`binds[].listeners[].policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`binds[].listeners[].policies.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`binds[].listeners[].policies.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`binds[].listeners[].policies.jwtAuth.mcp.provider.auth0`|object||
+|`binds[].listeners[].policies.jwtAuth.mcp.provider.keycloak`|object||
+|`binds[].listeners[].policies.jwtAuth.mcp.provider.okta`|object||
+|`binds[].listeners[].policies.jwtAuth.mcp.provider.descope`|object||
+|`binds[].listeners[].policies.jwtAuth.mcp.provider.authentik`|object||
+|`binds[].listeners[].policies.jwtAuth.mcp.provider.entra`|object||
+|`binds[].listeners[].policies.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`binds[].listeners[].policies.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`binds[].listeners[].policies.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`binds[].listeners[].policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -15551,6 +15572,7 @@
 |`binds[].listeners[].policies.jwtAuth.jwks.url`|string||
 |`binds[].listeners[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`binds[].listeners[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`binds[].listeners[].policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`binds[].listeners[].policies.authorization`|object|Authorization rules for incoming HTTP requests.|
 |`binds[].listeners[].policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`binds[].listeners[].policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -21592,6 +21614,16 @@
 |`policies[].policy.jwtAuth.providers[].jwks.url`|string||
 |`policies[].policy.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`policies[].policy.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`policies[].policy.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`policies[].policy.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`policies[].policy.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`policies[].policy.jwtAuth.mcp.provider.auth0`|object||
+|`policies[].policy.jwtAuth.mcp.provider.keycloak`|object||
+|`policies[].policy.jwtAuth.mcp.provider.okta`|object||
+|`policies[].policy.jwtAuth.mcp.provider.descope`|object||
+|`policies[].policy.jwtAuth.mcp.provider.authentik`|object||
+|`policies[].policy.jwtAuth.mcp.provider.entra`|object||
+|`policies[].policy.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`policies[].policy.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`policies[].policy.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`policies[].policy.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -21599,6 +21631,7 @@
 |`policies[].policy.jwtAuth.jwks.url`|string||
 |`policies[].policy.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`policies[].policy.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`policies[].policy.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`policies[].policy.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
 |`policies[].policy.oidc.issuer`|string|Issuer used for discovery and ID token validation.|
 |`policies[].policy.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
@@ -36674,6 +36707,16 @@
 |`routeGroups[].routes[].policies.jwtAuth.providers[].jwks.url`|string||
 |`routeGroups[].routes[].policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`routeGroups[].routes[].policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`routeGroups[].routes[].policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`routeGroups[].routes[].policies.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`routeGroups[].routes[].policies.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`routeGroups[].routes[].policies.jwtAuth.mcp.provider.auth0`|object||
+|`routeGroups[].routes[].policies.jwtAuth.mcp.provider.keycloak`|object||
+|`routeGroups[].routes[].policies.jwtAuth.mcp.provider.okta`|object||
+|`routeGroups[].routes[].policies.jwtAuth.mcp.provider.descope`|object||
+|`routeGroups[].routes[].policies.jwtAuth.mcp.provider.authentik`|object||
+|`routeGroups[].routes[].policies.jwtAuth.mcp.provider.entra`|object||
+|`routeGroups[].routes[].policies.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`routeGroups[].routes[].policies.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`routeGroups[].routes[].policies.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`routeGroups[].routes[].policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -36681,6 +36724,7 @@
 |`routeGroups[].routes[].policies.jwtAuth.jwks.url`|string||
 |`routeGroups[].routes[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`routeGroups[].routes[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`routeGroups[].routes[].policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`routeGroups[].routes[].policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
 |`routeGroups[].routes[].policies.oidc.issuer`|string|Issuer used for discovery and ID token validation.|
 |`routeGroups[].routes[].policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
@@ -48202,6 +48246,16 @@
 |`gateways.*.listeners[].jwtAuth.providers[].jwks.url`|string||
 |`gateways.*.listeners[].jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`gateways.*.listeners[].jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`gateways.*.listeners[].jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`gateways.*.listeners[].jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`gateways.*.listeners[].jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`gateways.*.listeners[].jwtAuth.mcp.provider.auth0`|object||
+|`gateways.*.listeners[].jwtAuth.mcp.provider.keycloak`|object||
+|`gateways.*.listeners[].jwtAuth.mcp.provider.okta`|object||
+|`gateways.*.listeners[].jwtAuth.mcp.provider.descope`|object||
+|`gateways.*.listeners[].jwtAuth.mcp.provider.authentik`|object||
+|`gateways.*.listeners[].jwtAuth.mcp.provider.entra`|object||
+|`gateways.*.listeners[].jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`gateways.*.listeners[].jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`gateways.*.listeners[].jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`gateways.*.listeners[].jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -48209,6 +48263,7 @@
 |`gateways.*.listeners[].jwtAuth.jwks.url`|string||
 |`gateways.*.listeners[].jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`gateways.*.listeners[].jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`gateways.*.listeners[].jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`gateways.*.listeners[].authorization`|object|Authorization rules for incoming HTTP requests.|
 |`gateways.*.listeners[].authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`gateways.*.listeners[].authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -49488,6 +49543,16 @@
 |`gateways.*.jwtAuth.providers[].jwks.url`|string||
 |`gateways.*.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`gateways.*.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`gateways.*.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`gateways.*.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`gateways.*.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`gateways.*.jwtAuth.mcp.provider.auth0`|object||
+|`gateways.*.jwtAuth.mcp.provider.keycloak`|object||
+|`gateways.*.jwtAuth.mcp.provider.okta`|object||
+|`gateways.*.jwtAuth.mcp.provider.descope`|object||
+|`gateways.*.jwtAuth.mcp.provider.authentik`|object||
+|`gateways.*.jwtAuth.mcp.provider.entra`|object||
+|`gateways.*.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`gateways.*.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`gateways.*.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`gateways.*.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -49495,6 +49560,7 @@
 |`gateways.*.jwtAuth.jwks.url`|string||
 |`gateways.*.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`gateways.*.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`gateways.*.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`gateways.*.authorization`|object|Authorization rules for incoming HTTP requests.|
 |`gateways.*.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`gateways.*.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -54340,6 +54406,16 @@
 |`routes[].policies.jwtAuth.providers[].jwks.url`|string||
 |`routes[].policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`routes[].policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`routes[].policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`routes[].policies.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`routes[].policies.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`routes[].policies.jwtAuth.mcp.provider.auth0`|object||
+|`routes[].policies.jwtAuth.mcp.provider.keycloak`|object||
+|`routes[].policies.jwtAuth.mcp.provider.okta`|object||
+|`routes[].policies.jwtAuth.mcp.provider.descope`|object||
+|`routes[].policies.jwtAuth.mcp.provider.authentik`|object||
+|`routes[].policies.jwtAuth.mcp.provider.entra`|object||
+|`routes[].policies.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`routes[].policies.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`routes[].policies.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`routes[].policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -54347,6 +54423,7 @@
 |`routes[].policies.jwtAuth.jwks.url`|string||
 |`routes[].policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`routes[].policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`routes[].policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`routes[].policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
 |`routes[].policies.oidc.issuer`|string|Issuer used for discovery and ID token validation.|
 |`routes[].policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
@@ -69561,6 +69638,16 @@
 |`llm.policies.jwtAuth.providers[].jwks.url`|string||
 |`llm.policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`llm.policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`llm.policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`llm.policies.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`llm.policies.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`llm.policies.jwtAuth.mcp.provider.auth0`|object||
+|`llm.policies.jwtAuth.mcp.provider.keycloak`|object||
+|`llm.policies.jwtAuth.mcp.provider.okta`|object||
+|`llm.policies.jwtAuth.mcp.provider.descope`|object||
+|`llm.policies.jwtAuth.mcp.provider.authentik`|object||
+|`llm.policies.jwtAuth.mcp.provider.entra`|object||
+|`llm.policies.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`llm.policies.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`llm.policies.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`llm.policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -69568,6 +69655,7 @@
 |`llm.policies.jwtAuth.jwks.url`|string||
 |`llm.policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`llm.policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`llm.policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`llm.policies.authorization`|object|Authorization rules for incoming HTTP requests.|
 |`llm.policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`llm.policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|
@@ -76943,6 +77031,16 @@
 |`mcp.policies.jwtAuth.providers[].jwks.url`|string||
 |`mcp.policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`mcp.policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`mcp.policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`mcp.policies.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`mcp.policies.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`mcp.policies.jwtAuth.mcp.provider.auth0`|object||
+|`mcp.policies.jwtAuth.mcp.provider.keycloak`|object||
+|`mcp.policies.jwtAuth.mcp.provider.okta`|object||
+|`mcp.policies.jwtAuth.mcp.provider.descope`|object||
+|`mcp.policies.jwtAuth.mcp.provider.authentik`|object||
+|`mcp.policies.jwtAuth.mcp.provider.entra`|object||
+|`mcp.policies.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`mcp.policies.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`mcp.policies.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`mcp.policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -76950,6 +77048,7 @@
 |`mcp.policies.jwtAuth.jwks.url`|string||
 |`mcp.policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`mcp.policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`mcp.policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`mcp.policies.oidc`|object|Authenticate browser requests with OIDC authorization code flow.|
 |`mcp.policies.oidc.issuer`|string|Issuer used for discovery and ID token validation.|
 |`mcp.policies.oidc.discovery`|object|Optional discovery document override. If omitted, discovery uses<br>`${issuer}/.well-known/openid-configuration`.|
@@ -78251,6 +78350,16 @@
 |`ui.policies.jwtAuth.providers[].jwks.url`|string||
 |`ui.policies.jwtAuth.providers[].jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`ui.policies.jwtAuth.providers[].jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`ui.policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires exactly one provider and<br>`mode: strict`.|
+|`ui.policies.jwtAuth.mcp.resourceMetadata`|object|Protected resource metadata returned to MCP clients at the OAuth discovery endpoint.|
+|`ui.policies.jwtAuth.mcp.provider`|object|Identity provider used to derive MCP authorization metadata.|
+|`ui.policies.jwtAuth.mcp.provider.auth0`|object||
+|`ui.policies.jwtAuth.mcp.provider.keycloak`|object||
+|`ui.policies.jwtAuth.mcp.provider.okta`|object||
+|`ui.policies.jwtAuth.mcp.provider.descope`|object||
+|`ui.policies.jwtAuth.mcp.provider.authentik`|object||
+|`ui.policies.jwtAuth.mcp.provider.entra`|object||
+|`ui.policies.jwtAuth.mcp.clientId`|string|Client ID to use for short-circuiting Dynamic Client Registration. If set, the gateway<br>will not proxy registration requests to the IDP and instead return this client ID.|
 |`ui.policies.jwtAuth.issuer`|string|Expected token issuer. The JWT `iss` claim is required and must match.|
 |`ui.policies.jwtAuth.audiences`|[]string|Accepted token audiences. A non-empty list requires a matching JWT `aud` claim.|
 |`ui.policies.jwtAuth.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.|
@@ -78258,6 +78367,7 @@
 |`ui.policies.jwtAuth.jwks.url`|string||
 |`ui.policies.jwtAuth.jwtValidationOptions`|object|Claim requirements to enforce after the token signature is verified.|
 |`ui.policies.jwtAuth.jwtValidationOptions.requiredClaims`|[]string|Claims that must be present in the token before validation.<br>Only "exp", "nbf", "aud", "iss", "sub" are enforced; others<br>(including "iat" and "jti") are ignored.<br>Defaults to ["exp"]. Use an empty list to add no claim requirements beyond<br>those implied by the configured issuer and audiences.|
+|`ui.policies.jwtAuth.mcp`|object|Enables MCP OAuth resource metadata (RFC 9728) and MCP-specific authentication<br>behavior on top of standard JWT validation. Requires `mode: strict`.|
 |`ui.policies.authorization`|object|Authorization rules for incoming HTTP requests.|
 |`ui.policies.authorization.rules`|[]object|CEL authorization rules to evaluate for a request.|
 |`ui.policies.authorization.rules[].allow`|string|Allow the request when this CEL expression is true.|


### PR DESCRIPTION
Closes #2949

## Problem

`mcpAuthentication` can serve RFC 9728 protected-resource metadata and a `WWW-Authenticate` challenge, but `jwtAuth` cannot, so non-MCP routes (A2A, plain HTTP) have no way to advertise the delegated OAuth2 flow.

The runtime already supports this: `agent::JwtAuthentication` carries `mcp: Option<McpAuthentication>`, and the JWT policy's own `apply()` both emits the challenge and serves `/.well-known/oauth-protected-resource` independently of the MCP router. The k8s CRD (`JWTAuthentication.mcp`) already populates it. The only gap was the standalone YAML surface: `LocalJwtConfig` had no such field and `types/local.rs` always set `mcp: None`.

## Change

- New optional `mcp` sub-object on `jwtAuth` (`resourceMetadata`, optional `provider`, optional `clientId`), added to both config shapes and threaded through the custom `Deserialize` impl that branches on the `providers` key.
- `LocalJwtConfig::try_into` now returns the resolved MCP extension alongside the `Jwt`, and `split_policies_for_target` builds the runtime `McpAuthentication` from it, mirroring the adjacent `mcpAuthentication` branch and the xds construction.
- Same constraints the k8s path enforces (CEL rules + xds translation): exactly one provider and `mode: strict`, otherwise config load fails with `jwtAuth.mcp requires exactly one provider` / `jwtAuth.mcp requires mode: strict`.
- Schema regenerated with `make generate-schema`; no controller, proto, xds, or response-layer changes were needed.

## Testing

- `jwt_auth_mcp_resource_metadata_challenges_and_serves_well_known_endpoint`: no-token request gets 401 with `WWW-Authenticate: Bearer resource_metadata="..."`, and the well-known endpoint returns RFC 9728 JSON whose `resource` and `scopes_supported` match what was configured.
- `jwt_auth_mcp_requires_exactly_one_provider` and `jwt_auth_mcp_requires_strict_mode` assert the exact rejection messages. These needed a fallible `try_attach_route_policy` next to the existing panicking test helper.
- `make lint` and `make test` pass; existing `mcpAuthentication` and jwt tests still pass.
- Smoke test on the built binary with a plain (non-MCP) HTTP route:
  - `GET /anything` -> `401` + `www-authenticate: Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/anything"`
  - `GET /.well-known/oauth-protected-resource/anything` -> `200` with `resource`, `authorization_servers`, `scopes_supported: [read, write]`, `bearer_methods_supported: [header]`.

## Naming decision worth a maintainer opinion

The issue sketches a flat `resourceMetadata:` directly under `jwtAuth`. I used a nested `mcp:` object instead, so the standalone YAML matches the existing k8s `JWTAuthentication.mcp` (`JWTMCPConfig`) field and can carry `provider`/`clientId` the same way. If you prefer the flat shape, say so and I will change it before this lands, since it is user-facing config.