### PR TITLE
fix(mcp): parent upstream span from gateway traceparent, not the caller's

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -84,17 +84,30 @@ impl IncomingRequestContext {
 				auto.target = Some(authority);
 			}
 		}
+		// When the gateway is tracing, its own span (not the caller's) must parent the upstream
+		// request; a gateway that is not tracing must not break trace continuity it doesn't own.
+		let gateway_span = self
+			.ext
+			.get::<crate::telemetry::trc::TraceParent>()
+			.cloned();
 		for (k, v) in &self.headers {
 			// Remove headers we do not want to propagate to the backend
 			if k == http::header::CONTENT_ENCODING
 				|| k == http::header::CONTENT_LENGTH
 				|| k.as_str().eq_ignore_ascii_case(HEADER_SESSION_ID)
+				|| (gateway_span.is_some()
+					&& (k == http::x_headers::TRACEPARENT
+						|| k.as_str().eq_ignore_ascii_case("tracestate")
+						|| k.as_str().eq_ignore_ascii_case("baggage")))
 			{
 				continue;
 			}
 			if !req.headers().contains_key(k) {
 				req.headers_mut().insert(k.clone(), v.clone());
 			}
+		}
+		if let Some(tp) = gateway_span {
+			tp.insert_header(req);
 		}
 		let Some(authority) = self.authority.clone() else {
 			return Ok(());
@@ -105,9 +118,24 @@ impl IncomingRequestContext {
 		})
 	}
 	// SEP-414: copy W3C trace context into the message's `_meta` (un-prefixed keys, per spec).
