### PR TITLE
fix(llm): classify Messages-shaped responses as cache-exclusive

### DIFF
--- a/crates/agentgateway/src/llm/cost/mod.rs
+++ b/crates/agentgateway/src/llm/cost/mod.rs
@@ -930,6 +930,22 @@ mod tests {
 	}
 
 	#[test]
+	fn messages_conversion_cache_exclusive_input_stays_billable() {
+		// #3041: completions->messages wire conversion already subtracted cache out of
+		// input_tokens; InputExcludesCache must not subtract it a second time (500-300-200=0 bug).
+		let resp = LLMResponse {
+			input_tokens: Some(500),
+			cached_input_tokens: Some(300),
+			cache_creation_input_tokens: Some(200),
+			..Default::default()
+		};
+		let u = usage_for(CacheTokenConvention::InputExcludesCache, &resp, true, true);
+		assert_eq!(u.input, 500, "fresh input must not be double-subtracted");
+		assert_eq!(u.cache_read, 300);
+		assert_eq!(u.cache_write, 200);
+	}
+
+	#[test]
 	fn inclusive_convention_splits_cache_out_of_input() {
 		// Regression guard: OpenAI-style providers keep the subtract-once behavior.
 		let resp = LLMResponse {

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -231,16 +231,22 @@ impl AIProvider {
 	}
 }
 
-/// Classify how the upstream reports cached tokens, from the source wire format the
-/// gateway is about to parse — not the provider name, which can carry another
-/// provider's native semantics (e.g. Vertex serving Anthropic models).
+/// Classify how the upstream reports cached tokens. Requests re-served in Anthropic
+/// Messages shape always carry cache-exclusive usage (the wire conversion in
+/// `crates/llm` subtracts cache tokens out before this is read), regardless of the
+/// upstream provider. Otherwise classify from the upstream provider/wire format, which
+/// can carry another provider's native semantics (e.g. Vertex serving Anthropic models).
 fn cache_convention_for(
 	provider: &AIProvider,
 	provider_format: Option<custom::ProviderFormat>,
 	request_model: &str,
+	original_format: InputFormat,
 ) -> CacheTokenConvention {
 	use CacheTokenConvention::*;
 	use custom::ProviderFormat::{AnthropicTokenCount, Messages};
+	if original_format == InputFormat::Messages {
+		return InputExcludesCache;
+	}
 	match provider {
 		AIProvider::Anthropic(_) | AIProvider::Bedrock(_) => InputExcludesCache,
 		AIProvider::Copilot(_) if copilot::Provider::is_anthropic_model(Some(request_model)) => {
@@ -1945,8 +1951,12 @@ impl AIProvider {
 		if original_format == InputFormat::Detect {
 			types::detect::amend_request_info(&mut llm_info, parts.uri.path());
 		}
-		llm_info.cache_convention =
-			cache_convention_for(self, provider_format, &llm_info.request_model);
+		llm_info.cache_convention = cache_convention_for(
+			self,
+			provider_format,
+			&llm_info.request_model,
+			original_format,
+		);
 		if let Some(log) = log
 			&& log.cel.cel_context.needs_llm_prompt()
 			&& original_format.supports_prompt_guard()

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -3452,7 +3452,12 @@ fn custom_provider_override_drives_provider_name() {
 fn vertex_anthropic_model_uses_exclusive_convention() {
 	let provider = vertex_provider("anthropic/claude-sonnet-4-5");
 	assert_eq!(
-		cache_convention_for(&provider, None, "anthropic/claude-sonnet-4-5"),
+		cache_convention_for(
+			&provider,
+			None,
+			"anthropic/claude-sonnet-4-5",
+			InputFormat::Completions
+		),
 		CacheTokenConvention::InputExcludesCache,
 	);
 }
@@ -3461,7 +3466,12 @@ fn vertex_anthropic_model_uses_exclusive_convention() {
 fn vertex_non_anthropic_model_uses_inclusive_convention() {
 	let provider = vertex_provider("gemini-2.0-flash");
 	assert_eq!(
-		cache_convention_for(&provider, None, "gemini-2.0-flash"),
+		cache_convention_for(
+			&provider,
+			None,
+			"gemini-2.0-flash",
+			InputFormat::Completions
+		),
 		CacheTokenConvention::InputIncludesCache,
 	);
 }
@@ -3473,7 +3483,8 @@ fn custom_messages_backend_uses_exclusive_convention() {
 		cache_convention_for(
 			&provider,
 			Some(custom::ProviderFormat::Messages),
-			"some-model"
+			"some-model",
+			InputFormat::Completions
 		),
 		CacheTokenConvention::InputExcludesCache,
 	);
@@ -3486,7 +3497,8 @@ fn custom_completions_backend_uses_inclusive_convention() {
 		cache_convention_for(
 			&provider,
 			Some(custom::ProviderFormat::Completions),
-			"some-model"
+			"some-model",
+			InputFormat::Completions
 		),
 		CacheTokenConvention::InputIncludesCache,
 	);
@@ -3498,7 +3510,8 @@ fn fixed_providers_classify_by_family() {
 		cache_convention_for(
 			&AIProvider::Anthropic(anthropic::Provider { model: None }),
 			None,
-			"claude-sonnet-4-5"
+			"claude-sonnet-4-5",
+			InputFormat::Completions
 		),
 		CacheTokenConvention::InputExcludesCache,
 	);
@@ -3509,8 +3522,25 @@ fn fixed_providers_classify_by_family() {
 				moderation: None,
 			}),
 			Some(custom::ProviderFormat::Completions),
-			"gpt-4o"
+			"gpt-4o",
+			InputFormat::Completions
 		),
+		CacheTokenConvention::InputIncludesCache,
+	);
+}
+
+#[test]
+fn messages_input_format_uses_exclusive_convention_regardless_of_provider() {
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: None,
+		moderation: None,
+	});
+	assert_eq!(
+		cache_convention_for(&provider, None, "gpt-4o", InputFormat::Messages),
+		CacheTokenConvention::InputExcludesCache,
+	);
+	assert_eq!(
+		cache_convention_for(&provider, None, "gpt-4o", InputFormat::Completions),
 		CacheTokenConvention::InputIncludesCache,
 	);
 }


### PR DESCRIPTION
Fixes #3041

Scope for this fix was committed to in advance in https://github.com/agentgateway/agentgateway/issues/3041#issuecomment-5300090594 — this PR implements exactly that.

## Root cause

For a buffered OpenAI Completions -> Anthropic Messages response, `cache_convention_for()` (`crates/agentgateway/src/llm/mod.rs`) classified `CacheTokenConvention` purely by upstream provider, so an OpenAI upstream always resolved to `InputIncludesCache` — even when the client-facing response is re-served in Messages shape.

The buffered Completions->Messages wire conversion (`crates/llm/src/conversion/completions.rs`) is spec-correct: it already subtracts cache read/write out of `input_tokens` before emitting Anthropic cache-exclusive wire usage. `usage_for()` (`crates/agentgateway/src/llm/cost/mod.rs`) then subtracts cache read+write a *second* time under `InputIncludesCache`:

```
input_tokens=500 (already fresh), cached=300, creation=200
usage_for(InputIncludesCache, ...) => 500 - 300 - 200 = 0 billable input
```

instead of the correct 500.

## Fix (classification-only)

`cache_convention_for()` gains an `original_format: InputFormat` parameter and short-circuits `InputFormat::Messages => CacheTokenConvention::InputExcludesCache` ahead of the provider match — a Messages-shaped response is always cache-exclusive on the wire regardless of upstream provider. All other target formats (Detect/Completions/Responses) keep the existing provider-based classification. Doc comment updated to match.

Zero edits under `crates/llm` — the wire arithmetic there is spec-correct and is contested territory for the stalled #2509; this PR is orthogonal to it and does not touch it.

The issue's second example (an OpenAI Responses upstream re-served through a buffered Responses->Messages/Completions path) is a no-op on `main`: `render_response`'s `ChatFormat::OpenAIResponses` arm only accepts `InputFormat::Responses` and returns `UnsupportedConversion` otherwise, so OpenAI Responses upstreams are only ever re-served as Responses. No such buffered path exists to undercount, so no speculative handling was added for it.

## Testing

- New unit test `messages_input_format_uses_exclusive_convention_regardless_of_provider` (`crates/agentgateway/src/llm/tests.rs`): OpenAI provider + `InputFormat::Messages` => `InputExcludesCache`; control assertion in the same test: same provider + `InputFormat::Completions` => `InputIncludesCache`.
- New cost regression test `messages_conversion_cache_exclusive_input_stays_billable` (`crates/agentgateway/src/llm/cost/mod.rs`) using the issue's exact numbers: `usage_for(InputExcludesCache, resp{input:500, cached:300, creation:200}, ...)` => billable input 500.
- Updated all 6 existing `cache_convention_for` call sites in `llm/tests.rs` for the new parameter (verified complete by grepping every call site in the crate, 8 total including the 2 new tests).
- `crates/llm/src/tests/response/completions/cache_write.completions-messages.snap` unchanged (`git status` clean under `crates/llm`), confirming the wire layer was not touched.
- `cargo test -p agentgateway --lib` for `llm::cost::tests` (31 passed) and the touched `llm::tests::*` cache-convention tests (97 passed across two runs) — all pass.
- `cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true` clean.
- `cargo clippy -p agentgateway --all-targets` clean.

No config-facing types touched; no schema regen needed.
