### PR TITLE
feat(import): support LiteLLM default_fallbacks and define behavior for conditional fallbacks

### DIFF
--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -1207,6 +1207,7 @@ fn apply_default_fallbacks(
 
 	let mut seen = HashSet::new();
 	let mut defaults: Vec<String> = Vec::new();
+	let mut default_names: Vec<&str> = Vec::new();
 	for entry in entries {
 		let Some(name) = entry.as_str() else {
 			plan.findings.push(ImportFinding {
@@ -1219,6 +1220,7 @@ fn apply_default_fallbacks(
 		if !seen.insert(name) {
 			continue;
 		}
+		default_names.push(name);
 		if plan.routes.contains_key(name) {
 			defaults.push(name.to_string());
 		} else {
@@ -1263,7 +1265,6 @@ fn apply_default_fallbacks(
 				.or_insert_with(|| targets.iter().filter_map(Value::as_str).collect());
 		}
 	}
-	let default_names: Vec<&str> = defaults.iter().map(String::as_str).collect();
 
 	let mut wildcard_routes: Vec<String> = Vec::new();
 	let mut updates: Vec<(String, Vec<Vec<String>>)> = Vec::new();
@@ -1358,8 +1359,9 @@ fn apply_default_fallbacks(
 /// Mirrors `run_async_fallback`: the budget check happens once per frame on entry, and `depth`
 /// increments per attempted sibling within a frame and is inherited by that sibling's own frame, so
 /// earlier siblings' attempts consume the descent budget of later siblings rather than capping the
-/// sibling list itself. Children that were never imported are skipped without consuming depth
-/// because they cannot be emitted; LiteLLM would attempt and fail them.
+/// sibling list itself. Children that were never imported consume a depth slot and visitation like
+/// any attempted sibling, because LiteLLM attempts and fails them, but they are not emitted and
+/// their own fallback entries are not walked.
 #[allow(clippy::too_many_arguments)]
 fn extend_fallback_chain<'a>(
 	node: &'a str,
@@ -1377,13 +1379,13 @@ fn extend_fallback_chain<'a>(
 	let mut depth = depth;
 	let children = explicit.get(node).map(Vec::as_slice).unwrap_or(defaults);
 	for child in children.iter().copied() {
-		let Some((child, _)) = routes.get_key_value(child) else {
-			continue;
-		};
 		if !visited.insert(child) {
 			continue;
 		}
 		depth += 1;
+		if !routes.contains_key(child) {
+			continue;
+		}
 		chain.push(child);
 		extend_fallback_chain(
 			child,
@@ -1563,6 +1565,11 @@ mod tests {
 	#[test]
 	fn reports_conditional_fallback_settings_as_manual() {
 		assert_litellm_golden("conditional-fallbacks");
+	}
+
+	#[test]
+	fn counts_unimported_fallback_targets_against_depth() {
+		assert_litellm_golden("default-fallbacks-unimported-depth");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -409,9 +409,19 @@ impl ConfigImporter for LiteLlmImporter {
 			.router_settings
 			.get("max_fallbacks")
 			.and_then(Value::as_u64)
-			.filter(|max_fallbacks| *max_fallbacks > 0)
 			.map(|max_fallbacks| max_fallbacks as usize)
 			.unwrap_or(DEFAULT_MAX_FALLBACKS);
+		let mut removed_fallback_targets = false;
+		if max_fallbacks == 0 {
+			// LiteLLM raises before attempting any fallback group, so no failover survives, not even
+			// the explicitly configured groups applied above.
+			for route in plan.routes.values_mut() {
+				if !route.fallback_groups.is_empty() {
+					route.fallback_groups = Vec::new();
+					removed_fallback_targets = true;
+				}
+			}
+		}
 		if let Some((source_path, default_fallbacks)) = default_fallbacks {
 			apply_default_fallbacks(
 				default_fallbacks,
@@ -449,11 +459,36 @@ impl ConfigImporter for LiteLlmImporter {
 		for setting in config.router_settings.keys() {
 			match setting.as_str() {
 				"fallbacks" | "routing_strategy" | "default_fallbacks" => continue,
-				"max_fallbacks" if default_fallbacks.is_some() => {
+				"max_fallbacks" => {
+					let (status, message) = match config.router_settings.get(setting).and_then(Value::as_u64)
+					{
+						None => (
+							ImportStatus::Manual,
+							"max_fallbacks must be a non-negative integer; the LiteLLM default of 5 was assumed"
+								.to_string(),
+						),
+						Some(0) if removed_fallback_targets => (
+							ImportStatus::Exact,
+							"max_fallbacks: 0 disables LiteLLM fallbacks; emitted failover targets were removed"
+								.to_string(),
+						),
+						Some(0) => (
+							ImportStatus::Exact,
+							"max_fallbacks: 0 disables LiteLLM fallbacks".to_string(),
+						),
+						Some(_) if default_fallbacks.is_none() => (
+							ImportStatus::Manual,
+							"No automatic mapping is available; review this router setting".to_string(),
+						),
+						Some(_) => (
+							ImportStatus::Exact,
+							"max_fallbacks bounds the flattened failover chain length".to_string(),
+						),
+					};
 					plan.findings.push(ImportFinding {
 						source_path: format!("router_settings.{setting}"),
-						status: ImportStatus::Exact,
-						message: "max_fallbacks bounds the flattened failover chain length".to_string(),
+						status,
+						message,
 					});
 				},
 				"context_window_fallbacks" | "content_policy_fallbacks" => {
@@ -1195,6 +1230,23 @@ fn apply_default_fallbacks(
 		}
 	}
 
+	if max_fallbacks == 0 {
+		// Fallbacks are already disabled at the call site; only the unknown-model re-assign survives,
+		// because LiteLLM resolves that during deployment lookup rather than in run_async_fallback.
+		if let Some(first) = defaults.first()
+			&& !plan.routes.contains_key("*")
+		{
+			plan.findings.push(ImportFinding {
+				source_path: source_path.to_string(),
+				status: ImportStatus::Manual,
+				message: format!(
+					"LiteLLM serves unknown model names via the first default fallback {first:?}; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a \"*\" model manually if unknown names must be served"
+				),
+			});
+		}
+		return;
+	}
+
 	let mut explicit: IndexMap<&str, Vec<&str>> = IndexMap::new();
 	for entry in explicit_fallbacks
 		.and_then(Value::as_array)
@@ -1226,6 +1278,7 @@ fn apply_default_fallbacks(
 		let mut visited: HashSet<&str> = HashSet::from([route_name.as_str()]);
 		extend_fallback_chain(
 			route_name,
+			0,
 			&explicit,
 			&default_names,
 			&plan.routes,
@@ -1301,8 +1354,16 @@ fn apply_default_fallbacks(
 
 /// Walks the LiteLLM fallback graph depth-first in attempt order, appending every model group that
 /// would be tried after `node` fails.
+///
+/// Mirrors `run_async_fallback`: the budget check happens once per frame on entry, and `depth`
+/// increments per attempted sibling within a frame and is inherited by that sibling's own frame, so
+/// earlier siblings' attempts consume the descent budget of later siblings rather than capping the
+/// sibling list itself. Children that were never imported are skipped without consuming depth
+/// because they cannot be emitted; LiteLLM would attempt and fail them.
+#[allow(clippy::too_many_arguments)]
 fn extend_fallback_chain<'a>(
 	node: &'a str,
+	depth: usize,
 	explicit: &IndexMap<&'a str, Vec<&'a str>>,
 	defaults: &[&'a str],
 	routes: &'a IndexMap<String, ImportedRoute>,
@@ -1310,20 +1371,23 @@ fn extend_fallback_chain<'a>(
 	visited: &mut HashSet<&'a str>,
 	chain: &mut Vec<&'a str>,
 ) {
+	if depth >= max_fallbacks {
+		return;
+	}
+	let mut depth = depth;
 	let children = explicit.get(node).map(Vec::as_slice).unwrap_or(defaults);
 	for child in children.iter().copied() {
-		if chain.len() >= max_fallbacks {
-			return;
-		}
 		let Some((child, _)) = routes.get_key_value(child) else {
 			continue;
 		};
 		if !visited.insert(child) {
 			continue;
 		}
+		depth += 1;
 		chain.push(child);
 		extend_fallback_chain(
 			child,
+			depth,
 			explicit,
 			defaults,
 			routes,
@@ -1474,6 +1538,26 @@ mod tests {
 	#[test]
 	fn reports_wildcard_default_fallback_limitations() {
 		assert_litellm_golden("default-fallbacks-wildcard");
+	}
+
+	#[test]
+	fn flattens_branching_fallbacks_with_depth_budget() {
+		assert_litellm_golden("default-fallbacks-branching");
+	}
+
+	#[test]
+	fn disables_fallbacks_when_max_fallbacks_is_zero() {
+		assert_litellm_golden("default-fallbacks-max-zero");
+	}
+
+	#[test]
+	fn reports_invalid_max_fallbacks() {
+		assert_litellm_golden("default-fallbacks-max-invalid");
+	}
+
+	#[test]
+	fn disables_explicit_fallbacks_when_max_fallbacks_is_zero_without_defaults() {
+		assert_litellm_golden("max-fallbacks-zero-without-defaults");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -385,6 +385,20 @@ impl ConfigImporter for LiteLlmImporter {
 			apply_fallbacks(fallbacks, source_path, &mut plan);
 		}
 
+		let default_fallbacks = config
+			.router_settings
+			.get("default_fallbacks")
+			.map(|default_fallbacks| ("router_settings.default_fallbacks", default_fallbacks))
+			.or_else(|| {
+				config
+					.litellm_settings
+					.get("default_fallbacks")
+					.map(|default_fallbacks| ("litellm_settings.default_fallbacks", default_fallbacks))
+			});
+		if let Some((source_path, default_fallbacks)) = default_fallbacks {
+			apply_default_fallbacks(default_fallbacks, source_path, &mut plan);
+		}
+
 		if let Some(strategy) = config.router_settings.get("routing_strategy") {
 			let (status, message) = match strategy.as_str() {
 				Some("simple-shuffle") => (
@@ -410,14 +424,25 @@ impl ConfigImporter for LiteLlmImporter {
 			});
 		}
 		for setting in config.router_settings.keys() {
-			if matches!(setting.as_str(), "fallbacks" | "routing_strategy") {
-				continue;
+			match setting.as_str() {
+				"fallbacks" | "routing_strategy" | "default_fallbacks" => continue,
+				"context_window_fallbacks" | "content_policy_fallbacks" => {
+					plan.findings.push(ImportFinding {
+						source_path: format!("router_settings.{setting}"),
+						status: ImportStatus::Manual,
+						message: format!(
+							"LiteLLM {setting} is conditional on specific error types and cannot be represented by agentgateway's unconditional priority failover; configure equivalent behavior manually"
+						),
+					});
+				},
+				_ => {
+					plan.findings.push(ImportFinding {
+						source_path: format!("router_settings.{setting}"),
+						status: ImportStatus::Manual,
+						message: "No automatic mapping is available; review this router setting".to_string(),
+					});
+				},
 			}
-			plan.findings.push(ImportFinding {
-				source_path: format!("router_settings.{setting}"),
-				status: ImportStatus::Manual,
-				message: "No automatic mapping is available; review this router setting".to_string(),
-			});
 		}
 		for (section, values) in [
 			("general_settings", &config.general_settings),
@@ -438,7 +463,7 @@ impl ConfigImporter for LiteLlmImporter {
 			}
 		}
 		for setting in config.litellm_settings.keys() {
-			if setting == "fallbacks" {
+			if matches!(setting.as_str(), "fallbacks" | "default_fallbacks") {
 				continue;
 			}
 			if setting == "database_url" {
@@ -1091,6 +1116,83 @@ fn apply_fallbacks(value: &Value, source_path: &str, plan: &mut ImportPlan) {
 	});
 }
 
+fn apply_default_fallbacks(value: &Value, source_path: &str, plan: &mut ImportPlan) {
+	let Some(entries) = value.as_array() else {
+		plan.findings.push(ImportFinding {
+			source_path: source_path.to_string(),
+			status: ImportStatus::Unsupported,
+			message: "Default fallbacks must be a list of model names".to_string(),
+		});
+		return;
+	};
+	if entries.is_empty() {
+		plan.findings.push(ImportFinding {
+			source_path: source_path.to_string(),
+			status: ImportStatus::Exact,
+			message: "default_fallbacks is empty; no routes changed".to_string(),
+		});
+		return;
+	}
+
+	let mut seen = HashSet::new();
+	let mut default_targets: Vec<(String, Vec<String>)> = Vec::new();
+	for entry in entries {
+		let Some(name) = entry.as_str() else {
+			plan.findings.push(ImportFinding {
+				source_path: source_path.to_string(),
+				status: ImportStatus::Manual,
+				message: "Default fallback entry must be a string and was not emitted".to_string(),
+			});
+			continue;
+		};
+		if !seen.insert(name) {
+			continue;
+		}
+		if let Some(route) = plan.routes.get(name) {
+			default_targets.push((name.to_string(), route.targets.clone()));
+		} else {
+			plan.findings.push(ImportFinding {
+				source_path: source_path.to_string(),
+				status: ImportStatus::Manual,
+				message: format!("Default fallback target model {name:?} was not imported"),
+			});
+		}
+	}
+
+	let mut changed = false;
+	for (route_name, route) in plan.routes.iter_mut() {
+		if !route.fallback_groups.is_empty() {
+			continue;
+		}
+		let own_targets: HashSet<&str> = route.targets.iter().map(String::as_str).collect();
+		let groups = default_targets
+			.iter()
+			.filter(|(name, _)| name != route_name)
+			.map(|(_, targets)| {
+				targets
+					.iter()
+					.filter(|target| !own_targets.contains(target.as_str()))
+					.cloned()
+					.collect::<Vec<String>>()
+			})
+			.filter(|group| !group.is_empty());
+		for group in groups {
+			route.fallback_groups.push(group);
+			changed = true;
+		}
+	}
+
+	if changed {
+		plan.findings.push(ImportFinding {
+			source_path: source_path.to_string(),
+			status: ImportStatus::Approximate,
+			message:
+				"Mapped default_fallbacks to priority-based failover for routes without explicit fallbacks"
+					.to_string(),
+		});
+	}
+}
+
 fn sanitize_name(name: &str) -> String {
 	let sanitized = name
 		.chars()
@@ -1216,6 +1318,16 @@ mod tests {
 	#[test]
 	fn keeps_routing_for_a_single_model_with_fallbacks() {
 		assert_litellm_golden("single-model-fallback");
+	}
+
+	#[test]
+	fn applies_default_fallbacks_to_routes_without_explicit_fallbacks() {
+		assert_litellm_golden("default-fallbacks");
+	}
+
+	#[test]
+	fn reports_conditional_fallback_settings_as_manual() {
+		assert_litellm_golden("conditional-fallbacks");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/import.rs
+++ b/crates/agentgateway/src/import.rs
@@ -11,6 +11,9 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 
+/// LiteLLM's `ROUTER_MAX_FALLBACKS`, the recursion depth cap for fallback attempts.
+const DEFAULT_MAX_FALLBACKS: usize = 5;
+
 /// A source-specific configuration adapter.
 pub trait ConfigImporter: Send + Sync {
 	fn source(&self) -> &'static str;
@@ -385,18 +388,38 @@ impl ConfigImporter for LiteLlmImporter {
 			apply_fallbacks(fallbacks, source_path, &mut plan);
 		}
 
-		let default_fallbacks = config
-			.router_settings
-			.get("default_fallbacks")
+		let router_default_fallbacks = config.router_settings.get("default_fallbacks");
+		let litellm_default_fallbacks = config.litellm_settings.get("default_fallbacks");
+		if router_default_fallbacks.is_some() && litellm_default_fallbacks.is_some() {
+			plan.findings.push(ImportFinding {
+				source_path: "litellm_settings.default_fallbacks".to_string(),
+				status: ImportStatus::Manual,
+				message:
+					"litellm_settings.default_fallbacks is shadowed by router_settings.default_fallbacks; the router_settings value was applied"
+						.to_string(),
+			});
+		}
+		let default_fallbacks = router_default_fallbacks
 			.map(|default_fallbacks| ("router_settings.default_fallbacks", default_fallbacks))
 			.or_else(|| {
-				config
-					.litellm_settings
-					.get("default_fallbacks")
+				litellm_default_fallbacks
 					.map(|default_fallbacks| ("litellm_settings.default_fallbacks", default_fallbacks))
 			});
+		let max_fallbacks = config
+			.router_settings
+			.get("max_fallbacks")
+			.and_then(Value::as_u64)
+			.filter(|max_fallbacks| *max_fallbacks > 0)
+			.map(|max_fallbacks| max_fallbacks as usize)
+			.unwrap_or(DEFAULT_MAX_FALLBACKS);
 		if let Some((source_path, default_fallbacks)) = default_fallbacks {
-			apply_default_fallbacks(default_fallbacks, source_path, &mut plan);
+			apply_default_fallbacks(
+				default_fallbacks,
+				source_path,
+				fallbacks.map(|(_, fallbacks)| fallbacks),
+				max_fallbacks,
+				&mut plan,
+			);
 		}
 
 		if let Some(strategy) = config.router_settings.get("routing_strategy") {
@@ -426,6 +449,13 @@ impl ConfigImporter for LiteLlmImporter {
 		for setting in config.router_settings.keys() {
 			match setting.as_str() {
 				"fallbacks" | "routing_strategy" | "default_fallbacks" => continue,
+				"max_fallbacks" if default_fallbacks.is_some() => {
+					plan.findings.push(ImportFinding {
+						source_path: format!("router_settings.{setting}"),
+						status: ImportStatus::Exact,
+						message: "max_fallbacks bounds the flattened failover chain length".to_string(),
+					});
+				},
 				"context_window_fallbacks" | "content_policy_fallbacks" => {
 					plan.findings.push(ImportFinding {
 						source_path: format!("router_settings.{setting}"),
@@ -1116,7 +1146,13 @@ fn apply_fallbacks(value: &Value, source_path: &str, plan: &mut ImportPlan) {
 	});
 }
 
-fn apply_default_fallbacks(value: &Value, source_path: &str, plan: &mut ImportPlan) {
+fn apply_default_fallbacks(
+	value: &Value,
+	source_path: &str,
+	explicit_fallbacks: Option<&Value>,
+	max_fallbacks: usize,
+	plan: &mut ImportPlan,
+) {
 	let Some(entries) = value.as_array() else {
 		plan.findings.push(ImportFinding {
 			source_path: source_path.to_string(),
@@ -1135,7 +1171,7 @@ fn apply_default_fallbacks(value: &Value, source_path: &str, plan: &mut ImportPl
 	}
 
 	let mut seen = HashSet::new();
-	let mut default_targets: Vec<(String, Vec<String>)> = Vec::new();
+	let mut defaults: Vec<String> = Vec::new();
 	for entry in entries {
 		let Some(name) = entry.as_str() else {
 			plan.findings.push(ImportFinding {
@@ -1148,8 +1184,8 @@ fn apply_default_fallbacks(value: &Value, source_path: &str, plan: &mut ImportPl
 		if !seen.insert(name) {
 			continue;
 		}
-		if let Some(route) = plan.routes.get(name) {
-			default_targets.push((name.to_string(), route.targets.clone()));
+		if plan.routes.contains_key(name) {
+			defaults.push(name.to_string());
 		} else {
 			plan.findings.push(ImportFinding {
 				source_path: source_path.to_string(),
@@ -1159,37 +1195,142 @@ fn apply_default_fallbacks(value: &Value, source_path: &str, plan: &mut ImportPl
 		}
 	}
 
-	let mut changed = false;
-	for (route_name, route) in plan.routes.iter_mut() {
-		if !route.fallback_groups.is_empty() {
+	let mut explicit: IndexMap<&str, Vec<&str>> = IndexMap::new();
+	for entry in explicit_fallbacks
+		.and_then(Value::as_array)
+		.into_iter()
+		.flatten()
+		.filter_map(Value::as_object)
+	{
+		for (source, targets) in entry {
+			let Some(targets) = targets.as_array() else {
+				continue;
+			};
+			explicit
+				.entry(source.as_str())
+				.or_insert_with(|| targets.iter().filter_map(Value::as_str).collect());
+		}
+	}
+	let default_names: Vec<&str> = defaults.iter().map(String::as_str).collect();
+
+	let mut wildcard_routes: Vec<String> = Vec::new();
+	let mut updates: Vec<(String, Vec<Vec<String>>)> = Vec::new();
+	for (route_name, route) in &plan.routes {
+		if route_name.contains('*') {
+			if !defaults.is_empty() {
+				wildcard_routes.push(route_name.clone());
+			}
 			continue;
 		}
-		let own_targets: HashSet<&str> = route.targets.iter().map(String::as_str).collect();
-		let groups = default_targets
-			.iter()
-			.filter(|(name, _)| name != route_name)
-			.map(|(_, targets)| {
-				targets
-					.iter()
-					.filter(|target| !own_targets.contains(target.as_str()))
-					.cloned()
-					.collect::<Vec<String>>()
-			})
-			.filter(|group| !group.is_empty());
-		for group in groups {
-			route.fallback_groups.push(group);
-			changed = true;
+		let mut chain: Vec<&str> = Vec::new();
+		let mut visited: HashSet<&str> = HashSet::from([route_name.as_str()]);
+		extend_fallback_chain(
+			route_name,
+			&explicit,
+			&default_names,
+			&plan.routes,
+			max_fallbacks,
+			&mut visited,
+			&mut chain,
+		);
+		let mut reached: HashSet<&str> = route.targets.iter().map(String::as_str).collect();
+		let mut groups: Vec<Vec<String>> = Vec::new();
+		for hop in chain {
+			let group: Vec<String> = plan.routes[hop]
+				.targets
+				.iter()
+				.filter(|target| reached.insert(target.as_str()))
+				.cloned()
+				.collect();
+			if !group.is_empty() {
+				groups.push(group);
+			}
+		}
+		if groups != route.fallback_groups {
+			updates.push((route_name.clone(), groups));
 		}
 	}
 
-	if changed {
+	let changed = !updates.is_empty();
+	for (route_name, groups) in updates {
+		plan
+			.routes
+			.get_mut(&route_name)
+			.expect("route name taken from plan.routes")
+			.fallback_groups = groups;
+	}
+
+	for route_name in wildcard_routes {
 		plan.findings.push(ImportFinding {
+			source_path: source_path.to_string(),
+			status: ImportStatus::Manual,
+			message: format!(
+				"Default fallbacks cannot be attached to wildcard model {route_name:?}: failover requires a virtual model and virtual model names match exactly; configure failover for requests served by this wildcard manually"
+			),
+		});
+	}
+	plan.findings.push(if changed {
+		ImportFinding {
 			source_path: source_path.to_string(),
 			status: ImportStatus::Approximate,
 			message:
-				"Mapped default_fallbacks to priority-based failover for routes without explicit fallbacks"
+				"Flattened LiteLLM fallback recursion (per-hop explicit fallbacks, default_fallbacks at hops without one, attempted models skipped) into static priority-ordered failover targets"
 					.to_string(),
+		}
+	} else {
+		ImportFinding {
+			source_path: source_path.to_string(),
+			status: ImportStatus::Exact,
+			message:
+				"default_fallbacks changed no routes; every chain already matches the explicit fallbacks or self-exclusion removed every candidate"
+					.to_string(),
+		}
+	});
+	if let Some(first) = defaults.first()
+		&& !plan.routes.contains_key("*")
+	{
+		plan.findings.push(ImportFinding {
+			source_path: source_path.to_string(),
+			status: ImportStatus::Manual,
+			message: format!(
+				"LiteLLM serves unknown model names via the first default fallback {first:?}; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a \"*\" model manually if unknown names must be served"
+			),
 		});
+	}
+}
+
+/// Walks the LiteLLM fallback graph depth-first in attempt order, appending every model group that
+/// would be tried after `node` fails.
+fn extend_fallback_chain<'a>(
+	node: &'a str,
+	explicit: &IndexMap<&'a str, Vec<&'a str>>,
+	defaults: &[&'a str],
+	routes: &'a IndexMap<String, ImportedRoute>,
+	max_fallbacks: usize,
+	visited: &mut HashSet<&'a str>,
+	chain: &mut Vec<&'a str>,
+) {
+	let children = explicit.get(node).map(Vec::as_slice).unwrap_or(defaults);
+	for child in children.iter().copied() {
+		if chain.len() >= max_fallbacks {
+			return;
+		}
+		let Some((child, _)) = routes.get_key_value(child) else {
+			continue;
+		};
+		if !visited.insert(child) {
+			continue;
+		}
+		chain.push(child);
+		extend_fallback_chain(
+			child,
+			explicit,
+			defaults,
+			routes,
+			max_fallbacks,
+			visited,
+			chain,
+		);
 	}
 }
 
@@ -1323,6 +1464,16 @@ mod tests {
 	#[test]
 	fn applies_default_fallbacks_to_routes_without_explicit_fallbacks() {
 		assert_litellm_golden("default-fallbacks");
+	}
+
+	#[test]
+	fn reports_shadowed_and_noop_default_fallbacks() {
+		assert_litellm_golden("default-fallbacks-shadowed");
+	}
+
+	#[test]
+	fn reports_wildcard_default_fallback_limitations() {
+		assert_litellm_golden("default-fallbacks-wildcard");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/tests/import/litellm/conditional-fallbacks.snap
+++ b/crates/agentgateway/src/tests/import/litellm/conditional-fallbacks.snap
@@ -1,0 +1,38 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/conditional-fallbacks.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: primary
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: backup
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for primary
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: router_settings.context_window_fallbacks
+    status: manual
+    message: "LiteLLM context_window_fallbacks is conditional on specific error types and cannot be represented by agentgateway's unconditional priority failover; configure equivalent behavior manually"
+  - sourcePath: router_settings.content_policy_fallbacks
+    status: manual
+    message: "LiteLLM content_policy_fallbacks is conditional on specific error types and cannot be represented by agentgateway's unconditional priority failover; configure equivalent behavior manually"

--- a/crates/agentgateway/src/tests/import/litellm/conditional-fallbacks.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/conditional-fallbacks.yaml
@@ -1,0 +1,12 @@
+model_list:
+- model_name: primary
+  litellm_params:
+    model: openai/gpt-4o
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+router_settings:
+  context_window_fallbacks:
+  - primary: [backup]
+  content_policy_fallbacks:
+  - primary: [backup]

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-branching.snap
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-branching.snap
@@ -1,0 +1,101 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/default-fallbacks-branching.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: imported/litellm/primary/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: imported/litellm/backup/1
+        visibility: internal
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+      - name: imported/litellm/spare/1
+        visibility: internal
+        provider: anthropic
+        params:
+          model: claude-sonnet-4
+      - name: imported/litellm/deep/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o-mini
+    virtualModels:
+      - name: primary
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/primary/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+              - model: imported/litellm/deep/1
+                priority: 2
+              - model: imported/litellm/spare/1
+                priority: 3
+      - name: backup
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/backup/1
+                priority: 0
+              - model: imported/litellm/deep/1
+                priority: 1
+      - name: spare
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/spare/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+              - model: imported/litellm/deep/1
+                priority: 2
+      - name: deep
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/deep/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for primary
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: "model_list[2]"
+    status: exact
+    message: Imported model deployment for spare
+  - sourcePath: "model_list[3]"
+    status: exact
+    message: Imported model deployment for deep
+  - sourcePath: router_settings.fallbacks
+    status: approximate
+    message: Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover
+  - sourcePath: router_settings.default_fallbacks
+    status: approximate
+    message: "Flattened LiteLLM fallback recursion (per-hop explicit fallbacks, default_fallbacks at hops without one, attempted models skipped) into static priority-ordered failover targets"
+  - sourcePath: router_settings.default_fallbacks
+    status: manual
+    message: "LiteLLM serves unknown model names via the first default fallback \"backup\"; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a \"*\" model manually if unknown names must be served"
+  - sourcePath: router_settings.max_fallbacks
+    status: exact
+    message: max_fallbacks bounds the flattened failover chain length

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-branching.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-branching.yaml
@@ -1,0 +1,19 @@
+model_list:
+- model_name: primary
+  litellm_params:
+    model: openai/gpt-4o
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+- model_name: spare
+  litellm_params:
+    model: anthropic/claude-sonnet-4
+- model_name: deep
+  litellm_params:
+    model: openai/gpt-4o-mini
+router_settings:
+  fallbacks:
+  - primary: [backup, spare]
+  - backup: [deep]
+  max_fallbacks: 2
+  default_fallbacks: [backup]

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-max-invalid.snap
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-max-invalid.snap
@@ -1,0 +1,51 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/default-fallbacks-max-invalid.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: imported/litellm/primary/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: backup
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+    virtualModels:
+      - name: primary
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/primary/1
+                priority: 0
+              - model: backup
+                priority: 1
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for primary
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: router_settings.default_fallbacks
+    status: approximate
+    message: "Flattened LiteLLM fallback recursion (per-hop explicit fallbacks, default_fallbacks at hops without one, attempted models skipped) into static priority-ordered failover targets"
+  - sourcePath: router_settings.default_fallbacks
+    status: manual
+    message: "LiteLLM serves unknown model names via the first default fallback \"backup\"; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a \"*\" model manually if unknown names must be served"
+  - sourcePath: router_settings.max_fallbacks
+    status: manual
+    message: max_fallbacks must be a non-negative integer; the LiteLLM default of 5 was assumed

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-max-invalid.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-max-invalid.yaml
@@ -1,0 +1,10 @@
+model_list:
+- model_name: primary
+  litellm_params:
+    model: openai/gpt-4o
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+router_settings:
+  max_fallbacks: -1
+  default_fallbacks: [backup]

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-max-zero.snap
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-max-zero.snap
@@ -1,0 +1,41 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/default-fallbacks-max-zero.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: primary
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: backup
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for primary
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: router_settings.fallbacks
+    status: approximate
+    message: Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover
+  - sourcePath: router_settings.default_fallbacks
+    status: manual
+    message: "LiteLLM serves unknown model names via the first default fallback \"backup\"; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a \"*\" model manually if unknown names must be served"
+  - sourcePath: router_settings.max_fallbacks
+    status: exact
+    message: "max_fallbacks: 0 disables LiteLLM fallbacks; emitted failover targets were removed"

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-max-zero.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-max-zero.yaml
@@ -1,0 +1,12 @@
+model_list:
+- model_name: primary
+  litellm_params:
+    model: openai/gpt-4o
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+router_settings:
+  fallbacks:
+  - primary: [backup]
+  max_fallbacks: 0
+  default_fallbacks: [backup]

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-shadowed.snap
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-shadowed.snap
@@ -1,0 +1,34 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/default-fallbacks-shadowed.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: solo
+        provider: openAI
+        params:
+          model: gpt-4o
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for solo
+  - sourcePath: litellm_settings.default_fallbacks
+    status: manual
+    message: litellm_settings.default_fallbacks is shadowed by router_settings.default_fallbacks; the router_settings value was applied
+  - sourcePath: router_settings.default_fallbacks
+    status: exact
+    message: default_fallbacks changed no routes; every chain already matches the explicit fallbacks or self-exclusion removed every candidate
+  - sourcePath: router_settings.default_fallbacks
+    status: manual
+    message: "LiteLLM serves unknown model names via the first default fallback \"solo\"; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a \"*\" model manually if unknown names must be served"

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-shadowed.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-shadowed.yaml
@@ -1,0 +1,8 @@
+model_list:
+- model_name: solo
+  litellm_params:
+    model: openai/gpt-4o
+router_settings:
+  default_fallbacks: [solo]
+litellm_settings:
+  default_fallbacks: [ignored-model]

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-unimported-depth.snap
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-unimported-depth.snap
@@ -1,0 +1,101 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/default-fallbacks-unimported-depth.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: imported/litellm/primary/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: imported/litellm/backup/1
+        visibility: internal
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+      - name: imported/litellm/deep/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o-mini
+      - name: imported/litellm/extra/1
+        visibility: internal
+        provider: anthropic
+        params:
+          model: claude-sonnet-4
+    virtualModels:
+      - name: primary
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/primary/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+      - name: backup
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/backup/1
+                priority: 0
+              - model: imported/litellm/deep/1
+                priority: 1
+      - name: deep
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/deep/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+      - name: extra
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/extra/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for primary
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: "model_list[2]"
+    status: exact
+    message: Imported model deployment for deep
+  - sourcePath: "model_list[3]"
+    status: exact
+    message: Imported model deployment for extra
+  - sourcePath: router_settings.fallbacks
+    status: manual
+    message: "Fallback target model \"missing\" was not imported"
+  - sourcePath: router_settings.fallbacks
+    status: approximate
+    message: Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover
+  - sourcePath: router_settings.default_fallbacks
+    status: manual
+    message: "Default fallback target model \"ghost\" was not imported"
+  - sourcePath: router_settings.default_fallbacks
+    status: approximate
+    message: "Flattened LiteLLM fallback recursion (per-hop explicit fallbacks, default_fallbacks at hops without one, attempted models skipped) into static priority-ordered failover targets"
+  - sourcePath: router_settings.default_fallbacks
+    status: manual
+    message: "LiteLLM serves unknown model names via the first default fallback \"backup\"; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a \"*\" model manually if unknown names must be served"
+  - sourcePath: router_settings.max_fallbacks
+    status: exact
+    message: max_fallbacks bounds the flattened failover chain length

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-unimported-depth.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-unimported-depth.yaml
@@ -1,0 +1,19 @@
+model_list:
+- model_name: primary
+  litellm_params:
+    model: openai/gpt-4o
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+- model_name: deep
+  litellm_params:
+    model: openai/gpt-4o-mini
+- model_name: extra
+  litellm_params:
+    model: anthropic/claude-sonnet-4
+router_settings:
+  fallbacks:
+  - primary: [missing, backup]
+  - backup: [deep]
+  max_fallbacks: 2
+  default_fallbacks: [ghost, backup]

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-wildcard.snap
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-wildcard.snap
@@ -1,0 +1,37 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/default-fallbacks-wildcard.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: "*"
+        provider: openAI
+        params: {}
+      - name: fast
+        provider: openAI
+        params:
+          model: gpt-4o-mini
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for *
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for fast
+  - sourcePath: router_settings.default_fallbacks
+    status: manual
+    message: "Default fallbacks cannot be attached to wildcard model \"*\": failover requires a virtual model and virtual model names match exactly; configure failover for requests served by this wildcard manually"
+  - sourcePath: router_settings.default_fallbacks
+    status: exact
+    message: default_fallbacks changed no routes; every chain already matches the explicit fallbacks or self-exclusion removed every candidate

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks-wildcard.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks-wildcard.yaml
@@ -1,0 +1,9 @@
+model_list:
+- model_name: "*"
+  litellm_params:
+    model: "openai/*"
+- model_name: fast
+  litellm_params:
+    model: openai/gpt-4o-mini
+router_settings:
+  default_fallbacks: [fast]

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks.snap
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks.snap
@@ -44,6 +44,8 @@ config:
                 priority: 0
               - model: imported/litellm/backup/1
                 priority: 1
+              - model: imported/litellm/spare/1
+                priority: 2
       - name: backup
         routing:
           failover:
@@ -88,4 +90,7 @@ findings:
     message: Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover
   - sourcePath: router_settings.default_fallbacks
     status: approximate
-    message: Mapped default_fallbacks to priority-based failover for routes without explicit fallbacks
+    message: "Flattened LiteLLM fallback recursion (per-hop explicit fallbacks, default_fallbacks at hops without one, attempted models skipped) into static priority-ordered failover targets"
+  - sourcePath: router_settings.default_fallbacks
+    status: manual
+    message: "LiteLLM serves unknown model names via the first default fallback \"backup\"; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a \"*\" model manually if unknown names must be served"

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks.snap
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks.snap
@@ -1,0 +1,91 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/default-fallbacks.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: imported/litellm/primary/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: imported/litellm/backup/1
+        visibility: internal
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+      - name: imported/litellm/spare/1
+        visibility: internal
+        provider: anthropic
+        params:
+          model: claude-sonnet-4
+      - name: imported/litellm/extra/1
+        visibility: internal
+        provider: openAI
+        params:
+          model: gpt-4o-mini
+    virtualModels:
+      - name: primary
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/primary/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+      - name: backup
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/backup/1
+                priority: 0
+              - model: imported/litellm/spare/1
+                priority: 1
+      - name: spare
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/spare/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+      - name: extra
+        routing:
+          failover:
+            targets:
+              - model: imported/litellm/extra/1
+                priority: 0
+              - model: imported/litellm/backup/1
+                priority: 1
+              - model: imported/litellm/spare/1
+                priority: 2
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for primary
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: "model_list[2]"
+    status: exact
+    message: Imported model deployment for spare
+  - sourcePath: "model_list[3]"
+    status: exact
+    message: Imported model deployment for extra
+  - sourcePath: router_settings.fallbacks
+    status: approximate
+    message: Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover
+  - sourcePath: router_settings.default_fallbacks
+    status: approximate
+    message: Mapped default_fallbacks to priority-based failover for routes without explicit fallbacks

--- a/crates/agentgateway/src/tests/import/litellm/default-fallbacks.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/default-fallbacks.yaml
@@ -1,0 +1,17 @@
+model_list:
+- model_name: primary
+  litellm_params:
+    model: openai/gpt-4o
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+- model_name: spare
+  litellm_params:
+    model: anthropic/claude-sonnet-4
+- model_name: extra
+  litellm_params:
+    model: openai/gpt-4o-mini
+router_settings:
+  fallbacks:
+  - primary: [backup]
+  default_fallbacks: [backup, spare]

--- a/crates/agentgateway/src/tests/import/litellm/max-fallbacks-zero-without-defaults.snap
+++ b/crates/agentgateway/src/tests/import/litellm/max-fallbacks-zero-without-defaults.snap
@@ -1,0 +1,38 @@
+---
+source: crates/agentgateway/src/import.rs
+description: src/tests/import/litellm/max-fallbacks-zero-without-defaults.yaml
+---
+source: litellm
+config:
+  config:
+    database:
+      url: "sqlite://data.db"
+  gateways:
+    default:
+      port: 4000
+  ui:
+    gateways: default
+  llm:
+    gateways: default
+    models:
+      - name: primary
+        provider: openAI
+        params:
+          model: gpt-4o
+      - name: backup
+        provider: anthropic
+        params:
+          model: claude-haiku-4
+findings:
+  - sourcePath: "model_list[0]"
+    status: exact
+    message: Imported model deployment for primary
+  - sourcePath: "model_list[1]"
+    status: exact
+    message: Imported model deployment for backup
+  - sourcePath: router_settings.fallbacks
+    status: approximate
+    message: Mapped ordinary LiteLLM fallbacks to agentgateway priority-based failover
+  - sourcePath: router_settings.max_fallbacks
+    status: exact
+    message: "max_fallbacks: 0 disables LiteLLM fallbacks; emitted failover targets were removed"

--- a/crates/agentgateway/src/tests/import/litellm/max-fallbacks-zero-without-defaults.yaml
+++ b/crates/agentgateway/src/tests/import/litellm/max-fallbacks-zero-without-defaults.yaml
@@ -1,0 +1,11 @@
+model_list:
+- model_name: primary
+  litellm_params:
+    model: openai/gpt-4o
+- model_name: backup
+  litellm_params:
+    model: anthropic/claude-haiku-4
+router_settings:
+  fallbacks:
+  - primary: [backup]
+  max_fallbacks: 0


### PR DESCRIPTION
Refs #2607 — the checkbox: **"Add `default_fallbacks` support and define safe behavior for `context_window_fallbacks` and other condition-specific fallbacks"**. Scope was proposed on the issue first (https://github.com/agentgateway/agentgateway/issues/2607#issuecomment-5296359801); wildcard models, `model_group_alias`, and the inbound API-key policy are claimed by others and untouched here.

## Change

All in `crates/agentgateway/src/import.rs`.

`default_fallbacks` is resolved from `router_settings`, falling back to `litellm_settings`, the same way ordinary `fallbacks` already is.

`apply_default_fallbacks` flattens the effective LiteLLM fallback graph instead of emitting a single hop. LiteLLM resolves fallbacks per hop (explicit entry for the current model, else the generic `default_fallbacks` list) and recurses when a fallback also fails, skipping already-attempted models. The importer walks that graph in the same order and emits priority-ordered failover targets, so `fallbacks: [{primary: [backup]}]` plus `default_fallbacks: [backup, spare]` gives `primary -> [primary@0, backup@1, spare@2]`: the explicit hop is kept, and the defaults apply at `backup` because that hop has no mapping of its own. Depth is bounded the way `run_async_fallback` bounds it: `router_settings.max_fallbacks` (default 5) is checked once per recursive frame, and the counter increments per attempted sibling and is inherited by that sibling's own frame, so siblings are never truncated but earlier attempts consume the descent budget of later ones. `max_fallbacks: 0` disables fallbacks entirely, explicit groups included. Valid fallback names that were never imported consume a depth slot and count as attempted, but are not emitted. A model is never a fallback for itself.

Two cases can't be represented and are reported instead:

- **Wildcard models.** Attaching failover would make `emit()` convert the concrete wildcard model into a virtual model, and virtual model names are matched exactly at runtime (`ModelRouter::resolve`), breaking the wildcard matching it already has.
- **Unknown model names.** LiteLLM serves them via the first default fallback; agentgateway returns 404 `model_not_found` unless a concrete `"*"` model exists. Suppressed when the config already imports one, since LiteLLM's unknown-model branch never runs then.

Findings, all carrying the real source path:

| status | condition |
| --- | --- |
| `approximate` | at least one route changed: `Flattened LiteLLM fallback recursion (per-hop explicit fallbacks, default_fallbacks at hops without one, attempted models skipped) into static priority-ordered failover targets` |
| `exact` | valid non-empty defaults changed no route |
| `exact` | empty list |
| `exact` | `max_fallbacks` bounds the emitted chain depth (generic sweep without defaults, where it really is unconsumed) |
| `exact` | `max_fallbacks: 0` disables fallbacks, noting when already-emitted failover targets were removed |
| `manual` | `max_fallbacks` is not a non-negative integer; the LiteLLM default of 5 was assumed |
| `manual` | `litellm_settings.default_fallbacks` shadowed by the `router_settings` value |
| `manual` | unknown model names 404 here, naming the first default fallback |
| `manual` | defaults can't attach to a wildcard model, one per wildcard route |
| `manual` | per unresolvable or non-string entry |
| `unsupported` | value is not a list |

`context_window_fallbacks` and `content_policy_fallbacks` get targeted `manual` findings explaining they are conditional on specific error types and cannot be represented by unconditional priority failover, rather than falling into the generic router-settings sweep.

## Testing

Nine golden fixtures: `default-fallbacks` (pins the flattened chains `primary -> backup@1, spare@2`, `backup -> spare@1`, `spare -> backup@1`, `extra -> backup@1, spare@2`), `default-fallbacks-shadowed` (shadowing, no-op, unknown-model), `default-fallbacks-wildcard` (wildcard limitation, no-op, and no unknown-model finding because a `"*"` model exists), `default-fallbacks-branching` (`fallbacks: [{primary: [backup, spare]}, {backup: [deep]}]` with `max_fallbacks: 2` pins `primary -> backup@1, deep@2, spare@3`, the sibling a global cap would have dropped), `default-fallbacks-max-zero` and `max-fallbacks-zero-without-defaults` (`max_fallbacks: 0` emits no failover at all, with and without `default_fallbacks`), `default-fallbacks-max-invalid` (`max_fallbacks: -1` keeps the default 5 and reports `manual`), `default-fallbacks-unimported-depth` (`fallbacks: [{primary: [missing, backup]}, {backup: [deep]}]` plus `default_fallbacks: [ghost, backup]` and `max_fallbacks: 2` pins `primary -> backup@1` with no `deep`, because the unimported `missing` and `ghost` consume depth), `conditional-fallbacks`. `emit()` already round-trips every emitted config through the native `LocalConfig` loader, covering the issue's loader-validation criterion. `make lint` and `make test` pass.

End-to-end with the built binary on `default-fallbacks.yaml`:

```
approximate: router_settings.default_fallbacks: Flattened LiteLLM fallback recursion (per-hop explicit fallbacks, default_fallbacks at hops without one, attempted models skipped) into static priority-ordered failover targets
manual: router_settings.default_fallbacks: LiteLLM serves unknown model names via the first default fallback "backup"; agentgateway returns 404 for unmatched model names because wildcard matching applies only to concrete llm.models entries; add a "*" model manually if unknown names must be served
```

Emitted virtual models: `primary -> [primary@0, backup@1, spare@2]`, `backup -> [backup@0, spare@1]`, `spare -> [spare@0, backup@1]`, `extra -> [extra@0, backup@1, spare@2]`. Adding `max_fallbacks: 1` truncates `primary` to `[primary@0, backup@1]`. Starting the gateway with the emitted file reaches ready; `primary` resolves to its provider and an unknown model name returns `model_not_found`, which is what the unknown-model finding documents.


