### PR TITLE
Fix a2a path rewriting

### DIFF
--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -287,7 +287,7 @@ fn public_interface_url(
 			return None;
 		};
 		let rest = strip_complete_path_prefix(iface_path, replacement)?;
-		Some(format!("{matched}{rest}"))
+		Some(join_path_prefix(matched, rest))
 	}) {
 		return replace_path(gateway_base, &path);
 	}
@@ -300,7 +300,19 @@ fn replace_path(uri: &str, path: &str) -> String {
 	let Ok(uri) = uri.parse::<Uri>() else {
 		return format!("{uri}{path}");
 	};
-	uri.to_string().replace(uri.path(), path)
+	let original = uri.to_string();
+	let query = uri.query().map(str::to_string);
+	let mut path_and_query = path.to_string();
+	if let Some(query) = query {
+		path_and_query.push('?');
+		path_and_query.push_str(&query);
+	}
+	let Ok(path_and_query) = path_and_query.parse() else {
+		return original;
+	};
+	let mut parts = uri.into_parts();
+	parts.path_and_query = Some(path_and_query);
+	Uri::from_parts(parts).map_or(original, |uri| uri.to_string())
 }
 
 /// Strip `prefix` only when it ends on a path-segment boundary.
@@ -308,7 +320,8 @@ fn strip_complete_path_prefix<'a>(path: &'a str, prefix: &str) -> Option<&'a str
 	if prefix.is_empty() {
 		return None;
 	}
-	if prefix == "/" {
+	let prefix = prefix.trim_end_matches('/');
+	if prefix.is_empty() {
 		return Some(path);
 	}
 	if path == prefix {
@@ -316,6 +329,17 @@ fn strip_complete_path_prefix<'a>(path: &'a str, prefix: &str) -> Option<&'a str
 	}
 	let stripped = path.strip_prefix(prefix)?;
 	stripped.starts_with('/').then_some(stripped)
+}
+
+fn join_path_prefix(prefix: &str, rest: &str) -> String {
+	let prefix = prefix.trim_end_matches('/');
+	let rest = rest.trim_start_matches('/');
+	match (prefix, rest) {
+		("", "") => "/".to_string(),
+		("", rest) => format!("/{rest}"),
+		(prefix, "") => prefix.to_string(),
+		(prefix, rest) => format!("{prefix}/{rest}"),
+	}
 }
 
 #[cfg(test)]