-	// The only trace carrier for stdio upstreams, which have no request headers.
+	// The only trace carrier for stdio upstreams, which have no request headers. `traceparent`
+	// prefers the gateway's own span over the caller's, matching `apply()`; `tracestate`/`baggage`
+	// have no gateway equivalent and are always header-sourced.
 	fn stamp_trace_context(&self, meta: &mut rmcp::model::MetaObject) {
-		for key in ["traceparent", "tracestate", "baggage"] {
+		let traceparent = match self.ext.get::<crate::telemetry::trc::TraceParent>() {
+			Some(tp) => Some(format!("{tp:?}")),
+			None => self
+				.headers
+				.get("traceparent")
+				.and_then(|v| v.to_str().ok())
+				.map(str::to_string),
+		};
+		if let Some(value) = traceparent {
+			meta
+				.0
+				.insert("traceparent".to_string(), serde_json::Value::String(value));
+		}
+		for key in ["tracestate", "baggage"] {
 			let Some(value) = self.headers.get(key).and_then(|v| v.to_str().ok()) else {
 				continue;
 			};
@@ -723,6 +751,56 @@ mod tests {
 		assert_eq!(meta.get("baggage").unwrap(), "userId=42");
 		// Non-trace headers are not smuggled into `_meta`.
 		assert!(meta.get("authorization").is_none());
+	}
+
+	#[test]
+	fn apply_prefers_gateway_traceparent_extension_over_client_header() {
+		let client_traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+		let gateway_span = crate::telemetry::trc::TraceParent {
+			version: 0,
+			trace_id: 0x4bf92f3577b34da6a3ce929d0e0e4736,
+			span_id: 0x1111_2222_3333_4444,
+			flags: 1,
+		};
+		let mut ctx = ctx_with_headers(&[("traceparent", client_traceparent)]);
+		ctx.extensions_mut().insert(gateway_span.clone());
+		let mut req = empty_upstream_req();
+		ctx.apply(&mut req).unwrap();
+		assert_eq!(
+			req.headers().get("traceparent").unwrap(),
+			format!("{gateway_span:?}").as_str()
+		);
+	}
+
+	#[test]
+	fn apply_passes_through_client_traceparent_without_gateway_extension() {
+		let client_traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+		let ctx = ctx_with_headers(&[("traceparent", client_traceparent)]);
+		let mut req = empty_upstream_req();
+		ctx.apply(&mut req).unwrap();
+		assert_eq!(
+			req.headers().get("traceparent").unwrap(),
+			client_traceparent
+		);
+	}
+
+	#[test]
+	fn stamp_trace_context_prefers_gateway_traceparent_extension() {
+		let client_traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+		let gateway_span = crate::telemetry::trc::TraceParent {
+			version: 0,
+			trace_id: 0x4bf92f3577b34da6a3ce929d0e0e4736,
+			span_id: 0x1111_2222_3333_4444,
+			flags: 1,
+		};
+		let mut ctx = ctx_with_headers(&[("traceparent", client_traceparent)]);
+		ctx.extensions_mut().insert(gateway_span.clone());
+		let mut req = ping_request();
+		ctx.stamp_trace_context(&mut req.get_meta_mut().0);
+		assert_eq!(
+			req.get_meta().0.get("traceparent").unwrap(),
+			format!("{gateway_span:?}").as_str()
+		);
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes #2904

## Root cause

`IncomingRequestContext::apply()` (`crates/agentgateway/src/mcp/upstream/mod.rs`) copies downstream headers onto the upstream MCP request, excluding only `Content-Encoding`/`Content-Length`/`mcp-session-id`. `traceparent`/`tracestate`/`baggage` passed straight through, so a client-supplied `traceparent` survived unchanged and the upstream MCP server's span parented to the caller instead of the gateway. `stamp_trace_context()` had the same issue for the stdio `_meta` `traceparent` key.

The gateway's own span was already available and just unused on this path: `handle_frontend_policies` (`crates/agentgateway/src/proxy/httpproxy.rs`, ~1256-1257) builds the gateway span `ns` and does both `ns.insert_header(req)` **and** `req.extensions_mut().insert(ns.clone())`, so a typed `crate::telemetry::trc::TraceParent` extension rides the same `Request` into `mcp_state.serve`. `IncomingRequestContext` already clones `parts.extensions` into `self.ext` — the MCP path just wasn't reading it.

## Fix

`apply()` now checks `self.ext.get::<crate::telemetry::trc::TraceParent>()`:
- **Present** (gateway is tracing): strips `traceparent`/`tracestate`/`baggage` from the header copy loop and calls `tp.insert_header(req)` afterward, mirroring `handle_frontend_policies`.
- **Absent** (gateway not tracing): unchanged pass-through behavior — a transparent proxy that isn't participating in tracing must not destroy trace continuity it doesn't own.

`stamp_trace_context()` applies the same preference for the stdio `_meta` `traceparent` key (serialized via the extension's `Debug` impl, matching `insert_header`'s formatting). `tracestate`/`baggage` have no gateway-generated equivalent, so those stay header-sourced in both code paths.

No config surface change; no schema regen needed.

**Open to maintainer veto:** the "no extension → pass-through unchanged" branch is a deliberate choice (don't break trace continuity for a gateway not configured to trace), not the only defensible option — flagging in case a different default is preferred (e.g. always stripping caller trace-context headers regardless of extension presence).

## Testing

Unit tests (`crates/agentgateway/src/mcp/upstream/mod.rs`):
- `apply_prefers_gateway_traceparent_extension_over_client_header`
- `apply_passes_through_client_traceparent_without_gateway_extension`
- `stamp_trace_context_prefers_gateway_traceparent_extension`

```
running 13 tests
test mcp::upstream::tests::apply_strips_content_encoding_and_length ... ok
test mcp::upstream::tests::apply_strips_inbound_mcp_session_id ... ok
test mcp::upstream::tests::apply_passes_through_client_traceparent_without_gateway_extension ... ok
test mcp::upstream::tests::apply_preserves_upstream_session_id_when_already_set ... ok
test mcp::upstream::tests::apply_propagates_other_headers ... ok
test mcp::upstream::tests::incoming_request_context_applies_original_authority ... ok
test mcp::upstream::tests::apply_prefers_gateway_traceparent_extension_over_client_header ... ok
test mcp::upstream::tests::stamp_trace_context_prefers_gateway_traceparent_extension ... ok
test mcp::upstream::tests::stamp_trace_context_noop_without_trace_headers ... ok
test mcp::upstream::tests::stamp_trace_context_copies_w3c_keys_into_meta_unprefixed ... ok
test mcp::upstream::tests::merge_extensions_divergent_settings_advertise_empty ... ok
test mcp::upstream::tests::merge_extensions_agreeing_settings_pass_through ... ok
test mcp::upstream::tests::merge_extensions_unions_distinct_extensions ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 1805 filtered out
```

Live smoke, matching the issue's own measurement methodology: built the binary, ran it with `frontendPolicies.tracing` enabled (`randomSampling: true`, `clientSampling: true`, pointed at a nonexistent OTLP collector — the collector need not be up for header behavior) and an `mcp:` backend (streamable-HTTP `mcp` target) pointing at a local Python HTTP server that logs received headers. Sent an `initialize` request with a synthetic inbound `traceparent`:

- Sent: `traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
- Upstream-observed: `traceparent: 00-4bf92f3577b34da6a3ce929d0e0e4736-1b9f2a25a1405473-01`

Same trace id (`4bf92f3577b34da6a3ce929d0e0e4736`), different parent span id (`00f067aa0ba902b7` sent vs. `1b9f2a25a1405473` observed at the upstream) — the gateway's own span, not the caller's.

`cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true` and `cargo clippy -p agentgateway --all-targets` both clean.
