### PR TITLE
fix(ui): support OpenAPI targets in the MCP Servers editor

### DIFF
--- a/ui/src/pages/McpServers.tsx
+++ b/ui/src/pages/McpServers.tsx
@@ -40,7 +40,7 @@ import type {
 	McpTargetKind
 } from '@/types';
 
-const targetKinds: McpTargetKind[] = ['mcp', 'sse', 'stdio'];
+const targetKinds: McpTargetKind[] = ['mcp', 'sse', 'stdio', 'openapi'];
 
 type McpSettingsPatch = Partial<Omit<McpConfig, 'gateways' | 'port'>> & {
 	gateways?: McpConfig['gateways'] | null;
@@ -545,17 +545,21 @@ function McpServerEditor(props: {
 	onSave: (target: McpTarget, previousName?: string) => void;
 }) {
 	const [name, setName] = useState(props.initial.name);
-	const [kind, setKind] = useState<McpTargetKind>(() => {
-		const kind = targetKind(props.initial);
-		return kind === 'openapi' ? 'mcp' : kind;
-	});
+	const [kind, setKind] = useState<McpTargetKind>(() => targetKind(props.initial));
 	const network = networkTarget(props.initial);
 	const stdio = 'stdio' in props.initial ? props.initial.stdio : undefined;
+	const initialSchema = 'openapi' in props.initial ? props.initial.openapi.schema : undefined;
 	const [url, setUrl] = useState(() => networkUrl(network, kind));
 	const [cmd, setCmd] = useState(stdio?.cmd ?? '');
 	const [args, setArgs] = useState((stdio?.args ?? []).join(' '));
 	const [envText, setEnvText] = useState(toYamlMappingText(stdio?.env));
 	const [clearEnv, setClearEnv] = useState(Boolean(stdio?.clear_env));
+	const [schemaMode, setSchemaMode] = useState<SchemaSourceMode>(() =>
+		schemaSourceMode(initialSchema)
+	);
+	const [schemaValue, setSchemaValue] = useState(() =>
+		schemaSourceValue(initialSchema, schemaMode)
+	);
 	const [error, setError] = useState<string | null>(null);
 	const draft = JSON.stringify({
 		name,
@@ -564,7 +568,9 @@ function McpServerEditor(props: {
 		cmd,
 		args,
 		envText,
-		clearEnv
+		clearEnv,
+		schemaMode,
+		schemaValue
 	});
 	const [initialDraft] = useState(() => draft);
 
@@ -593,7 +599,10 @@ function McpServerEditor(props: {
 		const target = {
 			host: url.trim() || null
 		};
-		return kind === 'sse' ? { ...base, sse: target } : { ...base, mcp: target };
+		if (kind === 'sse') return { ...base, sse: target };
+		if (kind === 'openapi')
+			return { ...base, openapi: { ...target, schema: schemaFromSource(schemaValue, schemaMode) } };
+		return { ...base, mcp: target };
 	}
 
 	function validTargetPreview() {
@@ -624,7 +633,11 @@ function McpServerEditor(props: {
 					diffTitle="MCP server config diff"
 					saveLabel="Save server"
 					saving={props.saving}
-					saveDisabled={!name.trim() || (kind === 'stdio' && !cmd.trim())}
+					saveDisabled={
+						!name.trim() ||
+						(kind === 'stdio' && !cmd.trim()) ||
+						(kind === 'openapi' && !schemaValue.trim())
+					}
 					onCancel={requestClose}
 					onSave={save}
 					beforeDiff={() => Boolean(validTargetPreview())}
@@ -722,28 +735,94 @@ function McpServerEditor(props: {
 					</label>
 				</>
 			) : (
-				<Field
-					label="URL"
-					tooltip={
-						kind === 'sse'
-							? props.help.field<McpTarget>(
+				<>
+					<Field
+						label="URL"
+						tooltip={
+							kind === 'sse'
+								? props.help.field<McpTarget>(
+										'LocalMcpTarget1',
+										'sse.host',
+										'URL of the MCP server endpoint.'
+									)
+								: kind === 'openapi'
+									? props.help.field<McpTarget>(
+											'LocalMcpTarget1',
+											'openapi.host',
+											'URL of the MCP server endpoint.'
+										)
+									: props.help.field<McpTarget>(
+											'LocalMcpTarget1',
+											'mcp.host',
+											'URL of the MCP server endpoint.'
+										)
+						}
+					>
+						<input
+							value={url}
+							onChange={event => setUrl(event.target.value)}
+							placeholder={
+								kind === 'sse' ? 'http://localhost:3001/sse' : 'http://localhost:3001/mcp'
+							}
+						/>
+					</Field>
+					{kind === 'openapi' ? (
+						<>
+							<FieldGroup
+								label="Schema source"
+								tooltip={props.help.field<McpTarget>(
 									'LocalMcpTarget1',
-									'sse.host',
-									'URL of the MCP server endpoint.'
-								)
-							: props.help.field<McpTarget>(
-									'LocalMcpTarget1',
-									'mcp.host',
-									'URL of the MCP server endpoint.'
-								)
-					}
-				>
-					<input
-						value={url}
-						onChange={event => setUrl(event.target.value)}
-						placeholder={kind === 'sse' ? 'http://localhost:3001/sse' : 'http://localhost:3001/mcp'}
-					/>
-				</Field>
+									'openapi.schema',
+									'Where to load the OpenAPI schema document from.'
+								)}
+							>
+								<SegmentedControl
+									ariaLabel="Schema source"
+									value={schemaMode}
+									options={[
+										{ value: 'url', label: 'URL' },
+										{ value: 'file', label: 'File' },
+										{ value: 'inline', label: 'Inline' }
+									]}
+									onChange={setSchemaMode}
+								/>
+							</FieldGroup>
+							{schemaMode === 'inline' ? (
+								<FieldGroup
+									label="Schema"
+									tooltip={props.help.field<McpTarget>(
+										'LocalMcpTarget1',
+										'openapi.schema',
+										'Inline OpenAPI schema document.'
+									)}
+								>
+									<MiniMonacoEditor language="yaml" value={schemaValue} onChange={setSchemaValue} />
+								</FieldGroup>
+							) : (
+								<Field
+									label="Schema"
+									tooltip={props.help.field<McpTarget>(
+										'LocalMcpTarget1',
+										'openapi.schema',
+										schemaMode === 'file'
+											? 'Path to the OpenAPI schema document on disk.'
+											: 'URL to fetch the OpenAPI schema document from.'
+									)}
+								>
+									<input
+										value={schemaValue}
+										onChange={event => setSchemaValue(event.target.value)}
+										placeholder={
+											schemaMode === 'file'
+												? '/etc/agentgateway/openapi.yaml'
+												: 'https://example.com/openapi.json'
+										}
+									/>
+								</Field>
+							)}
+						</>
+					) : null}
+				</>
 			)}
 			{error ? (
 				<StatusBanner state="bad" title="Invalid server">
@@ -800,6 +879,11 @@ function targetWarnings(target: McpTarget) {
 		const network = networkTarget(target);
 		if (!network?.host) warnings.push('URL should be set.');
 	}
+	if (
+		'openapi' in target &&
+		!schemaSourceValue(target.openapi.schema, schemaSourceMode(target.openapi.schema)).trim()
+	)
+		warnings.push('Schema is required.');
 	return warnings;
 }
 
@@ -828,6 +912,31 @@ function networkUrl(network: ReturnType<typeof networkTarget>, kind: McpTargetKi
 		return network.host;
 	const host = network.host ?? 'localhost';
 	const port = network.port ? `:${network.port}` : '';
-	const path = network.path ?? (kind === 'sse' ? '/sse' : '/mcp');
+	const path = network.path ?? (kind === 'openapi' ? '' : kind === 'sse' ? '/sse' : '/mcp');
 	return `http://${host}${port}${path}`;
+}
+
+type SchemaSourceMode = 'file' | 'url' | 'inline';
+
+function schemaSourceMode(value: unknown): SchemaSourceMode {
+	if (value && typeof value === 'object' && 'file' in value) return 'file';
+	if (value && typeof value === 'object' && 'url' in value) return 'url';
+	if (typeof value === 'string') return 'inline';
+	return 'url';
+}
+
+function schemaSourceValue(value: unknown, mode: SchemaSourceMode) {
+	if (mode === 'file' && value && typeof value === 'object' && 'file' in value)
+		return typeof value.file === 'string' ? value.file : '';
+	if (mode === 'url' && value && typeof value === 'object' && 'url' in value)
+		return typeof value.url === 'string' ? value.url : '';
+	if (mode === 'inline' && typeof value === 'string') return value;
+	return '';
+}
+
+function schemaFromSource(value: string, mode: SchemaSourceMode): unknown {
+	const trimmed = value.trim();
+	if (mode === 'file') return { file: trimmed };
+	if (mode === 'url') return { url: trimmed };
+	return value;
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -4775,7 +4775,7 @@ textarea {
 }
 
 .segmented-control.mcp-transport-control {
-	grid-template-columns: repeat(3, minmax(0, 1fr));
+	grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .segmented-control.api-key-mode-control {

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -692,6 +692,66 @@ test('database-backed MCP servers are available across hybrid UI pages', async (
 	expect(gateway.postedConfigs).toHaveLength(0);
 });
 
+test('creates an OpenAPI MCP target', async ({ page }) => {
+	const gateway = await mockGateway(page, emptyConfig());
+	await page.goto('/mcp/servers');
+
+	await page.getByRole('button', { name: 'Add server' }).first().click();
+	await page.getByLabel('Server name').fill('weather');
+	await page.getByRole('radio', { name: 'OpenAPI' }).click();
+	await page
+		.locator('label.field', { hasText: 'URL' })
+		.getByRole('textbox')
+		.fill('http://localhost:8101/mcp');
+	await page
+		.locator('label.field', { hasText: 'Schema' })
+		.getByRole('textbox')
+		.fill('https://example.com/weather-openapi.json');
+	await page.getByRole('button', { name: 'Save server' }).click();
+
+	await expect.poll(() => gateway.postedConfigs.length).toBe(1);
+	const saved = gateway.postedConfigs.at(-1) as { mcp?: { targets?: unknown[] } };
+	expect(saved.mcp?.targets?.[0]).toEqual({
+		name: 'weather',
+		openapi: {
+			host: 'http://localhost:8101/mcp',
+			schema: { url: 'https://example.com/weather-openapi.json' }
+		}
+	});
+});
+
+test('editing an OpenAPI MCP target preserves its schema', async ({ page }) => {
+	const config = emptyConfig();
+	(config.mcp as { targets?: unknown[] }).targets = [
+		{
+			name: 'invoices',
+			openapi: {
+				host: 'http://localhost:8102/openapi',
+				schema: { url: 'https://example.com/invoices-openapi.json' }
+			}
+		}
+	];
+	const gateway = await mockGateway(page, config);
+	await page.goto('/mcp/servers');
+
+	await page
+		.getByRole('row', { name: /invoices/ })
+		.getByRole('button', { name: 'Edit server' })
+		.click();
+	await page.getByLabel('Server name').fill('invoices-v2');
+	await page.getByRole('button', { name: 'Save server' }).click();
+
+	await expect.poll(() => gateway.postedConfigs.length).toBe(1);
+	const saved = gateway.postedConfigs.at(-1) as { mcp?: { targets?: unknown[] } };
+	expect(saved.mcp?.targets?.[0]).toEqual({
+		name: 'invoices-v2',
+		openapi: {
+			host: 'http://localhost:8102/openapi',
+			schema: { url: 'https://example.com/invoices-openapi.json' }
+		}
+	});
+});
+
 test('hybrid MCP settings only lock file-owned fields', async ({ page }) => {
 	const config = emptyConfig();
 	config.mcp = {


### PR DESCRIPTION
Refs #3028, narrowed to what @howardjohn approved on the issue ("just adding openapi to the mcp path is non controversial"). The original ask — authoring MCP backends from the routing page — is **not** in this PR, since v1.4 is deliberately pushing the top-level `mcp:`/`llm:` fields; `TrafficRoutes.tsx` is untouched.

## Problem

`mcp.targets` accepts `openapi`, but the MCP > Servers drawer only offered Streamable HTTP, Legacy SSE, and Command Line. Two consequences:

1. An OpenAPI target could not be created from the page users are meant to use.
2. Worse, opening an **existing** OpenAPI target coerced its kind to `mcp` and the save path deleted the `openapi` block, so saving silently rewrote it as a Streamable HTTP target and dropped its `schema`.

## Change

All in `ui/src/pages/McpServers.tsx`:

- `openapi` added to the transport options, labelled via the existing `transportLabel()`.
- Removed the `openapi -> mcp` coercion, so an existing OpenAPI target keeps its kind.
- Schema editing modeled on `FileInlineOrRemote` (`{url}` / `{file}` / inline string) with a URL/File/Inline selector, following the `apiKeyMode`/`apiKeyInputValue`/`apiKeyFromInput` pattern already used in `ProviderConfigEditor.tsx`. Inline uses the same `MiniMonacoEditor` this file already uses for stdio env vars. The schema value participates in the unsaved-changes check.
- Save emits `{openapi: {host, schema}}`, and an OpenAPI target requires a non-empty schema (`Schema is required.`), consistent with the existing stdio `cmd` requirement.
- `networkUrl()` no longer appends the `/mcp` default path for OpenAPI targets, which would otherwise be invented into the host on save.

No new primitives, no dependencies, no Rust or schema changes.

## Testing

- `creates an OpenAPI MCP target`: authors one through the drawer and asserts the posted config contains `{name, openapi: {host, schema: {url}}}`.
- `editing an OpenAPI MCP target preserves its schema`: opens an existing OpenAPI target, changes only the name, and asserts the posted target still has its `openapi` block and original `schema`. Reverting just the production change makes this fail with the posted target as `{mcp: {host: ...}}` and no schema, i.e. it pins the data-loss bug described above.
- `pnpm format`, `pnpm lint`, `pnpm typecheck` clean; `pnpm test:e2e` 30/30 pass.

## Still open on the issue

Route-level MCP backends remain invisible under MCP > Servers (that page reads only the top-level `mcp:` section), which affects configs like this repo's own `examples/mcp-authentication/config.yaml`. Left out of this PR since you had not weighed in on it; happy to send it separately if wanted.