### PR TITLE
fix(mcp): derive upstream trace context from the gateway's active span

### DIFF
--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1931,6 +1931,116 @@ async fn elicitation_roundtrip_completes_tool_call() {
 	);
 }
 
+// The traceparent forwarded to the MCP upstream must carry the gateway's own span id, not the
+// caller's, so the upstream's SERVER span nests under the gateway span like HTTP backends do.
+#[tokio::test]
+async fn mcp_upstream_traceparent_is_gateway_span() {
+	use wiremock::{Mock, ResponseTemplate};
+
+	use crate::types::agent::{
+		ListenerName, SimpleBackendReference, SimpleBackendReferenceWithPolicies, Target,
+		TracingConfig, TracingPolicy, TracingProtocol,
+	};
+
+	let upstream = wiremock::MockServer::start().await;
+	let upstream_frame = concat!(
+		"data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{",
+		"\"protocolVersion\":\"2025-06-18\",",
+		"\"capabilities\":{\"tools\":{}},",
+		"\"serverInfo\":{\"name\":\"mock\",\"version\":\"0.0.1\"}",
+		"}}\n\n",
+	);
+	Mock::given(wiremock::matchers::method("POST"))
+		.respond_with(ResponseTemplate::new(200).set_body_raw(upstream_frame, "text/event-stream"))
+		.mount(&upstream)
+		.await;
+
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend(*upstream.address(), true, false)
+		.with_bind(simple_bind())
+		.with_route(basic_route(*upstream.address()));
+	// Tracing must be active for the gateway to create its own span. Exported spans are
+	// not inspected; the collector target is just the upstream mock.
+	t.with_policy(TargetedPolicy {
+		key: "frontend/tracing".into(),
+		name: None,
+		target: PolicyTarget::Gateway(ListenerName::default().into()),
+		inheritance: Default::default(),
+		policy: FrontendPolicy::Tracing(Arc::new(TracingPolicy {
+			config: TracingConfig {
+				target: SimpleBackendReferenceWithPolicies {
+					target: Arc::new(SimpleBackendReference::InlineBackend(Target::Address(
+						*upstream.address(),
+					))),
+					policies: vec![],
+				},
+				attributes: Default::default(),
+				resources: Default::default(),
+				remove: vec![],
+				random_sampling: None,
+				client_sampling: None,
+				filter: None,
+				path: "/v1/traces".to_string(),
+				protocol: TracingProtocol::Http,
+			},
+			fields: Default::default(),
+			tracer: once_cell::sync::OnceCell::new(),
+		}))
+		.into(),
+	});
+	let io = t.serve_real_listener(BIND_KEY).await;
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+	let initialize = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "initialize",
+		"params": {
+			"protocolVersion": "2025-06-18",
+			"capabilities": {},
+			"clientInfo": {
+				"name": "test-client",
+				"version": "0.0.1"
+			}
+		}
+	});
+
+	let caller_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736";
+	let response = mcp_json_post(&client, &url, &initialize)
+		.header(
+			"traceparent",
+			format!("00-{caller_trace_id}-00f067aa0ba902b7-01"),
+		)
+		.send()
+		.await
+		.unwrap();
+	assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+	// The gateway's span id is `span.id` in the access log; the upstream must see exactly it.
+	let log = agent_core::telemetry::testing::eventually_find(&[
+		("mcp.method.name", "initialize"),
+		("trace.id", caller_trace_id),
+	])
+	.await
+	.unwrap();
+	let expected = format!(
+		"00-{caller_trace_id}-{}-01",
+		log["span.id"].as_str().unwrap()
+	);
+	// The mock also receives span exports; pick out the JSON-RPC initialize call.
+	let reqs = upstream.received_requests().await.unwrap();
+	let init = reqs
+		.iter()
+		.find(|r| {
+			serde_json::from_slice::<serde_json::Value>(&r.body)
+				.is_ok_and(|b| b["method"] == "initialize")
+		})
+		.expect("upstream initialize request");
+	let tp = init.headers.get("traceparent").unwrap().to_str().unwrap();
+	assert_eq!(tp, expected);
+}
+
 // Forwarded modern responses may come back as a single JSON object or as an SSE stream.
 // Validation-layer errors are always plain JSON.
 async fn read_response_message(response: reqwest::Response) -> serde_json::Value {

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -26,6 +26,7 @@ use crate::mcp::streamablehttp::StreamableHttpPostResponse;
 use crate::mcp::{FailureMode, mergestream, upstream};
 use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
+use crate::telemetry::trc::TraceParent;
 use crate::types::agent::{McpPrefixMode, McpTargetSpec};
 use crate::*;
 
@@ -50,10 +51,17 @@ impl IncomingRequestContext {
 		}
 	}
 	pub fn new(parts: &::http::request::Parts) -> Self {
+		let mut headers = parts.headers.clone();
+		if let Some(tp) = parts.extensions.get::<TraceParent>() {
+			headers.insert(
+				http::x_headers::TRACEPARENT,
+				::http::HeaderValue::from_bytes(format!("{tp:?}").as_bytes()).unwrap(),
+			);
+		}
 		Self {
 			method: parts.method.clone(),
 			uri: parts.uri.clone(),
-			headers: parts.headers.clone(),
+			headers,
 			ext: parts.extensions.clone(),
 			authority: parts.uri.authority().cloned(),
 		}
@@ -731,5 +739,42 @@ mod tests {
 		let mut req = ping_request();
 		ctx.stamp_trace_context(&mut req.get_meta_mut().0);
 		assert!(req.get_meta().0.get("traceparent").is_none());
+	}
+
+	const GATEWAY_TP: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-076240a3c93307bf-01";
+	const CALLER_TP: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+	// Inbound request carries the caller's traceparent; the gateway's own span must win.
+	fn ctx_with_stale_traceparent() -> IncomingRequestContext {
+		let mut req = ::http::Request::builder()
+			.uri("http://example/")
+			.header("traceparent", CALLER_TP)
+			.header("tracestate", "vendor=abc")
+			.body(())
+			.unwrap();
+		req
+			.extensions_mut()
+			.insert(TraceParent::try_from(GATEWAY_TP).unwrap());
+		IncomingRequestContext::new(&req.into_parts().0)
+	}
+
+	#[test]
+	fn apply_prefers_gateway_span() {
+		let ctx = ctx_with_stale_traceparent();
+		let mut req = empty_upstream_req();
+		ctx.apply(&mut req).unwrap();
+		assert_eq!(req.headers().get("traceparent").unwrap(), GATEWAY_TP);
+		// Other trace headers still pass through untouched.
+		assert_eq!(req.headers().get("tracestate").unwrap(), "vendor=abc");
+	}
+
+	#[test]
+	fn stamp_trace_context_prefers_gateway_span() {
+		let ctx = ctx_with_stale_traceparent();
+		let mut req = ping_request();
+		ctx.stamp_trace_context(&mut req.get_meta_mut().0);
+		let meta = &req.get_meta().0;
+		assert_eq!(meta.get("traceparent").unwrap(), GATEWAY_TP);
+		assert_eq!(meta.get("tracestate").unwrap(), "vendor=abc");
 	}
 }


### PR DESCRIPTION
fixes #2904 