### PR TITLE
fix: refetch remote JWKS on unknown key id before rejecting

### DIFF
--- a/crates/agentgateway/src/http/jwt.rs
+++ b/crates/agentgateway/src/http/jwt.rs
@@ -73,12 +73,59 @@ pub struct Jwt {
 	mode: Mode,
 	providers: Vec<Provider>,
 	location: AuthorizationLocation,
+	// Only remote JWKS sources get a refresher.
+	refreshers: Vec<JwksRefresher>,
 }
 
 #[derive(Clone)]
 pub struct Provider {
 	issuer: String,
 	keys: HashMap<String, Jwk>,
+}
+
+/// Rebuilds a single provider's keys from its remote JWKS source on demand,
+/// so a token whose `kid` predates a key rotation can succeed without
+/// waiting for the next scheduled refresh.
+#[derive(Clone)]
+struct JwksRefresher {
+	manager: crate::resource_manager::ResourceManager,
+	resource: crate::resource_manager::ResourceRef,
+	issuer: String,
+	audiences: Option<Vec<String>>,
+	jwt_validation_options: JWTValidationOptions,
+}
+
+impl JwksRefresher {
+	/// Returns `None` when the refresh was debounced, failed, or the key is still missing.
+	async fn refresh(&self, kid: &str) -> Option<Jwk> {
+		let bytes = match self.manager.refresh_and_wait(&self.resource).await {
+			Ok(bytes) => bytes,
+			Err(error) => {
+				debug!(%error, "on-demand JWKS refresh did not run");
+				return None;
+			},
+		};
+		let jwks: JwkSet = match serde_json::from_slice(&bytes) {
+			Ok(jwks) => jwks,
+			Err(error) => {
+				warn!(%error, "refetched JWKS could not be parsed");
+				return None;
+			},
+		};
+		let provider = match Provider::from_jwks(
+			jwks,
+			self.issuer.clone(),
+			self.audiences.clone(),
+			self.jwt_validation_options.clone(),
+		) {
+			Ok(provider) => provider,
+			Err(error) => {
+				warn!(%error, "refetched JWKS has no usable keys");
+				return None;
+			},
+		};
+		provider.keys.get(kid).cloned()
+	}
 }
 
 // TODO: can we give anything useful here?
@@ -331,19 +378,44 @@ impl LocalJwtConfig {
 		};
 
 		let mut providers = Vec::with_capacity(providers_cfg.len());
+		let mut refreshers = Vec::new();
 		for pc in providers_cfg {
+			let remote_resource = match pc
+				.jwks
+				.as_resource_ref(crate::resource_manager::ResourceKind::Jwks)
+			{
+				Some(resource @ crate::resource_manager::ResourceRef::Http { .. }) => Some(resource),
+				_ => None,
+			};
 			let jwks: JwkSet = pc
 				.jwks
 				.load::<JwkSet>(resources, crate::resource_manager::ResourceKind::Jwks)
 				.await
 				.map_err(JwkError::JwkLoadError)?;
-			let provider = Provider::from_jwks(jwks, pc.issuer, pc.audiences, pc.jwt_validation_options)?;
+			let provider = Provider::from_jwks(
+				jwks,
+				pc.issuer.clone(),
+				pc.audiences.clone(),
+				pc.jwt_validation_options.clone(),
+			)?;
+			if let (Some(resource), Some(manager)) =
+				(remote_resource, resources.managed_resource_manager())
+			{
+				refreshers.push(JwksRefresher {
+					manager,
+					resource,
+					issuer: pc.issuer,
+					audiences: pc.audiences,
+					jwt_validation_options: pc.jwt_validation_options,
+				});
+			}
 			providers.push(provider);
 		}
 		Ok(Jwt {
 			mode,
 			providers,
 			location: authorization_location,
+			refreshers,
 		})
 	}
 }
@@ -469,6 +541,7 @@ impl Jwt {
 			mode,
 			providers,
 			location: authorization_location,
+			refreshers: Vec::new(),
 		}
 	}
 }
