### PR TITLE
feat(helm): configure ui port in standalone deployment

### DIFF
--- a/controller/install/helm/agentgateway-standalone/templates/deployment.yaml
+++ b/controller/install/helm/agentgateway-standalone/templates/deployment.yaml
@@ -63,8 +63,11 @@ spec:
         args:
         - -f
         - /config/config.yaml
-        {{- if .Values.monitoring.enabled }}
         ports:
+        - name: ui
+          containerPort: 15000
+          protocol: TCP
+        {{- if .Values.monitoring.enabled }}
         - name: metrics
           containerPort: 15020
           protocol: TCP


### PR DESCRIPTION
Explicitly configure the ui port in the standalone deployment.  This makes it clear to operators how the UI is exposed.