### PR TITLE
fix(azure): support system-assigned managed identity

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2142,7 +2142,11 @@ type AzureAuth struct {
 	// +optional
 	SecretRef *LocalSecretObjectRef `json:"secretRef,omitempty"`
 
-	// Managed identity authentication settings.
+	// Managed identity authentication settings. Leave this object empty to use
+	// the system-assigned identity. To use a user-assigned identity, set one of
+	// `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
+	// identifiers are set, client ID takes precedence over object ID, which takes
+	// precedence over resource ID.
 	//
 	// +optional
 	ManagedIdentity *AzureManagedIdentity `json:"managedIdentity,omitempty"`
@@ -2155,13 +2159,26 @@ type AzureAuth struct {
 	WorkloadIdentity *AzureWorkloadIdentity `json:"workloadIdentity,omitempty"`
 }
 
+// AzureManagedIdentity configures authentication with an Azure managed
+// identity. Leave all identifiers unset to use the system-assigned identity.
+// To use a user-assigned identity, set one identifier. For compatibility, when
+// multiple identifiers are set, client ID takes precedence over object ID,
+// which takes precedence over resource ID.
 type AzureManagedIdentity struct {
-	// +required
-	ClientID string `json:"clientId"`
-	// +required
-	ObjectID string `json:"objectId"`
-	// +required
-	ResourceID string `json:"resourceId"`
+	// Client ID of the user-assigned managed identity.
+	//
+	// +optional
+	ClientID string `json:"clientId,omitempty"`
+
+	// Object ID of the user-assigned managed identity.
+	//
+	// +optional
+	ObjectID string `json:"objectId,omitempty"`
+
+	// Resource ID of the user-assigned managed identity.
+	//
+	// +optional
+	ResourceID string `json:"resourceId,omitempty"`
 }
 
 // AzureWorkloadIdentity configures Azure Workload Identity authentication.

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types_test.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types_test.go
@@ -154,20 +154,33 @@ func TestFrontendHTTPInvalidByteSizeDecodesAsUnsetValue(t *testing.T) {
 	}
 }
 
