### PR TITLE
fix(ext-authz): stop logging check responses

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -558,7 +558,6 @@ impl ExtAuthz {
 		let resp = grpc_client.check(authz_req).await;
 		drop(scope);
 
-		trace!("check response: {:?}", resp);
 		let cr = match resp {
 			Ok(response) => response,
 			Err(e) => {


### PR DESCRIPTION
## Summary

Remove a trace log that formats the full gRPC extAuth `CheckResponse`.

## Why

Successful extAuth responses can include upstream credential mutations such as `Authorization` headers. Logging the full response can expose injected bearer tokens in trace logs.

## Testing

- `rustup run 1.97 cargo fmt --all -- --check`
- `RUSTC="$(rustup which --toolchain 1.97 rustc)" rustup run 1.97 cargo test -p agentgateway --lib http::ext_authz::tests`
- `git diff --check`

π: `pi --session 019f481b` · Model: `openai/gpt-5.5`
