### PR TITLE
fix(azure/managed-identity): reject multiple identity selectors

### DIFF
--- a/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
+++ b/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
@@ -1694,3 +1694,20 @@ spec:
         - name: ca-bundle
           kind: Invalid
 ---
+_err: 'at most one of the fields in [clientId objectId resourceId] may be set'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: azure-managed-identity-multiple-identifiers
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: dummy
+  backend:
+    auth:
+      azure:
+        managedIdentity:
+          clientId: client-id
+          objectId: object-id
+---

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2144,9 +2144,7 @@ type AzureAuth struct {
 
 	// Managed identity authentication settings. Leave this object empty to use
 	// the system-assigned identity. To use a user-assigned identity, set one of
-	// `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
-	// identifiers are set, client ID takes precedence over object ID, which takes
-	// precedence over resource ID.
+	// `clientId`, `objectId`, or `resourceId`.
 	//
 	// +optional
 	ManagedIdentity *AzureManagedIdentity `json:"managedIdentity,omitempty"`
@@ -2161,9 +2159,9 @@ type AzureAuth struct {
 
 // AzureManagedIdentity configures authentication with an Azure managed
 // identity. Leave all identifiers unset to use the system-assigned identity.
-// To use a user-assigned identity, set one identifier. For compatibility, when
-// multiple identifiers are set, client ID takes precedence over object ID,
-// which takes precedence over resource ID.
+// To use a user-assigned identity, set one identifier.
+//
+// +kubebuilder:validation:AtMostOneOf=clientId;objectId;resourceId
 type AzureManagedIdentity struct {
 	// Client ID of the user-assigned managed identity.
 	//

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -4281,9 +4281,7 @@ spec:
                                             description: |-
                                               Managed identity authentication settings. Leave this object empty to use
                                               the system-assigned identity. To use a user-assigned identity, set one of
-                                              `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
-                                              identifiers are set, client ID takes precedence over object ID, which takes
-                                              precedence over resource ID.
+                                              `clientId`, `objectId`, or `resourceId`.
                                             properties:
                                               clientId:
                                                 description: Client ID of the user-assigned
@@ -4298,6 +4296,12 @@ spec:
                                                   managed identity.
                                                 type: string
                                             type: object
+                                            x-kubernetes-validations:
+                                            - message: at most one of the fields in
+                                                [clientId objectId resourceId] may
+                                                be set
+                                              rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                                <= 1'
                                           secretRef:
                                             description: |-
                                               Credential source for Azure credentials, defaulting to a Kubernetes
@@ -7559,9 +7563,7 @@ spec:
                                           description: |-
                                             Managed identity authentication settings. Leave this object empty to use
                                             the system-assigned identity. To use a user-assigned identity, set one of
-                                            `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
-                                            identifiers are set, client ID takes precedence over object ID, which takes
-                                            precedence over resource ID.
+                                            `clientId`, `objectId`, or `resourceId`.
                                           properties:
                                             clientId:
                                               description: Client ID of the user-assigned
@@ -7576,6 +7578,12 @@ spec:
                                                 managed identity.
                                               type: string
                                           type: object
+                                          x-kubernetes-validations:
+                                          - message: at most one of the fields in
+                                              [clientId objectId resourceId] may be
+                                              set
+                                            rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                              <= 1'
                                         secretRef:
                                           description: |-
                                             Credential source for Azure credentials, defaulting to a Kubernetes
@@ -13002,9 +13010,7 @@ spec:
                             description: |-
                               Managed identity authentication settings. Leave this object empty to use
                               the system-assigned identity. To use a user-assigned identity, set one of
-                              `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
-                              identifiers are set, client ID takes precedence over object ID, which takes
-                              precedence over resource ID.
+                              `clientId`, `objectId`, or `resourceId`.
                             properties:
                               clientId:
                                 description: Client ID of the user-assigned managed
@@ -13019,6 +13025,11 @@ spec:
                                   identity.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [clientId objectId
+                                resourceId] may be set
+                              rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                <= 1'
                           secretRef:
                             description: |-
                               Credential source for Azure credentials, defaulting to a Kubernetes

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -481,9 +481,7 @@ spec:
                             description: |-
                               Managed identity authentication settings. Leave this object empty to use
                               the system-assigned identity. To use a user-assigned identity, set one of
-                              `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
-                              identifiers are set, client ID takes precedence over object ID, which takes
-                              precedence over resource ID.
+                              `clientId`, `objectId`, or `resourceId`.
                             properties:
                               clientId:
                                 description: Client ID of the user-assigned managed
@@ -498,6 +496,11 @@ spec:
                                   identity.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [clientId objectId
+                                resourceId] may be set
+                              rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                <= 1'
                           secretRef:
                             description: |-
                               Credential source for Azure credentials, defaulting to a Kubernetes

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3416,9 +3416,7 @@ spec:
                             description: |-
                               Managed identity authentication settings. Leave this object empty to use
                               the system-assigned identity. To use a user-assigned identity, set one of
-                              `clientId`, `objectId`, or `resourceId`. For compatibility, when multiple
-                              identifiers are set, client ID takes precedence over object ID, which takes
-                              precedence over resource ID.
+                              `clientId`, `objectId`, or `resourceId`.
                             properties:
                               clientId:
                                 description: Client ID of the user-assigned managed
@@ -3433,6 +3431,11 @@ spec:
                                   identity.
                                 type: string
                             type: object
+                            x-kubernetes-validations:
+                            - message: at most one of the fields in [clientId objectId
+                                resourceId] may be set
+                              rule: '[has(self.clientId),has(self.objectId),has(self.resourceId)].filter(x,x==true).size()
+                                <= 1'
                           secretRef:
                             description: |-
                               Credential source for Azure credentials, defaulting to a Kubernetes

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/azureauth.yaml
@@ -12,8 +12,6 @@ spec:
     auth:
       azure:
         managedIdentity:
-          objectId: mi-object-id
-          resourceId: my-resource-id
           clientId: my-client-id
 ---
 # Output


### PR DESCRIPTION
## Summary

Azure managed identity accepts `clientId`, `objectId`, or `resourceId`, but the Kubernetes schema allowed all three at once. The controller then selected the first value by precedence and silently ignored the rest.

This adds an `AtMostOneOf` validation rule so Kubernetes rejects ambiguous configurations during admission. It also updates the generated CRDs and fixes the existing client ID fixture to use a valid single-selector configuration.

This follows up on [this comment](https://github.com/agentgateway/agentgateway/pull/3044#discussion_r3814981884).

## Verification

```console
go test ./controller/api/... ./controller/pkg/agentgateway/plugins -count=1
```