--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -35,7 +35,11 @@ async fn classify_request(req: &mut Request<Body>) -> RequestType {
 			// Also record the (possibly rewritten) backend path so we can compute
 			// relative interface URLs on the response side.
 			let backend_path = req.uri().path().to_string();
-			RequestType::AgentCard(uri, backend_path)
+			let rewrite = req
+				.extensions()
+				.get::<filters::AppliedUrlRewrite>()
+				.cloned();
+			RequestType::AgentCard(uri, backend_path, rewrite)
 		},
 		(m, _) if m == http::Method::POST => {
 			let method = match crate::http::classify_content_type(req.headers()) {
@@ -61,7 +65,7 @@ async fn classify_request(req: &mut Request<Body>) -> RequestType {
 pub enum RequestType {
 	#[default]
 	Unknown,
-	AgentCard(http::Uri, String),
+	AgentCard(http::Uri, String, Option<filters::AppliedUrlRewrite>),
 	Call(Strng),
 }
 
@@ -159,7 +163,7 @@ pub async fn apply_to_response(
 		return Ok(None);
 	};
 	match a2a_type {
-		RequestType::AgentCard(uri, backend_path) => {
+		RequestType::AgentCard(uri, backend_path, rewrite) => {
 			// For agent card, we need to mutate the request to insert the proper URL to reach it
 			// through the gateway.
 			let buffer_limit = crate::http::response_buffer_limit(resp);
@@ -194,22 +198,13 @@ pub async fn apply_to_response(
 						// that relative path at the gateway base.
 						// Only match complete path segments to avoid partial matches
 						// (e.g., /internal/weather should not match /internal/weather-v2).
-						let relative = if iface_path == backend_agent_path {
-							// Exact match - the interface is at the agent card location
-							""
-						} else if let Some(stripped) = iface_path.strip_prefix(backend_agent_path) {
-							// Check that we matched a complete path segment
-							if stripped.starts_with('/') {
-								stripped
-							} else {
-								// Partial segment match (e.g., /weather vs /weather-v2) - don't strip
-								iface_path
-							}
-						} else {
-							// No prefix match at all
-							iface_path
-						};
-						*url_val = Value::String(format!("{gateway_base}{relative}"));
+						let url = public_interface_url(
+							&gateway_base,
+							iface_path,
+							backend_agent_path,
+							rewrite.as_ref(),
+						);
+						*url_val = Value::String(url);
 					}
 				}
 			} else if let Some(url_field) = json::traverse_mut(&mut agent_card, &["url"]) {
@@ -276,6 +271,51 @@ fn strip_agent_card_suffix(path: &str) -> &str {
 	path
 		.strip_suffix("/.well-known/agent-card.json")
 		.unwrap_or(path)
+}
+
+fn public_interface_url(
+	gateway_base: &str,
+	iface_path: &str,
+	backend_agent_path: &str,
+	rewrite: Option<&filters::AppliedUrlRewrite>,
+) -> String {
+	if let Some(path) = rewrite.and_then(|rewrite| {
+		let crate::types::agent::PathRedirect::Prefix(replacement) = rewrite.path.as_ref()? else {
+			return None;
+		};
+		let crate::types::agent::PathMatch::PathPrefix(matched) = &rewrite.path_match else {
+			return None;
+		};
+		let rest = strip_complete_path_prefix(iface_path, replacement)?;
+		Some(format!("{matched}{rest}"))
+	}) {
+		return replace_path(gateway_base, &path);
+	}
+
+	let relative = strip_complete_path_prefix(iface_path, backend_agent_path).unwrap_or(iface_path);
+	format!("{gateway_base}{relative}")
+}
+
+fn replace_path(uri: &str, path: &str) -> String {
+	let Ok(uri) = uri.parse::<Uri>() else {
+		return format!("{uri}{path}");
+	};
+	uri.to_string().replace(uri.path(), path)
+}
+
+/// Strip `prefix` only when it ends on a path-segment boundary.
+fn strip_complete_path_prefix<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
+	if prefix.is_empty() {
+		return None;
+	}
+	if prefix == "/" {
+		return Some(path);
+	}
+	if path == prefix {
+		return Some("");
+	}
+	let stripped = path.strip_prefix(prefix)?;
+	stripped.starts_with('/').then_some(stripped)
 }
 
 #[cfg(test)]

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -770,6 +770,23 @@ async fn test_apply_to_response_uses_prefix_rewrite_context() {
 	);
 }
 
+#[test]
+fn test_strip_complete_path_prefix_normalizes_trailing_slashes() {
+	assert_eq!(
+		strip_complete_path_prefix("/svc/agent", "/svc/"),
+		Some("/agent")
+	);
+	assert_eq!(join_path_prefix("/gw/", "/svc/agent"), "/gw/svc/agent");
+}
+
+#[test]
+fn test_replace_path_changes_only_the_path() {
+	assert_eq!(
+		replace_path("https://gateway.example/?redirect=/", "/gw/svc/agent"),
+		"https://gateway.example/gw/svc/agent?redirect=/"
+	);
+}
+
 #[tokio::test]
 async fn test_apply_to_response_records_v1_nested_task_telemetry() {
 	// A2A v1.0 shape: the `oneof payload` puts the Task under `result.task`, with no

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -97,7 +97,7 @@ async fn test_classify_request_uses_original_url_for_agent_card() {
 	let ty = classify_request(&mut req).await;
 
 	match ty {
-		RequestType::AgentCard(uri, _) => assert_eq!(uri, original),
+		RequestType::AgentCard(uri, _, _) => assert_eq!(uri, original),
 		other => panic!("expected agent card request, got {other:?}"),
 	}
 }
@@ -119,7 +119,7 @@ async fn test_classify_request_uses_original_url_for_agent_card_with_subpath() {
 	let ty = classify_request(&mut req).await;
 
 	match ty {
-		RequestType::AgentCard(uri, _) => assert_eq!(uri, original),
+		RequestType::AgentCard(uri, _, _) => assert_eq!(uri, original),
 		other => panic!("expected agent card request, got {other:?}"),
 	}
 }
@@ -142,7 +142,7 @@ async fn test_classify_request_uses_x_forwarded_proto_for_agent_card() {
 	let ty = classify_request(&mut req).await;
 
 	match ty {
-		RequestType::AgentCard(uri, _) => {
+		RequestType::AgentCard(uri, _, _) => {
 			assert_eq!(
 				uri,
 				"https://example.com/api/.well-known/agent-card.json"
@@ -191,6 +191,7 @@ async fn test_apply_to_response_rewrites_agent_card_url() {
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -225,6 +226,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_single_interface() {
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -263,6 +265,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_multiple_interfaces() {
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -304,6 +307,7 @@ async fn test_apply_to_response_rewrites_v1_agent_card_root_path() {
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -342,6 +346,7 @@ async fn test_apply_to_response_skips_interface_without_url() {
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -374,6 +379,7 @@ async fn test_apply_to_response_errors_when_neither_url_field_present() {
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -613,6 +619,7 @@ async fn test_apply_to_response_rewrites_url_with_path_rewrite() {
 			// Backend (rewritten) request path — the URL rewrite policy translated
 			// /a2a/tick -> /a2a/tock before sending to the backend.
 			"/a2a/tock/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -654,6 +661,7 @@ async fn test_apply_to_response_preserves_subpath_with_path_rewrite() {
 				.parse()
 				.unwrap(),
 			"/a2a/tock/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -696,6 +704,7 @@ async fn test_apply_to_response_avoids_partial_path_segment_match() {
 				.parse()
 				.unwrap(),
 			"/internal/weather/.well-known/agent-card.json".to_string(),
+			None,
 		),
 		&mut resp,
 	)
@@ -718,6 +727,46 @@ async fn test_apply_to_response_avoids_partial_path_segment_match() {
 	assert_eq!(
 		json["supportedInterfaces"][1]["url"],
 		"http://gateway/public/weather/internal/weather-v2/jsonrpc"
+	);
+}
+
+#[tokio::test]
+async fn test_apply_to_response_uses_prefix_rewrite_context() {
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			serde_json::to_vec(&json!({
+				"name": "example",
+				"supportedInterfaces": [
+					{ "protocolBinding": "JSONRPC", "url": "https://upstream.example/svc/agent" }
+				],
+			}))
+			.unwrap(),
+		))
+		.unwrap();
+
+	apply_to_response(
+		Some(&A2aPolicy {}),
+		RequestType::AgentCard(
+			"http://gateway.example/gw/svc/agent/.well-known/agent-card.json"
+				.parse()
+				.unwrap(),
+			"/svc/agent/.well-known/agent-card.json".to_string(),
+			Some(crate::http::filters::AppliedUrlRewrite {
+				path: Some(crate::types::agent::PathRedirect::Prefix("/".into())),
+				path_match: crate::types::agent::PathMatch::PathPrefix("/gw".into()),
+			}),
+		),
+		&mut resp,
+	)
+	.await
+	.unwrap();
+
+	let body = http::read_resp_body(resp).await.unwrap();
+	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	assert_eq!(
+		json["supportedInterfaces"][0]["url"],
+		"http://gateway.example/gw/svc/agent"
 	);
 }
 

--- a/crates/agentgateway/src/http/filters.rs
+++ b/crates/agentgateway/src/http/filters.rs
@@ -213,6 +213,13 @@ pub struct UrlRewrite {
 #[derive(Debug, Clone)]
 pub struct OriginalUrl(pub Uri);
 
+/// AppliedUrlRewrite records the path-rewrite configuration that produced the current URI.
+#[derive(Debug, Clone)]
+pub struct AppliedUrlRewrite {
+	pub path: Option<PathRedirect>,
+	pub path_match: PathMatch,
+}
+
 /// AutoHostname is an HTTP Extension that signals that auto-hostname rewrite should be used.
 #[derive(Debug, Clone)]
 pub struct AutoHostname {
@@ -242,6 +249,10 @@ impl UrlRewrite {
 		let UrlRewrite { authority, path } = self;
 		let orig = req.uri().clone();
 		req.extensions_mut().insert(OriginalUrl(orig));
+		req.extensions_mut().insert(AppliedUrlRewrite {
+			path: path.clone(),
+			path_match: path_match.clone(),
+		});
 		let scheme = req.uri().scheme().cloned().unwrap_or(Scheme::HTTP);
 
 		let new_authority = rewrite_host(authority, req.uri(), Some(&scheme), &scheme)?;

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -392,7 +392,7 @@ async fn apply_backend_policies(
 		}
 		if matches!(
 			a2a_type,
-			a2a::RequestType::Call(_) | a2a::RequestType::AgentCard(_, _)
+			a2a::RequestType::Call(_) | a2a::RequestType::AgentCard(_, _, _)
 		) {
 			log.add(|l| {
 				l.backend_protocol = Some(cel::BackendProtocol::a2a);


### PR DESCRIPTION
Often times, A2A agent cards expect to be served on a well-known path at the root, so many routes in front of a2a backends use path rewriting. However, when the agent card provides a relative path to the resource, we were blindly adding the relative path to the original request's url, potentially leading to incorrect formats (e.g. double slashes or paths that otherwise didn't make sense to the backend). This PR pass through the path rewrite config as a request extension to help us later reassmble the correct path for the a2a resource. 