### PR TITLE
test(llm): regression coverage for buffered response Content-Encoding (#3040)

### DIFF
--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -2292,6 +2292,333 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 	);
 }
 
+/// Decodes a buffered LLM response body per the Content-Encoding contract exercised by
+/// #3040: a response that declares `Content-Encoding` must actually decompress to that
+/// encoding, and a response with no `Content-Encoding` must be plain with no
+/// `Transfer-Encoding`. Also asserts the stale `Content-Length` the issue observed is gone,
+/// since the production tail always removes it so the wire recomputes it.
+async fn decode_response_body(resp: Response) -> Value {
+	let (parts, body) = resp.into_parts();
+	assert!(
+		parts.headers.get(::http::header::CONTENT_LENGTH).is_none(),
+		"stale Content-Length must be removed so the wire recomputes it"
+	);
+	let raw = body.collect().await.unwrap().to_bytes();
+	match parts.headers.typed_get::<ContentEncoding>() {
+		Some(ce) => {
+			let (recognized, decoded) = crate::http::compression::to_bytes_with_decompression(
+				axum_core::body::Body::from(raw.clone()),
+				Some(&ce),
+				8 * 1024 * 1024,
+			)
+			.await
+			.unwrap_or_else(|e| {
+				panic!(
+					"response declares Content-Encoding {ce:?} but the body does not actually \
+					 decompress as that encoding (this is the #3040 bug): {e}"
+				)
+			});
+			assert!(
+				recognized.is_some(),
+				"Content-Encoding {ce:?} did not resolve to a single supported encoding"
+			);
+			serde_json::from_slice(&decoded).expect("decompressed body must be valid JSON")
+		},
+		None => {
+			assert!(
+				parts
+					.headers
+					.get(::http::header::TRANSFER_ENCODING)
+					.is_none(),
+				"response has no Content-Encoding but still carries Transfer-Encoding"
+			);
+			serde_json::from_slice(&raw).expect("plain body must be valid JSON")
+		},
+	}
+}
+
+fn brotli_response(compressed: &Bytes) -> Response {
+	let mut resp = Response::new(Body::from(compressed.to_vec()));
+	resp.headers_mut().insert(
+		::http::header::CONTENT_TYPE,
+		"application/json".parse().unwrap(),
+	);
+	resp
+		.headers_mut()
+		.insert(::http::header::CONTENT_ENCODING, "br".parse().unwrap());
+	resp.headers_mut().insert(
+		::http::header::CONTENT_LENGTH,
+		compressed.len().to_string().parse().unwrap(),
+	);
+	resp
+}
+
+#[tokio::test]
+async fn buffered_response_reencodes_brotli_body_chat_translate_path() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: None,
+		moderation: None,
+	});
+	let plaintext = fs::read(fixture_path("response/completions/basic.json")).expect("fixture");
+	let compressed = crate::http::compression::encode_body(&plaintext, "br")
+		.await
+		.expect("brotli encode");
+	let resp = brotli_response(&compressed);
+
+	let req = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Completions,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: "gpt-3.5-turbo-0125".into(),
+		provider: Default::default(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+		provider_state: None,
+	};
+
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
+	let result = provider
+		.process_response(
+			client,
+			req,
+			LLMResponsePolicies::default(),
+			None,
+			AsyncLog::default(),
+			LogContentFields::default(),
+			None,
+			resp,
+		)
+		.await
+		.expect("buffered response should translate");
+
+	assert!(result.status().is_success());
+	let body = decode_response_body(result).await;
+	assert_eq!(
+		body["choices"][0]["message"]["content"],
+		json!(
+			"Sorry, I couldn't find the name of the LLM provider. Could you please provide more information or context?"
+		)
+	);
+}
+
+#[tokio::test]
+async fn buffered_response_reencodes_brotli_body_error_path() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: None,
+		moderation: None,
+	});
+	let error_json = br#"{"error":{"message":"bad request","type":"invalid_request_error","param":null,"code":400}}"#;
+	let compressed = crate::http::compression::encode_body(error_json, "br")
+		.await
+		.expect("brotli encode");
+	let mut resp = brotli_response(&compressed);
+	*resp.status_mut() = ::http::StatusCode::BAD_REQUEST;
+
+	let req = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Messages,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: "gpt-4o".into(),
+		provider: Default::default(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+		provider_state: None,
+	};
+
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
+	let result = provider
+		.process_response(
+			client,
+			req,
+			LLMResponsePolicies::default(),
+			None,
+			AsyncLog::default(),
+			LogContentFields::default(),
+			None,
+			resp,
+		)
+		.await
+		.expect("buffered error response should translate");
+
+	assert_eq!(result.status(), ::http::StatusCode::BAD_REQUEST);
+	let body = decode_response_body(result).await;
+	assert_eq!(body["type"], json!("error"));
+	assert_eq!(body["error"]["message"], json!("bad request"));
+}
+
+#[tokio::test]
+async fn buffered_response_reencodes_brotli_body_prompt_guard_mask_path() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: None,
+		moderation: None,
+	});
+	let plaintext = fs::read(fixture_path("response/completions/basic.json")).expect("fixture");
+	let compressed = crate::http::compression::encode_body(&plaintext, "br")
+		.await
+		.expect("brotli encode");
+	let resp = brotli_response(&compressed);
+
+	let req = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Completions,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: "gpt-3.5-turbo-0125".into(),
+		provider: Default::default(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+		provider_state: None,
+	};
+
+	let response_policies = LLMResponsePolicies {
+		prompt_guard: vec![policy::ResponseGuard {
+			rejection: policy::RequestRejection::default(),
+			kind: policy::ResponseGuardKind::Regex(policy::RegexRules {
+				action: policy::Action::Mask,
+				rules: vec![policy::RegexRule::Regex {
+					pattern: regex::Regex::new("LLM provider").unwrap(),
+				}],
+			}),
+		}],
+		..Default::default()
+	};
+
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
+	let result = provider
+		.process_response(
+			client,
+			req,
+			response_policies,
+			None,
+			AsyncLog::default(),
+			LogContentFields::default(),
+			None,
+			resp,
+		)
+		.await
+		.expect("masked buffered response should translate");
+
+	assert!(result.status().is_success());
+	let body = decode_response_body(result).await;
+	let content = body["choices"][0]["message"]["content"]
+		.as_str()
+		.expect("content must be a string");
+	assert!(
+		!content.contains("LLM provider"),
+		"response prompt guard should have masked the match, got: {content}"
+	);
+}
+
+#[tokio::test]
+async fn buffered_response_reencodes_brotli_body_messages_input_format() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+
+	let provider = AIProvider::Anthropic(anthropic::Provider { model: None });
+	let plaintext = fs::read(fixture_path("response/anthropic/basic.json")).expect("fixture");
+	let compressed = crate::http::compression::encode_body(&plaintext, "br")
+		.await
+		.expect("brotli encode");
+	let resp = brotli_response(&compressed);
+
+	let req = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Messages,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: "claude-haiku-4-5-20251001".into(),
+		provider: Default::default(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+		provider_state: None,
+	};
+
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
+	let result = provider
+		.process_response(
+			client,
+			req,
+			LLMResponsePolicies::default(),
+			None,
+			AsyncLog::default(),
+			LogContentFields::default(),
+			None,
+			resp,
+		)
+		.await
+		.expect("buffered /v1/messages response should translate");
+
+	assert!(result.status().is_success());
+	let body = decode_response_body(result).await;
+	assert_eq!(
+		body["content"][0]["text"],
+		json!("Hi there! How are you doing today? Is there anything I can help you with?")
+	);
+}
+
+#[tokio::test]
+async fn buffered_response_reencodes_brotli_body_detect_input_format() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: None,
+		moderation: None,
+	});
+	let plaintext = fs::read(fixture_path("response/completions/basic.json")).expect("fixture");
+	let compressed = crate::http::compression::encode_body(&plaintext, "br")
+		.await
+		.expect("brotli encode");
+	let resp = brotli_response(&compressed);
+
+	let req = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::Detect,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: "gpt-3.5-turbo-0125".into(),
+		provider: Default::default(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+		provider_state: None,
+	};
+
+	let client = PolicyClient::new(setup_proxy_test("{}").unwrap().pi);
+	let result = provider
+		.process_response(
+			client,
+			req,
+			LLMResponsePolicies::default(),
+			None,
+			AsyncLog::default(),
+			LogContentFields::default(),
+			None,
+			resp,
+		)
+		.await
+		.expect("buffered Detect passthrough response should translate");
+
+	assert!(result.status().is_success());
+	let body = decode_response_body(result).await;
+	assert_eq!(
+		body["choices"][0]["message"]["content"],
+		json!(
+			"Sorry, I couldn't find the name of the LLM provider. Could you please provide more information or context?"
+		)
+	);
+}
+
 #[test]
 fn openai_completions_error_translates_to_messages_client() {
 	let provider = AIProvider::OpenAI(openai::Provider {


### PR DESCRIPTION
## Root cause investigation

This is a `test(llm):`-only PR, not a fix. Per the reproduction-first plan for this issue: I could not reproduce the bug at `upstream/main` @ `25664ff5` on any of the dispatch arms named in the issue's "Relevant code" section.

`process_chat_or_detect_buffered_response` (`crates/agentgateway/src/llm/mod.rs`) already re-encodes correctly on every path I exercised: `buffer_response` decompresses + strips `Content-Encoding`/`Transfer-Encoding`, and the tail (mod.rs ~2220-2232) re-inserts `Content-Encoding` and re-encodes with `http::compression::encode_body`, always removing `Content-Length` so it gets recomputed on the wire. That tail was added by #1645 (2026-04-23), which postdates whatever build produced this report.

I specifically checked the response-prompt-guard early return (`return Ok(dr)` at mod.rs ~2212), since it visibly bypasses the tail on the guard's `Reject` outcome. It turns out not to leak: `Reject` builds a synthetic `Response` from `RequestRejection::as_response()` (fresh `Builder`, no `Content-Encoding` at all), and `Mask` — the case this issue's regression-test suggestion implies — does **not** take that early return, so masked responses still flow through the tail.

## What this PR adds

Refutes/pins that investigation with tests, not code changes to `mod.rs`. Regression coverage in `crates/agentgateway/src/llm/tests.rs::llm::tests`, exercising every dispatch arm reachable with a genuinely Brotli-compressed upstream body:

- `buffered_response_reencodes_brotli_body_chat_translate_path` — OpenAI Completions → Completions translate path
- `buffered_response_reencodes_brotli_body_detect_input_format` — `InputFormat::Detect` raw passthrough
- `buffered_response_reencodes_brotli_body_error_path` — non-200 upstream via `process_error`
- `buffered_response_reencodes_brotli_body_prompt_guard_mask_path` — response prompt-guard configured to `Mask` a regex match (the early-return suspect above)
- `buffered_response_reencodes_brotli_body_messages_input_format` — `/v1/messages` (`InputFormat::Messages`) against an Anthropic-native upstream, the issue's own repro shape

Each asserts the invariant from the issue: if the response declares `Content-Encoding`, the body must actually decompress (via `to_bytes_with_decompression`) to the expected translated JSON; if not, the body must be plain with no `Transfer-Encoding`; and `Content-Length` must never be stale either way.

**All five pass unmodified at `25664ff5`.**

To confirm the tests are not vacuous, I temporarily reintroduced the exact bug (skipped `encode_body` re-encoding while still setting `Content-Encoding`) and re-ran:

```
thread '...buffered_response_reencodes_brotli_body_messages_input_format' panicked at .../tests.rs:2316:17:
response declares Content-Encoding ContentEncoding("br") but the body does not actually decompress as that encoding (this is the #3040 bug): body read error: brotli error
```
All five failed with that same signature, then I reverted `mod.rs` back to a clean `25664ff5` (verified via `git diff --stat`, only `tests.rs` is touched in this PR).

## Live smoke

Built the binary and routed an `openAI`-provider `llm:` model at a mock upstream via `baseUrl`, serving genuinely Brotli-compressed OpenAI Completions JSON (`brotli` CLI):

```
$ curl -sS -D - "http://127.0.0.1:14000/v1/messages?beta=true" -d '{"model":"gpt-3.5-turbo-0125","max_tokens":64,"messages":[...]}'
HTTP/1.0 200 OK
Content-Type: application/json
Content-Encoding: br
Content-Length: 231

$ brotli -d -c <raw body> 
{"id":"chatcmpl-...","type":"message","role":"assistant","content":[{"type":"text","text":"Sorry, I couldn't find the name of the LLM provider..."}],...}
```
The local `curl` build here (`libcurl` via SecureTransport) doesn't support Brotli auto-decompression, so `curl --compressed` errors with `Unrecognized content encoding type` — a client-library limitation, not a gateway issue. I fetched the raw bytes with plain `curl` and decompressed with the `brotli` CLI, which is functionally what a Brotli-aware client (including `curl --compressed` on a build that supports it) would do; the bytes are genuinely Brotli and decode to the correctly translated Anthropic Messages shape, with `Content-Length: 231` matching the actual encoded size.

I also pointed a second model at an upstream returning plain (uncompressed) JSON and confirmed the other half of the invariant: no `Content-Encoding`, no `Transfer-Encoding`, `Content-Length` matches the plain body exactly.

## What I'd ask the reporter

The fix in #1645 landed 2026-04-23 and covers everything I could exercise. Could you confirm:
- the exact agentgateway version/build you observed this on (the report doesn't state one, and the shape of the JSON body shown — no `id`/`created`/`model`/`usage` fields — reads like it may predate the current translation output), and
- whether `promptGuard` (response-side, masking) was configured on that route, in case there's a config shape I haven't reproduced.

If a maintainer can point at a still-reproducing config/version, I'll follow up with the actual fix using the pre-decided rule (re-encode via the existing tail, or strip `Content-Encoding`/`Transfer-Encoding`/`Content-Length` — never duplicate encode logic).

## Verification

- `cargo test -p agentgateway --lib llm::tests::buffered_response_reencodes` — 5 passed
- `cargo test -p agentgateway --lib llm::` — 332 passed (no regressions)
- `cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true` — clean
- `cargo clippy -p agentgateway --all-targets` — clean
- Live smoke against a mock upstream as described above

Refs #3040 (not "Fixes" — this is test-only; see "What I'd ask the reporter" above).