-func TestAzureManagedIdentityJSONOmitsSecretRef(t *testing.T) {
-	auth := AzureAuth{
-		ManagedIdentity: &AzureManagedIdentity{
-			ClientID:   "client-id",
-			ObjectID:   "object-id",
-			ResourceID: "resource-id",
-		},
+func TestAzureManagedIdentityJSONPreservesFlatFields(t *testing.T) {
+	want := `{"managedIdentity":{"clientId":"client-id","objectId":"object-id","resourceId":"resource-id"}}`
+	var auth AzureAuth
+	if err := json.Unmarshal([]byte(want), &auth); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
 	}
 
 	got, err := json.Marshal(auth)
 	if err != nil {
 		t.Fatalf("Marshal() error = %v", err)
 	}
-	want := `{"managedIdentity":{"clientId":"client-id","objectId":"object-id","resourceId":"resource-id"}}`
+	if string(got) != want {
+		t.Fatalf("Marshal() = %s, want %s", got, want)
+	}
+}
+
+func TestAzureManagedIdentityEmptyJSON(t *testing.T) {
+	var auth AzureAuth
+	if err := json.Unmarshal([]byte(`{"managedIdentity":{}}`), &auth); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	got, err := json.Marshal(auth)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	want := `{"managedIdentity":{}}`
 	if string(got) != want {
 		t.Fatalf("Marshal() = %s, want %s", got, want)
 	}

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -4278,19 +4278,25 @@ spec:
                                           the backend.
                                         properties:
                                           managedIdentity:
-                                            description: Managed identity authentication
-                                              settings.
+                                            description: |-
+                                              Managed identity authentication settings. Leave this object empty to use
+                                              the system-assigned identity. To use a user-assigned identity, set one of
+                                              `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
+                                              identifiers are set, client ID takes precedence over object ID, which takes
+                                              precedence over resource ID.
                                             properties:
                                               clientId:
+                                                description: Client ID of the user-assigned
+                                                  managed identity.
                                                 type: string
                                               objectId:
+                                                description: Object ID of the user-assigned
+                                                  managed identity.
                                                 type: string
                                               resourceId:
+                                                description: Resource ID of the user-assigned
+                                                  managed identity.
                                                 type: string
-                                            required:
-                                            - clientId
-                                            - objectId
-                                            - resourceId
                                             type: object
                                           secretRef:
                                             description: |-
@@ -7550,19 +7556,25 @@ spec:
                                         the backend.
                                       properties:
                                         managedIdentity:
-                                          description: Managed identity authentication
-                                            settings.
+                                          description: |-
+                                            Managed identity authentication settings. Leave this object empty to use
+                                            the system-assigned identity. To use a user-assigned identity, set one of
+                                            `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
+                                            identifiers are set, client ID takes precedence over object ID, which takes
+                                            precedence over resource ID.
                                           properties:
                                             clientId:
+                                              description: Client ID of the user-assigned
+                                                managed identity.
                                               type: string
                                             objectId:
+                                              description: Object ID of the user-assigned
+                                                managed identity.
                                               type: string
                                             resourceId:
+                                              description: Resource ID of the user-assigned
+                                                managed identity.
                                               type: string
-                                          required:
-                                          - clientId
-                                          - objectId
-                                          - resourceId
                                           type: object
                                         secretRef:
                                           description: |-
@@ -12987,18 +12999,25 @@ spec:
                         description: Azure authentication method for the backend.
                         properties:
                           managedIdentity:
-                            description: Managed identity authentication settings.
+                            description: |-
+                              Managed identity authentication settings. Leave this object empty to use
+                              the system-assigned identity. To use a user-assigned identity, set one of
+                              `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
+                              identifiers are set, client ID takes precedence over object ID, which takes
+                              precedence over resource ID.
                             properties:
                               clientId:
+                                description: Client ID of the user-assigned managed
+                                  identity.
                                 type: string
                               objectId:
+                                description: Object ID of the user-assigned managed
+                                  identity.
                                 type: string
                               resourceId:
+                                description: Resource ID of the user-assigned managed
+                                  identity.
                                 type: string
-                            required:
-                            - clientId
-                            - objectId
-                            - resourceId
                             type: object
                           secretRef:
                             description: |-

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -478,18 +478,25 @@ spec:
                         description: Azure authentication method for the model provider.
                         properties:
                           managedIdentity:
-                            description: Managed identity authentication settings.
+                            description: |-
+                              Managed identity authentication settings. Leave this object empty to use
+                              the system-assigned identity. To use a user-assigned identity, set one of
+                              `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
+                              identifiers are set, client ID takes precedence over object ID, which takes
+                              precedence over resource ID.
                             properties:
                               clientId:
+                                description: Client ID of the user-assigned managed
+                                  identity.
                                 type: string
                               objectId:
+                                description: Object ID of the user-assigned managed
+                                  identity.
                                 type: string
                               resourceId:
+                                description: Resource ID of the user-assigned managed
+                                  identity.
                                 type: string
-                            required:
-                            - clientId
-                            - objectId
-                            - resourceId
                             type: object
                           secretRef:
                             description: |-

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3413,18 +3413,25 @@ spec:
                         description: Azure authentication method for the backend.
                         properties:
                           managedIdentity:
-                            description: Managed identity authentication settings.
+                            description: |-
+                              Managed identity authentication settings. Leave this object empty to use
+                              the system-assigned identity. To use a user-assigned identity, set one of
+                              `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
+                              identifiers are set, client ID takes precedence over object ID, which takes
+                              precedence over resource ID.
                             properties:
                               clientId:
+                                description: Client ID of the user-assigned managed
+                                  identity.
                                 type: string
                               objectId:
+                                description: Object ID of the user-assigned managed
+                                  identity.
                                 type: string
                               resourceId:
+                                description: Resource ID of the user-assigned managed
+                                  identity.
                                 type: string
-                            required:
-                            - clientId
-                            - objectId
-                            - resourceId
                             type: object
                           secretRef:
                             description: |-

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -1610,28 +1610,28 @@ func buildAwsAuthPolicy(ctx PolicyCtx, auth *agentgateway.AwsAuth, namespace str
 }
 
 func buildAzureAuthPolicy(ctx PolicyCtx, auth *agentgateway.AzureAuth, namespace string) (*api.BackendAuthPolicy, error) {
-	var errs []error
 	if auth.SecretRef != nil {
-		return buildAzureClientSecret(ctx, auth, namespace, errs)
+		return buildAzureClientSecret(ctx, auth, namespace)
 	}
 
 	if auth.ManagedIdentity != nil {
-		uaid := &api.AzureManagedIdentityCredential_UserAssignedIdentity{}
+		managedIdentity := &api.AzureManagedIdentityCredential{}
+		userAssigned := &api.AzureManagedIdentityCredential_UserAssignedIdentity{}
 		if auth.ManagedIdentity.ClientID != "" {
-			uaid.Id = &api.AzureManagedIdentityCredential_UserAssignedIdentity_ClientId{
+			userAssigned.Id = &api.AzureManagedIdentityCredential_UserAssignedIdentity_ClientId{
 				ClientId: auth.ManagedIdentity.ClientID,
 			}
 		} else if auth.ManagedIdentity.ObjectID != "" {
-			uaid.Id = &api.AzureManagedIdentityCredential_UserAssignedIdentity_ObjectId{
+			userAssigned.Id = &api.AzureManagedIdentityCredential_UserAssignedIdentity_ObjectId{
 				ObjectId: auth.ManagedIdentity.ObjectID,
 			}
 		} else if auth.ManagedIdentity.ResourceID != "" {
-			uaid.Id = &api.AzureManagedIdentityCredential_UserAssignedIdentity_ResourceId{
+			userAssigned.Id = &api.AzureManagedIdentityCredential_UserAssignedIdentity_ResourceId{
 				ResourceId: auth.ManagedIdentity.ResourceID,
 			}
-		} else {
-			errs = append(errs, errors.New("no valid User Assigned Identity identifier provided"))
-			return nil, errors.Join(errs...)
+		}
+		if userAssigned.Id != nil {
+			managedIdentity.UserAssignedIdentity = userAssigned
 		}
 		return &api.BackendAuthPolicy{
 			Kind: &api.BackendAuthPolicy_Azure{
@@ -1639,9 +1639,7 @@ func buildAzureAuthPolicy(ctx PolicyCtx, auth *agentgateway.AzureAuth, namespace
 					Kind: &api.Azure_ExplicitConfig{
 						ExplicitConfig: &api.AzureExplicitConfig{
 							CredentialSource: &api.AzureExplicitConfig_ManagedIdentityCredential{
-								ManagedIdentityCredential: &api.AzureManagedIdentityCredential{
-									UserAssignedIdentity: uaid,
-								},
+								ManagedIdentityCredential: managedIdentity,
 							},
 						},
 					},
@@ -1678,7 +1676,8 @@ func buildAzureAuthPolicy(ctx PolicyCtx, auth *agentgateway.AzureAuth, namespace
 	}, nil
 }
 
-func buildAzureClientSecret(ctx PolicyCtx, auth *agentgateway.AzureAuth, namespace string, errs []error) (*api.BackendAuthPolicy, error) {
+func buildAzureClientSecret(ctx PolicyCtx, auth *agentgateway.AzureAuth, namespace string) (*api.BackendAuthPolicy, error) {
+	var errs []error
 	var clientID, tenantID, clientSecret string
 	data, err := ctx.ResolveCredentialRef(*auth.SecretRef, namespace)
 	if err != nil {

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth-mi-object.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth-mi-object.yaml
@@ -1,0 +1,67 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: HTTPRoute
+      name: test
+      group: gateway.networking.k8s.io
+  backend:
+    auth:
+      azure:
+        managedIdentity:
+          objectId: mi-object-id
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        auth:
+          azure:
+            explicitConfig:
+              managedIdentityCredential:
+                userAssignedIdentity:
+                  objectId: mi-object-id
+      key: backend/default/agw:backend-auth:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: test
+          namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth-mi-resource.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth-mi-resource.yaml
@@ -1,0 +1,67 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: HTTPRoute
+      name: test
+      group: gateway.networking.k8s.io
+  backend:
+    auth:
+      azure:
+        managedIdentity:
+          resourceId: my-resource-id
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        auth:
+          azure:
+            explicitConfig:
+              managedIdentityCredential:
+                userAssignedIdentity:
+                  resourceId: my-resource-id
+      key: backend/default/agw:backend-auth:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: test
+          namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth-mi-system.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth-mi-system.yaml
@@ -1,0 +1,64 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: agw
+  namespace: default
+spec:
+  targetRefs:
+    - kind: HTTPRoute
+      name: test
+      group: gateway.networking.k8s.io
+  backend:
+    auth:
+      azure:
+        managedIdentity: {}
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        auth:
+          azure:
+            explicitConfig:
+              managedIdentityCredential: {}
+      key: backend/default/agw:backend-auth:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: agw
+        namespace: default
+      target:
+        route:
+          kind: HTTPRoute
+          name: test
+          namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: agw
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: Policy accepted
+        reason: Valid
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Attached to all targets
+        reason: Attached
+        status: "True"
+        type: Attached
+      controllerName: agentgateway.dev/agentgateway

--- a/crates/agentgateway/src/http/auth/azure.rs
+++ b/crates/agentgateway/src/http/auth/azure.rs
@@ -461,3 +461,32 @@ pub(super) async fn get_token(
 	trace!("attached Azure token (scope: {})", scopes[0]);
 	Ok(hv)
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn existing_user_assigned_managed_identity_parses() {
+		serde_json::from_str::<AzureAuthCredentialSource>(
+			r#"{"managedIdentity":{"userAssignedIdentity":{"clientId":"cid"}}}"#,
+		)
+		.expect("the existing managed identity shape must remain supported");
+	}
+
+	#[tokio::test]
+	async fn empty_managed_identity_builds_sdk_credential() {
+		let credential_source =
+			serde_json::from_str(r#"{"managedIdentity":{}}"#).expect("managed identity should parse");
+		let auth = AzureAuth::ExplicitConfig {
+			credential_source,
+			cached_cred: Default::default(),
+		};
+		let config = crate::config::parse_config("{}".to_string(), None).expect("config");
+		let client = crate::client::Client::new(&config.dns, None, Default::default(), None);
+
+		build_credential(&client, &auth)
+			.await
+			.expect("system-assigned managed identity should build");
+	}
+}


### PR DESCRIPTION
## Summary

This fixes Azure system-assigned managed identity without changing the existing Kubernetes or standalone configuration shapes.

Kubernetes can now use the host identity with an empty managed identity object:

```yaml
managedIdentity: {}
```

The existing flat user-assigned fields remain supported:

```yaml
managedIdentity:
  clientId: <id>
  # objectId and resourceId are also supported
```

The first version of this PR tried to standardize the shapes across Kubernetes, standalone, and protobuf. That would have broken existing configuration, so that part was removed. The chart changes here only publish the updated Kubernetes schema and descriptions.

## Compatibility

Kubernetes keeps `clientId`, `objectId`, and `resourceId` as flat fields. If a stored object contains more than one, the existing precedence still applies: client ID, then object ID, then resource ID.

Standalone keeps `userAssignedIdentity`. An absent or null `userAssignedIdentity`, including `managedIdentity: {}`, selects the system-assigned identity. Existing user-assigned standalone configuration continues to parse unchanged.

No nested Kubernetes identity selector was added. Existing Helm values and manifests do not need to migrate.

## Changes

- Makes the Kubernetes managed identity identifiers optional so `managedIdentity: {}` can represent the system-assigned identity.
- Translates an empty Kubernetes managed identity into an Azure managed identity credential without a user-assigned identifier.
- Keeps all three user-assigned identifier forms and their current precedence in the controller.
- Adds Rust regression coverage for the existing Azure SDK credential path used by both system-assigned and user-assigned credentials, including the configured HTTP transport that avoids the `NoopClient` panic described in [#900](https://github.com/agentgateway/agentgateway/issues/900).
- Regenerates the three CRD chart templates that embed `AzureManagedIdentity`.

## Coverage

Controller fixtures cover system-assigned identity plus client ID, object ID, and resource ID user-assigned identities. Go API tests pin the flat and empty JSON forms. Rust tests cover parsing and credential construction for the system-assigned and existing user-assigned shapes.

## Verification

- `ulimit -n 65536; make test`
- `make lint`
- `go test -race ./...`
- `make -C controller analyze`
- `go mod tidy` with no `go.mod` or `go.sum` diff
- `make check-default-members`
- Schema, API, and controller regeneration with a clean repository afterward
