### PR TITLE
metrics: add mode to enable native histograms

### DIFF
--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -74,6 +74,7 @@ pub async fn run(
 	let metrics_handle = Arc::new(crate::metrics::Metrics::new(
 		sub_registry,
 		config.metrics.excluded_metrics.clone(),
+		config.histograms,
 	));
 	let client = client::Client::new(
 		&config.dns,

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -777,6 +777,7 @@ mod tests {
 		let metrics = Arc::new(crate::metrics::Metrics::new(
 			&mut registry,
 			FzHashSet::default(),
+			Default::default(),
 		));
 
 		let client = Client::new(

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -522,6 +522,7 @@ pub fn parse_config(
 				.ctx("invalid config.metrics.fields")?
 				.unwrap_or_default(),
 		},
+		histograms: raw.histograms,
 		logging: telemetry::log::Config {
 			filter: raw
 					.logging

--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -693,7 +693,11 @@ fn make_min_req_log() -> crate::telemetry::log::RequestLog {
 	};
 	let cel = log::CelLogging::new(log_cfg, MetricsConfig::default());
 	let mut prom = Registry::default();
-	let metrics = Arc::new(Metrics::new(&mut prom, FzHashSet::default()));
+	let metrics = Arc::new(Metrics::new(
+		&mut prom,
+		FzHashSet::default(),
+		Default::default(),
+	));
 	let start = agent_core::Timestamp::now();
 	let tcp_info = TCPConnectionInfo {
 		peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 12345),

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -196,6 +196,10 @@ pub struct RawConfig {
 	standard_attributes: Option<RawStandardAttributes>,
 	/// Stats/metrics server address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"
 	stats_addr: Option<String>,
+	/// Histogram representation to collect. Native histograms are exposed only through the
+	/// Prometheus protobuf format. Defaults to classic.
+	#[serde(default)]
+	histograms: HistogramMode,
 	/// Readiness probe server address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"
 	readiness_addr: Option<String>,
 
@@ -450,6 +454,18 @@ pub enum LoggingFormat {
 	Json,
 }
 
+#[apply(schema!)]
+#[derive(Default, Copy, Eq, PartialEq)]
+pub enum HistogramMode {
+	/// Collect classic histogram buckets only.
+	#[default]
+	Classic,
+	/// Collect native histogram buckets only.
+	Native,
+	/// Collect both classic and native histogram buckets.
+	Both,
+}
+
 #[apply(schema_de!)]
 pub struct RawMetrics {
 	/// Metric names to exclude from collection.
@@ -613,6 +629,7 @@ pub struct Config {
 	pub num_worker_threads: usize,
 	pub admin_addr: Address,
 	pub stats_addr: Address,
+	pub histograms: HistogramMode,
 	pub readiness_addr: Address,
 	// For waypoint identification
 	pub self_addr: Option<types::discovery::WaypointIdentity>,

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -47,6 +47,7 @@ async fn setup_with_prefix(prefix: &str) -> (MockServer, Handler) {
 		metrics: Arc::new(crate::metrics::Metrics::new(
 			metrics::sub_registry(&mut Registry::default()),
 			Default::default(),
+			Default::default(),
 		)),
 		model_catalog: crate::llm::cost::ModelCatalog::empty(),
 		admin: None,
@@ -1829,6 +1830,7 @@ async fn test_call_tool_with_binary_body() {
 		stores: stores.clone(),
 		metrics: Arc::new(crate::metrics::Metrics::new(
 			agent_core::metrics::sub_registry(&mut prometheus_client::registry::Registry::default()),
+			Default::default(),
 			Default::default(),
 		)),
 		model_catalog: crate::llm::cost::ModelCatalog::empty(),

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -967,6 +967,7 @@ mod tests {
 			metrics: Arc::new(crate::metrics::Metrics::new(
 				metrics::sub_registry(&mut Registry::default()),
 				Default::default(),
+				Default::default(),
 			)),
 			model_catalog: ModelCatalog::empty(),
 			admin: None,

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -2336,7 +2336,11 @@ mod tests {
 			database_fields: LoggingFields::default(),
 		};
 		let mut registry = Registry::default();
-		let metrics = Arc::new(Metrics::new(&mut registry, Default::default()));
+		let metrics = Arc::new(Metrics::new(
+			&mut registry,
+			Default::default(),
+			Default::default(),
+		));
 		RequestLog::new(
 			cel,
 			metrics,

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -6,12 +6,13 @@ use agent_core::version;
 use frozen_collections::FzHashSet;
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter;
-use prometheus_client::metrics::family::Family;
-use prometheus_client::metrics::histogram::Histogram as PromHistogram;
+use prometheus_client::metrics::family::{Family, MetricConstructor};
+use prometheus_client::metrics::histogram::{Histogram as PromHistogram, NativeHistogramConfig};
 use prometheus_client::metrics::info::Info;
 use prometheus_client::registry::{Metric, Registry, Unit};
 use tracing::{debug, trace};
 
+use crate::HistogramMode;
 use crate::mcp::MCPOperation;
 use crate::proxy::ProxyResponseReason;
 use crate::types::agent::TransportProtocol;
@@ -184,8 +185,28 @@ pub struct OutboundCallLabels {
 }
 
 type Counter = Family<HTTPLabels, counter::Counter>;
-type Histogram<T> = Family<T, prometheus_client::metrics::histogram::Histogram>;
+type Histogram<T> = Family<T, PromHistogram, HistogramConstructor>;
 type TCPCounter = Family<TCPLabels, counter::Counter>;
+
+#[derive(Clone, Copy)]
+#[doc(hidden)]
+pub struct HistogramConstructor {
+	mode: HistogramMode,
+	buckets: &'static [f64],
+}
+
+impl MetricConstructor<PromHistogram> for HistogramConstructor {
+	fn new_metric(&self) -> PromHistogram {
+		match self.mode {
+			HistogramMode::Classic => PromHistogram::new(self.buckets.iter().copied()),
+			HistogramMode::Native => PromHistogram::new_native(NativeHistogramConfig::default()),
+			HistogramMode::Both => PromHistogram::new_classic_and_native(
+				self.buckets.iter().copied(),
+				NativeHistogramConfig::default(),
+			),
+		}
+	}
+}
 
 #[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct BuildLabel {
@@ -294,7 +315,11 @@ impl<'a> FilteredRegistry<'a> {
 }
 
 impl Metrics {
-	pub fn new(registry: &mut Registry, removes: FzHashSet<String>) -> Self {
+	pub fn new(
+		registry: &mut Registry,
+		removes: FzHashSet<String>,
+		histogram_mode: HistogramMode,
+	) -> Self {
 		let mut registry = FilteredRegistry { registry, removes };
 		registry.register(
 			"build",
@@ -304,9 +329,7 @@ impl Metrics {
 			}),
 		);
 
-		let gen_ai_token_usage = Family::<GenAILabelsTokenUsage, _>::new_with_constructor(move || {
-			PromHistogram::new(TOKEN_USAGE_BUCKET)
-		});
+		let gen_ai_token_usage = histogram_family(histogram_mode, &TOKEN_USAGE_BUCKET);
 		registry.register(
 			"gen_ai_client_token_usage",
 			"Number of tokens used per request",
@@ -322,27 +345,21 @@ impl Metrics {
 		);
 
 		// TODO: add error attribute if it ends with an error
-		let gen_ai_request_duration = Family::<GenAILabels, _>::new_with_constructor(move || {
-			PromHistogram::new(REQUEST_DURATION_BUCKET)
-		});
+		let gen_ai_request_duration = histogram_family(histogram_mode, &REQUEST_DURATION_BUCKET);
 		registry.register(
 			"gen_ai_server_request_duration",
 			"Duration of generative AI request",
 			gen_ai_request_duration.clone(),
 		);
 
-		let gen_ai_time_per_output_token = Family::<GenAILabels, _>::new_with_constructor(move || {
-			PromHistogram::new(OUTPUT_TOKEN_BUCKET)
-		});
+		let gen_ai_time_per_output_token = histogram_family(histogram_mode, &OUTPUT_TOKEN_BUCKET);
 		registry.register(
 			"gen_ai_server_time_per_output_token",
 			"Time to generate each output token for a given request",
 			gen_ai_time_per_output_token.clone(),
 		);
 
-		let gen_ai_time_to_first_token = Family::<GenAILabels, _>::new_with_constructor(move || {
-			PromHistogram::new(FIRST_TOKEN_BUCKET)
-		});
+		let gen_ai_time_to_first_token = histogram_family(histogram_mode, &FIRST_TOKEN_BUCKET);
 		registry.register(
 			"gen_ai_server_time_to_first_token",
 			"Time to generate the first token for a given request",
@@ -402,9 +419,7 @@ impl Metrics {
 				m
 			},
 			request_duration: {
-				let m = Family::<HTTPLabels, _>::new_with_constructor(move || {
-					PromHistogram::new(HTTP_REQUEST_DURATION_BUCKET)
-				});
+				let m = histogram_family(histogram_mode, &HTTP_REQUEST_DURATION_BUCKET);
 				registry.register_with_unit(
 					"request_duration",
 					"Duration of HTTP requests (seconds)",
@@ -414,9 +429,7 @@ impl Metrics {
 				m
 			},
 			request_processing_duration: {
-				let m = Family::<MinimalHTTPLabels, _>::new_with_constructor(move || {
-					PromHistogram::new(PROCESSING_DURATION_BUCKETS)
-				});
+				let m = histogram_family(histogram_mode, &PROCESSING_DURATION_BUCKETS);
 				registry.register_with_unit(
 					"request_processing",
 					"Duration from receiving an HTTP request to sending the primary outbound call (seconds)",
@@ -426,9 +439,7 @@ impl Metrics {
 				m
 			},
 			response_processing_duration: {
-				let m = Family::<MinimalHTTPLabels, _>::new_with_constructor(move || {
-					PromHistogram::new(PROCESSING_DURATION_BUCKETS)
-				});
+				let m = histogram_family(histogram_mode, &PROCESSING_DURATION_BUCKETS);
 				registry.register_with_unit(
 					"response_processing",
 					"Duration from receiving the primary outbound response to sending the HTTP response (seconds)",
@@ -458,9 +469,7 @@ impl Metrics {
 				m
 			},
 			upstream_connect_duration: {
-				let m = Family::<ConnectLabels, _>::new_with_constructor(move || {
-					PromHistogram::new(CONNECT_DURATION_BUCKET)
-				});
+				let m = histogram_family(histogram_mode, &CONNECT_DURATION_BUCKET);
 				registry.register_with_unit(
 					"upstream_connect_duration",
 					"Duration to establish upstream connection (seconds)",
@@ -470,9 +479,7 @@ impl Metrics {
 				m
 			},
 			upstream_call_duration: {
-				let m = Family::<OutboundCallLabels, _>::new_with_constructor(move || {
-					PromHistogram::new(HTTP_REQUEST_DURATION_BUCKET)
-				});
+				let m = histogram_family(histogram_mode, &HTTP_REQUEST_DURATION_BUCKET);
 				registry.register_with_unit(
 					"upstream_call_duration",
 					"Duration of outbound calls made by agentgateway (seconds)",
@@ -482,9 +489,7 @@ impl Metrics {
 				m
 			},
 			tls_handshake_duration: {
-				let m = Family::<TCPLabels, _>::new_with_constructor(move || {
-					PromHistogram::new(CONNECT_DURATION_BUCKET)
-				});
+				let m = histogram_family(histogram_mode, &CONNECT_DURATION_BUCKET);
 				registry.register_with_unit(
 					"tls_handshake_duration",
 					"Duration to complete inbound TLS/HTTPS handshake (seconds)",
@@ -500,6 +505,13 @@ impl Metrics {
 			),
 		}
 	}
+}
+
+fn histogram_family<T>(mode: HistogramMode, buckets: &'static [f64]) -> Histogram<T>
+where
+	T: Clone + std::hash::Hash + Eq,
+{
+	Family::new_with_constructor(HistogramConstructor { mode, buckets })
 }
 
 fn build<'a, T: Clone + std::hash::Hash + Eq + Send + Sync + Debug + EncodeLabelSet + 'static>(
@@ -565,3 +577,42 @@ const OUTPUT_TOKEN_BUCKET: [f64; 14] = [
 const FIRST_TOKEN_BUCKET: [f64; 16] = [
 	0.001, 0.005, 0.01, 0.02, 0.04, 0.06, 0.08, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
 ];
+
+#[cfg(test)]
+mod tests {
+	use prometheus_client::encoding::prometheus_protobuf;
+	use prometheus_client::registry::Registry;
+
+	use super::*;
+
+	#[test]
+	fn histogram_mode_controls_collected_representations() {
+		for (mode, want_classic, want_native) in [
+			(HistogramMode::Classic, true, false),
+			(HistogramMode::Native, false, true),
+			(HistogramMode::Both, true, true),
+		] {
+			let mut registry = Registry::default();
+			let metrics = Metrics::new(&mut registry, Default::default(), mode);
+			metrics
+				.request_duration
+				.get_or_create(&HTTPLabels::default())
+				.observe(1.0);
+
+			let families = prometheus_protobuf::encode(&registry).expect("protobuf encoding succeeds");
+			let histogram = families
+				.iter()
+				.find(|family| family.name == "request_duration_seconds")
+				.and_then(|family| family.metric.first())
+				.and_then(|metric| metric.histogram.as_ref())
+				.expect("request duration histogram is encoded");
+
+			assert_eq!(!histogram.bucket.is_empty(), want_classic, "mode: {mode:?}");
+			assert_eq!(
+				!histogram.positive_span.is_empty(),
+				want_native,
+				"mode: {mode:?}"
+			);
+		}
+	}
+}

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -844,7 +844,11 @@ mod tests {
 			database_fields: LoggingFields::default(),
 		};
 		let mut registry = Registry::default();
-		let metrics = Arc::new(Metrics::new(&mut registry, Default::default()));
+		let metrics = Arc::new(Metrics::new(
+			&mut registry,
+			Default::default(),
+			Default::default(),
+		));
 		RequestLog::new(
 			cel,
 			metrics,

--- a/crates/agentgateway/src/test_helpers/policy.rs
+++ b/crates/agentgateway/src/test_helpers/policy.rs
@@ -40,7 +40,11 @@ fn make_min_req_log() -> crate::telemetry::log::RequestLog {
 	};
 	let cel = log::CelLogging::new(log_cfg, MetricsConfig::default());
 	let mut prom = Registry::default();
-	let metrics = Arc::new(Metrics::new(&mut prom, FzHashSet::default()));
+	let metrics = Arc::new(Metrics::new(
+		&mut prom,
+		FzHashSet::default(),
+		Default::default(),
+	));
 	let model_catalog = ModelCatalog::empty();
 	let start = agent_core::Timestamp::now();
 	let tcp_info = TCPConnectionInfo {

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -1300,6 +1300,7 @@ pub fn setup_proxy_test(cfg: &str) -> anyhow::Result<TestBind> {
 pub fn setup_proxy_test_with_config(config: crate::Config) -> TestBind {
 	crate::crypto::init();
 	let encoder = config.session_encoder.clone();
+	let histogram_mode = config.histograms;
 	let stores = Stores::new(config.ipv6_enabled, config.threading_mode);
 	let client = client::Client::new(&config.dns, None, Default::default(), None);
 	let (drain_tx, drain_rx) = drain::new();
@@ -1309,6 +1310,7 @@ pub fn setup_proxy_test_with_config(config: crate::Config) -> TestBind {
 		metrics: Arc::new(crate::metrics::Metrics::new(
 			metrics::sub_registry(&mut Registry::default()),
 			Default::default(),
+			histogram_mode,
 		)),
 		model_catalog: cost::ModelCatalog::empty(),
 		admin: None,

--- a/schema/config.json
+++ b/schema/config.json
@@ -291,6 +291,11 @@
             "null"
           ]
         },
+        "histograms": {
+          "description": "Histogram representation to collect. Native histograms are exposed only through the\nPrometheus protobuf format. Defaults to classic.",
+          "$ref": "#/$defs/HistogramMode",
+          "default": "classic"
+        },
         "readinessAddr": {
           "description": "Readiness probe server address in the format \"ip:port\", \"localhost:port\", \"unix:/path/to/socket\", or \"off\"",
           "type": [
@@ -731,6 +736,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "HistogramMode": {
+      "oneOf": [
+        {
+          "description": "Collect classic histogram buckets only.",
+          "type": "string",
+          "const": "classic"
+        },
+        {
+          "description": "Collect native histogram buckets only.",
+          "type": "string",
+          "const": "native"
+        },
+        {
+          "description": "Collect both classic and native histogram buckets.",
+          "type": "string",
+          "const": "both"
+        }
+      ]
     },
     "RawSession": {
       "type": "object",

--- a/schema/config.md
+++ b/schema/config.md
@@ -54,6 +54,7 @@
 |`config.standardAttributes.user`|string|CEL expression used to populate the `agentgateway.user` request log attribute.|
 |`config.standardAttributes.group`|string|CEL expression used to populate the `agentgateway.group` request log attribute.|
 |`config.statsAddr`|string|Stats/metrics server address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"|
+|`config.histograms`|enum|Histogram representation to collect. Native histograms are exposed only through the<br>Prometheus protobuf format. Defaults to classic.<br>Possible values: `classic`, `native`, `both`.|
 |`config.readinessAddr`|string|Readiness probe server address in the format "ip:port", "localhost:port", "unix:/path/to/socket", or "off"|
 |`config.session`|object|Configuration for stateful session management|
 |`config.session.key`|string|The AES-256-GCM session protection key to be used for session tokens.<br>If not set, sessions will not be encrypted.<br>For example, generated via `openssl rand -hex 32`.|


### PR DESCRIPTION
Currently made it off by default since idk how many people scrape this and it has an overhead...