### PR TITLE
llm: defer re-encoding body

### DIFF
--- a/crates/agentgateway/src/http/compression/mod.rs
+++ b/crates/agentgateway/src/http/compression/mod.rs
@@ -190,6 +190,31 @@ pub async fn encode_body(body: &[u8], encoding: &str) -> Result<Bytes, axum_core
 		.map_err(Into::into)
 }
 
+/// Compress a body as it is sent instead of buffering it again.
+///
+/// Buffered LLM responses use this at the final response boundary: policies need plaintext while
+/// evaluating and replacing `response.body`, but the selected upstream encoding must be restored
+/// after those policies have finished.
+pub fn encode_body_stream(
+	body: axum_core::body::Body,
+	encoding: &str,
+) -> Result<axum_core::body::Body, Error> {
+	let byte_stream = TryStreamExt::map_err(body.into_data_stream(), std::io::Error::other);
+	let stream_reader = BufReader::new(StreamReader::new(byte_stream));
+
+	let encoder: Box<dyn AsyncRead + Unpin + Send> = match encoding {
+		GZIP => Box::new(GzipEncoder::new(stream_reader)),
+		DEFLATE => Box::new(ZlibEncoder::new(stream_reader)),
+		BR => Box::new(BrotliEncoder::new(stream_reader)),
+		ZSTD => Box::new(ZstdEncoder::new(stream_reader)),
+		_ => return Err(Error::UnsupportedEncoding),
+	};
+
+	Ok(axum_core::body::Body::from_stream(ReaderStream::new(
+		encoder,
+	)))
+}
+
 async fn decode_body<B>(body: B, encoding: &str, limit: usize) -> Result<Bytes, Error>
 where
 	B: Body<Data = Bytes> + Send + Unpin + 'static,