@@ -477,6 +550,20 @@ impl Jwt {
 struct Jwk {
 	decoding: DecodingKey,
 	validation: Validation,
+}
+
+fn decode_with_key(token: &str, key: &Jwk) -> Result<Claims, TokenError> {
+	let decoded_token =
+		decode::<Map<String, Value>>(token, &key.decoding, &key.validation).map_err(|error| {
+			debug!(?error, "Token is malformed or does not pass validation.");
+
+			TokenError::Invalid(error)
+		})?;
+
+	Ok(Claims {
+		inner: decoded_token.claims,
+		jwt: SecretString::new(token.into()),
+	})
 }
 
 #[derive(Clone, Debug, Default)]
@@ -568,7 +655,7 @@ impl Jwt {
 			);
 			return Ok(());
 		};
-		let claims = match self.validate_claims(&token) {
+		let claims = match self.validate_claims_with_refresh(&token).await {
 			Ok(claims) => claims,
 			Err(e) if self.mode == Mode::Permissive => {
 				dtrace::pol_result!(
@@ -632,17 +719,23 @@ impl Jwt {
 				TokenError::UnknownKeyId(kid.to_owned())
 			})?;
 
-		let decoded_token = decode::<Map<String, Value>>(token, &key.decoding, &key.validation)
-			.map_err(|error| {
-				debug!(?error, "Token is malformed or does not pass validation.");
+		decode_with_key(token, key)
+	}
 
-				TokenError::Invalid(error)
-			})?;
-
-		let claims = Claims {
-			inner: decoded_token.claims,
-			jwt: SecretString::new(token.into()),
-		};
-		Ok(claims)
+	/// Validates a token, retrying once against a freshly fetched JWKS when
+	/// the key id is unknown. Only providers backed by a remote JWKS source
+	/// have a refresher attached, so this is a no-op elsewhere.
+	async fn validate_claims_with_refresh(&self, token: &str) -> Result<Claims, TokenError> {
+		match self.validate_claims(token) {
+			Err(TokenError::UnknownKeyId(kid)) => {
+				for refresher in &self.refreshers {
+					if let Some(key) = refresher.refresh(&kid).await {
+						return decode_with_key(token, &key);
+					}
+				}
+				Err(TokenError::UnknownKeyId(kid))
+			},
+			result => result,
+		}
 	}
 }

--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -258,6 +258,7 @@ pub fn test_ed25519_jwt_validation() {
 		mode: Mode::Strict,
 		providers: vec![provider],
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 	let now = std::time::SystemTime::now()
 		.duration_since(std::time::UNIX_EPOCH)
@@ -357,6 +358,7 @@ fn setup_test_jwt_with_required_claims(
 			mode: Mode::Strict,
 			providers: vec![provider],
 			location: bearer_location(),
+			refreshers: Vec::new(),
 		},
 		kid,
 		issuer,
@@ -488,6 +490,7 @@ pub async fn test_apply_strict_missing_token() {
 		mode: super::Mode::Strict,
 		providers: vec![],
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 
 	// Minimal Request without Authorization header
@@ -508,6 +511,7 @@ pub async fn test_apply_permissive_no_token_ok() {
 		mode: Mode::Permissive,
 		providers: base.providers.clone(),
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 	let mut req = crate::http::Request::new(crate::http::Body::empty());
 	let mut log = make_min_req_log();
@@ -524,6 +528,7 @@ pub async fn test_apply_permissive_invalid_token_ok_and_keeps_header() {
 		mode: Mode::Permissive,
 		providers: base.providers.clone(),
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 	let mut req = crate::http::Request::new(crate::http::Body::empty());
 	req.headers_mut().insert(
@@ -553,6 +558,7 @@ pub async fn test_apply_permissive_valid_token_inserts_claims_and_removes_header
 		mode: Mode::Permissive,
 		providers: base.providers.clone(),
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 	let now = SystemTime::now()
 		.duration_since(UNIX_EPOCH)
@@ -584,6 +590,7 @@ pub async fn test_apply_optional_no_token_ok() {
 		mode: Mode::Optional,
 		providers: base.providers.clone(),
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 	let mut req = crate::http::Request::new(crate::http::Body::empty());
 	let mut log = make_min_req_log();
@@ -600,6 +607,7 @@ pub async fn test_apply_optional_invalid_token_err() {
 		mode: Mode::Optional,
 		providers: base.providers.clone(),
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 	let mut req = crate::http::Request::new(crate::http::Body::empty());
 	req.headers_mut().insert(
@@ -620,6 +628,7 @@ pub async fn test_apply_optional_valid_token_inserts_claims_and_removes_header()
 		mode: Mode::Optional,
 		providers: base.providers.clone(),
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 	let now = SystemTime::now()
 		.duration_since(UNIX_EPOCH)
@@ -654,6 +663,7 @@ pub async fn test_apply_query_parameter_token_inserts_claims_and_removes_query_p
 		location: crate::http::auth::AuthorizationLocation::QueryParameter {
 			name: "token".into(),
 		},
+		refreshers: Vec::new(),
 	};
 	let now = SystemTime::now()
 		.duration_since(UNIX_EPOCH)
@@ -786,6 +796,7 @@ fn setup_test_multi_jwt() -> (Jwt, ProviderInfo, ProviderInfo) {
 			mode: Mode::Strict,
 			providers: vec![provider1, provider2],
 			location: bearer_location(),
+			refreshers: Vec::new(),
 		},
 		(kid1, issuer1, aud1),
 		(kid2, issuer2, aud2),
@@ -881,6 +892,7 @@ pub fn test_empty_required_claims_accepts_token_without_exp() {
 		mode: Mode::Strict,
 		providers: vec![provider],
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 
 	let token = build_unsigned_token_without_exp(kid, issuer, aud);
@@ -940,6 +952,7 @@ pub fn test_default_required_claims_rejects_token_without_exp() {
 		mode: Mode::Strict,
 		providers: vec![provider],
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 
 	let token = build_unsigned_token_without_exp(kid, issuer, aud);
@@ -997,6 +1010,7 @@ pub fn test_empty_required_claims_still_rejects_expired_tokens() {
 		mode: Mode::Strict,
 		providers: vec![provider],
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 
 	let token = build_unsigned_token_with_expired_exp(kid, issuer, aud);
@@ -1054,6 +1068,7 @@ pub fn test_required_claims_with_nbf_rejects_missing_nbf() {
 		mode: Mode::Strict,
 		providers: vec![provider],
 		location: bearer_location(),
+		refreshers: Vec::new(),
 	};
 
 	// Token with exp but without nbf should be rejected when nbf is required
@@ -1067,5 +1082,160 @@ pub fn test_required_claims_with_nbf_rejects_missing_nbf() {
 	assert!(
 		result.is_err(),
 		"required_claims with nbf should reject tokens missing nbf claim"
+	);
+}
+
+#[tokio::test]
+async fn test_unknown_kid_triggers_on_demand_jwks_refresh() {
+	use std::sync::Arc;
+
+	use parking_lot::Mutex;
+	use wiremock::matchers::{method, path};
+	use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+	// Reuse the ed25519 fixture private key for both kids so a single
+	// signature verifies against either; this test is about kid lookup and
+	// on-demand refetching, not distinct key material.
+	const ED25519_PRIVATE_KEY: &[u8] = &[
+		0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04, 0x22, 0x04, 0x20,
+		0x6a, 0xc3, 0xfd, 0xee, 0xee, 0x29, 0x8a, 0x92, 0x63, 0x8b, 0x70, 0x0c, 0x4b, 0x11, 0x7c, 0xc3,
+		0x2e, 0x2d, 0x2a, 0xce, 0x0d, 0xfd, 0x78, 0x76, 0x94, 0xe2, 0x4c, 0xae, 0x8a, 0xd5, 0x82, 0x34,
+	];
+	const ED25519_PUBLIC_X: &str = "2-Jj2UvNCvQiUPNYRgSi0cJSPiJI6Rs6D0UTeEpQVj8";
+
+	fn jwks_with_kids(kids: &[&str]) -> serde_json::Value {
+		json!({
+			"keys": kids
+				.iter()
+				.map(|kid| json!({
+					"use": "sig",
+					"kty": "OKP",
+					"kid": kid,
+					"crv": "Ed25519",
+					"x": ED25519_PUBLIC_X,
+				}))
+				.collect::<Vec<_>>()
+		})
+	}
+
+	fn build_token(kid: &str, issuer: &str, aud: &str, exp: u64) -> String {
+		let claims = json!({ "iss": issuer, "aud": aud, "sub": "test-user", "exp": exp });
+		let mut header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::EdDSA);
+		header.kid = Some(kid.to_string());
+		jsonwebtoken::encode(
+			&header,
+			&claims,
+			&jsonwebtoken::EncodingKey::from_ed_der(ED25519_PRIVATE_KEY),
+		)
+		.unwrap()
+	}
+
+	fn test_client() -> crate::client::Client {
+		crate::client::Client::new(
+			&crate::client::Config {
+				resolver_cfg: hickory_resolver::config::ResolverConfig::default(),
+				resolver_opts: hickory_resolver::config::ResolverOpts::default(),
+			},
+			None,
+			crate::BackendConfig::default(),
+			None,
+		)
+	}
+
+	struct RotatingJwks {
+		body: Arc<Mutex<serde_json::Value>>,
+	}
+	impl Respond for RotatingJwks {
+		fn respond(&self, _req: &Request) -> ResponseTemplate {
+			ResponseTemplate::new(200).set_body_json(self.body.lock().clone())
+		}
+	}
+
+	let issuer = "https://example.com";
+	let aud = "test-aud";
+	let body = Arc::new(Mutex::new(jwks_with_kids(&["kid-a"])));
+	let mock = MockServer::start().await;
+	Mock::given(method("GET"))
+		.and(path("/jwks"))
+		.respond_with(RotatingJwks { body: body.clone() })
+		.mount(&mock)
+		.await;
+
+	let config: LocalJwtConfig = serde_json::from_value(json!({
+		"mode": "strict",
+		"issuer": issuer,
+		"audiences": [aud],
+		"jwks": { "url": format!("{}/jwks", mock.uri()) },
+	}))
+	.unwrap();
+
+	// Managed mode is required: it is the only mode that attaches a
+	// JwksRefresher, matching the standalone/local-config runtime path.
+	let manager = crate::resource_manager::ResourceManager::new(test_client()).unwrap();
+	let resources = crate::resource_manager::ResourceFetcher::managed(manager);
+	let scope = resources.scope_full_computation();
+	let jwt = config
+		.try_into(&resources)
+		.await
+		.expect("initial jwks load");
+	scope.finish(true);
+
+	assert_eq!(
+		mock
+			.received_requests()
+			.await
+			.expect("jwks recording")
+			.len(),
+		1,
+		"startup should fetch the jwks exactly once"
+	);
+
+	let now = std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.unwrap()
+		.as_secs();
+
+	*body.lock() = jwks_with_kids(&["kid-a", "kid-b"]);
+
+	let token_b = build_token("kid-b", issuer, aud, now + 600);
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	req.headers_mut().insert(
+		crate::http::header::AUTHORIZATION,
+		crate::http::HeaderValue::from_str(&format!("Bearer {token_b}")).unwrap(),
+	);
+	let res = jwt.apply(None, &mut req).await;
+	assert!(
+		res.is_ok(),
+		"unknown kid should trigger a refresh and then succeed: {res:?}"
+	);
+	assert_eq!(
+		mock
+			.received_requests()
+			.await
+			.expect("jwks recording")
+			.len(),
+		2,
+		"unknown kid should trigger exactly one on-demand refetch"
+	);
+
+	let token_c = build_token("kid-c", issuer, aud, now + 600);
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	req.headers_mut().insert(
+		crate::http::header::AUTHORIZATION,
+		crate::http::HeaderValue::from_str(&format!("Bearer {token_c}")).unwrap(),
+	);
+	let res = jwt.apply(None, &mut req).await;
+	assert!(
+		matches!(res, Err(TokenError::UnknownKeyId(_))),
+		"still-unknown kid inside the debounce window must fail: {res:?}"
+	);
+	assert_eq!(
+		mock
+			.received_requests()
+			.await
+			.expect("jwks recording")
+			.len(),
+		2,
+		"debounce window must prevent a second refetch"
 	);
 }

--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -49,9 +49,11 @@ pub(super) async fn apply_token_validation(
 		"MCP auth configured; validating Authorization header (mode={:?})",
 		auth.mode
 	);
-	auth.jwt_validator.apply(None, req).await.map_err(|e| {
-		create_auth_required_response(ProxyError::JwtAuthenticationFailure(e), req, auth)
-	})?;
+	Box::pin(auth.jwt_validator.apply(None, req))
+		.await
+		.map_err(|e| {
+			create_auth_required_response(ProxyError::JwtAuthenticationFailure(e), req, auth)
+		})?;
 	Ok(())
 }
 

--- a/crates/agentgateway/src/resource_manager.rs
+++ b/crates/agentgateway/src/resource_manager.rs
@@ -23,6 +23,7 @@ const OPENAPI_TTL: Duration = Duration::from_hours(24);
 const GENERIC_TTL: Duration = Duration::from_mins(15);
 const FAILED_HTTP_REFRESH: Duration = Duration::from_secs(15);
 const MIN_HTTP_REFRESH: Duration = Duration::from_secs(60);
+const ON_DEMAND_REFRESH_MIN_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum ResourceKind {
@@ -145,6 +146,18 @@ impl ResourceFetcher {
 		}
 	}
 
+	/// Returns the underlying resource manager when this fetcher participates
+	/// in config reloads, so callers can trigger an on-demand refresh (e.g. on
+	/// an unknown JWKS key id) that persists via the normal config-rebuild path.
+	pub(crate) fn managed_resource_manager(&self) -> Option<ResourceManager> {
+		match &self.mode {
+			ResourceFetcherMode::Managed(manager) => Some(manager.clone()),
+			ResourceFetcherMode::CachedOrDirect(_)
+			| ResourceFetcherMode::Direct(_)
+			| ResourceFetcherMode::FilesOnly => None,
+		}
+	}
+
 	/// Records managed resource lookups during a full config computation.
 	/// The returned guard commits fetched resources on success, or restores the
 	/// last committed set on failure so failed reloads do not leave stale state.
@@ -225,6 +238,9 @@ struct Inner {
 	scheduler_tx: mpsc::UnboundedSender<ScheduledRefresh>,
 	change_tx: watch::Sender<ResourceChange>,
 	change_counter: AtomicU64,
+	// Timestamp of the last on-demand (out-of-band) refresh per resource, used
+	// to debounce refresh_and_wait.
+	on_demand_refresh: Mutex<HashMap<ResourceRef, Instant>>,
 }
 
 struct Entry {
@@ -343,6 +359,7 @@ impl ResourceManager {
 				scheduler_tx,
 				change_tx,
 				change_counter: AtomicU64::new(0),
+				on_demand_refresh: Default::default(),
 			}),
 		};
 		manager.start_http_scheduler(scheduler_rx);
@@ -468,8 +485,7 @@ impl ResourceManager {
 		if !self.is_active(&resource) {
 			return;
 		}
-		let result = self.fetch(&resource).await;
-		let FetchResult { content, next } = match result {
+		let FetchResult { content, next } = match self.fetch(&resource).await {
 			Ok(result) => result,
 			Err(e) => {
 				warn!(resource = %resource_key(&resource), "failed to refresh resource: {e}");
@@ -487,7 +503,48 @@ impl ResourceManager {
 		if !self.is_active(&resource) {
 			return;
 		}
+		if self.store_if_changed(resource.clone(), content, next) {
+			self.notify_changed(&resource);
+		}
+	}
 
+	/// Immediately refetches `resource`, bypassing the cache, and returns the
+	/// fresh bytes. Used to recover from an unknown JWKS key id before the next
+	/// scheduled refresh. Debounced per-resource so a burst of tokens
+	/// referencing unknown key ids cannot flood the upstream endpoint.
+	pub async fn refresh_and_wait(&self, resource: &ResourceRef) -> anyhow::Result<Bytes> {
+		if !self.mark_on_demand_refresh(resource) {
+			return Err(anyhow!(
+				"on-demand refresh for {} debounced",
+				resource_key(resource)
+			));
+		}
+		let FetchResult { content, next } = self.fetch(resource).await?;
+		if self.store_if_changed(resource.clone(), content.clone(), next) {
+			self.notify_changed(resource);
+		}
+		Ok(content)
+	}
+
+	fn mark_on_demand_refresh(&self, resource: &ResourceRef) -> bool {
+		let mut last_refresh = self
+			.inner
+			.on_demand_refresh
+			.lock()
+			.expect("on-demand refresh mutex poisoned");
+		let now = Instant::now();
+		if let Some(last) = last_refresh.get(resource)
+			&& now.duration_since(*last) < ON_DEMAND_REFRESH_MIN_INTERVAL
+		{
+			return false;
+		}
+		last_refresh.insert(resource.clone(), now);
+		true
+	}
+
+	/// Stores freshly fetched content and schedules its next refresh, returning
+	/// whether the content differs from what was previously cached.
+	fn store_if_changed(&self, resource: ResourceRef, content: Bytes, next: Option<Instant>) -> bool {
 		let changed = {
 			let mut entries = self
 				.inner
@@ -512,14 +569,12 @@ impl ResourceManager {
 				refresh_in = ?at.saturating_duration_since(Instant::now()),
 				"scheduled resource refresh"
 			);
-			let _ = self.inner.scheduler_tx.send(ScheduledRefresh {
-				at,
-				resource: resource.clone(),
-			});
+			let _ = self
+				.inner
+				.scheduler_tx
+				.send(ScheduledRefresh { at, resource });
 		}
-		if changed {
-			self.notify_changed(&resource);
-		}
+		changed
 	}
 
 	async fn fetch(&self, resource: &ResourceRef) -> anyhow::Result<FetchResult> {

--- a/crates/agentgateway/src/serdes.rs
+++ b/crates/agentgateway/src/serdes.rs
@@ -73,7 +73,7 @@ impl FileInlineOrRemote {
 		})
 	}
 
-	fn as_resource_ref(&self, kind: ResourceKind) -> Option<ResourceRef> {
+	pub(crate) fn as_resource_ref(&self, kind: ResourceKind) -> Option<ResourceRef> {
 		match self {
 			FileInlineOrRemote::File { file } => Some(ResourceRef::File(file.clone())),
 			FileInlineOrRemote::Inline(_) => None,


### PR DESCRIPTION
Fixes #2798

## Problem

When an IdP rotates its signing key, standalone agentgateway keeps rejecting tokens signed with the new `kid` (`token uses the unknown key ...`) until the JWKS TTL elapses, because remote JWKS is only refreshed on a timer. Reproduced with the reporter's harness (https://github.com/rinormaloku/repro-jwks-refresh-bug-agw).

## Change

- `ResourceManager::refresh_and_wait` performs an immediate refetch, updates the cache entry and next-refresh schedule, and calls `notify_changed` when the bytes changed, so the normal config-rebuild path persists the new keys for later requests. The store-and-schedule half of `refetch_and_notify_if_changed` was factored into `store_if_changed` and reused rather than duplicated.
- Per-resource debounce (`ON_DEMAND_REFRESH_MIN_INTERVAL`, 10s) guards the upstream endpoint: a burst of tokens with unknown key ids triggers at most one refetch per resource per window. The timestamp is taken before fetching, so a failing fetch also consumes the window.
- `Jwt` carries a refresher only for providers whose JWKS is a remote source. On `TokenError::UnknownKeyId`, `Jwt::apply` refreshes once, rebuilds the provider, and validates against the rebuilt keys; if the refresh is debounced or the key is still absent, the original `UnknownKeyId` error is returned unchanged. File/inline JWKS and the xds-inline path get no refresher and keep byte-identical behavior. Nothing was added to hot structs.

## Testing

- `test_unknown_kid_triggers_on_demand_jwks_refresh` (wiremock): startup fetches JWKS once; after the mock rotates in a second key, a token with the new `kid` succeeds and the mock has recorded **exactly 2** fetches; a further unknown `kid` inside the debounce window fails with `UnknownKeyId` and the count **stays 2**.
- `make lint` and `make test` pass.
- End-to-end against the reporter's repro, same steps on both binaries:

  | request | `main` | this branch |
  |---|---|---|
  | token before rotation | 200 | 200 |
  | token after `/rotate` (new kid) | **401** `token uses the unknown key "k..."` | **200** |
  | same token again | 401 | 200 |

  The fake IdP logs exactly one extra `JWKS fetched` on this branch (startup + on-miss), and none for the repeated request, confirming the refreshed keys persisted through the config rebuild instead of refetching per request.

## Scope

Standalone/local-config only. Under k8s the Go controller owns JWKS fetching and pushes inline keys over xds, so there is no remote source to refresh in that path, matching the maintainer note on the issue.

One unrelated-looking change: growing `Jwt::apply`'s state machine pushed `mcp::router::App::serve()` past its 4 KiB `assert_size` budget, which only trips during codegen (`cargo test`), not `cargo check`. Fixed by `Box::pin`-ing the single cold call site in `mcp/auth.rs`, the same pattern already used elsewhere for rare-path futures.