### PR TITLE
fix(a2a): populate response telemetry for A2A v1.0 nested payloads and record contextId

### DIFF
--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -71,6 +71,7 @@ pub struct ResponseInfo {
 	pub error_code: Option<i64>,
 	pub result_kind: Option<Strng>,
 	pub task_state: Option<Strng>,
+	pub context_id: Option<Strng>,
 }
 
 impl ResponseInfo {
@@ -87,13 +88,39 @@ impl ResponseInfo {
 		let error_code = error
 			.and_then(|e| e.get("code"))
 			.and_then(serde_json::Value::as_i64);
+		// A2A v0.3 puts the Task/Message fields directly on `result`, discriminated by
+		// `kind`. A2A v1.0 models the response as `oneof payload { Task task = 1;
+		// Message message = 2; }`, so the payload is nested under `result.task` or
+		// `result.message` and carries no `kind` field. Prefer the flat v0.3 shape and
+		// fall back to the nested v1.0 shape so both spec generations populate.
+		let payload = |name: &str| result.and_then(|r| r.get(name)).filter(|v| !v.is_null());
+		let task = payload("task");
+		let message = payload("message");
 		let result_kind = result
 			.and_then(|r| r.get("kind"))
 			.and_then(serde_json::Value::as_str)
-			.map(Strng::from);
+			.map(Strng::from)
+			// v1.0: the populated `oneof` arm names the kind.
+			.or_else(|| task.map(|_| Strng::from("task")))
+			.or_else(|| message.map(|_| Strng::from("message")));
 		let task_state = result
 			.and_then(|r| r.get("status"))
 			.and_then(|status| status.get("state"))
+			.and_then(serde_json::Value::as_str)
+			.or_else(|| {
+				// v1.0: result.task.status.state. A Message has no status.
+				task
+					.and_then(|t| t.get("status"))
+					.and_then(|status| status.get("state"))
+					.and_then(serde_json::Value::as_str)
+			})
+			.map(Strng::from);
+		// context_id ties multiple turns of a conversation together. Both Task and
+		// Message carry it, so check the flat v0.3 location and then either v1.0 arm.
+		let context_id = result
+			.and_then(|r| r.get("contextId"))
+			.or_else(|| task.and_then(|t| t.get("contextId")))
+			.or_else(|| message.and_then(|m| m.get("contextId")))
 			.and_then(serde_json::Value::as_str)
 			.map(Strng::from);
 		Self {
@@ -101,6 +128,7 @@ impl ResponseInfo {
 			error_code,
 			result_kind,
 			task_state,
+			context_id,
 		}
 	}
 }

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -395,6 +395,7 @@ async fn test_apply_to_response_records_success_call_telemetry() {
 		"id": "1",
 		"result": {
 			"kind": "task",
+			"contextId": "ctx",
 			"status": { "state": "completed" }
 		}
 	});
@@ -420,6 +421,7 @@ async fn test_apply_to_response_records_success_call_telemetry() {
 		info.task_state.as_ref().map(|s| s.as_str()),
 		Some("completed")
 	);
+	assert_eq!(info.context_id.as_ref().map(|s| s.as_str()), Some("ctx"));
 	assert_eq!(http::read_resp_body(resp).await.unwrap(), raw);
 }
 
@@ -717,4 +719,80 @@ async fn test_apply_to_response_avoids_partial_path_segment_match() {
 		json["supportedInterfaces"][1]["url"],
 		"http://gateway/public/weather/internal/weather-v2/jsonrpc"
 	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_records_v1_nested_task_telemetry() {
+	// A2A v1.0 shape: the `oneof payload` puts the Task under `result.task`, with no
+	// `kind` discriminator.
+	let payload = json!({
+		"jsonrpc": "2.0",
+		"id": "1",
+		"result": {
+			"task": {
+				"id": "abc",
+				"contextId": "ctx",
+				"status": { "state": "completed" }
+			}
+		}
+	});
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(serde_json::to_vec(&payload).unwrap()))
+		.unwrap();
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("SendMessage")),
+		&mut resp,
+	)
+	.await
+	.unwrap()
+	.expect("v1.0 nested task response should produce telemetry");
+
+	assert_eq!(info.outcome, ResponseOutcome::Success);
+	assert_eq!(info.result_kind.as_ref().map(|s| s.as_str()), Some("task"));
+	assert_eq!(
+		info.task_state.as_ref().map(|s| s.as_str()),
+		Some("completed")
+	);
+	assert_eq!(info.context_id.as_ref().map(|s| s.as_str()), Some("ctx"));
+}
+
+#[tokio::test]
+async fn test_apply_to_response_records_v1_nested_message_telemetry() {
+	// A2A v1.0 shape: the other `oneof payload` arm puts a Message under
+	// `result.message`. A Message carries `contextId` but has no status.
+	let payload = json!({
+		"jsonrpc": "2.0",
+		"id": "1",
+		"result": {
+			"message": {
+				"messageId": "msg-1",
+				"contextId": "ctx",
+				"role": "ROLE_AGENT"
+			}
+		}
+	});
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(serde_json::to_vec(&payload).unwrap()))
+		.unwrap();
+
+	let info = apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::Call(Strng::from("SendMessage")),
+		&mut resp,
+	)
+	.await
+	.unwrap()
+	.expect("v1.0 nested message response should produce telemetry");
+
+	assert_eq!(info.outcome, ResponseOutcome::Success);
+	assert_eq!(
+		info.result_kind.as_ref().map(|s| s.as_str()),
+		Some("message")
+	);
+	assert_eq!(info.task_state, None);
+	assert_eq!(info.context_id.as_ref().map(|s| s.as_str()), Some("ctx"));
 }

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1475,6 +1475,14 @@ impl Drop for DropOnLog {
 						.map(display),
 				),
 				(
+					"a2a.context.id",
+					log
+						.a2a_response
+						.as_ref()
+						.and_then(|r| r.context_id.as_ref())
+						.map(display),
+				),
+				(
 					"mcp.method.name",
 					mcp
 						.as_ref()
@@ -2688,6 +2696,7 @@ mod tests {
 			error_code: Some(-32602),
 			result_kind: Some(strng::literal!("task")),
 			task_state: Some(strng::literal!("failed")),
+			context_id: Some(strng::literal!("ctx-123")),
 		});
 
 		drop(DropOnLog::from(log));