--- a/crates/agentgateway/src/llm/gemini_tests.rs
+++ b/crates/agentgateway/src/llm/gemini_tests.rs
@@ -958,7 +958,6 @@ async fn count_tokens_errors_pass_through_unchanged() {
 	let buffered = BufferedResponse {
 		parts,
 		bytes: body.clone(),
-		encoding: None,
 	};
 
 	let resp = provider

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -823,7 +823,31 @@ enum PreparedRequest {
 struct BufferedResponse {
 	parts: ::http::response::Parts,
 	bytes: Bytes,
-	encoding: Option<&'static str>,
+}
+
+// The upstream chose this representation encoding. Keep it out of the headers while the decoded
+// response is translated and passed through generic response-body policies; otherwise a policy can
+// replace the body with plaintext while accidentally retaining (for example) `Content-Encoding: br`.
+#[derive(Clone, Copy)]
+struct DeferredResponseEncoding(&'static str);
+
+// Called once, after all response policies. Encoding here guarantees that the header describes the
+// body that will actually be sent, including any transformation or ext-proc replacement. A policy
+// that returns a new direct response naturally drops the extension and is therefore not encoded.
+pub(crate) fn encode_deferred_response(resp: &mut Response) {
+	let Some(DeferredResponseEncoding(encoding)) =
+		resp.extensions_mut().remove::<DeferredResponseEncoding>()
+	else {
+		return;
+	};
+	let body = std::mem::replace(resp.body_mut(), Body::empty());
+	*resp.body_mut() = http::compression::encode_body_stream(body, encoding)
+		.expect("deferred response encoding was validated while decoding the upstream response");
+	resp
+		.headers_mut()
+		.insert(header::CONTENT_ENCODING, HeaderValue::from_static(encoding));
+	resp.headers_mut().remove(header::CONTENT_LENGTH);
+	resp.headers_mut().remove(header::TRANSFER_ENCODING);
 }
 
 impl AIProvider {
@@ -2182,11 +2206,7 @@ impl AIProvider {
 		model_catalog: Option<&cost::ModelCatalog>,
 		buffered: BufferedResponse,
 	) -> Result<Response, AIError> {
-		let BufferedResponse {
-			mut parts,
-			bytes,
-			encoding,
-		} = buffered;
+		let BufferedResponse { mut parts, bytes } = buffered;
 
 		let (llm_resp, body) = if !parts.status.is_success() {
 			let body = self.process_error(&req, parts.status, &bytes)?;
@@ -2217,18 +2237,6 @@ impl AIProvider {
 			(llm_resp, Bytes::copy_from_slice(&body))
 		};
 
-		let body = if let Some(encoding) = encoding {
-			parts
-				.headers
-				.insert(header::CONTENT_ENCODING, HeaderValue::from_static(encoding));
-			Body::from(
-				http::compression::encode_body(&body, encoding)
-					.await
-					.map_err(AIError::Encoding)?,
-			)
-		} else {
-			Body::from(body)
-		};
 		parts.headers.remove(header::CONTENT_LENGTH);
 		let llm_info = LLMInfo::new(req, llm_resp);
 		parts
@@ -2237,7 +2245,7 @@ impl AIProvider {
 				llm_info.clone(),
 				model_catalog,
 			));
-		let resp = Response::from_parts(parts, body);
+		let resp = Response::from_parts(parts, Body::from(body));
 
 		if !rate_limit.local_rate_limit.is_empty() || rate_limit.remote_rate_limit.is_some() {
 			let exec = cel::Executor::new_response(req_snapshot.as_deref(), &resp);
@@ -2259,21 +2267,17 @@ impl AIProvider {
 				.await
 				.map_err(|e| map_response_compression_error(e, &parts.headers))?;
 
-		// Snapshot decompressed bytes for CEL response.body access before re-compression,
-		// so maybe_buffer_response_body can skip decompression entirely.
-		if encoding.is_some() {
-			parts
-				.extensions
-				.insert(crate::cel::BufferedBody::complete(bytes.clone()));
-			parts.headers.remove(header::CONTENT_ENCODING);
-			parts.headers.remove(header::TRANSFER_ENCODING);
+		// From here until the final proxy response boundary, the body is plaintext and may be
+		// translated or replaced. Remove all headers that describe the upstream wire representation
+		// and carry only the validated encoding choice in an internal extension.
+		parts.headers.remove(header::CONTENT_ENCODING);
+		parts.headers.remove(header::CONTENT_LENGTH);
+		parts.headers.remove(header::TRANSFER_ENCODING);
+		if let Some(encoding) = encoding {
+			parts.extensions.insert(DeferredResponseEncoding(encoding));
 		}
 
-		Ok(BufferedResponse {
-			parts,
-			bytes,
-			encoding,
-		})
+		Ok(BufferedResponse { parts, bytes })
 	}
 
 	fn finalize_response(

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1352,7 +1352,6 @@ fn gemini_count_tokens_response_reports_total_tokens() {
 	let buffered = BufferedResponse {
 		parts: ::http::Response::new(()).into_parts().0,
 		bytes: bytes::Bytes::from_static(body),
-		encoding: None,
 	};
 
 	let log = AsyncLog::<llm::LLMInfo>::default();
@@ -2290,6 +2289,83 @@ async fn process_response_routes_streaming_error_to_buffered_path() {
 		message.contains("toolResult"),
 		"translated error should preserve the original message, got: {message}",
 	);
+}
+
+#[tokio::test]
+async fn upstream_encoding_is_applied_after_messages_response_translation() {
+	use crate::proxy::httpproxy::PolicyClient;
+	use crate::test_helpers::proxymock::setup_proxy_test;
+
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: None,
+		moderation: None,
+	});
+	let mut req = llm_request_with_tokens(None);
+	req.input_format = InputFormat::Messages;
+	req.request_model = "gpt-4o".into();
+	req.streaming = false;
+	let upstream_body = br#"{"id":"chatcmpl-1","object":"chat.completion","created":0,"model":"gpt-4o","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Hello!"}}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}"#;
+	let compressed = crate::http::compression::encode_body(upstream_body, "br")
+		.await
+		.unwrap();
+	let upstream = ::http::Response::builder()
+		.header(::http::header::CONTENT_ENCODING, "br")
+		.header(::http::header::CONTENT_LENGTH, compressed.len())
+		.body(Body::from(compressed))
+		.unwrap();
+
+	let response = provider
+		.process_response(
+			PolicyClient::new(setup_proxy_test("{}").unwrap().pi),
+			req,
+			LLMResponsePolicies::default(),
+			None,
+			AsyncLog::default(),
+			llm::LogContentFields::default(),
+			None,
+			upstream,
+		)
+		.await
+		.unwrap();
+
+	// Keep the response plain while later response policies can still replace its body.
+	assert!(
+		!response
+			.headers()
+			.contains_key(::http::header::CONTENT_ENCODING)
+	);
+	assert!(
+		response
+			.extensions()
+			.get::<crate::cel::BufferedBody>()
+			.is_none()
+	);
+	let (parts, body) = response.into_parts();
+	let mut body: Value = serde_json::from_slice(&body.collect().await.unwrap().to_bytes()).unwrap();
+	assert_eq!(body["type"], "message");
+	assert_eq!(body["content"][0]["text"], "Hello!");
+	// Stand in for a later response-body policy mutation.
+	body["policy_applied"] = true.into();
+	let mut response = Response::from_parts(parts, Body::from(serde_json::to_vec(&body).unwrap()));
+
+	encode_deferred_response(&mut response);
+	assert_eq!(response.headers()[::http::header::CONTENT_ENCODING], "br");
+	assert!(
+		!response
+			.headers()
+			.contains_key(::http::header::CONTENT_LENGTH)
+	);
+	let content_encoding = response.headers().typed_get::<ContentEncoding>();
+	let (_, body) = crate::http::compression::to_bytes_with_decompression(
+		response.into_body(),
+		content_encoding.as_ref(),
+		1024 * 1024,
+	)
+	.await
+	.unwrap();
+	let body: Value = serde_json::from_slice(&body).unwrap();
+	assert_eq!(body["type"], "message");
+	assert_eq!(body["policy_applied"], true);
 }
 
 #[test]

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -681,6 +681,9 @@ impl HTTPProxy {
 				ProxyResponse::DirectResponse(dr) => *dr,
 			},
 		};
+		// LLM buffering deliberately leaves decoded bodies plain so response policies can safely read
+		// and replace them. Restore the upstream-selected encoding only after every such policy ran.
+		llm::encode_deferred_response(&mut resp);
 		if let Some(log) = log.as_mut() {
 			dtrace::snapshot!(Response, "final response", log, &resp);
 		}


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/3040.

Without this, a response transformation would result in plaintext but
keep the encoding header, breaking clients

Signed-off-by: John Howard <john.howard@solo.io>