@@ -2704,6 +2713,7 @@ mod tests {
 			"a2a.response.error_code",
 			"a2a.result.kind",
 			"a2a.task.state",
+			"a2a.context.id",
 		] {
 			assert!(has(expected), "expected {expected} span attribute");
 		}

--- a/examples/traffic-a2a/README.md
+++ b/examples/traffic-a2a/README.md
@@ -57,8 +57,12 @@ Additionally, as we send requests we can see A2A specific information in the log
     route=route0 endpoint=localhost:9999 src.addr=127.0.0.1:57408
     http.method=POST http.host=localhost http.path=/ http.version=HTTP/1.1 http.status=200
     a2a.method=message/stream a2a.response.outcome=success a2a.result.kind=task
-    a2a.task.state=completed duration=2ms
+    a2a.task.state=completed a2a.context.id=8f2b1c94 duration=2ms
 ```
+
+`a2a.context.id` is the A2A `contextId`, which is stable across every turn of one conversation. It
+is recorded for both the A2A v0.3 response shape (fields directly on `result`) and the v1.0 shape
+(the payload nested under `result.task` or `result.message`).
 
 If the upstream agent returns a JSON-RPC error with an HTTP 200 status, the log includes the A2A response outcome and error code:
 


### PR DESCRIPTION
Fixes #3061

## Summary

- read A2A v1.0 response payloads nested under `result.task` / `result.message`, in addition to the flat v0.3 shape
- derive `a2a.result.kind` from the populated `oneof` arm, since v1.0 `Task` has no `kind` field
- record the conversation `contextId` as a new `a2a.context.id` field

## Details

`ResponseInfo::from_json` only read the flat v0.3 result shape, so the fields added in #2646 (`a2a.result.kind`, `a2a.task.state`) came out empty for every v1.0 response. v1.0 defines `SendMessageResponse` as `oneof payload { Task task = 1; Message message = 2; }`, so the task is a level deeper and carries no `kind` discriminator. The flat shape is still preferred; the nested arms are a fallback, so v0.3 behavior is unchanged.

`contextId` is what ties the turns of one conversation together, and it was being parsed and thrown away — MCP already exposes the equivalent via `mcp.session.id`. `inspect_call_response` has the deserialized body in hand, so this is a map lookup, no extra I/O. Streaming is untouched: `BodyInspection::Partial` still bails before telemetry.

I named it `a2a.context.id` to sit with the other `a2a.*` fields, but `gen_ai.conversation.id` is the OTel semconv name for this and there's precedent here — MCP tool and prompt names are emitted as `gen_ai.tool.name` / `gen_ai.prompt.name`. Flagging it now rather than after it ships, since the name becomes a contract for log consumers. Happy to rename or emit both.

No metrics involvement — these fields only reach logs, OTLP logs and span attributes, so the added cardinality doesn't land on a time series.

## Testing

New tests cover both v1.0 arms and add a `contextId` assertion to the existing v0.3 case; all three fail on `main`. `examples/traffic-a2a/README.md` updated with the new field.

- `cargo test -p agentgateway a2a::`
- `cargo test -p agentgateway telemetry::`
- `cargo test --tests --benches --examples`
- `make lint`
- `make generate-schema check-clean-repo check-default-members`

### AI assistance

I used non-trivial AI assistance while implementing and testing this change. I reviewed and verified the resulting code, understand the changes, and take full ownership of the contribution.
