### PR TITLE
Support CONNECT tunneling through dynamic proxy backends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,7 +91,7 @@ mkdir /out
 mv /app/target/$(cat /build/target)/${PROFILE}/agentgateway /out
 /out/agentgateway --version || exit 1
 # Fail if version is not set
-if /out/agentgateway --version | grep -q '"unknown"'; then
+if /out/agentgateway --version | grep -q '"version": "unknown"'; then
   exit 1
 fi
 EOF

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -13824,8 +13824,10 @@ type BackendPolicySpec_BackendTunnel struct {
 	Proxy *BackendReference      `protobuf:"bytes,1,opt,name=proxy,proto3" json:"proxy,omitempty"`
 	// Inline backend policies (e.g. TLS, auth) for the tunnel proxy backend.
 	InlinePolicies []*BackendPolicySpec `protobuf:"bytes,2,rep,name=inline_policies,json=inlinePolicies,proto3" json:"inline_policies,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Use CONNECT even when the tunneled application transport is plaintext HTTP.
+	Connect       bool `protobuf:"varint,3,opt,name=connect,proto3" json:"connect,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *BackendPolicySpec_BackendTunnel) Reset() {
@@ -13870,6 +13872,13 @@ func (x *BackendPolicySpec_BackendTunnel) GetInlinePolicies() []*BackendPolicySp
 		return x.InlinePolicies
 	}
 	return nil
+}
+
+func (x *BackendPolicySpec_BackendTunnel) GetConnect() bool {
+	if x != nil {
+		return x.Connect
+	}
+	return false
 }
 
 type BackendPolicySpec_BackendTCP struct {
@@ -18448,7 +18457,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xfca\n" +
+	"\x04kind\"\x96b\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -18691,10 +18700,11 @@ const file_resource_proto_rawDesc = "" +
 	"\vHttpVersion\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05HTTP1\x10\x01\x12\t\n" +
-	"\x05HTTP2\x10\x02\x1a\xa9\x01\n" +
+	"\x05HTTP2\x10\x02\x1a\xc3\x01\n" +
 	"\rBackendTunnel\x12A\n" +
 	"\x05proxy\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\x05proxy\x12U\n" +
-	"\x0finline_policies\x18\x02 \x03(\v2,.agentgateway.dev.resource.BackendPolicySpecR\x0einlinePolicies\x1a\x9a\x01\n" +
+	"\x0finline_policies\x18\x02 \x03(\v2,.agentgateway.dev.resource.BackendPolicySpecR\x0einlinePolicies\x12\x18\n" +
+	"\aconnect\x18\x03 \x01(\bR\aconnect\x1a\x9a\x01\n" +
 	"\n" +
 	"BackendTCP\x12H\n" +
 	"\tkeepalive\x18\x01 \x01(\v2*.agentgateway.dev.resource.KeepaliveConfigR\tkeepalive\x12B\n" +

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -2104,7 +2104,7 @@ type BackendPolicySpec_BackendTunnel_Mode int32
 const (
 	// Use CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.
 	BackendPolicySpec_BackendTunnel_AUTO BackendPolicySpec_BackendTunnel_Mode = 0
-	// Always use CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.
+	// Use CONNECT for all transports, including plaintext HTTP.
 	BackendPolicySpec_BackendTunnel_CONNECT BackendPolicySpec_BackendTunnel_Mode = 1
 )
 

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -2099,6 +2099,54 @@ func (BackendPolicySpec_BackendHTTP_HttpVersion) EnumDescriptor() ([]byte, []int
 	return file_resource_proto_rawDescGZIP(), []int{58, 6, 0}
 }
 
+type BackendPolicySpec_BackendTunnel_Mode int32
+
+const (
+	// Use CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.
+	BackendPolicySpec_BackendTunnel_AUTO BackendPolicySpec_BackendTunnel_Mode = 0
+	// Always use CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.
+	BackendPolicySpec_BackendTunnel_CONNECT BackendPolicySpec_BackendTunnel_Mode = 1
+)
+
+// Enum value maps for BackendPolicySpec_BackendTunnel_Mode.
+var (
+	BackendPolicySpec_BackendTunnel_Mode_name = map[int32]string{
+		0: "AUTO",
+		1: "CONNECT",
+	}
+	BackendPolicySpec_BackendTunnel_Mode_value = map[string]int32{
+		"AUTO":    0,
+		"CONNECT": 1,
+	}
+)
+
+func (x BackendPolicySpec_BackendTunnel_Mode) Enum() *BackendPolicySpec_BackendTunnel_Mode {
+	p := new(BackendPolicySpec_BackendTunnel_Mode)
+	*p = x
+	return p
+}
+
+func (x BackendPolicySpec_BackendTunnel_Mode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (BackendPolicySpec_BackendTunnel_Mode) Descriptor() protoreflect.EnumDescriptor {
+	return file_resource_proto_enumTypes[40].Descriptor()
+}
+
+func (BackendPolicySpec_BackendTunnel_Mode) Type() protoreflect.EnumType {
+	return &file_resource_proto_enumTypes[40]
+}
+
+func (x BackendPolicySpec_BackendTunnel_Mode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use BackendPolicySpec_BackendTunnel_Mode.Descriptor instead.
+func (BackendPolicySpec_BackendTunnel_Mode) EnumDescriptor() ([]byte, []int) {
+	return file_resource_proto_rawDescGZIP(), []int{58, 7, 0}
+}
+
 type BackendPolicySpec_McpAuthentication_McpIDP int32
 
 const (
@@ -2144,11 +2192,11 @@ func (x BackendPolicySpec_McpAuthentication_McpIDP) String() string {
 }
 
 func (BackendPolicySpec_McpAuthentication_McpIDP) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[40].Descriptor()
+	return file_resource_proto_enumTypes[41].Descriptor()
 }
 
 func (BackendPolicySpec_McpAuthentication_McpIDP) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[40]
+	return &file_resource_proto_enumTypes[41]
 }
 
 func (x BackendPolicySpec_McpAuthentication_McpIDP) Number() protoreflect.EnumNumber {
@@ -2197,11 +2245,11 @@ func (x BackendPolicySpec_McpAuthentication_Mode) String() string {
 }
 
 func (BackendPolicySpec_McpAuthentication_Mode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[41].Descriptor()
+	return file_resource_proto_enumTypes[42].Descriptor()
 }
 
 func (BackendPolicySpec_McpAuthentication_Mode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[41]
+	return &file_resource_proto_enumTypes[42]
 }
 
 func (x BackendPolicySpec_McpAuthentication_Mode) Number() protoreflect.EnumNumber {
@@ -2251,11 +2299,11 @@ func (x BackendPolicySpec_McpGuardrails_Phase) String() string {
 }
 
 func (BackendPolicySpec_McpGuardrails_Phase) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[42].Descriptor()
+	return file_resource_proto_enumTypes[43].Descriptor()
 }
 
 func (BackendPolicySpec_McpGuardrails_Phase) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[42]
+	return &file_resource_proto_enumTypes[43]
 }
 
 func (x BackendPolicySpec_McpGuardrails_Phase) Number() protoreflect.EnumNumber {
@@ -2297,11 +2345,11 @@ func (x BackendPolicySpec_McpGuardrails_FailureMode) String() string {
 }
 
 func (BackendPolicySpec_McpGuardrails_FailureMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[43].Descriptor()
+	return file_resource_proto_enumTypes[44].Descriptor()
 }
 
 func (BackendPolicySpec_McpGuardrails_FailureMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[43]
+	return &file_resource_proto_enumTypes[44]
 }
 
 func (x BackendPolicySpec_McpGuardrails_FailureMode) Number() protoreflect.EnumNumber {
@@ -2343,11 +2391,11 @@ func (x AIBackend_AzureResourceType) String() string {
 }
 
 func (AIBackend_AzureResourceType) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[44].Descriptor()
+	return file_resource_proto_enumTypes[45].Descriptor()
 }
 
 func (AIBackend_AzureResourceType) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[44]
+	return &file_resource_proto_enumTypes[45]
 }
 
 func (x AIBackend_AzureResourceType) Number() protoreflect.EnumNumber {
@@ -2407,11 +2455,11 @@ func (x AIBackend_ProviderFormat) String() string {
 }
 
 func (AIBackend_ProviderFormat) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[45].Descriptor()
+	return file_resource_proto_enumTypes[46].Descriptor()
 }
 
 func (AIBackend_ProviderFormat) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[45]
+	return &file_resource_proto_enumTypes[46]
 }
 
 func (x AIBackend_ProviderFormat) Number() protoreflect.EnumNumber {
@@ -2493,11 +2541,11 @@ func (x AIBackend_ProviderPreset) String() string {
 }
 
 func (AIBackend_ProviderPreset) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[46].Descriptor()
+	return file_resource_proto_enumTypes[47].Descriptor()
 }
 
 func (AIBackend_ProviderPreset) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[46]
+	return &file_resource_proto_enumTypes[47]
 }
 
 func (x AIBackend_ProviderPreset) Number() protoreflect.EnumNumber {
@@ -2542,11 +2590,11 @@ func (x AIBackend_OpenAI_ModerationMode) String() string {
 }
 
 func (AIBackend_OpenAI_ModerationMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[47].Descriptor()
+	return file_resource_proto_enumTypes[48].Descriptor()
 }
 
 func (AIBackend_OpenAI_ModerationMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[47]
+	return &file_resource_proto_enumTypes[48]
 }
 
 func (x AIBackend_OpenAI_ModerationMode) Number() protoreflect.EnumNumber {
@@ -2588,11 +2636,11 @@ func (x MCPBackend_StatefulMode) String() string {
 }
 
 func (MCPBackend_StatefulMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[48].Descriptor()
+	return file_resource_proto_enumTypes[49].Descriptor()
 }
 
 func (MCPBackend_StatefulMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[48]
+	return &file_resource_proto_enumTypes[49]
 }
 
 func (x MCPBackend_StatefulMode) Number() protoreflect.EnumNumber {
@@ -2639,11 +2687,11 @@ func (x MCPBackend_PrefixMode) String() string {
 }
 
 func (MCPBackend_PrefixMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[49].Descriptor()
+	return file_resource_proto_enumTypes[50].Descriptor()
 }
 
 func (MCPBackend_PrefixMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[49]
+	return &file_resource_proto_enumTypes[50]
 }
 
 func (x MCPBackend_PrefixMode) Number() protoreflect.EnumNumber {
@@ -2687,11 +2735,11 @@ func (x MCPBackend_FailureMode) String() string {
 }
 
 func (MCPBackend_FailureMode) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[50].Descriptor()
+	return file_resource_proto_enumTypes[51].Descriptor()
 }
 
 func (MCPBackend_FailureMode) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[50]
+	return &file_resource_proto_enumTypes[51]
 }
 
 func (x MCPBackend_FailureMode) Number() protoreflect.EnumNumber {
@@ -2736,11 +2784,11 @@ func (x MCPTarget_Protocol) String() string {
 }
 
 func (MCPTarget_Protocol) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[51].Descriptor()
+	return file_resource_proto_enumTypes[52].Descriptor()
 }
 
 func (MCPTarget_Protocol) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[51]
+	return &file_resource_proto_enumTypes[52]
 }
 
 func (x MCPTarget_Protocol) Number() protoreflect.EnumNumber {
@@ -2788,11 +2836,11 @@ func (x OAuthClientAuth_Method) String() string {
 }
 
 func (OAuthClientAuth_Method) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[52].Descriptor()
+	return file_resource_proto_enumTypes[53].Descriptor()
 }
 
 func (OAuthClientAuth_Method) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[52]
+	return &file_resource_proto_enumTypes[53]
 }
 
 func (x OAuthClientAuth_Method) Number() protoreflect.EnumNumber {
@@ -2837,11 +2885,11 @@ func (x OAuthClientAuth_PrivateKeyJwt_CertificateHeader) String() string {
 }
 
 func (OAuthClientAuth_PrivateKeyJwt_CertificateHeader) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[53].Descriptor()
+	return file_resource_proto_enumTypes[54].Descriptor()
 }
 
 func (OAuthClientAuth_PrivateKeyJwt_CertificateHeader) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[53]
+	return &file_resource_proto_enumTypes[54]
 }
 
 func (x OAuthClientAuth_PrivateKeyJwt_CertificateHeader) Number() protoreflect.EnumNumber {
@@ -2886,11 +2934,11 @@ func (x OAuthTokenExchange_GrantType) String() string {
 }
 
 func (OAuthTokenExchange_GrantType) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[54].Descriptor()
+	return file_resource_proto_enumTypes[55].Descriptor()
 }
 
 func (OAuthTokenExchange_GrantType) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[54]
+	return &file_resource_proto_enumTypes[55]
 }
 
 func (x OAuthTokenExchange_GrantType) Number() protoreflect.EnumNumber {
@@ -2932,11 +2980,11 @@ func (x ModelRoute_ConcreteModel_ModelVisibility) String() string {
 }
 
 func (ModelRoute_ConcreteModel_ModelVisibility) Descriptor() protoreflect.EnumDescriptor {
-	return file_resource_proto_enumTypes[55].Descriptor()
+	return file_resource_proto_enumTypes[56].Descriptor()
 }
 
 func (ModelRoute_ConcreteModel_ModelVisibility) Type() protoreflect.EnumType {
-	return &file_resource_proto_enumTypes[55]
+	return &file_resource_proto_enumTypes[56]
 }
 
 func (x ModelRoute_ConcreteModel_ModelVisibility) Number() protoreflect.EnumNumber {
@@ -13823,11 +13871,10 @@ type BackendPolicySpec_BackendTunnel struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Proxy *BackendReference      `protobuf:"bytes,1,opt,name=proxy,proto3" json:"proxy,omitempty"`
 	// Inline backend policies (e.g. TLS, auth) for the tunnel proxy backend.
-	InlinePolicies []*BackendPolicySpec `protobuf:"bytes,2,rep,name=inline_policies,json=inlinePolicies,proto3" json:"inline_policies,omitempty"`
-	// Use CONNECT even when the tunneled application transport is plaintext HTTP.
-	Connect       bool `protobuf:"varint,3,opt,name=connect,proto3" json:"connect,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	InlinePolicies []*BackendPolicySpec                 `protobuf:"bytes,2,rep,name=inline_policies,json=inlinePolicies,proto3" json:"inline_policies,omitempty"`
+	Mode           BackendPolicySpec_BackendTunnel_Mode `protobuf:"varint,3,opt,name=mode,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_BackendTunnel_Mode" json:"mode,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *BackendPolicySpec_BackendTunnel) Reset() {
@@ -13874,11 +13921,11 @@ func (x *BackendPolicySpec_BackendTunnel) GetInlinePolicies() []*BackendPolicySp
 	return nil
 }
 
-func (x *BackendPolicySpec_BackendTunnel) GetConnect() bool {
+func (x *BackendPolicySpec_BackendTunnel) GetMode() BackendPolicySpec_BackendTunnel_Mode {
 	if x != nil {
-		return x.Connect
+		return x.Mode
 	}
-	return false
+	return BackendPolicySpec_BackendTunnel_AUTO
 }
 
 type BackendPolicySpec_BackendTCP struct {
@@ -18457,7 +18504,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\x96b\n" +
+	"\x04kind\"\xf0b\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -18700,11 +18747,14 @@ const file_resource_proto_rawDesc = "" +
 	"\vHttpVersion\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05HTTP1\x10\x01\x12\t\n" +
-	"\x05HTTP2\x10\x02\x1a\xc3\x01\n" +
+	"\x05HTTP2\x10\x02\x1a\x9d\x02\n" +
 	"\rBackendTunnel\x12A\n" +
 	"\x05proxy\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\x05proxy\x12U\n" +
-	"\x0finline_policies\x18\x02 \x03(\v2,.agentgateway.dev.resource.BackendPolicySpecR\x0einlinePolicies\x12\x18\n" +
-	"\aconnect\x18\x03 \x01(\bR\aconnect\x1a\x9a\x01\n" +
+	"\x0finline_policies\x18\x02 \x03(\v2,.agentgateway.dev.resource.BackendPolicySpecR\x0einlinePolicies\x12S\n" +
+	"\x04mode\x18\x03 \x01(\x0e2?.agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.ModeR\x04mode\"\x1d\n" +
+	"\x04Mode\x12\b\n" +
+	"\x04AUTO\x10\x00\x12\v\n" +
+	"\aCONNECT\x10\x01\x1a\x9a\x01\n" +
 	"\n" +
 	"BackendTCP\x12H\n" +
 	"\tkeepalive\x18\x01 \x01(\v2*.agentgateway.dev.resource.KeepaliveConfigR\tkeepalive\x12B\n" +
@@ -19131,7 +19181,7 @@ func file_resource_proto_rawDescGZIP() []byte {
 	return file_resource_proto_rawDescData
 }
 
-var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 56)
+var file_resource_proto_enumTypes = make([]protoimpl.EnumInfo, 57)
 var file_resource_proto_msgTypes = make([]protoimpl.MessageInfo, 214)
 var file_resource_proto_goTypes = []any{
 	(Protocol)(0),                                               // 0: agentgateway.dev.resource.Protocol
@@ -19174,641 +19224,643 @@ var file_resource_proto_goTypes = []any{
 	(BackendPolicySpec_BackendTLS_VerificationMode)(0),          // 37: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
 	(BackendPolicySpec_BackendTLS_CertificateSource)(0),         // 38: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.CertificateSource
 	(BackendPolicySpec_BackendHTTP_HttpVersion)(0),              // 39: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	(BackendPolicySpec_McpAuthentication_McpIDP)(0),             // 40: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	(BackendPolicySpec_McpAuthentication_Mode)(0),               // 41: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	(BackendPolicySpec_McpGuardrails_Phase)(0),                  // 42: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
-	(BackendPolicySpec_McpGuardrails_FailureMode)(0),            // 43: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
-	(AIBackend_AzureResourceType)(0),                            // 44: agentgateway.dev.resource.AIBackend.AzureResourceType
-	(AIBackend_ProviderFormat)(0),                               // 45: agentgateway.dev.resource.AIBackend.ProviderFormat
-	(AIBackend_ProviderPreset)(0),                               // 46: agentgateway.dev.resource.AIBackend.ProviderPreset
-	(AIBackend_OpenAI_ModerationMode)(0),                        // 47: agentgateway.dev.resource.AIBackend.OpenAI.ModerationMode
-	(MCPBackend_StatefulMode)(0),                                // 48: agentgateway.dev.resource.MCPBackend.StatefulMode
-	(MCPBackend_PrefixMode)(0),                                  // 49: agentgateway.dev.resource.MCPBackend.PrefixMode
-	(MCPBackend_FailureMode)(0),                                 // 50: agentgateway.dev.resource.MCPBackend.FailureMode
-	(MCPTarget_Protocol)(0),                                     // 51: agentgateway.dev.resource.MCPTarget.Protocol
-	(OAuthClientAuth_Method)(0),                                 // 52: agentgateway.dev.resource.OAuthClientAuth.Method
-	(OAuthClientAuth_PrivateKeyJwt_CertificateHeader)(0),        // 53: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
-	(OAuthTokenExchange_GrantType)(0),                           // 54: agentgateway.dev.resource.OAuthTokenExchange.GrantType
-	(ModelRoute_ConcreteModel_ModelVisibility)(0),               // 55: agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
-	(*Resource)(nil),                                            // 56: agentgateway.dev.resource.Resource
-	(*Bind)(nil),                                                // 57: agentgateway.dev.resource.Bind
-	(*RouteName)(nil),                                           // 58: agentgateway.dev.resource.RouteName
-	(*ListenerName)(nil),                                        // 59: agentgateway.dev.resource.ListenerName
-	(*ResourceName)(nil),                                        // 60: agentgateway.dev.resource.ResourceName
-	(*TypedResourceName)(nil),                                   // 61: agentgateway.dev.resource.TypedResourceName
-	(*Listener)(nil),                                            // 62: agentgateway.dev.resource.Listener
-	(*Route)(nil),                                               // 63: agentgateway.dev.resource.Route
-	(*RouteGroup)(nil),                                          // 64: agentgateway.dev.resource.RouteGroup
-	(*TCPRoute)(nil),                                            // 65: agentgateway.dev.resource.TCPRoute
-	(*ConditionalPolicies)(nil),                                 // 66: agentgateway.dev.resource.ConditionalPolicies
-	(*ConditionalPolicy)(nil),                                   // 67: agentgateway.dev.resource.ConditionalPolicy
-	(*Policy)(nil),                                              // 68: agentgateway.dev.resource.Policy
-	(*Backend)(nil),                                             // 69: agentgateway.dev.resource.Backend
-	(*ModelRouterBackend)(nil),                                  // 70: agentgateway.dev.resource.ModelRouterBackend
-	(*GuardrailBackend)(nil),                                    // 71: agentgateway.dev.resource.GuardrailBackend
-	(*TLSConfig)(nil),                                           // 72: agentgateway.dev.resource.TLSConfig
-	(*Timeout)(nil),                                             // 73: agentgateway.dev.resource.Timeout
-	(*Retry)(nil),                                               // 74: agentgateway.dev.resource.Retry
-	(*Delay)(nil),                                               // 75: agentgateway.dev.resource.Delay
-	(*BackendAuthPolicy)(nil),                                   // 76: agentgateway.dev.resource.BackendAuthPolicy
-	(*BackendAuthCredential)(nil),                               // 77: agentgateway.dev.resource.BackendAuthCredential
-	(*AuthorizationLocation)(nil),                               // 78: agentgateway.dev.resource.AuthorizationLocation
-	(*Passthrough)(nil),                                         // 79: agentgateway.dev.resource.Passthrough
-	(*Key)(nil),                                                 // 80: agentgateway.dev.resource.Key
-	(*JwtSign)(nil),                                             // 81: agentgateway.dev.resource.JwtSign
-	(*Gcp)(nil),                                                 // 82: agentgateway.dev.resource.Gcp
-	(*Aws)(nil),                                                 // 83: agentgateway.dev.resource.Aws
-	(*Azure)(nil),                                               // 84: agentgateway.dev.resource.Azure
-	(*AwsExplicitConfig)(nil),                                   // 85: agentgateway.dev.resource.AwsExplicitConfig
-	(*AwsImplicit)(nil),                                         // 86: agentgateway.dev.resource.AwsImplicit
-	(*AwsAssumeRole)(nil),                                       // 87: agentgateway.dev.resource.AwsAssumeRole
-	(*AwsSessionTag)(nil),                                       // 88: agentgateway.dev.resource.AwsSessionTag
-	(*AzureExplicitConfig)(nil),                                 // 89: agentgateway.dev.resource.AzureExplicitConfig
-	(*AzureClientSecret)(nil),                                   // 90: agentgateway.dev.resource.AzureClientSecret
-	(*AzureManagedIdentityCredential)(nil),                      // 91: agentgateway.dev.resource.AzureManagedIdentityCredential
-	(*AzureWorkloadIdentityCredential)(nil),                     // 92: agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	(*AzureDeveloperImplicit)(nil),                              // 93: agentgateway.dev.resource.AzureDeveloperImplicit
-	(*AzureImplicit)(nil),                                       // 94: agentgateway.dev.resource.AzureImplicit
-	(*RouteMatch)(nil),                                          // 95: agentgateway.dev.resource.RouteMatch
-	(*PathMatch)(nil),                                           // 96: agentgateway.dev.resource.PathMatch
-	(*QueryMatch)(nil),                                          // 97: agentgateway.dev.resource.QueryMatch
-	(*MethodMatch)(nil),                                         // 98: agentgateway.dev.resource.MethodMatch
-	(*HeaderMatch)(nil),                                         // 99: agentgateway.dev.resource.HeaderMatch
-	(*CORS)(nil),                                                // 100: agentgateway.dev.resource.CORS
-	(*DirectResponse)(nil),                                      // 101: agentgateway.dev.resource.DirectResponse
-	(*ExpressionHeader)(nil),                                    // 102: agentgateway.dev.resource.ExpressionHeader
-	(*HeaderModifier)(nil),                                      // 103: agentgateway.dev.resource.HeaderModifier
-	(*RequestMirrors)(nil),                                      // 104: agentgateway.dev.resource.RequestMirrors
-	(*RequestRedirect)(nil),                                     // 105: agentgateway.dev.resource.RequestRedirect
-	(*UrlRewrite)(nil),                                          // 106: agentgateway.dev.resource.UrlRewrite
-	(*Header)(nil),                                              // 107: agentgateway.dev.resource.Header
-	(*RouteBackend)(nil),                                        // 108: agentgateway.dev.resource.RouteBackend
-	(*PolicyTarget)(nil),                                        // 109: agentgateway.dev.resource.PolicyTarget
-	(*KeepaliveConfig)(nil),                                     // 110: agentgateway.dev.resource.KeepaliveConfig
-	(*FrontendPolicySpec)(nil),                                  // 111: agentgateway.dev.resource.FrontendPolicySpec
-	(*JWTValidationOptions)(nil),                                // 112: agentgateway.dev.resource.JWTValidationOptions
-	(*TrafficPolicySpec)(nil),                                   // 113: agentgateway.dev.resource.TrafficPolicySpec
-	(*BackendPolicySpec)(nil),                                   // 114: agentgateway.dev.resource.BackendPolicySpec
-	(*StaticBackend)(nil),                                       // 115: agentgateway.dev.resource.StaticBackend
-	(*DynamicForwardProxy)(nil),                                 // 116: agentgateway.dev.resource.DynamicForwardProxy
-	(*AwsBackend)(nil),                                          // 117: agentgateway.dev.resource.AwsBackend
-	(*AwsAgentCoreBackend)(nil),                                 // 118: agentgateway.dev.resource.AwsAgentCoreBackend
-	(*AIBackend)(nil),                                           // 119: agentgateway.dev.resource.AIBackend
-	(*MCPBackend)(nil),                                          // 120: agentgateway.dev.resource.MCPBackend
-	(*MCPTarget)(nil),                                           // 121: agentgateway.dev.resource.MCPTarget
-	(*BackendReference)(nil),                                    // 122: agentgateway.dev.resource.BackendReference
-	(*Alpn)(nil),                                                // 123: agentgateway.dev.resource.Alpn
-	(*OAuthClientAuth)(nil),                                     // 124: agentgateway.dev.resource.OAuthClientAuth
-	(*OAuthTokenExchange)(nil),                                  // 125: agentgateway.dev.resource.OAuthTokenExchange
-	(*CrossAppAccessAuth)(nil),                                  // 126: agentgateway.dev.resource.CrossAppAccessAuth
-	(*ModelRoute)(nil),                                          // 127: agentgateway.dev.resource.ModelRoute
-	(*GuardrailBackend_Bedrock)(nil),                            // 128: agentgateway.dev.resource.GuardrailBackend.Bedrock
-	(*GuardrailBackend_GoogleModelArmor)(nil),                   // 129: agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
-	(*GuardrailBackend_AzureContentSafety)(nil),                 // 130: agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
-	(*GuardrailBackend_OpenAIModeration)(nil),                   // 131: agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
-	(*AuthorizationLocation_Header)(nil),                        // 132: agentgateway.dev.resource.AuthorizationLocation.Header
-	(*AuthorizationLocation_QueryParameter)(nil),                // 133: agentgateway.dev.resource.AuthorizationLocation.QueryParameter
-	(*AuthorizationLocation_Cookie)(nil),                        // 134: agentgateway.dev.resource.AuthorizationLocation.Cookie
-	nil,                                                         // 135: agentgateway.dev.resource.JwtSign.ClaimsEntry
-	(*Gcp_AccessToken)(nil),                                     // 136: agentgateway.dev.resource.Gcp.AccessToken
-	(*Gcp_IdToken)(nil),                                         // 137: agentgateway.dev.resource.Gcp.IdToken
-	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 138: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	(*RequestMirrors_Mirror)(nil),                               // 139: agentgateway.dev.resource.RequestMirrors.Mirror
-	(*PolicyTarget_ServiceTarget)(nil),                          // 140: agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	(*PolicyTarget_BackendTarget)(nil),                          // 141: agentgateway.dev.resource.PolicyTarget.BackendTarget
-	(*PolicyTarget_GatewayTarget)(nil),                          // 142: agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	(*PolicyTarget_RouteTarget)(nil),                            // 143: agentgateway.dev.resource.PolicyTarget.RouteTarget
-	(*PolicyTarget_ListenerSetTarget)(nil),                      // 144: agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
-	(*FrontendPolicySpec_HTTP)(nil),                             // 145: agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	(*FrontendPolicySpec_TLS)(nil),                              // 146: agentgateway.dev.resource.FrontendPolicySpec.TLS
-	(*FrontendPolicySpec_TCP)(nil),                              // 147: agentgateway.dev.resource.FrontendPolicySpec.TCP
-	(*FrontendPolicySpec_NetworkAuthorization)(nil),             // 148: agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
-	(*FrontendPolicySpec_Logging)(nil),                          // 149: agentgateway.dev.resource.FrontendPolicySpec.Logging
-	(*FrontendPolicySpec_Tracing)(nil),                          // 150: agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 151: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	(*FrontendPolicySpec_ProxyProtocol)(nil),                    // 152: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
-	(*FrontendPolicySpec_Connect)(nil),                          // 153: agentgateway.dev.resource.FrontendPolicySpec.Connect
-	(*FrontendPolicySpec_Metrics)(nil),                          // 154: agentgateway.dev.resource.FrontendPolicySpec.Metrics
-	(*FrontendPolicySpec_Logging_Field)(nil),                    // 155: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 156: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 157: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	(*FrontendPolicySpec_Metrics_Field)(nil),                    // 158: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
-	(*FrontendPolicySpec_Metrics_Fields)(nil),                   // 159: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
-	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 160: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 161: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 162: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	(*TrafficPolicySpec_RBAC)(nil),                              // 163: agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	(*TrafficPolicySpec_JWTProvider)(nil),                       // 164: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	(*TrafficPolicySpec_JWT)(nil),                               // 165: agentgateway.dev.resource.TrafficPolicySpec.JWT
-	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 166: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	(*TrafficPolicySpec_APIKey)(nil),                            // 167: agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 168: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 169: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	(*TrafficPolicySpec_BodyTransformation)(nil),                // 170: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	(*TrafficPolicySpec_CSRF)(nil),                              // 171: agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	(*TrafficPolicySpec_ExtProc)(nil),                           // 172: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	(*TrafficPolicySpec_HostRewrite)(nil),                       // 173: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	(*TrafficPolicySpec_Buffer)(nil),                            // 174: agentgateway.dev.resource.TrafficPolicySpec.Buffer
-	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 175: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 176: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
-	(*TrafficPolicySpec_LocalRateLimit_Rule)(nil),               // 177: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Rule
-	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 178: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	(*TrafficPolicySpec_ExternalAuth_Cache)(nil),                // 179: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
-	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 180: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 181: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
-	nil,                                   // 182: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	nil,                                   // 183: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	nil,                                   // 184: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	nil,                                   // 185: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	(*TrafficPolicySpec_JWT_MCP)(nil),     // 186: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
-	(*TrafficPolicySpec_APIKey_User)(nil), // 187: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
-	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 188: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	nil, // 189: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	nil, // 190: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	nil, // 191: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 192: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
-	(*TrafficPolicySpec_ExtProc_ProcessingOptions)(nil),         // 193: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
-	nil, // 194: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	nil, // 195: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
-	(*TrafficPolicySpec_Buffer_BufferBody)(nil),     // 196: agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
-	(*BackendPolicySpec_Ai)(nil),                    // 197: agentgateway.dev.resource.BackendPolicySpec.Ai
-	(*BackendPolicySpec_A2A)(nil),                   // 198: agentgateway.dev.resource.BackendPolicySpec.A2a
-	(*BackendPolicySpec_InferenceRouting)(nil),      // 199: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	(*BackendPolicySpec_Eviction)(nil),              // 200: agentgateway.dev.resource.BackendPolicySpec.Eviction
-	(*BackendPolicySpec_Health)(nil),                // 201: agentgateway.dev.resource.BackendPolicySpec.Health
-	(*BackendPolicySpec_BackendTLS)(nil),            // 202: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	(*BackendPolicySpec_BackendHTTP)(nil),           // 203: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	(*BackendPolicySpec_BackendTunnel)(nil),         // 204: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	(*BackendPolicySpec_BackendTCP)(nil),            // 205: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	(*BackendPolicySpec_McpAuthorization)(nil),      // 206: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	(*BackendPolicySpec_McpAuthentication)(nil),     // 207: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	(*BackendPolicySpec_McpGuardrails)(nil),         // 208: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
-	(*BackendPolicySpec_Ai_Message)(nil),            // 209: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),   // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	(*BackendPolicySpec_Ai_RegexRule)(nil),          // 211: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	(*BackendPolicySpec_Ai_RegexRules)(nil),         // 212: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	(*BackendPolicySpec_Ai_Webhook)(nil),            // 213: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	(*BackendPolicySpec_Ai_Moderation)(nil),         // 214: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil),  // 215: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),   // 216: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	(*BackendPolicySpec_Ai_AzureContentSafety)(nil), // 217: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	(*BackendPolicySpec_Ai_RequestRejection)(nil),   // 218: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	(*BackendPolicySpec_Ai_ResponseGuard)(nil),      // 219: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	(*BackendPolicySpec_Ai_RequestGuard)(nil),       // 220: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	(*BackendPolicySpec_Ai_PromptGuard)(nil),        // 221: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	(*BackendPolicySpec_Ai_PromptCaching)(nil),      // 222: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	nil, // 223: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	nil, // 224: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	nil, // 225: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	nil, // 226: agentgateway.dev.resource.BackendPolicySpec.Ai.FinalTransformationsEntry
-	nil, // 227: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	nil, // 228: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	nil, // 229: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
-	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 230: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	nil, // 231: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	(*BackendPolicySpec_McpGuardrails_Remote)(nil),    // 232: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	(*BackendPolicySpec_McpGuardrails_Processor)(nil), // 233: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	nil,                                                // 234: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	nil,                                                // 235: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
-	(*AIBackend_HostOverride)(nil),                     // 236: agentgateway.dev.resource.AIBackend.HostOverride
-	(*AIBackend_OpenAI)(nil),                           // 237: agentgateway.dev.resource.AIBackend.OpenAI
-	(*AIBackend_Gemini)(nil),                           // 238: agentgateway.dev.resource.AIBackend.Gemini
-	(*AIBackend_Vertex)(nil),                           // 239: agentgateway.dev.resource.AIBackend.Vertex
-	(*AIBackend_Anthropic)(nil),                        // 240: agentgateway.dev.resource.AIBackend.Anthropic
-	(*AIBackend_Bedrock)(nil),                          // 241: agentgateway.dev.resource.AIBackend.Bedrock
-	(*AIBackend_AzureOpenAI)(nil),                      // 242: agentgateway.dev.resource.AIBackend.AzureOpenAI
-	(*AIBackend_Azure)(nil),                            // 243: agentgateway.dev.resource.AIBackend.Azure
-	(*AIBackend_ProviderFormatConfig)(nil),             // 244: agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	(*AIBackend_Custom)(nil),                           // 245: agentgateway.dev.resource.AIBackend.Custom
-	(*AIBackend_Provider)(nil),                         // 246: agentgateway.dev.resource.AIBackend.Provider
-	(*AIBackend_ProviderGroup)(nil),                    // 247: agentgateway.dev.resource.AIBackend.ProviderGroup
-	(*AIBackend_OpenAI_Moderation)(nil),                // 248: agentgateway.dev.resource.AIBackend.OpenAI.Moderation
-	(*AIBackend_OpenAI_ModerationPolicy)(nil),          // 249: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy
-	(*AIBackend_OpenAI_ModerationConfig)(nil),          // 250: agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
-	(*BackendReference_Service)(nil),                   // 251: agentgateway.dev.resource.BackendReference.Service
-	(*BackendReference_Inline)(nil),                    // 252: agentgateway.dev.resource.BackendReference.Inline
-	(*OAuthClientAuth_PrivateKeyJwt)(nil),              // 253: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt
-	(*OAuthTokenExchange_TokenSpec)(nil),               // 254: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec
-	(*OAuthTokenExchange_ActorToken)(nil),              // 255: agentgateway.dev.resource.OAuthTokenExchange.ActorToken
-	nil,                                                // 256: agentgateway.dev.resource.OAuthTokenExchange.AdditionalParamsEntry
-	(*OAuthTokenExchange_TokenCache)(nil),              // 257: agentgateway.dev.resource.OAuthTokenExchange.TokenCache
-	(*OAuthTokenExchange_TokenCache_InMemory)(nil),     // 258: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
-	(*CrossAppAccessAuth_ScopeOverride)(nil),           // 259: agentgateway.dev.resource.CrossAppAccessAuth.ScopeOverride
-	(*CrossAppAccessAuth_Endpoint)(nil),                // 260: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
-	(*CrossAppAccessAuth_SubjectToken)(nil),            // 261: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken
-	(*ModelRoute_Match)(nil),                           // 262: agentgateway.dev.resource.ModelRoute.Match
-	(*ModelRoute_VirtualModel)(nil),                    // 263: agentgateway.dev.resource.ModelRoute.VirtualModel
-	(*ModelRoute_ConcreteModel)(nil),                   // 264: agentgateway.dev.resource.ModelRoute.ConcreteModel
-	(*ModelRoute_VirtualModel_Weighted)(nil),           // 265: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
-	(*ModelRoute_VirtualModel_Conditional)(nil),        // 266: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
-	(*ModelRoute_VirtualModel_Failover)(nil),           // 267: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
-	(*ModelRoute_VirtualModel_Weighted_Target)(nil),    // 268: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
-	(*ModelRoute_VirtualModel_Conditional_Target)(nil), // 269: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
-	(*workloadapi.Workload)(nil),                       // 270: istio.workload.Workload
-	(*workloadapi.Service)(nil),                        // 271: istio.workload.Service
-	(*workloadapi.NamespacedHostname)(nil),             // 272: istio.workload.NamespacedHostname
-	(*durationpb.Duration)(nil),                        // 273: google.protobuf.Duration
-	(*structpb.Value)(nil),                             // 274: google.protobuf.Value
-	(*structpb.Struct)(nil),                            // 275: google.protobuf.Struct
+	(BackendPolicySpec_BackendTunnel_Mode)(0),                   // 40: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.Mode
+	(BackendPolicySpec_McpAuthentication_McpIDP)(0),             // 41: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	(BackendPolicySpec_McpAuthentication_Mode)(0),               // 42: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	(BackendPolicySpec_McpGuardrails_Phase)(0),                  // 43: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
+	(BackendPolicySpec_McpGuardrails_FailureMode)(0),            // 44: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
+	(AIBackend_AzureResourceType)(0),                            // 45: agentgateway.dev.resource.AIBackend.AzureResourceType
+	(AIBackend_ProviderFormat)(0),                               // 46: agentgateway.dev.resource.AIBackend.ProviderFormat
+	(AIBackend_ProviderPreset)(0),                               // 47: agentgateway.dev.resource.AIBackend.ProviderPreset
+	(AIBackend_OpenAI_ModerationMode)(0),                        // 48: agentgateway.dev.resource.AIBackend.OpenAI.ModerationMode
+	(MCPBackend_StatefulMode)(0),                                // 49: agentgateway.dev.resource.MCPBackend.StatefulMode
+	(MCPBackend_PrefixMode)(0),                                  // 50: agentgateway.dev.resource.MCPBackend.PrefixMode
+	(MCPBackend_FailureMode)(0),                                 // 51: agentgateway.dev.resource.MCPBackend.FailureMode
+	(MCPTarget_Protocol)(0),                                     // 52: agentgateway.dev.resource.MCPTarget.Protocol
+	(OAuthClientAuth_Method)(0),                                 // 53: agentgateway.dev.resource.OAuthClientAuth.Method
+	(OAuthClientAuth_PrivateKeyJwt_CertificateHeader)(0),        // 54: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
+	(OAuthTokenExchange_GrantType)(0),                           // 55: agentgateway.dev.resource.OAuthTokenExchange.GrantType
+	(ModelRoute_ConcreteModel_ModelVisibility)(0),               // 56: agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
+	(*Resource)(nil),                                            // 57: agentgateway.dev.resource.Resource
+	(*Bind)(nil),                                                // 58: agentgateway.dev.resource.Bind
+	(*RouteName)(nil),                                           // 59: agentgateway.dev.resource.RouteName
+	(*ListenerName)(nil),                                        // 60: agentgateway.dev.resource.ListenerName
+	(*ResourceName)(nil),                                        // 61: agentgateway.dev.resource.ResourceName
+	(*TypedResourceName)(nil),                                   // 62: agentgateway.dev.resource.TypedResourceName
+	(*Listener)(nil),                                            // 63: agentgateway.dev.resource.Listener
+	(*Route)(nil),                                               // 64: agentgateway.dev.resource.Route
+	(*RouteGroup)(nil),                                          // 65: agentgateway.dev.resource.RouteGroup
+	(*TCPRoute)(nil),                                            // 66: agentgateway.dev.resource.TCPRoute
+	(*ConditionalPolicies)(nil),                                 // 67: agentgateway.dev.resource.ConditionalPolicies
+	(*ConditionalPolicy)(nil),                                   // 68: agentgateway.dev.resource.ConditionalPolicy
+	(*Policy)(nil),                                              // 69: agentgateway.dev.resource.Policy
+	(*Backend)(nil),                                             // 70: agentgateway.dev.resource.Backend
+	(*ModelRouterBackend)(nil),                                  // 71: agentgateway.dev.resource.ModelRouterBackend
+	(*GuardrailBackend)(nil),                                    // 72: agentgateway.dev.resource.GuardrailBackend
+	(*TLSConfig)(nil),                                           // 73: agentgateway.dev.resource.TLSConfig
+	(*Timeout)(nil),                                             // 74: agentgateway.dev.resource.Timeout
+	(*Retry)(nil),                                               // 75: agentgateway.dev.resource.Retry
+	(*Delay)(nil),                                               // 76: agentgateway.dev.resource.Delay
+	(*BackendAuthPolicy)(nil),                                   // 77: agentgateway.dev.resource.BackendAuthPolicy
+	(*BackendAuthCredential)(nil),                               // 78: agentgateway.dev.resource.BackendAuthCredential
+	(*AuthorizationLocation)(nil),                               // 79: agentgateway.dev.resource.AuthorizationLocation
+	(*Passthrough)(nil),                                         // 80: agentgateway.dev.resource.Passthrough
+	(*Key)(nil),                                                 // 81: agentgateway.dev.resource.Key
+	(*JwtSign)(nil),                                             // 82: agentgateway.dev.resource.JwtSign
+	(*Gcp)(nil),                                                 // 83: agentgateway.dev.resource.Gcp
+	(*Aws)(nil),                                                 // 84: agentgateway.dev.resource.Aws
+	(*Azure)(nil),                                               // 85: agentgateway.dev.resource.Azure
+	(*AwsExplicitConfig)(nil),                                   // 86: agentgateway.dev.resource.AwsExplicitConfig
+	(*AwsImplicit)(nil),                                         // 87: agentgateway.dev.resource.AwsImplicit
+	(*AwsAssumeRole)(nil),                                       // 88: agentgateway.dev.resource.AwsAssumeRole
+	(*AwsSessionTag)(nil),                                       // 89: agentgateway.dev.resource.AwsSessionTag
+	(*AzureExplicitConfig)(nil),                                 // 90: agentgateway.dev.resource.AzureExplicitConfig
+	(*AzureClientSecret)(nil),                                   // 91: agentgateway.dev.resource.AzureClientSecret
+	(*AzureManagedIdentityCredential)(nil),                      // 92: agentgateway.dev.resource.AzureManagedIdentityCredential
+	(*AzureWorkloadIdentityCredential)(nil),                     // 93: agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	(*AzureDeveloperImplicit)(nil),                              // 94: agentgateway.dev.resource.AzureDeveloperImplicit
+	(*AzureImplicit)(nil),                                       // 95: agentgateway.dev.resource.AzureImplicit
+	(*RouteMatch)(nil),                                          // 96: agentgateway.dev.resource.RouteMatch
+	(*PathMatch)(nil),                                           // 97: agentgateway.dev.resource.PathMatch
+	(*QueryMatch)(nil),                                          // 98: agentgateway.dev.resource.QueryMatch
+	(*MethodMatch)(nil),                                         // 99: agentgateway.dev.resource.MethodMatch
+	(*HeaderMatch)(nil),                                         // 100: agentgateway.dev.resource.HeaderMatch
+	(*CORS)(nil),                                                // 101: agentgateway.dev.resource.CORS
+	(*DirectResponse)(nil),                                      // 102: agentgateway.dev.resource.DirectResponse
+	(*ExpressionHeader)(nil),                                    // 103: agentgateway.dev.resource.ExpressionHeader
+	(*HeaderModifier)(nil),                                      // 104: agentgateway.dev.resource.HeaderModifier
+	(*RequestMirrors)(nil),                                      // 105: agentgateway.dev.resource.RequestMirrors
+	(*RequestRedirect)(nil),                                     // 106: agentgateway.dev.resource.RequestRedirect
+	(*UrlRewrite)(nil),                                          // 107: agentgateway.dev.resource.UrlRewrite
+	(*Header)(nil),                                              // 108: agentgateway.dev.resource.Header
+	(*RouteBackend)(nil),                                        // 109: agentgateway.dev.resource.RouteBackend
+	(*PolicyTarget)(nil),                                        // 110: agentgateway.dev.resource.PolicyTarget
+	(*KeepaliveConfig)(nil),                                     // 111: agentgateway.dev.resource.KeepaliveConfig
+	(*FrontendPolicySpec)(nil),                                  // 112: agentgateway.dev.resource.FrontendPolicySpec
+	(*JWTValidationOptions)(nil),                                // 113: agentgateway.dev.resource.JWTValidationOptions
+	(*TrafficPolicySpec)(nil),                                   // 114: agentgateway.dev.resource.TrafficPolicySpec
+	(*BackendPolicySpec)(nil),                                   // 115: agentgateway.dev.resource.BackendPolicySpec
+	(*StaticBackend)(nil),                                       // 116: agentgateway.dev.resource.StaticBackend
+	(*DynamicForwardProxy)(nil),                                 // 117: agentgateway.dev.resource.DynamicForwardProxy
+	(*AwsBackend)(nil),                                          // 118: agentgateway.dev.resource.AwsBackend
+	(*AwsAgentCoreBackend)(nil),                                 // 119: agentgateway.dev.resource.AwsAgentCoreBackend
+	(*AIBackend)(nil),                                           // 120: agentgateway.dev.resource.AIBackend
+	(*MCPBackend)(nil),                                          // 121: agentgateway.dev.resource.MCPBackend
+	(*MCPTarget)(nil),                                           // 122: agentgateway.dev.resource.MCPTarget
+	(*BackendReference)(nil),                                    // 123: agentgateway.dev.resource.BackendReference
+	(*Alpn)(nil),                                                // 124: agentgateway.dev.resource.Alpn
+	(*OAuthClientAuth)(nil),                                     // 125: agentgateway.dev.resource.OAuthClientAuth
+	(*OAuthTokenExchange)(nil),                                  // 126: agentgateway.dev.resource.OAuthTokenExchange
+	(*CrossAppAccessAuth)(nil),                                  // 127: agentgateway.dev.resource.CrossAppAccessAuth
+	(*ModelRoute)(nil),                                          // 128: agentgateway.dev.resource.ModelRoute
+	(*GuardrailBackend_Bedrock)(nil),                            // 129: agentgateway.dev.resource.GuardrailBackend.Bedrock
+	(*GuardrailBackend_GoogleModelArmor)(nil),                   // 130: agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
+	(*GuardrailBackend_AzureContentSafety)(nil),                 // 131: agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
+	(*GuardrailBackend_OpenAIModeration)(nil),                   // 132: agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
+	(*AuthorizationLocation_Header)(nil),                        // 133: agentgateway.dev.resource.AuthorizationLocation.Header
+	(*AuthorizationLocation_QueryParameter)(nil),                // 134: agentgateway.dev.resource.AuthorizationLocation.QueryParameter
+	(*AuthorizationLocation_Cookie)(nil),                        // 135: agentgateway.dev.resource.AuthorizationLocation.Cookie
+	nil,                                                         // 136: agentgateway.dev.resource.JwtSign.ClaimsEntry
+	(*Gcp_AccessToken)(nil),                                     // 137: agentgateway.dev.resource.Gcp.AccessToken
+	(*Gcp_IdToken)(nil),                                         // 138: agentgateway.dev.resource.Gcp.IdToken
+	(*AzureManagedIdentityCredential_UserAssignedIdentity)(nil), // 139: agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	(*RequestMirrors_Mirror)(nil),                               // 140: agentgateway.dev.resource.RequestMirrors.Mirror
+	(*PolicyTarget_ServiceTarget)(nil),                          // 141: agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	(*PolicyTarget_BackendTarget)(nil),                          // 142: agentgateway.dev.resource.PolicyTarget.BackendTarget
+	(*PolicyTarget_GatewayTarget)(nil),                          // 143: agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	(*PolicyTarget_RouteTarget)(nil),                            // 144: agentgateway.dev.resource.PolicyTarget.RouteTarget
+	(*PolicyTarget_ListenerSetTarget)(nil),                      // 145: agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
+	(*FrontendPolicySpec_HTTP)(nil),                             // 146: agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	(*FrontendPolicySpec_TLS)(nil),                              // 147: agentgateway.dev.resource.FrontendPolicySpec.TLS
+	(*FrontendPolicySpec_TCP)(nil),                              // 148: agentgateway.dev.resource.FrontendPolicySpec.TCP
+	(*FrontendPolicySpec_NetworkAuthorization)(nil),             // 149: agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
+	(*FrontendPolicySpec_Logging)(nil),                          // 150: agentgateway.dev.resource.FrontendPolicySpec.Logging
+	(*FrontendPolicySpec_Tracing)(nil),                          // 151: agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	(*FrontendPolicySpec_TracingAttribute)(nil),                 // 152: agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	(*FrontendPolicySpec_ProxyProtocol)(nil),                    // 153: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
+	(*FrontendPolicySpec_Connect)(nil),                          // 154: agentgateway.dev.resource.FrontendPolicySpec.Connect
+	(*FrontendPolicySpec_Metrics)(nil),                          // 155: agentgateway.dev.resource.FrontendPolicySpec.Metrics
+	(*FrontendPolicySpec_Logging_Field)(nil),                    // 156: agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	(*FrontendPolicySpec_Logging_Fields)(nil),                   // 157: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	(*FrontendPolicySpec_Logging_OtlpAccessLog)(nil),            // 158: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	(*FrontendPolicySpec_Metrics_Field)(nil),                    // 159: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
+	(*FrontendPolicySpec_Metrics_Fields)(nil),                   // 160: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
+	(*TrafficPolicySpec_RemoteRateLimit)(nil),                   // 161: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	(*TrafficPolicySpec_LocalRateLimit)(nil),                    // 162: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	(*TrafficPolicySpec_ExternalAuth)(nil),                      // 163: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	(*TrafficPolicySpec_RBAC)(nil),                              // 164: agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	(*TrafficPolicySpec_JWTProvider)(nil),                       // 165: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	(*TrafficPolicySpec_JWT)(nil),                               // 166: agentgateway.dev.resource.TrafficPolicySpec.JWT
+	(*TrafficPolicySpec_BasicAuthentication)(nil),               // 167: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	(*TrafficPolicySpec_APIKey)(nil),                            // 168: agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	(*TrafficPolicySpec_TransformationPolicy)(nil),              // 169: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	(*TrafficPolicySpec_HeaderTransformation)(nil),              // 170: agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	(*TrafficPolicySpec_BodyTransformation)(nil),                // 171: agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	(*TrafficPolicySpec_CSRF)(nil),                              // 172: agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	(*TrafficPolicySpec_ExtProc)(nil),                           // 173: agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	(*TrafficPolicySpec_HostRewrite)(nil),                       // 174: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	(*TrafficPolicySpec_Buffer)(nil),                            // 175: agentgateway.dev.resource.TrafficPolicySpec.Buffer
+	(*TrafficPolicySpec_RemoteRateLimit_Descriptor)(nil),        // 176: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	(*TrafficPolicySpec_RemoteRateLimit_Entry)(nil),             // 177: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	(*TrafficPolicySpec_LocalRateLimit_Rule)(nil),               // 178: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Rule
+	(*TrafficPolicySpec_ExternalAuth_BodyOptions)(nil),          // 179: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	(*TrafficPolicySpec_ExternalAuth_Cache)(nil),                // 180: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
+	(*TrafficPolicySpec_ExternalAuth_GRPCProtocol)(nil),         // 181: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	(*TrafficPolicySpec_ExternalAuth_HTTPProtocol)(nil),         // 182: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	nil,                                   // 183: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	nil,                                   // 184: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	nil,                                   // 185: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	nil,                                   // 186: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	(*TrafficPolicySpec_JWT_MCP)(nil),     // 187: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
+	(*TrafficPolicySpec_APIKey_User)(nil), // 188: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	(*TrafficPolicySpec_TransformationPolicy_Transform)(nil), // 189: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	nil, // 190: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	nil, // 191: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	nil, // 192: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	(*TrafficPolicySpec_ExtProc_NamespacedMetadataContext)(nil), // 193: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	(*TrafficPolicySpec_ExtProc_ProcessingOptions)(nil),         // 194: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
+	nil, // 195: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	nil, // 196: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	(*TrafficPolicySpec_Buffer_BufferBody)(nil),     // 197: agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
+	(*BackendPolicySpec_Ai)(nil),                    // 198: agentgateway.dev.resource.BackendPolicySpec.Ai
+	(*BackendPolicySpec_A2A)(nil),                   // 199: agentgateway.dev.resource.BackendPolicySpec.A2a
+	(*BackendPolicySpec_InferenceRouting)(nil),      // 200: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	(*BackendPolicySpec_Eviction)(nil),              // 201: agentgateway.dev.resource.BackendPolicySpec.Eviction
+	(*BackendPolicySpec_Health)(nil),                // 202: agentgateway.dev.resource.BackendPolicySpec.Health
+	(*BackendPolicySpec_BackendTLS)(nil),            // 203: agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	(*BackendPolicySpec_BackendHTTP)(nil),           // 204: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	(*BackendPolicySpec_BackendTunnel)(nil),         // 205: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	(*BackendPolicySpec_BackendTCP)(nil),            // 206: agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	(*BackendPolicySpec_McpAuthorization)(nil),      // 207: agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	(*BackendPolicySpec_McpAuthentication)(nil),     // 208: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	(*BackendPolicySpec_McpGuardrails)(nil),         // 209: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
+	(*BackendPolicySpec_Ai_Message)(nil),            // 210: agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	(*BackendPolicySpec_Ai_PromptEnrichment)(nil),   // 211: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	(*BackendPolicySpec_Ai_RegexRule)(nil),          // 212: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	(*BackendPolicySpec_Ai_RegexRules)(nil),         // 213: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	(*BackendPolicySpec_Ai_Webhook)(nil),            // 214: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	(*BackendPolicySpec_Ai_Moderation)(nil),         // 215: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	(*BackendPolicySpec_Ai_BedrockGuardrails)(nil),  // 216: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	(*BackendPolicySpec_Ai_GoogleModelArmor)(nil),   // 217: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	(*BackendPolicySpec_Ai_AzureContentSafety)(nil), // 218: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	(*BackendPolicySpec_Ai_RequestRejection)(nil),   // 219: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	(*BackendPolicySpec_Ai_ResponseGuard)(nil),      // 220: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	(*BackendPolicySpec_Ai_RequestGuard)(nil),       // 221: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	(*BackendPolicySpec_Ai_PromptGuard)(nil),        // 222: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	(*BackendPolicySpec_Ai_PromptCaching)(nil),      // 223: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	nil, // 224: agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	nil, // 225: agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	nil, // 226: agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	nil, // 227: agentgateway.dev.resource.BackendPolicySpec.Ai.FinalTransformationsEntry
+	nil, // 228: agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	nil, // 229: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	nil, // 230: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
+	(*BackendPolicySpec_McpAuthentication_ResourceMetadata)(nil), // 231: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	nil, // 232: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	(*BackendPolicySpec_McpGuardrails_Remote)(nil),    // 233: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	(*BackendPolicySpec_McpGuardrails_Processor)(nil), // 234: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	nil,                                                // 235: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	nil,                                                // 236: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	(*AIBackend_HostOverride)(nil),                     // 237: agentgateway.dev.resource.AIBackend.HostOverride
+	(*AIBackend_OpenAI)(nil),                           // 238: agentgateway.dev.resource.AIBackend.OpenAI
+	(*AIBackend_Gemini)(nil),                           // 239: agentgateway.dev.resource.AIBackend.Gemini
+	(*AIBackend_Vertex)(nil),                           // 240: agentgateway.dev.resource.AIBackend.Vertex
+	(*AIBackend_Anthropic)(nil),                        // 241: agentgateway.dev.resource.AIBackend.Anthropic
+	(*AIBackend_Bedrock)(nil),                          // 242: agentgateway.dev.resource.AIBackend.Bedrock
+	(*AIBackend_AzureOpenAI)(nil),                      // 243: agentgateway.dev.resource.AIBackend.AzureOpenAI
+	(*AIBackend_Azure)(nil),                            // 244: agentgateway.dev.resource.AIBackend.Azure
+	(*AIBackend_ProviderFormatConfig)(nil),             // 245: agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	(*AIBackend_Custom)(nil),                           // 246: agentgateway.dev.resource.AIBackend.Custom
+	(*AIBackend_Provider)(nil),                         // 247: agentgateway.dev.resource.AIBackend.Provider
+	(*AIBackend_ProviderGroup)(nil),                    // 248: agentgateway.dev.resource.AIBackend.ProviderGroup
+	(*AIBackend_OpenAI_Moderation)(nil),                // 249: agentgateway.dev.resource.AIBackend.OpenAI.Moderation
+	(*AIBackend_OpenAI_ModerationPolicy)(nil),          // 250: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy
+	(*AIBackend_OpenAI_ModerationConfig)(nil),          // 251: agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
+	(*BackendReference_Service)(nil),                   // 252: agentgateway.dev.resource.BackendReference.Service
+	(*BackendReference_Inline)(nil),                    // 253: agentgateway.dev.resource.BackendReference.Inline
+	(*OAuthClientAuth_PrivateKeyJwt)(nil),              // 254: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt
+	(*OAuthTokenExchange_TokenSpec)(nil),               // 255: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec
+	(*OAuthTokenExchange_ActorToken)(nil),              // 256: agentgateway.dev.resource.OAuthTokenExchange.ActorToken
+	nil,                                                // 257: agentgateway.dev.resource.OAuthTokenExchange.AdditionalParamsEntry
+	(*OAuthTokenExchange_TokenCache)(nil),              // 258: agentgateway.dev.resource.OAuthTokenExchange.TokenCache
+	(*OAuthTokenExchange_TokenCache_InMemory)(nil),     // 259: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
+	(*CrossAppAccessAuth_ScopeOverride)(nil),           // 260: agentgateway.dev.resource.CrossAppAccessAuth.ScopeOverride
+	(*CrossAppAccessAuth_Endpoint)(nil),                // 261: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
+	(*CrossAppAccessAuth_SubjectToken)(nil),            // 262: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken
+	(*ModelRoute_Match)(nil),                           // 263: agentgateway.dev.resource.ModelRoute.Match
+	(*ModelRoute_VirtualModel)(nil),                    // 264: agentgateway.dev.resource.ModelRoute.VirtualModel
+	(*ModelRoute_ConcreteModel)(nil),                   // 265: agentgateway.dev.resource.ModelRoute.ConcreteModel
+	(*ModelRoute_VirtualModel_Weighted)(nil),           // 266: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
+	(*ModelRoute_VirtualModel_Conditional)(nil),        // 267: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
+	(*ModelRoute_VirtualModel_Failover)(nil),           // 268: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
+	(*ModelRoute_VirtualModel_Weighted_Target)(nil),    // 269: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
+	(*ModelRoute_VirtualModel_Conditional_Target)(nil), // 270: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
+	(*workloadapi.Workload)(nil),                       // 271: istio.workload.Workload
+	(*workloadapi.Service)(nil),                        // 272: istio.workload.Service
+	(*workloadapi.NamespacedHostname)(nil),             // 273: istio.workload.NamespacedHostname
+	(*durationpb.Duration)(nil),                        // 274: google.protobuf.Duration
+	(*structpb.Value)(nil),                             // 275: google.protobuf.Value
+	(*structpb.Struct)(nil),                            // 276: google.protobuf.Struct
 }
 var file_resource_proto_depIdxs = []int32{
-	57,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
-	62,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
-	63,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
-	69,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
-	68,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
-	65,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
-	270, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
-	271, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
-	64,  // 8: agentgateway.dev.resource.Resource.route_group:type_name -> agentgateway.dev.resource.RouteGroup
-	127, // 9: agentgateway.dev.resource.Resource.model_route:type_name -> agentgateway.dev.resource.ModelRoute
+	58,  // 0: agentgateway.dev.resource.Resource.bind:type_name -> agentgateway.dev.resource.Bind
+	63,  // 1: agentgateway.dev.resource.Resource.listener:type_name -> agentgateway.dev.resource.Listener
+	64,  // 2: agentgateway.dev.resource.Resource.route:type_name -> agentgateway.dev.resource.Route
+	70,  // 3: agentgateway.dev.resource.Resource.backend:type_name -> agentgateway.dev.resource.Backend
+	69,  // 4: agentgateway.dev.resource.Resource.policy:type_name -> agentgateway.dev.resource.Policy
+	66,  // 5: agentgateway.dev.resource.Resource.tcp_route:type_name -> agentgateway.dev.resource.TCPRoute
+	271, // 6: agentgateway.dev.resource.Resource.workload:type_name -> istio.workload.Workload
+	272, // 7: agentgateway.dev.resource.Resource.service:type_name -> istio.workload.Service
+	65,  // 8: agentgateway.dev.resource.Resource.route_group:type_name -> agentgateway.dev.resource.RouteGroup
+	128, // 9: agentgateway.dev.resource.Resource.model_route:type_name -> agentgateway.dev.resource.ModelRoute
 	2,   // 10: agentgateway.dev.resource.Bind.protocol:type_name -> agentgateway.dev.resource.Bind.Protocol
 	3,   // 11: agentgateway.dev.resource.Bind.tunnel_protocol:type_name -> agentgateway.dev.resource.Bind.TunnelProtocol
 	4,   // 12: agentgateway.dev.resource.Bind.mode:type_name -> agentgateway.dev.resource.Bind.Mode
-	60,  // 13: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
-	59,  // 14: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
+	61,  // 13: agentgateway.dev.resource.ListenerName.listener_set:type_name -> agentgateway.dev.resource.ResourceName
+	60,  // 14: agentgateway.dev.resource.Listener.name:type_name -> agentgateway.dev.resource.ListenerName
 	0,   // 15: agentgateway.dev.resource.Listener.protocol:type_name -> agentgateway.dev.resource.Protocol
-	72,  // 16: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
-	272, // 17: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
-	58,  // 18: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
-	95,  // 19: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
-	108, // 20: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	113, // 21: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	272, // 22: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
-	58,  // 23: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
-	108, // 24: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
-	67,  // 25: agentgateway.dev.resource.ConditionalPolicies.policies:type_name -> agentgateway.dev.resource.ConditionalPolicy
-	113, // 26: agentgateway.dev.resource.ConditionalPolicy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	61,  // 27: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
-	109, // 28: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
+	73,  // 16: agentgateway.dev.resource.Listener.tls:type_name -> agentgateway.dev.resource.TLSConfig
+	273, // 17: agentgateway.dev.resource.Route.service_key:type_name -> istio.workload.NamespacedHostname
+	59,  // 18: agentgateway.dev.resource.Route.name:type_name -> agentgateway.dev.resource.RouteName
+	96,  // 19: agentgateway.dev.resource.Route.matches:type_name -> agentgateway.dev.resource.RouteMatch
+	109, // 20: agentgateway.dev.resource.Route.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	114, // 21: agentgateway.dev.resource.Route.traffic_policies:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	273, // 22: agentgateway.dev.resource.TCPRoute.service_key:type_name -> istio.workload.NamespacedHostname
+	59,  // 23: agentgateway.dev.resource.TCPRoute.name:type_name -> agentgateway.dev.resource.RouteName
+	109, // 24: agentgateway.dev.resource.TCPRoute.backends:type_name -> agentgateway.dev.resource.RouteBackend
+	68,  // 25: agentgateway.dev.resource.ConditionalPolicies.policies:type_name -> agentgateway.dev.resource.ConditionalPolicy
+	114, // 26: agentgateway.dev.resource.ConditionalPolicy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	62,  // 27: agentgateway.dev.resource.Policy.name:type_name -> agentgateway.dev.resource.TypedResourceName
+	110, // 28: agentgateway.dev.resource.Policy.target:type_name -> agentgateway.dev.resource.PolicyTarget
 	5,   // 29: agentgateway.dev.resource.Policy.inheritance:type_name -> agentgateway.dev.resource.Policy.Inheritance
-	113, // 30: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
-	114, // 31: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	111, // 32: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
-	66,  // 33: agentgateway.dev.resource.Policy.conditional:type_name -> agentgateway.dev.resource.ConditionalPolicies
-	60,  // 34: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
-	115, // 35: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
-	119, // 36: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
-	120, // 37: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
-	116, // 38: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
-	117, // 39: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
-	71,  // 40: agentgateway.dev.resource.Backend.guardrail:type_name -> agentgateway.dev.resource.GuardrailBackend
-	70,  // 41: agentgateway.dev.resource.Backend.model_router:type_name -> agentgateway.dev.resource.ModelRouterBackend
-	114, // 42: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	128, // 43: agentgateway.dev.resource.GuardrailBackend.bedrock:type_name -> agentgateway.dev.resource.GuardrailBackend.Bedrock
-	129, // 44: agentgateway.dev.resource.GuardrailBackend.google_model_armor:type_name -> agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
-	130, // 45: agentgateway.dev.resource.GuardrailBackend.azure_content_safety:type_name -> agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
-	131, // 46: agentgateway.dev.resource.GuardrailBackend.openai_moderation:type_name -> agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
+	114, // 30: agentgateway.dev.resource.Policy.traffic:type_name -> agentgateway.dev.resource.TrafficPolicySpec
+	115, // 31: agentgateway.dev.resource.Policy.backend:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	112, // 32: agentgateway.dev.resource.Policy.frontend:type_name -> agentgateway.dev.resource.FrontendPolicySpec
+	67,  // 33: agentgateway.dev.resource.Policy.conditional:type_name -> agentgateway.dev.resource.ConditionalPolicies
+	61,  // 34: agentgateway.dev.resource.Backend.name:type_name -> agentgateway.dev.resource.ResourceName
+	116, // 35: agentgateway.dev.resource.Backend.static:type_name -> agentgateway.dev.resource.StaticBackend
+	120, // 36: agentgateway.dev.resource.Backend.ai:type_name -> agentgateway.dev.resource.AIBackend
+	121, // 37: agentgateway.dev.resource.Backend.mcp:type_name -> agentgateway.dev.resource.MCPBackend
+	117, // 38: agentgateway.dev.resource.Backend.dynamic:type_name -> agentgateway.dev.resource.DynamicForwardProxy
+	118, // 39: agentgateway.dev.resource.Backend.aws:type_name -> agentgateway.dev.resource.AwsBackend
+	72,  // 40: agentgateway.dev.resource.Backend.guardrail:type_name -> agentgateway.dev.resource.GuardrailBackend
+	71,  // 41: agentgateway.dev.resource.Backend.model_router:type_name -> agentgateway.dev.resource.ModelRouterBackend
+	115, // 42: agentgateway.dev.resource.Backend.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	129, // 43: agentgateway.dev.resource.GuardrailBackend.bedrock:type_name -> agentgateway.dev.resource.GuardrailBackend.Bedrock
+	130, // 44: agentgateway.dev.resource.GuardrailBackend.google_model_armor:type_name -> agentgateway.dev.resource.GuardrailBackend.GoogleModelArmor
+	131, // 45: agentgateway.dev.resource.GuardrailBackend.azure_content_safety:type_name -> agentgateway.dev.resource.GuardrailBackend.AzureContentSafety
+	132, // 46: agentgateway.dev.resource.GuardrailBackend.openai_moderation:type_name -> agentgateway.dev.resource.GuardrailBackend.OpenAIModeration
 	9,   // 47: agentgateway.dev.resource.TLSConfig.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
 	7,   // 48: agentgateway.dev.resource.TLSConfig.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	7,   // 49: agentgateway.dev.resource.TLSConfig.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	8,   // 50: agentgateway.dev.resource.TLSConfig.mtls_mode:type_name -> agentgateway.dev.resource.TLSConfig.MTLSMode
 	10,  // 51: agentgateway.dev.resource.TLSConfig.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
 	6,   // 52: agentgateway.dev.resource.TLSConfig.certificate_source:type_name -> agentgateway.dev.resource.TLSConfig.CertificateSource
-	273, // 53: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
-	273, // 54: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
-	273, // 55: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
-	79,  // 56: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
-	80,  // 57: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
-	82,  // 58: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
-	83,  // 59: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
-	84,  // 60: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
-	125, // 61: agentgateway.dev.resource.BackendAuthPolicy.oauth_token_exchange:type_name -> agentgateway.dev.resource.OAuthTokenExchange
-	126, // 62: agentgateway.dev.resource.BackendAuthPolicy.cross_app_access:type_name -> agentgateway.dev.resource.CrossAppAccessAuth
-	81,  // 63: agentgateway.dev.resource.BackendAuthPolicy.jwt_sign:type_name -> agentgateway.dev.resource.JwtSign
-	77,  // 64: agentgateway.dev.resource.BackendAuthPolicy.credentials:type_name -> agentgateway.dev.resource.BackendAuthCredential
-	78,  // 65: agentgateway.dev.resource.BackendAuthCredential.location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	132, // 66: agentgateway.dev.resource.AuthorizationLocation.header:type_name -> agentgateway.dev.resource.AuthorizationLocation.Header
-	133, // 67: agentgateway.dev.resource.AuthorizationLocation.query_parameter:type_name -> agentgateway.dev.resource.AuthorizationLocation.QueryParameter
-	134, // 68: agentgateway.dev.resource.AuthorizationLocation.cookie:type_name -> agentgateway.dev.resource.AuthorizationLocation.Cookie
-	78,  // 69: agentgateway.dev.resource.Passthrough.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	78,  // 70: agentgateway.dev.resource.Key.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	274, // 53: agentgateway.dev.resource.Timeout.request:type_name -> google.protobuf.Duration
+	274, // 54: agentgateway.dev.resource.Timeout.backend_request:type_name -> google.protobuf.Duration
+	274, // 55: agentgateway.dev.resource.Retry.backoff:type_name -> google.protobuf.Duration
+	80,  // 56: agentgateway.dev.resource.BackendAuthPolicy.passthrough:type_name -> agentgateway.dev.resource.Passthrough
+	81,  // 57: agentgateway.dev.resource.BackendAuthPolicy.key:type_name -> agentgateway.dev.resource.Key
+	83,  // 58: agentgateway.dev.resource.BackendAuthPolicy.gcp:type_name -> agentgateway.dev.resource.Gcp
+	84,  // 59: agentgateway.dev.resource.BackendAuthPolicy.aws:type_name -> agentgateway.dev.resource.Aws
+	85,  // 60: agentgateway.dev.resource.BackendAuthPolicy.azure:type_name -> agentgateway.dev.resource.Azure
+	126, // 61: agentgateway.dev.resource.BackendAuthPolicy.oauth_token_exchange:type_name -> agentgateway.dev.resource.OAuthTokenExchange
+	127, // 62: agentgateway.dev.resource.BackendAuthPolicy.cross_app_access:type_name -> agentgateway.dev.resource.CrossAppAccessAuth
+	82,  // 63: agentgateway.dev.resource.BackendAuthPolicy.jwt_sign:type_name -> agentgateway.dev.resource.JwtSign
+	78,  // 64: agentgateway.dev.resource.BackendAuthPolicy.credentials:type_name -> agentgateway.dev.resource.BackendAuthCredential
+	79,  // 65: agentgateway.dev.resource.BackendAuthCredential.location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	133, // 66: agentgateway.dev.resource.AuthorizationLocation.header:type_name -> agentgateway.dev.resource.AuthorizationLocation.Header
+	134, // 67: agentgateway.dev.resource.AuthorizationLocation.query_parameter:type_name -> agentgateway.dev.resource.AuthorizationLocation.QueryParameter
+	135, // 68: agentgateway.dev.resource.AuthorizationLocation.cookie:type_name -> agentgateway.dev.resource.AuthorizationLocation.Cookie
+	79,  // 69: agentgateway.dev.resource.Passthrough.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	79,  // 70: agentgateway.dev.resource.Key.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
 	1,   // 71: agentgateway.dev.resource.JwtSign.alg:type_name -> agentgateway.dev.resource.JwtSigningAlg
-	135, // 72: agentgateway.dev.resource.JwtSign.claims:type_name -> agentgateway.dev.resource.JwtSign.ClaimsEntry
-	273, // 73: agentgateway.dev.resource.JwtSign.ttl:type_name -> google.protobuf.Duration
-	78,  // 74: agentgateway.dev.resource.JwtSign.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	136, // 75: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
-	137, // 76: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
-	85,  // 77: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
-	86,  // 78: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
-	87,  // 79: agentgateway.dev.resource.Aws.assume_role:type_name -> agentgateway.dev.resource.AwsAssumeRole
-	89,  // 80: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
-	93,  // 81: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
-	94,  // 82: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
-	88,  // 83: agentgateway.dev.resource.AwsAssumeRole.tags:type_name -> agentgateway.dev.resource.AwsSessionTag
-	90,  // 84: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
-	91,  // 85: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
-	92,  // 86: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
-	138, // 87: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
-	96,  // 88: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
-	99,  // 89: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
-	98,  // 90: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
-	97,  // 91: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
-	273, // 92: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
-	102, // 93: agentgateway.dev.resource.DirectResponse.headers:type_name -> agentgateway.dev.resource.ExpressionHeader
-	107, // 94: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
-	107, // 95: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
-	139, // 96: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
-	122, // 97: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
-	114, // 98: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	142, // 99: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
-	143, // 100: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
-	141, // 101: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
-	140, // 102: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
-	144, // 103: agentgateway.dev.resource.PolicyTarget.listener_set:type_name -> agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
-	273, // 104: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
-	273, // 105: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
-	147, // 106: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
-	146, // 107: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
-	145, // 108: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
-	149, // 109: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
-	150, // 110: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
-	148, // 111: agentgateway.dev.resource.FrontendPolicySpec.network_authorization:type_name -> agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
-	152, // 112: agentgateway.dev.resource.FrontendPolicySpec.proxy_protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
-	154, // 113: agentgateway.dev.resource.FrontendPolicySpec.metrics:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics
-	153, // 114: agentgateway.dev.resource.FrontendPolicySpec.connect:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect
+	136, // 72: agentgateway.dev.resource.JwtSign.claims:type_name -> agentgateway.dev.resource.JwtSign.ClaimsEntry
+	274, // 73: agentgateway.dev.resource.JwtSign.ttl:type_name -> google.protobuf.Duration
+	79,  // 74: agentgateway.dev.resource.JwtSign.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	137, // 75: agentgateway.dev.resource.Gcp.access_token:type_name -> agentgateway.dev.resource.Gcp.AccessToken
+	138, // 76: agentgateway.dev.resource.Gcp.id_token:type_name -> agentgateway.dev.resource.Gcp.IdToken
+	86,  // 77: agentgateway.dev.resource.Aws.explicit_config:type_name -> agentgateway.dev.resource.AwsExplicitConfig
+	87,  // 78: agentgateway.dev.resource.Aws.implicit:type_name -> agentgateway.dev.resource.AwsImplicit
+	88,  // 79: agentgateway.dev.resource.Aws.assume_role:type_name -> agentgateway.dev.resource.AwsAssumeRole
+	90,  // 80: agentgateway.dev.resource.Azure.explicit_config:type_name -> agentgateway.dev.resource.AzureExplicitConfig
+	94,  // 81: agentgateway.dev.resource.Azure.developer_implicit:type_name -> agentgateway.dev.resource.AzureDeveloperImplicit
+	95,  // 82: agentgateway.dev.resource.Azure.implicit:type_name -> agentgateway.dev.resource.AzureImplicit
+	89,  // 83: agentgateway.dev.resource.AwsAssumeRole.tags:type_name -> agentgateway.dev.resource.AwsSessionTag
+	91,  // 84: agentgateway.dev.resource.AzureExplicitConfig.client_secret:type_name -> agentgateway.dev.resource.AzureClientSecret
+	92,  // 85: agentgateway.dev.resource.AzureExplicitConfig.managed_identity_credential:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential
+	93,  // 86: agentgateway.dev.resource.AzureExplicitConfig.workload_identity_credential:type_name -> agentgateway.dev.resource.AzureWorkloadIdentityCredential
+	139, // 87: agentgateway.dev.resource.AzureManagedIdentityCredential.user_assigned_identity:type_name -> agentgateway.dev.resource.AzureManagedIdentityCredential.UserAssignedIdentity
+	97,  // 88: agentgateway.dev.resource.RouteMatch.path:type_name -> agentgateway.dev.resource.PathMatch
+	100, // 89: agentgateway.dev.resource.RouteMatch.headers:type_name -> agentgateway.dev.resource.HeaderMatch
+	99,  // 90: agentgateway.dev.resource.RouteMatch.method:type_name -> agentgateway.dev.resource.MethodMatch
+	98,  // 91: agentgateway.dev.resource.RouteMatch.query_params:type_name -> agentgateway.dev.resource.QueryMatch
+	274, // 92: agentgateway.dev.resource.CORS.max_age:type_name -> google.protobuf.Duration
+	103, // 93: agentgateway.dev.resource.DirectResponse.headers:type_name -> agentgateway.dev.resource.ExpressionHeader
+	108, // 94: agentgateway.dev.resource.HeaderModifier.add:type_name -> agentgateway.dev.resource.Header
+	108, // 95: agentgateway.dev.resource.HeaderModifier.set:type_name -> agentgateway.dev.resource.Header
+	140, // 96: agentgateway.dev.resource.RequestMirrors.mirrors:type_name -> agentgateway.dev.resource.RequestMirrors.Mirror
+	123, // 97: agentgateway.dev.resource.RouteBackend.backend:type_name -> agentgateway.dev.resource.BackendReference
+	115, // 98: agentgateway.dev.resource.RouteBackend.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	143, // 99: agentgateway.dev.resource.PolicyTarget.gateway:type_name -> agentgateway.dev.resource.PolicyTarget.GatewayTarget
+	144, // 100: agentgateway.dev.resource.PolicyTarget.route:type_name -> agentgateway.dev.resource.PolicyTarget.RouteTarget
+	142, // 101: agentgateway.dev.resource.PolicyTarget.backend:type_name -> agentgateway.dev.resource.PolicyTarget.BackendTarget
+	141, // 102: agentgateway.dev.resource.PolicyTarget.service:type_name -> agentgateway.dev.resource.PolicyTarget.ServiceTarget
+	145, // 103: agentgateway.dev.resource.PolicyTarget.listener_set:type_name -> agentgateway.dev.resource.PolicyTarget.ListenerSetTarget
+	274, // 104: agentgateway.dev.resource.KeepaliveConfig.time:type_name -> google.protobuf.Duration
+	274, // 105: agentgateway.dev.resource.KeepaliveConfig.interval:type_name -> google.protobuf.Duration
+	148, // 106: agentgateway.dev.resource.FrontendPolicySpec.tcp:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TCP
+	147, // 107: agentgateway.dev.resource.FrontendPolicySpec.tls:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TLS
+	146, // 108: agentgateway.dev.resource.FrontendPolicySpec.http:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP
+	150, // 109: agentgateway.dev.resource.FrontendPolicySpec.logging:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging
+	151, // 110: agentgateway.dev.resource.FrontendPolicySpec.tracing:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing
+	149, // 111: agentgateway.dev.resource.FrontendPolicySpec.network_authorization:type_name -> agentgateway.dev.resource.FrontendPolicySpec.NetworkAuthorization
+	153, // 112: agentgateway.dev.resource.FrontendPolicySpec.proxy_protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol
+	155, // 113: agentgateway.dev.resource.FrontendPolicySpec.metrics:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics
+	154, // 114: agentgateway.dev.resource.FrontendPolicySpec.connect:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect
 	17,  // 115: agentgateway.dev.resource.TrafficPolicySpec.phase:type_name -> agentgateway.dev.resource.TrafficPolicySpec.PolicyPhase
-	73,  // 116: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
-	74,  // 117: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
-	161, // 118: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
-	162, // 119: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	163, // 120: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	165, // 121: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
-	168, // 122: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	160, // 123: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
-	171, // 124: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
-	172, // 125: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
-	103, // 126: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	103, // 127: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	105, // 128: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	106, // 129: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
-	104, // 130: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	101, // 131: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
-	100, // 132: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
-	166, // 133: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
-	167, // 134: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
-	173, // 135: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
-	174, // 136: agentgateway.dev.resource.TrafficPolicySpec.buffer:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer
-	75,  // 137: agentgateway.dev.resource.TrafficPolicySpec.delay:type_name -> agentgateway.dev.resource.Delay
-	198, // 138: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
-	199, // 139: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
-	202, // 140: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
-	76,  // 141: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
-	206, // 142: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
-	207, // 143: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
-	197, // 144: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	103, // 145: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	103, // 146: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
-	105, // 147: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
-	104, // 148: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
-	203, // 149: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
-	205, // 150: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
-	168, // 151: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
-	201, // 152: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
-	204, // 153: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
-	162, // 154: agentgateway.dev.resource.BackendPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
-	208, // 155: agentgateway.dev.resource.BackendPolicySpec.mcp_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
-	163, // 156: agentgateway.dev.resource.BackendPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	118, // 157: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
-	247, // 158: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
-	121, // 159: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
-	48,  // 160: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
-	49,  // 161: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
-	50,  // 162: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
-	122, // 163: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
-	51,  // 164: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
-	251, // 165: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
-	252, // 166: agentgateway.dev.resource.BackendReference.inline:type_name -> agentgateway.dev.resource.BackendReference.Inline
-	52,  // 167: agentgateway.dev.resource.OAuthClientAuth.method:type_name -> agentgateway.dev.resource.OAuthClientAuth.Method
-	253, // 168: agentgateway.dev.resource.OAuthClientAuth.private_key_jwt:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt
-	122, // 169: agentgateway.dev.resource.OAuthTokenExchange.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
-	114, // 170: agentgateway.dev.resource.OAuthTokenExchange.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	54,  // 171: agentgateway.dev.resource.OAuthTokenExchange.grant_type:type_name -> agentgateway.dev.resource.OAuthTokenExchange.GrantType
-	254, // 172: agentgateway.dev.resource.OAuthTokenExchange.subject_token:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenSpec
-	255, // 173: agentgateway.dev.resource.OAuthTokenExchange.actor_token:type_name -> agentgateway.dev.resource.OAuthTokenExchange.ActorToken
-	256, // 174: agentgateway.dev.resource.OAuthTokenExchange.additional_params:type_name -> agentgateway.dev.resource.OAuthTokenExchange.AdditionalParamsEntry
-	124, // 175: agentgateway.dev.resource.OAuthTokenExchange.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
-	78,  // 176: agentgateway.dev.resource.OAuthTokenExchange.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	257, // 177: agentgateway.dev.resource.OAuthTokenExchange.cache:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache
-	260, // 178: agentgateway.dev.resource.CrossAppAccessAuth.identity_provider:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
-	260, // 179: agentgateway.dev.resource.CrossAppAccessAuth.resource_authorization_server:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
-	257, // 180: agentgateway.dev.resource.CrossAppAccessAuth.cache:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache
-	261, // 181: agentgateway.dev.resource.CrossAppAccessAuth.subject_token:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken
-	259, // 182: agentgateway.dev.resource.CrossAppAccessAuth.access_token_scopes:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.ScopeOverride
-	262, // 183: agentgateway.dev.resource.ModelRoute.match:type_name -> agentgateway.dev.resource.ModelRoute.Match
-	263, // 184: agentgateway.dev.resource.ModelRoute.virtual_model:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel
-	264, // 185: agentgateway.dev.resource.ModelRoute.concrete_model:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel
-	197, // 186: agentgateway.dev.resource.ModelRoute.ai_policy:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
-	163, // 187: agentgateway.dev.resource.ModelRoute.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
-	274, // 188: agentgateway.dev.resource.JwtSign.ClaimsEntry.value:type_name -> google.protobuf.Value
-	122, // 189: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
-	273, // 190: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
-	273, // 191: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
-	273, // 192: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
-	273, // 193: agentgateway.dev.resource.FrontendPolicySpec.HTTP.max_connection_duration:type_name -> google.protobuf.Duration
+	74,  // 116: agentgateway.dev.resource.TrafficPolicySpec.timeout:type_name -> agentgateway.dev.resource.Timeout
+	75,  // 117: agentgateway.dev.resource.TrafficPolicySpec.retry:type_name -> agentgateway.dev.resource.Retry
+	162, // 118: agentgateway.dev.resource.TrafficPolicySpec.local_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit
+	163, // 119: agentgateway.dev.resource.TrafficPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	164, // 120: agentgateway.dev.resource.TrafficPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	166, // 121: agentgateway.dev.resource.TrafficPolicySpec.jwt:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT
+	169, // 122: agentgateway.dev.resource.TrafficPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	161, // 123: agentgateway.dev.resource.TrafficPolicySpec.remote_rate_limit:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit
+	172, // 124: agentgateway.dev.resource.TrafficPolicySpec.csrf:type_name -> agentgateway.dev.resource.TrafficPolicySpec.CSRF
+	173, // 125: agentgateway.dev.resource.TrafficPolicySpec.ext_proc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc
+	104, // 126: agentgateway.dev.resource.TrafficPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	104, // 127: agentgateway.dev.resource.TrafficPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	106, // 128: agentgateway.dev.resource.TrafficPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	107, // 129: agentgateway.dev.resource.TrafficPolicySpec.url_rewrite:type_name -> agentgateway.dev.resource.UrlRewrite
+	105, // 130: agentgateway.dev.resource.TrafficPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	102, // 131: agentgateway.dev.resource.TrafficPolicySpec.direct_response:type_name -> agentgateway.dev.resource.DirectResponse
+	101, // 132: agentgateway.dev.resource.TrafficPolicySpec.cors:type_name -> agentgateway.dev.resource.CORS
+	167, // 133: agentgateway.dev.resource.TrafficPolicySpec.basic_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication
+	168, // 134: agentgateway.dev.resource.TrafficPolicySpec.api_key_auth:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey
+	174, // 135: agentgateway.dev.resource.TrafficPolicySpec.host_rewrite:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite
+	175, // 136: agentgateway.dev.resource.TrafficPolicySpec.buffer:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer
+	76,  // 137: agentgateway.dev.resource.TrafficPolicySpec.delay:type_name -> agentgateway.dev.resource.Delay
+	199, // 138: agentgateway.dev.resource.BackendPolicySpec.a2a:type_name -> agentgateway.dev.resource.BackendPolicySpec.A2a
+	200, // 139: agentgateway.dev.resource.BackendPolicySpec.inference_routing:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting
+	203, // 140: agentgateway.dev.resource.BackendPolicySpec.backend_tls:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS
+	77,  // 141: agentgateway.dev.resource.BackendPolicySpec.auth:type_name -> agentgateway.dev.resource.BackendAuthPolicy
+	207, // 142: agentgateway.dev.resource.BackendPolicySpec.mcp_authorization:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthorization
+	208, // 143: agentgateway.dev.resource.BackendPolicySpec.mcp_authentication:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication
+	198, // 144: agentgateway.dev.resource.BackendPolicySpec.ai:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	104, // 145: agentgateway.dev.resource.BackendPolicySpec.request_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	104, // 146: agentgateway.dev.resource.BackendPolicySpec.response_header_modifier:type_name -> agentgateway.dev.resource.HeaderModifier
+	106, // 147: agentgateway.dev.resource.BackendPolicySpec.request_redirect:type_name -> agentgateway.dev.resource.RequestRedirect
+	105, // 148: agentgateway.dev.resource.BackendPolicySpec.request_mirror:type_name -> agentgateway.dev.resource.RequestMirrors
+	204, // 149: agentgateway.dev.resource.BackendPolicySpec.backend_http:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP
+	206, // 150: agentgateway.dev.resource.BackendPolicySpec.backend_tcp:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTCP
+	169, // 151: agentgateway.dev.resource.BackendPolicySpec.transformation:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy
+	202, // 152: agentgateway.dev.resource.BackendPolicySpec.health:type_name -> agentgateway.dev.resource.BackendPolicySpec.Health
+	205, // 153: agentgateway.dev.resource.BackendPolicySpec.backend_tunnel:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel
+	163, // 154: agentgateway.dev.resource.BackendPolicySpec.ext_authz:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth
+	209, // 155: agentgateway.dev.resource.BackendPolicySpec.mcp_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails
+	164, // 156: agentgateway.dev.resource.BackendPolicySpec.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	119, // 157: agentgateway.dev.resource.AwsBackend.agent_core:type_name -> agentgateway.dev.resource.AwsAgentCoreBackend
+	248, // 158: agentgateway.dev.resource.AIBackend.provider_groups:type_name -> agentgateway.dev.resource.AIBackend.ProviderGroup
+	122, // 159: agentgateway.dev.resource.MCPBackend.targets:type_name -> agentgateway.dev.resource.MCPTarget
+	49,  // 160: agentgateway.dev.resource.MCPBackend.stateful_mode:type_name -> agentgateway.dev.resource.MCPBackend.StatefulMode
+	50,  // 161: agentgateway.dev.resource.MCPBackend.prefix_mode:type_name -> agentgateway.dev.resource.MCPBackend.PrefixMode
+	51,  // 162: agentgateway.dev.resource.MCPBackend.failure_mode:type_name -> agentgateway.dev.resource.MCPBackend.FailureMode
+	123, // 163: agentgateway.dev.resource.MCPTarget.backend:type_name -> agentgateway.dev.resource.BackendReference
+	52,  // 164: agentgateway.dev.resource.MCPTarget.protocol:type_name -> agentgateway.dev.resource.MCPTarget.Protocol
+	252, // 165: agentgateway.dev.resource.BackendReference.service:type_name -> agentgateway.dev.resource.BackendReference.Service
+	253, // 166: agentgateway.dev.resource.BackendReference.inline:type_name -> agentgateway.dev.resource.BackendReference.Inline
+	53,  // 167: agentgateway.dev.resource.OAuthClientAuth.method:type_name -> agentgateway.dev.resource.OAuthClientAuth.Method
+	254, // 168: agentgateway.dev.resource.OAuthClientAuth.private_key_jwt:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt
+	123, // 169: agentgateway.dev.resource.OAuthTokenExchange.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
+	115, // 170: agentgateway.dev.resource.OAuthTokenExchange.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	55,  // 171: agentgateway.dev.resource.OAuthTokenExchange.grant_type:type_name -> agentgateway.dev.resource.OAuthTokenExchange.GrantType
+	255, // 172: agentgateway.dev.resource.OAuthTokenExchange.subject_token:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenSpec
+	256, // 173: agentgateway.dev.resource.OAuthTokenExchange.actor_token:type_name -> agentgateway.dev.resource.OAuthTokenExchange.ActorToken
+	257, // 174: agentgateway.dev.resource.OAuthTokenExchange.additional_params:type_name -> agentgateway.dev.resource.OAuthTokenExchange.AdditionalParamsEntry
+	125, // 175: agentgateway.dev.resource.OAuthTokenExchange.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
+	79,  // 176: agentgateway.dev.resource.OAuthTokenExchange.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	258, // 177: agentgateway.dev.resource.OAuthTokenExchange.cache:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache
+	261, // 178: agentgateway.dev.resource.CrossAppAccessAuth.identity_provider:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
+	261, // 179: agentgateway.dev.resource.CrossAppAccessAuth.resource_authorization_server:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.Endpoint
+	258, // 180: agentgateway.dev.resource.CrossAppAccessAuth.cache:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache
+	262, // 181: agentgateway.dev.resource.CrossAppAccessAuth.subject_token:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken
+	260, // 182: agentgateway.dev.resource.CrossAppAccessAuth.access_token_scopes:type_name -> agentgateway.dev.resource.CrossAppAccessAuth.ScopeOverride
+	263, // 183: agentgateway.dev.resource.ModelRoute.match:type_name -> agentgateway.dev.resource.ModelRoute.Match
+	264, // 184: agentgateway.dev.resource.ModelRoute.virtual_model:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel
+	265, // 185: agentgateway.dev.resource.ModelRoute.concrete_model:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel
+	198, // 186: agentgateway.dev.resource.ModelRoute.ai_policy:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai
+	164, // 187: agentgateway.dev.resource.ModelRoute.authorization:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RBAC
+	275, // 188: agentgateway.dev.resource.JwtSign.ClaimsEntry.value:type_name -> google.protobuf.Value
+	123, // 189: agentgateway.dev.resource.RequestMirrors.Mirror.backend:type_name -> agentgateway.dev.resource.BackendReference
+	274, // 190: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_idle_timeout:type_name -> google.protobuf.Duration
+	274, // 191: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_interval:type_name -> google.protobuf.Duration
+	274, // 192: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http2_keepalive_timeout:type_name -> google.protobuf.Duration
+	274, // 193: agentgateway.dev.resource.FrontendPolicySpec.HTTP.max_connection_duration:type_name -> google.protobuf.Duration
 	11,  // 194: agentgateway.dev.resource.FrontendPolicySpec.HTTP.http1_header_case:type_name -> agentgateway.dev.resource.FrontendPolicySpec.HTTP.HTTPHeaderCase
-	273, // 195: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
-	123, // 196: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	274, // 195: agentgateway.dev.resource.FrontendPolicySpec.TLS.handshake_timeout:type_name -> google.protobuf.Duration
+	124, // 196: agentgateway.dev.resource.FrontendPolicySpec.TLS.alpn:type_name -> agentgateway.dev.resource.Alpn
 	9,   // 197: agentgateway.dev.resource.FrontendPolicySpec.TLS.cipher_suites:type_name -> agentgateway.dev.resource.TLSConfig.CipherSuite
 	7,   // 198: agentgateway.dev.resource.FrontendPolicySpec.TLS.min_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	7,   // 199: agentgateway.dev.resource.FrontendPolicySpec.TLS.max_version:type_name -> agentgateway.dev.resource.TLSConfig.TLSVersion
 	10,  // 200: agentgateway.dev.resource.FrontendPolicySpec.TLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
-	110, // 201: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	156, // 202: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	157, // 203: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
-	122, // 204: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	151, // 205: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	151, // 206: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
-	114, // 207: agentgateway.dev.resource.FrontendPolicySpec.Tracing.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	111, // 201: agentgateway.dev.resource.FrontendPolicySpec.TCP.keepalives:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	157, // 202: agentgateway.dev.resource.FrontendPolicySpec.Logging.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	158, // 203: agentgateway.dev.resource.FrontendPolicySpec.Logging.otlp_access_log:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog
+	123, // 204: agentgateway.dev.resource.FrontendPolicySpec.Tracing.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	152, // 205: agentgateway.dev.resource.FrontendPolicySpec.Tracing.attributes:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	152, // 206: agentgateway.dev.resource.FrontendPolicySpec.Tracing.resources:type_name -> agentgateway.dev.resource.FrontendPolicySpec.TracingAttribute
+	115, // 207: agentgateway.dev.resource.FrontendPolicySpec.Tracing.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
 	13,  // 208: agentgateway.dev.resource.FrontendPolicySpec.Tracing.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Tracing.Protocol
 	14,  // 209: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.version:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Version
 	15,  // 210: agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.ProxyProtocol.Mode
 	16,  // 211: agentgateway.dev.resource.FrontendPolicySpec.Connect.mode:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Connect.Mode
-	159, // 212: agentgateway.dev.resource.FrontendPolicySpec.Metrics.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
-	155, // 213: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
-	122, // 214: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	114, // 215: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	160, // 212: agentgateway.dev.resource.FrontendPolicySpec.Metrics.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields
+	156, // 213: agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Field
+	123, // 214: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	115, // 215: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
 	12,  // 216: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.protocol:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.Protocol
-	156, // 217: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
-	158, // 218: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
-	175, // 219: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
-	122, // 220: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
+	157, // 217: agentgateway.dev.resource.FrontendPolicySpec.Logging.OtlpAccessLog.fields:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Logging.Fields
+	159, // 218: agentgateway.dev.resource.FrontendPolicySpec.Metrics.Fields.add:type_name -> agentgateway.dev.resource.FrontendPolicySpec.Metrics.Field
+	176, // 219: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.descriptors:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor
+	123, // 220: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.target:type_name -> agentgateway.dev.resource.BackendReference
 	19,  // 221: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.FailureMode
-	114, // 222: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	273, // 223: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
+	115, // 222: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	274, // 223: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.fill_interval:type_name -> google.protobuf.Duration
 	20,  // 224: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
-	177, // 225: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.rules:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Rule
-	122, // 226: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
-	180, // 227: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
-	181, // 228: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
+	178, // 225: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.rules:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Rule
+	123, // 226: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.target:type_name -> agentgateway.dev.resource.BackendReference
+	181, // 227: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.grpc:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol
+	182, // 228: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.http:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol
 	21,  // 229: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.FailureMode
-	178, // 230: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
-	179, // 231: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.cache:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
-	114, // 232: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	112, // 233: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	179, // 230: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.include_request_body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.BodyOptions
+	180, // 231: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.cache:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.Cache
+	115, // 232: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	113, // 233: agentgateway.dev.resource.TrafficPolicySpec.JWTProvider.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
 	22,  // 234: agentgateway.dev.resource.TrafficPolicySpec.JWT.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.Mode
-	164, // 235: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
-	186, // 236: agentgateway.dev.resource.TrafficPolicySpec.JWT.mcp:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
-	78,  // 237: agentgateway.dev.resource.TrafficPolicySpec.JWT.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	165, // 235: agentgateway.dev.resource.TrafficPolicySpec.JWT.providers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWTProvider
+	187, // 236: agentgateway.dev.resource.TrafficPolicySpec.JWT.mcp:type_name -> agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP
+	79,  // 237: agentgateway.dev.resource.TrafficPolicySpec.JWT.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
 	23,  // 238: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.Mode
-	78,  // 239: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	187, // 240: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
+	79,  // 239: agentgateway.dev.resource.TrafficPolicySpec.BasicAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	188, // 240: agentgateway.dev.resource.TrafficPolicySpec.APIKey.api_keys:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.User
 	24,  // 241: agentgateway.dev.resource.TrafficPolicySpec.APIKey.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.APIKey.Mode
-	78,  // 242: agentgateway.dev.resource.TrafficPolicySpec.APIKey.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	188, // 243: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	188, // 244: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
-	122, // 245: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
+	79,  // 242: agentgateway.dev.resource.TrafficPolicySpec.APIKey.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	189, // 243: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	189, // 244: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform
+	123, // 245: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.target:type_name -> agentgateway.dev.resource.BackendReference
 	25,  // 246: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.FailureMode
-	190, // 247: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
-	191, // 248: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
-	194, // 249: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
-	193, // 250: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.processing_options:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
-	114, // 251: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	191, // 247: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.request_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.RequestAttributesEntry
+	192, // 248: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.response_attributes:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ResponseAttributesEntry
+	195, // 249: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.metadata_context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry
+	194, // 250: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.processing_options:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions
+	115, // 251: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
 	28,  // 252: agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HostRewrite.Mode
-	196, // 253: agentgateway.dev.resource.TrafficPolicySpec.Buffer.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
-	196, // 254: agentgateway.dev.resource.TrafficPolicySpec.Buffer.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
-	176, // 255: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
+	197, // 253: agentgateway.dev.resource.TrafficPolicySpec.Buffer.request:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
+	197, // 254: agentgateway.dev.resource.TrafficPolicySpec.Buffer.response:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody
+	177, // 255: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.entries:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Entry
 	18,  // 256: agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Descriptor.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.RemoteRateLimit.Type
-	273, // 257: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Rule.fill_interval:type_name -> google.protobuf.Duration
+	274, // 257: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Rule.fill_interval:type_name -> google.protobuf.Duration
 	20,  // 258: agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Rule.type:type_name -> agentgateway.dev.resource.TrafficPolicySpec.LocalRateLimit.Type
-	182, // 259: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
-	183, // 260: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
-	184, // 261: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
-	185, // 262: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
-	40,  // 263: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	230, // 264: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	275, // 265: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
-	169, // 266: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	169, // 267: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
-	170, // 268: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
-	189, // 269: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
-	195, // 270: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
+	183, // 259: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.ContextEntry
+	184, // 260: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.GRPCProtocol.MetadataEntry
+	185, // 261: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.add_request_headers:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.AddRequestHeadersEntry
+	186, // 262: agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExternalAuth.HTTPProtocol.MetadataEntry
+	41,  // 263: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	231, // 264: agentgateway.dev.resource.TrafficPolicySpec.JWT.MCP.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	276, // 265: agentgateway.dev.resource.TrafficPolicySpec.APIKey.User.metadata:type_name -> google.protobuf.Struct
+	170, // 266: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.set:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	170, // 267: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.add:type_name -> agentgateway.dev.resource.TrafficPolicySpec.HeaderTransformation
+	171, // 268: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.body:type_name -> agentgateway.dev.resource.TrafficPolicySpec.BodyTransformation
+	190, // 269: agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.metadata:type_name -> agentgateway.dev.resource.TrafficPolicySpec.TransformationPolicy.Transform.MetadataEntry
+	196, // 270: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.context:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext.ContextEntry
 	26,  // 271: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
 	26,  // 272: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_body_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.BodySendMode
 	27,  // 273: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	27,  // 274: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_header_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	27,  // 275: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.request_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
 	27,  // 276: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.ProcessingOptions.response_trailer_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.HeaderTrailerSendMode
-	192, // 277: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
+	193, // 277: agentgateway.dev.resource.TrafficPolicySpec.ExtProc.MetadataContextEntry.value:type_name -> agentgateway.dev.resource.TrafficPolicySpec.ExtProc.NamespacedMetadataContext
 	29,  // 278: agentgateway.dev.resource.TrafficPolicySpec.Buffer.BufferBody.failure_mode:type_name -> agentgateway.dev.resource.TrafficPolicySpec.Buffer.FailureMode
-	221, // 279: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
-	223, // 280: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
-	224, // 281: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
-	225, // 282: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
-	226, // 283: agentgateway.dev.resource.BackendPolicySpec.Ai.final_transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.FinalTransformationsEntry
-	210, // 284: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
-	227, // 285: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
-	222, // 286: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
-	228, // 287: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
-	122, // 288: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
+	222, // 279: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_guard:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard
+	224, // 280: agentgateway.dev.resource.BackendPolicySpec.Ai.defaults:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.DefaultsEntry
+	225, // 281: agentgateway.dev.resource.BackendPolicySpec.Ai.overrides:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.OverridesEntry
+	226, // 282: agentgateway.dev.resource.BackendPolicySpec.Ai.transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.TransformationsEntry
+	227, // 283: agentgateway.dev.resource.BackendPolicySpec.Ai.final_transformations:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.FinalTransformationsEntry
+	211, // 284: agentgateway.dev.resource.BackendPolicySpec.Ai.prompts:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment
+	228, // 285: agentgateway.dev.resource.BackendPolicySpec.Ai.model_aliases:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ModelAliasesEntry
+	223, // 286: agentgateway.dev.resource.BackendPolicySpec.Ai.prompt_caching:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptCaching
+	229, // 287: agentgateway.dev.resource.BackendPolicySpec.Ai.routes:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry
+	123, // 288: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.endpoint_picker:type_name -> agentgateway.dev.resource.BackendReference
 	36,  // 289: agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureMode
-	273, // 290: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
-	200, // 291: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
+	274, // 290: agentgateway.dev.resource.BackendPolicySpec.Eviction.duration:type_name -> google.protobuf.Duration
+	201, // 291: agentgateway.dev.resource.BackendPolicySpec.Health.eviction:type_name -> agentgateway.dev.resource.BackendPolicySpec.Eviction
 	37,  // 292: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.verification:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.VerificationMode
-	123, // 293: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
+	124, // 293: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.alpn:type_name -> agentgateway.dev.resource.Alpn
 	10,  // 294: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.key_exchange_groups:type_name -> agentgateway.dev.resource.TLSConfig.KeyExchangeGroup
 	38,  // 295: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.certificate_source:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.CertificateSource
 	39,  // 296: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
-	273, // 297: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	122, // 298: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
-	114, // 299: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	110, // 300: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	273, // 301: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
-	40,  // 302: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	230, // 303: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	41,  // 304: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	112, // 305: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	78,  // 306: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	233, // 307: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	209, // 308: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	209, // 309: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	30,  // 310: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
-	31,  // 311: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	211, // 312: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	122, // 313: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	229, // 314: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.headers:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
-	99,  // 315: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	34,  // 316: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
-	114, // 317: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	122, // 318: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	114, // 319: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	122, // 320: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	114, // 321: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	122, // 322: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	114, // 323: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	122, // 324: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	218, // 325: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	212, // 326: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	213, // 327: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	216, // 328: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	215, // 329: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	217, // 330: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	218, // 331: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	212, // 332: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	213, // 333: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	214, // 334: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	216, // 335: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	215, // 336: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	217, // 337: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	32,  // 338: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.scope:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ContentScope
-	220, // 339: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	219, // 340: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	35,  // 341: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.streaming:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
-	33,  // 342: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	231, // 343: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	274, // 344: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	122, // 345: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
-	43,  // 346: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
-	234, // 347: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	114, // 348: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	232, // 349: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	235, // 350: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
-	42,  // 351: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
-	248, // 352: agentgateway.dev.resource.AIBackend.OpenAI.moderation:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.Moderation
-	44,  // 353: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
-	45,  // 354: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
-	244, // 355: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	236, // 356: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	122, // 357: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	237, // 358: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	238, // 359: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	239, // 360: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	240, // 361: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	241, // 362: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	242, // 363: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	243, // 364: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
-	245, // 365: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
-	46,  // 366: agentgateway.dev.resource.AIBackend.Provider.provider_preset:type_name -> agentgateway.dev.resource.AIBackend.ProviderPreset
-	114, // 367: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	246, // 368: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	249, // 369: agentgateway.dev.resource.AIBackend.OpenAI.Moderation.policy:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy
-	250, // 370: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy.input:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
-	250, // 371: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy.output:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
-	47,  // 372: agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig.mode:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationMode
-	1,   // 373: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.alg:type_name -> agentgateway.dev.resource.JwtSigningAlg
-	53,  // 374: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.certificate_header:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
-	78,  // 375: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	78,  // 376: agentgateway.dev.resource.OAuthTokenExchange.ActorToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	258, // 377: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.in_memory:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
-	273, // 378: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory.default_ttl:type_name -> google.protobuf.Duration
-	122, // 379: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
-	124, // 380: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
-	114, // 381: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	78,  // 382: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	265, // 383: agentgateway.dev.resource.ModelRoute.VirtualModel.weighted:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
-	266, // 384: agentgateway.dev.resource.ModelRoute.VirtualModel.conditional:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
-	267, // 385: agentgateway.dev.resource.ModelRoute.VirtualModel.failover:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
-	55,  // 386: agentgateway.dev.resource.ModelRoute.ConcreteModel.model_visibility:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
-	122, // 387: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend:type_name -> agentgateway.dev.resource.BackendReference
-	114, // 388: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	268, // 389: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
-	269, // 390: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
-	122, // 391: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover.backend:type_name -> agentgateway.dev.resource.BackendReference
-	392, // [392:392] is the sub-list for method output_type
-	392, // [392:392] is the sub-list for method input_type
-	392, // [392:392] is the sub-list for extension type_name
-	392, // [392:392] is the sub-list for extension extendee
-	0,   // [0:392] is the sub-list for field type_name
+	274, // 297: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
+	123, // 298: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
+	115, // 299: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	40,  // 300: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.Mode
+	111, // 301: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	274, // 302: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	41,  // 303: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	231, // 304: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	42,  // 305: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	113, // 306: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	79,  // 307: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	234, // 308: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	210, // 309: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	210, // 310: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	30,  // 311: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
+	31,  // 312: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
+	212, // 313: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	123, // 314: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	230, // 315: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.headers:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
+	100, // 316: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	34,  // 317: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
+	115, // 318: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	123, // 319: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	115, // 320: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	123, // 321: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	115, // 322: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	123, // 323: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	115, // 324: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	123, // 325: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	219, // 326: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	213, // 327: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	214, // 328: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	217, // 329: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	216, // 330: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	218, // 331: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	219, // 332: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	213, // 333: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	214, // 334: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	215, // 335: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	217, // 336: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	216, // 337: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	218, // 338: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	32,  // 339: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.scope:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ContentScope
+	221, // 340: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	220, // 341: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	35,  // 342: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.streaming:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
+	33,  // 343: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
+	232, // 344: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	275, // 345: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	123, // 346: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
+	44,  // 347: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
+	235, // 348: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	115, // 349: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	233, // 350: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	236, // 351: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	43,  // 352: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
+	249, // 353: agentgateway.dev.resource.AIBackend.OpenAI.moderation:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.Moderation
+	45,  // 354: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
+	46,  // 355: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
+	245, // 356: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	237, // 357: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	123, // 358: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	238, // 359: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	239, // 360: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	240, // 361: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	241, // 362: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	242, // 363: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	243, // 364: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	244, // 365: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
+	246, // 366: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
+	47,  // 367: agentgateway.dev.resource.AIBackend.Provider.provider_preset:type_name -> agentgateway.dev.resource.AIBackend.ProviderPreset
+	115, // 368: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	247, // 369: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	250, // 370: agentgateway.dev.resource.AIBackend.OpenAI.Moderation.policy:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy
+	251, // 371: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy.input:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
+	251, // 372: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy.output:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
+	48,  // 373: agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig.mode:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationMode
+	1,   // 374: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.alg:type_name -> agentgateway.dev.resource.JwtSigningAlg
+	54,  // 375: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.certificate_header:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
+	79,  // 376: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	79,  // 377: agentgateway.dev.resource.OAuthTokenExchange.ActorToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	259, // 378: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.in_memory:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
+	274, // 379: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory.default_ttl:type_name -> google.protobuf.Duration
+	123, // 380: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
+	125, // 381: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
+	115, // 382: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	79,  // 383: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	266, // 384: agentgateway.dev.resource.ModelRoute.VirtualModel.weighted:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
+	267, // 385: agentgateway.dev.resource.ModelRoute.VirtualModel.conditional:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
+	268, // 386: agentgateway.dev.resource.ModelRoute.VirtualModel.failover:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
+	56,  // 387: agentgateway.dev.resource.ModelRoute.ConcreteModel.model_visibility:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
+	123, // 388: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend:type_name -> agentgateway.dev.resource.BackendReference
+	115, // 389: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	269, // 390: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
+	270, // 391: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
+	123, // 392: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover.backend:type_name -> agentgateway.dev.resource.BackendReference
+	393, // [393:393] is the sub-list for method output_type
+	393, // [393:393] is the sub-list for method input_type
+	393, // [393:393] is the sub-list for extension type_name
+	393, // [393:393] is the sub-list for extension extendee
+	0,   // [0:393] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }
@@ -20088,7 +20140,7 @@ func file_resource_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resource_proto_rawDesc), len(file_resource_proto_rawDesc)),
-			NumEnums:      56,
+			NumEnums:      57,
 			NumMessages:   214,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2489,7 +2489,7 @@ type BackendTunnelMode string
 const (
 	// Auto uses CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.
 	BackendTunnelModeAuto BackendTunnelMode = "Auto"
-	// Connect always uses CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.
+	// Connect uses CONNECT for all transports, including plaintext HTTP.
 	BackendTunnelModeConnect BackendTunnelMode = "Connect"
 )
 
@@ -2501,8 +2501,7 @@ type BackendTunnel struct {
 	// +optional
 	PolicyBackendEndpoint `json:",inline"`
 
-	// How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-	// do not run on tunneled requests; HTTP policies on the destination backend still run.
+	// How requests are sent through the proxy.
 	// Defaults to `Auto`.
 	// +kubebuilder:default=Auto
 	// +optional

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2490,6 +2490,10 @@ type BackendTunnel struct {
 	// +kubebuilder:validation:XValidation:rule="!has(self.url) || self.url.matches('^https?://[^/?#]+$')",message="url must not include a path for backend tunnel"
 	// +optional
 	PolicyBackendEndpoint `json:",inline"`
+
+	// Use CONNECT even when the tunneled application transport is plaintext HTTP.
+	// +optional
+	Connect bool `json:"connect,omitempty"`
 }
 
 type BackendHTTP struct {

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2483,6 +2483,16 @@ const (
 	Entra     McpIDP = "Entra"
 )
 
+// +k8s:enum
+type BackendTunnelMode string
+
+const (
+	// Auto uses CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.
+	BackendTunnelModeAuto BackendTunnelMode = "Auto"
+	// Connect always uses CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.
+	BackendTunnelModeConnect BackendTunnelMode = "Connect"
+)
+
 // +kubebuilder:validation:ExactlyOneOf=backendRef;url
 type BackendTunnel struct {
 	// Proxy server to reach.
@@ -2491,9 +2501,12 @@ type BackendTunnel struct {
 	// +optional
 	PolicyBackendEndpoint `json:",inline"`
 
-	// Use CONNECT even when the tunneled application transport is plaintext HTTP.
+	// How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+	// do not run on tunneled requests; HTTP policies on the destination backend still run.
+	// Defaults to `Auto`.
+	// +kubebuilder:default=Auto
 	// +optional
-	Connect bool `json:"connect,omitempty"`
+	Mode BackendTunnelMode `json:"mode,omitempty"`
 }
 
 type BackendHTTP struct {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -1373,6 +1373,12 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
+                                                            connect:
+                                                              description: Use CONNECT
+                                                                even when the tunneled
+                                                                application transport
+                                                                is plaintext HTTP.
+                                                              type: boolean
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -1901,6 +1907,12 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
+                                                            connect:
+                                                              description: Use CONNECT
+                                                                even when the tunneled
+                                                                application transport
+                                                                is plaintext HTTP.
+                                                              type: boolean
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -2448,6 +2460,12 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
+                                                            connect:
+                                                              description: Use CONNECT
+                                                                even when the tunneled
+                                                                application transport
+                                                                is plaintext HTTP.
+                                                              type: boolean
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3405,6 +3423,12 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
+                                                            connect:
+                                                              description: Use CONNECT
+                                                                even when the tunneled
+                                                                application transport
+                                                                is plaintext HTTP.
+                                                              type: boolean
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3933,6 +3957,12 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
+                                                            connect:
+                                                              description: Use CONNECT
+                                                                even when the tunneled
+                                                                application transport
+                                                                is plaintext HTTP.
+                                                              type: boolean
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -6844,6 +6874,10 @@ spec:
                                         - message: Must have port for Service reference
                                           rule: '(size(self.group) == 0 && self.kind
                                             == ''Service'') ? has(self.port) : true'
+                                      connect:
+                                        description: Use CONNECT even when the tunneled
+                                          application transport is plaintext HTTP.
+                                        type: boolean
                                       url:
                                         description: |-
                                           `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -9771,6 +9805,10 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
+                                    connect:
+                                      description: Use CONNECT even when the tunneled
+                                        application transport is plaintext HTTP.
+                                      type: boolean
                                     url:
                                       description: |-
                                         `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -10635,6 +10673,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -11084,6 +11127,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -11555,6 +11603,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -12386,6 +12439,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -12835,6 +12893,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -16173,6 +16236,10 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
+                      connect:
+                        description: Use CONNECT even when the tunneled application
+                          transport is plaintext HTTP.
+                        type: boolean
                       url:
                         description: |-
                           `url` directly specifies the HTTP(S) endpoint for this policy.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -1373,12 +1373,16 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                            connect:
-                                                              description: Use CONNECT
-                                                                even when the tunneled
-                                                                application transport
-                                                                is plaintext HTTP.
-                                                              type: boolean
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -1907,12 +1911,16 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                            connect:
-                                                              description: Use CONNECT
-                                                                even when the tunneled
-                                                                application transport
-                                                                is plaintext HTTP.
-                                                              type: boolean
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -2460,12 +2468,16 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                            connect:
-                                                              description: Use CONNECT
-                                                                even when the tunneled
-                                                                application transport
-                                                                is plaintext HTTP.
-                                                              type: boolean
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3423,12 +3435,16 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                            connect:
-                                                              description: Use CONNECT
-                                                                even when the tunneled
-                                                                application transport
-                                                                is plaintext HTTP.
-                                                              type: boolean
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3957,12 +3973,16 @@ spec:
                                                                   == ''Service'')
                                                                   ? has(self.port)
                                                                   : true'
-                                                            connect:
-                                                              description: Use CONNECT
-                                                                even when the tunneled
-                                                                application transport
-                                                                is plaintext HTTP.
-                                                              type: boolean
+                                                            mode:
+                                                              default: Auto
+                                                              description: |-
+                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                Defaults to `Auto`.
+                                                              enum:
+                                                              - Auto
+                                                              - Connect
+                                                              type: string
                                                             url:
                                                               description: |-
                                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -6874,10 +6894,16 @@ spec:
                                         - message: Must have port for Service reference
                                           rule: '(size(self.group) == 0 && self.kind
                                             == ''Service'') ? has(self.port) : true'
-                                      connect:
-                                        description: Use CONNECT even when the tunneled
-                                          application transport is plaintext HTTP.
-                                        type: boolean
+                                      mode:
+                                        default: Auto
+                                        description: |-
+                                          How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                          do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                          Defaults to `Auto`.
+                                        enum:
+                                        - Auto
+                                        - Connect
+                                        type: string
                                       url:
                                         description: |-
                                           `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -9805,10 +9831,16 @@ spec:
                                       - message: Must have port for Service reference
                                         rule: '(size(self.group) == 0 && self.kind
                                           == ''Service'') ? has(self.port) : true'
-                                    connect:
-                                      description: Use CONNECT even when the tunneled
-                                        application transport is plaintext HTTP.
-                                      type: boolean
+                                    mode:
+                                      default: Auto
+                                      description: |-
+                                        How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                        do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                        Defaults to `Auto`.
+                                      enum:
+                                      - Auto
+                                      - Connect
+                                      type: string
                                     url:
                                       description: |-
                                         `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -10673,11 +10705,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -11127,11 +11164,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -11603,11 +11645,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -12439,11 +12486,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -12893,11 +12945,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -16236,10 +16293,16 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
-                      connect:
-                        description: Use CONNECT even when the tunneled application
-                          transport is plaintext HTTP.
-                        type: boolean
+                      mode:
+                        default: Auto
+                        description: |-
+                          How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                          do not run on tunneled requests; HTTP policies on the destination backend still run.
+                          Defaults to `Auto`.
+                        enum:
+                        - Auto
+                        - Connect
+                        type: string
                       url:
                         description: |-
                           `url` directly specifies the HTTP(S) endpoint for this policy.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -1376,8 +1376,7 @@ spec:
                                                             mode:
                                                               default: Auto
                                                               description: |-
-                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                How requests are sent through the proxy.
                                                                 Defaults to `Auto`.
                                                               enum:
                                                               - Auto
@@ -1914,8 +1913,7 @@ spec:
                                                             mode:
                                                               default: Auto
                                                               description: |-
-                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                How requests are sent through the proxy.
                                                                 Defaults to `Auto`.
                                                               enum:
                                                               - Auto
@@ -2471,8 +2469,7 @@ spec:
                                                             mode:
                                                               default: Auto
                                                               description: |-
-                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                How requests are sent through the proxy.
                                                                 Defaults to `Auto`.
                                                               enum:
                                                               - Auto
@@ -3438,8 +3435,7 @@ spec:
                                                             mode:
                                                               default: Auto
                                                               description: |-
-                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                How requests are sent through the proxy.
                                                                 Defaults to `Auto`.
                                                               enum:
                                                               - Auto
@@ -3976,8 +3972,7 @@ spec:
                                                             mode:
                                                               default: Auto
                                                               description: |-
-                                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                                How requests are sent through the proxy.
                                                                 Defaults to `Auto`.
                                                               enum:
                                                               - Auto
@@ -6897,8 +6892,7 @@ spec:
                                       mode:
                                         default: Auto
                                         description: |-
-                                          How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                          do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                          How requests are sent through the proxy.
                                           Defaults to `Auto`.
                                         enum:
                                         - Auto
@@ -9834,8 +9828,7 @@ spec:
                                     mode:
                                       default: Auto
                                       description: |-
-                                        How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                        do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                        How requests are sent through the proxy.
                                         Defaults to `Auto`.
                                       enum:
                                       - Auto
@@ -10708,8 +10701,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -11167,8 +11159,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -11648,8 +11639,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -12489,8 +12479,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -12948,8 +12937,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -16296,8 +16284,7 @@ spec:
                       mode:
                         default: Auto
                         description: |-
-                          How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                          do not run on tunneled requests; HTTP policies on the destination backend still run.
+                          How requests are sent through the proxy.
                           Defaults to `Auto`.
                         enum:
                         - Auto

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -2275,10 +2275,16 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                        connect:
-                                          description: Use CONNECT even when the tunneled
-                                            application transport is plaintext HTTP.
-                                          type: boolean
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -2720,10 +2726,16 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                        connect:
-                                          description: Use CONNECT even when the tunneled
-                                            application transport is plaintext HTTP.
-                                          type: boolean
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3184,10 +3196,16 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                        connect:
-                                          description: Use CONNECT even when the tunneled
-                                            application transport is plaintext HTTP.
-                                          type: boolean
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -4003,10 +4021,16 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                        connect:
-                                          description: Use CONNECT even when the tunneled
-                                            application transport is plaintext HTTP.
-                                          type: boolean
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -4448,10 +4472,16 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
-                                        connect:
-                                          description: Use CONNECT even when the tunneled
-                                            application transport is plaintext HTTP.
-                                          type: boolean
+                                        mode:
+                                          default: Auto
+                                          description: |-
+                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            Defaults to `Auto`.
+                                          enum:
+                                          - Auto
+                                          - Connect
+                                          type: string
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -4935,10 +4965,16 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
-                      connect:
-                        description: Use CONNECT even when the tunneled application
-                          transport is plaintext HTTP.
-                        type: boolean
+                      mode:
+                        default: Auto
+                        description: |-
+                          How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                          do not run on tunneled requests; HTTP policies on the destination backend still run.
+                          Defaults to `Auto`.
+                        enum:
+                        - Auto
+                        - Connect
+                        type: string
                       url:
                         description: |-
                           `url` directly specifies the HTTP(S) endpoint for this policy.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -2275,6 +2275,10 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
+                                        connect:
+                                          description: Use CONNECT even when the tunneled
+                                            application transport is plaintext HTTP.
+                                          type: boolean
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -2716,6 +2720,10 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
+                                        connect:
+                                          description: Use CONNECT even when the tunneled
+                                            application transport is plaintext HTTP.
+                                          type: boolean
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3176,6 +3184,10 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
+                                        connect:
+                                          description: Use CONNECT even when the tunneled
+                                            application transport is plaintext HTTP.
+                                          type: boolean
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3991,6 +4003,10 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
+                                        connect:
+                                          description: Use CONNECT even when the tunneled
+                                            application transport is plaintext HTTP.
+                                          type: boolean
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -4432,6 +4448,10 @@ spec:
                                           - message: Must have port for Service reference
                                             rule: '(size(self.group) == 0 && self.kind
                                               == ''Service'') ? has(self.port) : true'
+                                        connect:
+                                          description: Use CONNECT even when the tunneled
+                                            application transport is plaintext HTTP.
+                                          type: boolean
                                         url:
                                           description: |-
                                             `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -4915,6 +4935,10 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
+                      connect:
+                        description: Use CONNECT even when the tunneled application
+                          transport is plaintext HTTP.
+                        type: boolean
                       url:
                         description: |-
                           `url` directly specifies the HTTP(S) endpoint for this policy.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -2278,8 +2278,7 @@ spec:
                                         mode:
                                           default: Auto
                                           description: |-
-                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            How requests are sent through the proxy.
                                             Defaults to `Auto`.
                                           enum:
                                           - Auto
@@ -2729,8 +2728,7 @@ spec:
                                         mode:
                                           default: Auto
                                           description: |-
-                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            How requests are sent through the proxy.
                                             Defaults to `Auto`.
                                           enum:
                                           - Auto
@@ -3199,8 +3197,7 @@ spec:
                                         mode:
                                           default: Auto
                                           description: |-
-                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            How requests are sent through the proxy.
                                             Defaults to `Auto`.
                                           enum:
                                           - Auto
@@ -4024,8 +4021,7 @@ spec:
                                         mode:
                                           default: Auto
                                           description: |-
-                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            How requests are sent through the proxy.
                                             Defaults to `Auto`.
                                           enum:
                                           - Auto
@@ -4475,8 +4471,7 @@ spec:
                                         mode:
                                           default: Auto
                                           description: |-
-                                            How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                            do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                            How requests are sent through the proxy.
                                             Defaults to `Auto`.
                                           enum:
                                           - Auto
@@ -4968,8 +4963,7 @@ spec:
                       mode:
                         default: Auto
                         description: |-
-                          How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                          do not run on tunneled requests; HTTP policies on the destination backend still run.
+                          How requests are sent through the proxy.
                           Defaults to `Auto`.
                         enum:
                         - Auto

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -875,6 +875,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -1324,6 +1329,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -1795,6 +1805,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -2626,6 +2641,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3075,6 +3095,11 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
+                                            connect:
+                                              description: Use CONNECT even when the
+                                                tunneled application transport is
+                                                plaintext HTTP.
+                                              type: boolean
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -6413,6 +6438,10 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
+                      connect:
+                        description: Use CONNECT even when the tunneled application
+                          transport is plaintext HTTP.
+                        type: boolean
                       url:
                         description: |-
                           `url` directly specifies the HTTP(S) endpoint for this policy.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -875,11 +875,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -1329,11 +1334,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -1805,11 +1815,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -2641,11 +2656,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -3095,11 +3115,16 @@ spec:
                                                 rule: '(size(self.group) == 0 && self.kind
                                                   == ''Service'') ? has(self.port)
                                                   : true'
-                                            connect:
-                                              description: Use CONNECT even when the
-                                                tunneled application transport is
-                                                plaintext HTTP.
-                                              type: boolean
+                                            mode:
+                                              default: Auto
+                                              description: |-
+                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                Defaults to `Auto`.
+                                              enum:
+                                              - Auto
+                                              - Connect
+                                              type: string
                                             url:
                                               description: |-
                                                 `url` directly specifies the HTTP(S) endpoint for this policy.
@@ -6438,10 +6463,16 @@ spec:
                         - message: Must have port for Service reference
                           rule: '(size(self.group) == 0 && self.kind == ''Service'')
                             ? has(self.port) : true'
-                      connect:
-                        description: Use CONNECT even when the tunneled application
-                          transport is plaintext HTTP.
-                        type: boolean
+                      mode:
+                        default: Auto
+                        description: |-
+                          How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
+                          do not run on tunneled requests; HTTP policies on the destination backend still run.
+                          Defaults to `Auto`.
+                        enum:
+                        - Auto
+                        - Connect
+                        type: string
                       url:
                         description: |-
                           `url` directly specifies the HTTP(S) endpoint for this policy.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -878,8 +878,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -1337,8 +1336,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -1818,8 +1816,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -2659,8 +2656,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -3118,8 +3114,7 @@ spec:
                                             mode:
                                               default: Auto
                                               description: |-
-                                                How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                                                do not run on tunneled requests; HTTP policies on the destination backend still run.
+                                                How requests are sent through the proxy.
                                                 Defaults to `Auto`.
                                               enum:
                                               - Auto
@@ -6466,8 +6461,7 @@ spec:
                       mode:
                         default: Auto
                         description: |-
-                          How requests are sent through the proxy. In `Connect` mode, HTTP policies on the proxy backend
-                          do not run on tunneled requests; HTTP policies on the destination backend still run.
+                          How requests are sent through the proxy.
                           Defaults to `Auto`.
                         enum:
                         - Auto

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -560,6 +560,7 @@ func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPoli
 					BackendTunnel: &api.BackendPolicySpec_BackendTunnel{
 						Proxy:          proxy,
 						InlinePolicies: inlinePolicies,
+						Connect:        tunnel.Connect,
 					},
 				},
 			},

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -548,6 +548,10 @@ func translateBackendHTTP(policy *agentgateway.AgentgatewayPolicy) *api.Policy {
 
 func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPolicy) (*api.Policy, error) {
 	tunnel := policy.Spec.Backend.Tunnel
+	mode := api.BackendPolicySpec_BackendTunnel_AUTO
+	if tunnel.Mode == agentgateway.BackendTunnelModeConnect {
+		mode = api.BackendPolicySpec_BackendTunnel_CONNECT
+	}
 
 	proxy, inlinePolicies, _, err := buildPolicyBackendEndpoint(ctx, tunnel.PolicyBackendEndpoint, policy.Namespace)
 
@@ -560,7 +564,7 @@ func translateBackendTunnel(ctx PolicyCtx, policy *agentgateway.AgentgatewayPoli
 					BackendTunnel: &api.BackendPolicySpec_BackendTunnel{
 						Proxy:          proxy,
 						InlinePolicies: inlinePolicies,
-						Connect:        tunnel.Connect,
+						Mode:           mode,
 					},
 				},
 			},

--- a/crates/agentgateway/src/client/connect_tunnel.rs
+++ b/crates/agentgateway/src/client/connect_tunnel.rs
@@ -1,14 +1,14 @@
 use http::HeaderValue;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-use crate::transport::stream::Socket;
+use crate::transport::stream::{Socket, TLSConnectionInfo};
 
 pub async fn handshake(
 	conn: Socket,
 	dest: &str,
 	auth: Option<HeaderValue>,
 ) -> Result<Socket, anyhow::Error> {
-	let (ext, metrics, inner) = conn.into_parts();
+	let (mut ext, metrics, inner) = conn.into_parts();
 	let mut conn = Socket::new_rewind(inner);
 	// While the raw HTTP/1 usage here looks pretty sketchy, hyper itself is doing this so its probably sufficient
 	// for our simple needs here.
@@ -46,6 +46,11 @@ pub async fn handshake(
 			let recvd = &buf[..pos];
 			if recvd.starts_with(b"HTTP/1.1 200") || recvd.starts_with(b"HTTP/1.0 200") {
 				let conn = conn.keep_after(end);
+				// The proxy's ALPN does not describe the protocol inside the tunnel.
+				if let Some(mut tls) = ext.get::<TLSConnectionInfo>().cloned() {
+					tls.negotiated_alpn = None;
+					ext.insert(tls);
+				}
 				return Ok(Socket::from_rewind(ext, metrics, conn));
 			} else if recvd.starts_with(b"HTTP/1.1 407") || recvd.starts_with(b"HTTP/1.0 407") {
 				return Err(anyhow::anyhow!("tunnel required auth"));
@@ -74,7 +79,7 @@ mod tests {
 	use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 	use super::*;
-	use crate::transport::stream::TCPConnectionInfo;
+	use crate::transport::stream::{Alpn, TCPConnectionInfo};
 
 	fn memory_socket(stream: tokio::io::DuplexStream) -> Socket {
 		Socket::from_memory(
@@ -105,9 +110,18 @@ mod tests {
 				.expect("write response");
 		});
 
-		let mut tunneled = handshake(memory_socket(client), "dest:443", None)
+		let mut client = memory_socket(client);
+		client.ext_mut().insert(TLSConnectionInfo {
+			server_name: Some("proxy.example".to_string()),
+			negotiated_alpn: Some(Alpn::Http11),
+			..Default::default()
+		});
+		let mut tunneled = handshake(client, "dest:443", None)
 			.await
 			.expect("handshake should succeed");
+		let tls = tunneled.must_ext::<TLSConnectionInfo>();
+		assert_eq!(tls.server_name.as_deref(), Some("proxy.example"));
+		assert_eq!(tls.negotiated_alpn, None);
 		let mut first_bytes = [0; 5];
 		tunneled
 			.read_exact(&mut first_bytes)

--- a/crates/agentgateway/src/client/connect_tunnel.rs
+++ b/crates/agentgateway/src/client/connect_tunnel.rs
@@ -46,11 +46,8 @@ pub async fn handshake(
 			let recvd = &buf[..pos];
 			if recvd.starts_with(b"HTTP/1.1 200") || recvd.starts_with(b"HTTP/1.0 200") {
 				let conn = conn.keep_after(end);
-				// The proxy's ALPN does not describe the protocol inside the tunnel.
-				if let Some(mut tls) = ext.get::<TLSConnectionInfo>().cloned() {
-					tls.negotiated_alpn = None;
-					ext.insert(tls);
-				}
+				// The proxy's TLS metadata does not describe the connection inside the tunnel.
+				ext.remove::<TLSConnectionInfo>();
 				return Ok(Socket::from_rewind(ext, metrics, conn));
 			} else if recvd.starts_with(b"HTTP/1.1 407") || recvd.starts_with(b"HTTP/1.0 407") {
 				return Err(anyhow::anyhow!("tunnel required auth"));
@@ -119,9 +116,7 @@ mod tests {
 		let mut tunneled = handshake(client, "dest:443", None)
 			.await
 			.expect("handshake should succeed");
-		let tls = tunneled.must_ext::<TLSConnectionInfo>();
-		assert_eq!(tls.server_name.as_deref(), Some("proxy.example"));
-		assert_eq!(tls.negotiated_alpn, None);
+		assert!(tunneled.ext::<TLSConnectionInfo>().is_none());
 		let mut first_bytes = [0; 5];
 		tunneled
 			.read_exact(&mut first_bytes)

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -76,6 +76,7 @@ pub struct TunnelConfig {
 	pub target: Target,
 	pub transport: Box<Transport>,
 	pub token: Option<HeaderValue>,
+	pub connect: bool,
 }
 
 /// The role this agentgateway is acting as when originating an HBONE CONNECT.
@@ -307,8 +308,8 @@ impl Connector {
 		trace!(?transport, "connecting");
 		let stream = match transport {
 			Transport::Plain(_) => dial(&target, ep, &self.backend_config).await?,
-			Transport::Tunnel(_, tcfg) if tls.is_some() || !http => {
-				// Tunnel case one: use CONNECT for non-plaintext HTTP
+			Transport::Tunnel(_, tcfg) if tcfg.connect || tls.is_some() || !http => {
+				// Use CONNECT when required by the transport or explicitly configured.
 				let proxy_dst: SocketAddr = self
 					// Never skip resolution for the actually proxy itself
 					.resolve_target(false, &tcfg.target)
@@ -647,6 +648,7 @@ impl Client {
 			if let Transport::Tunnel(app, tc) = &transport
 				&& let Some(h) = tc.token.as_ref()
 				&& matches!(app, ApplicationTransport::Plaintext)
+				&& !tc.connect
 			{
 				req
 					.headers_mut()

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -1871,19 +1871,16 @@ mod dynamic_metadata_flow {
 }
 
 mod dynamic_backend_target {
+	use tokio::io::{AsyncReadExt, AsyncWriteExt};
+	use tokio::net::{TcpListener, TcpStream};
+	use tokio::sync::oneshot;
+
 	use super::*;
 	use crate::proxy::request_builder::RequestBuilder;
-	use crate::types::{
-		agent::{
-			Backend, BackendTrafficPolicy, BackendWithPolicies, ResourceName, SimpleBackendReference,
-		},
-		backend,
+	use crate::types::agent::{
+		Backend, BackendTrafficPolicy, BackendWithPolicies, ResourceName, SimpleBackendReference,
 	};
-	use tokio::{
-		io::{AsyncReadExt, AsyncWriteExt},
-		net::{TcpListener, TcpStream},
-		sync::oneshot,
-	};
+	use crate::types::backend;
 
 	struct WorkerTargetExtProc {
 		target: String,
@@ -2012,7 +2009,7 @@ mod dynamic_backend_target {
 				backend: actor_backend,
 				inline_policies: vec![BackendTrafficPolicy::Tunnel(backend::Tunnel {
 					proxy: Arc::new(SimpleBackendReference::Backend(worker_backend.name())),
-					connect: true,
+					mode: backend::TunnelMode::Connect,
 					policies: vec![],
 				})],
 			};

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -1975,6 +1975,7 @@ mod dynamic_backend_target {
 				loop {
 					let mut chunk = [0; 1024];
 					let n = downstream.read(&mut chunk).await.unwrap();
+					assert!(n > 0, "CONNECT request unexpectedly closed");
 					request.extend_from_slice(&chunk[..n]);
 					if request.windows(4).any(|w| w == b"\r\n\r\n") {
 						break;

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -1872,7 +1872,18 @@ mod dynamic_metadata_flow {
 
 mod dynamic_backend_target {
 	use super::*;
-	use crate::types::agent::{Backend, ResourceName};
+	use crate::proxy::request_builder::RequestBuilder;
+	use crate::types::{
+		agent::{
+			Backend, BackendTrafficPolicy, BackendWithPolicies, ResourceName, SimpleBackendReference,
+		},
+		backend,
+	};
+	use tokio::{
+		io::{AsyncReadExt, AsyncWriteExt},
+		net::{TcpListener, TcpStream},
+		sync::oneshot,
+	};
 
 	struct WorkerTargetExtProc {
 		target: String,
@@ -1951,6 +1962,94 @@ mod dynamic_backend_target {
 		.await
 		.unwrap();
 		assert_eq!(res.status(), 200);
+	}
+
+	#[tokio::test]
+	async fn resolves_dynamic_connect_proxy_without_changing_actor_target() {
+		async fn run(version: ::http::Version) {
+			let actor = simple_mock().await;
+			let actor_addr = *actor.address();
+			let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+			let worker_addr = listener.local_addr().unwrap();
+			let (connect_tx, connect_rx) = oneshot::channel();
+			let worker = tokio::spawn(async move {
+				let (mut downstream, _) = listener.accept().await.unwrap();
+				let mut request = Vec::new();
+				loop {
+					let mut chunk = [0; 1024];
+					let n = downstream.read(&mut chunk).await.unwrap();
+					request.extend_from_slice(&chunk[..n]);
+					if request.windows(4).any(|w| w == b"\r\n\r\n") {
+						break;
+					}
+				}
+				connect_tx.send(request).unwrap();
+				downstream
+					.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+					.await
+					.unwrap();
+				let mut upstream = TcpStream::connect(actor_addr).await.unwrap();
+				let _ = tokio::io::copy_bidirectional(&mut downstream, &mut upstream).await;
+			});
+
+			let ext_proc = ExtProcMock::new(move || WorkerTargetExtProc {
+				target: worker_addr.to_string(),
+			})
+			.spawn()
+			.await;
+			let worker_backend = Backend::Dynamic(
+				ResourceName::new("worker".into(), "".into()),
+				Some(Arc::new(
+					Expression::new_strict("extproc.workerTarget").unwrap(),
+				)),
+			);
+			let actor_backend = Backend::Opaque(
+				ResourceName::new("actor".into(), "".into()),
+				Target::Address(actor_addr),
+			);
+			let route = basic_named_route(actor_backend.name());
+			let actor_backend = BackendWithPolicies {
+				backend: actor_backend,
+				inline_policies: vec![BackendTrafficPolicy::Tunnel(backend::Tunnel {
+					proxy: Arc::new(SimpleBackendReference::Backend(worker_backend.name())),
+					connect: true,
+					policies: vec![],
+				})],
+			};
+			let t = setup_proxy_test("{}")
+				.unwrap()
+				.with_raw_backend(worker_backend.into())
+				.with_raw_backend(actor_backend)
+				.with_backend(ext_proc.address)
+				.with_bind(simple_bind())
+				.with_route(route)
+				.attach_route_policy_builder(json!({
+					"extProc": {
+						"host": ext_proc.address,
+						"failureMode": "failClosed",
+					},
+				}))
+				.await;
+
+			let io = if version == ::http::Version::HTTP_2 {
+				t.serve_http2(strng::new("bind"))
+			} else {
+				t.serve_http(strng::new("bind"))
+			};
+			let res = RequestBuilder::new(Method::GET, "http://actor-authority/test")
+				.version(version)
+				.send(io)
+				.await
+				.unwrap();
+			assert_eq!(res.status(), 200);
+			assert_eq!(read_body(res.into_body()).await.version, version);
+			let connect = String::from_utf8(connect_rx.await.unwrap()).unwrap();
+			assert!(connect.starts_with(&format!("CONNECT {actor_addr} HTTP/1.1\r\n")));
+			worker.abort();
+		}
+
+		run(::http::Version::HTTP_11).await;
+		run(::http::Version::HTTP_2).await;
 	}
 
 	/// Omitting `target` keeps today's behavior: the request's own

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1660,10 +1660,18 @@ pub async fn build_transport(
 		ApplicationTransport::Plaintext
 	};
 	if let Some(tun) = backend_tunnel {
-		let backend: BackendWithPolicies =
-			super::resolve_simple_backend_with_policies(&tun.proxy, inputs)?.into();
-		let pols = crate::proxy::tcpproxy::get_backend_policies(inputs, &backend, &tun.policies, None);
-		let call = TCPProxy::build_backend_call(&mut None, None, inputs, &backend.backend, pols, None)?;
+		let resolved;
+		let call = if let Some(call) = backend_call.tunnel_proxy.as_deref() {
+			call
+		} else {
+			let backend: BackendWithPolicies =
+				super::resolve_simple_backend_with_policies(&tun.proxy, inputs)?.into();
+			let pols =
+				crate::proxy::tcpproxy::get_backend_policies(inputs, &backend, &tun.policies, None);
+			resolved =
+				TCPProxy::build_backend_call(&mut None, None, inputs, &backend.backend, pols, None)?;
+			&resolved
+		};
 		let tunnel_backend_tls = call.backend_policies.backend_tls.clone();
 		let tunnel_auth = call.backend_policies.backend_auth.clone();
 		// This is a bounded recursion; this code is only called when backend_tunnel is set, and in this call
@@ -1686,8 +1694,9 @@ pub async fn build_transport(
 		};
 		let tc = client::TunnelConfig {
 			transport: Box::new(transport),
-			target: call.target,
+			target: call.target.clone(),
 			token,
+			connect: tun.connect,
 		};
 		return Ok(Transport::Tunnel(app_transport, tc));
 	}
@@ -1913,6 +1922,36 @@ pub(super) fn dynamic_backend_target_override<'a>(
 	let target = Target::try_from(s.as_str())
 		.map_err(|e| ProxyError::ProcessingString(format!("dynamic backend target {s:?}: {e}")))?;
 	Ok(Some(target))
+}
+
+fn resolve_tunnel_backend_call(
+	inputs: &ProxyInputs,
+	tunnel: &backend::Tunnel,
+	req: &Request,
+) -> Result<BackendCall, ProxyError> {
+	let reference = match tunnel.proxy.as_ref() {
+		SimpleBackendReference::Service { name, port } => BackendReference::Service {
+			name: name.clone(),
+			port: *port,
+		},
+		SimpleBackendReference::Backend(name) => BackendReference::Backend(name.clone()),
+		SimpleBackendReference::InlineBackend(target) => {
+			BackendReference::InlineBackend(target.clone())
+		},
+		SimpleBackendReference::Invalid => BackendReference::Invalid,
+	};
+	let backend = super::resolve_backend(&reference, inputs)?;
+	let policies =
+		crate::proxy::tcpproxy::get_backend_policies(inputs, &backend, &tunnel.policies, None);
+	if let Backend::Dynamic(_, expr) = &backend.backend {
+		let executor = crate::cel::Executor::new_request(req);
+		let target = match dynamic_backend_target_override(&executor, expr)? {
+			Some(target) => target,
+			None => target_from_request(req)?,
+		};
+		return Ok(BackendCall::new(target, policies));
+	}
+	TCPProxy::build_backend_call(&mut None, None, inputs, &backend.backend, policies, None)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2361,6 +2400,11 @@ async fn make_backend_call(
 			Some(target) => target,
 			None => target_from_request(&req)?,
 		};
+	}
+	if let Some(tunnel) = backend_call.backend_policies.tunnel.clone() {
+		backend_call.tunnel_proxy = Some(Box::new(resolve_tunnel_backend_call(
+			&inputs, &tunnel, &req,
+		)?));
 	}
 
 	log.add(|l| {
@@ -2916,6 +2960,7 @@ pub fn build_service_call(
 			hbone_port: agent_hbone::DEFAULT_HBONE_PORT,
 			advanced_routing: None,
 			backend_policies,
+			tunnel_proxy: None,
 		});
 	}
 
@@ -3087,6 +3132,7 @@ pub fn build_service_call(
 		hbone_port,
 		advanced_routing: BackendCallAdvancedRouting::new(network_gateway, waypoint),
 		backend_policies,
+		tunnel_proxy: None,
 	})
 }
 
@@ -4128,6 +4174,7 @@ pub struct BackendCall {
 	pub hbone_port: u16,
 	advanced_routing: Option<Box<BackendCallAdvancedRouting>>,
 	pub backend_policies: Arc<BackendPolicies>,
+	tunnel_proxy: Option<Box<BackendCall>>,
 }
 
 impl BackendCall {
@@ -4148,6 +4195,7 @@ impl BackendCall {
 			hbone_port: agent_hbone::DEFAULT_HBONE_PORT,
 			advanced_routing: None,
 			backend_policies,
+			tunnel_proxy: None,
 		}
 	}
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1696,7 +1696,7 @@ pub async fn build_transport(
 			transport: Box::new(transport),
 			target: call.target.clone(),
 			token,
-			connect: tun.connect,
+			connect: tun.mode == backend::TunnelMode::Connect,
 		};
 		return Ok(Transport::Tunnel(app_transport, tc));
 	}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1678,7 +1678,7 @@ pub async fn build_transport(
 		// we never set it.
 		let transport = Box::pin(build_transport(
 			inputs,
-			&call,
+			call,
 			hbone_source,
 			tunnel_backend_tls,
 			None,
@@ -1929,18 +1929,7 @@ fn resolve_tunnel_backend_call(
 	tunnel: &backend::Tunnel,
 	req: &Request,
 ) -> Result<BackendCall, ProxyError> {
-	let reference = match tunnel.proxy.as_ref() {
-		SimpleBackendReference::Service { name, port } => BackendReference::Service {
-			name: name.clone(),
-			port: *port,
-		},
-		SimpleBackendReference::Backend(name) => BackendReference::Backend(name.clone()),
-		SimpleBackendReference::InlineBackend(target) => {
-			BackendReference::InlineBackend(target.clone())
-		},
-		SimpleBackendReference::Invalid => BackendReference::Invalid,
-	};
-	let backend = super::resolve_backend(&reference, inputs)?;
+	let backend = super::resolve_tunnel_backend(&tunnel.proxy, inputs)?;
 	let policies =
 		crate::proxy::tcpproxy::get_backend_policies(inputs, &backend, &tunnel.policies, None);
 	if let Backend::Dynamic(_, expr) = &backend.backend {
@@ -2402,9 +2391,7 @@ async fn make_backend_call(
 		};
 	}
 	if let Some(tunnel) = backend_call.backend_policies.tunnel.clone() {
-		backend_call.tunnel_proxy = Some(Box::new(resolve_tunnel_backend_call(
-			&inputs, &tunnel, &req,
-		)?));
+		backend_call.set_tunnel_proxy(resolve_tunnel_backend_call(&inputs, &tunnel, &req)?);
 	}
 
 	log.add(|l| {
@@ -4197,6 +4184,10 @@ impl BackendCall {
 			backend_policies,
 			tunnel_proxy: None,
 		}
+	}
+
+	pub(super) fn set_tunnel_proxy(&mut self, call: BackendCall) {
+		self.tunnel_proxy = Some(Box::new(call));
 	}
 
 	pub(crate) fn network_gateway(&self) -> Option<&(GatewayAddress, Vec<Identity>)> {

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -590,6 +590,34 @@ pub fn resolve_simple_backend(
 	resolve_simple_backend_with_policies(b, pi)
 }
 
+pub fn resolve_tunnel_backend(
+	b: &SimpleBackendReference,
+	pi: &ProxyInputs,
+) -> Result<BackendWithPolicies, ProxyError> {
+	let reference = match b {
+		SimpleBackendReference::Service { name, port } => BackendReference::Service {
+			name: name.clone(),
+			port: *port,
+		},
+		SimpleBackendReference::Backend(name) => BackendReference::Backend(name.clone()),
+		SimpleBackendReference::InlineBackend(target) => {
+			BackendReference::InlineBackend(target.clone())
+		},
+		SimpleBackendReference::Invalid => BackendReference::Invalid,
+	};
+	let backend = resolve_backend(&reference, pi)?;
+	match &backend.backend {
+		Backend::Service(_, _)
+		| Backend::Opaque(_, _)
+		| Backend::Aws(_, _)
+		| Backend::Dynamic(_, _)
+		| Backend::Invalid => Ok(backend),
+		Backend::MCP(_, _) | Backend::AI(_, _) | Backend::LLMRouter(_, _) | Backend::Internal(_, _) => {
+			Err(ProxyError::InvalidBackendType)
+		},
+	}
+}
+
 pub fn resolve_simple_backend_with_policies(
 	b: &SimpleBackendReference,
 	pi: &ProxyInputs,

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -190,7 +190,7 @@ impl TCPProxy {
 			port: self.target_address.port(),
 			hostname: sni.as_deref().map(strng::new),
 		};
-		let backend_call = Self::build_backend_call(
+		let mut backend_call = Self::build_backend_call(
 			&mut Some(log),
 			Some(&destination),
 			&inputs,
@@ -198,6 +198,14 @@ impl TCPProxy {
 			backend_policies,
 			hbone_source,
 		)?;
+		if let Some(tunnel) = backend_call.backend_policies.tunnel.clone() {
+			backend_call.set_tunnel_proxy(resolve_tunnel_backend_call(
+				&mut Some(log),
+				Some(&destination),
+				&inputs,
+				&tunnel,
+			)?);
+		}
 
 		let bi = selected_backend.backend.backend.backend_info();
 		log.endpoint = Some(backend_call.target.clone());
@@ -321,6 +329,17 @@ impl TCPProxy {
 		};
 		tokio::time::timeout(to, handshake).await?
 	}
+}
+
+fn resolve_tunnel_backend_call(
+	log: &mut Option<&mut RequestLog>,
+	destination: Option<&crate::cel::DestinationContext>,
+	inputs: &ProxyInputs,
+	tunnel: &crate::types::backend::Tunnel,
+) -> Result<BackendCall, ProxyError> {
+	let backend = super::resolve_tunnel_backend(&tunnel.proxy, inputs)?;
+	let policies = get_backend_policies(inputs, &backend, &tunnel.policies, None);
+	TCPProxy::build_backend_call(log, destination, inputs, &backend.backend, policies, None)
 }
 
 fn select_best_route(
@@ -490,7 +509,7 @@ mod tests {
 
 	use crate::llm::catalog::ModelCatalog;
 	use crate::store::{BackendPolicies, Stores};
-	use crate::types::agent::{BackendReference, ListenerProtocol};
+	use crate::types::agent::{BackendReference, ListenerProtocol, SimpleBackendReference};
 	use crate::types::discovery::gatewayaddress::Destination;
 	use crate::types::discovery::{
 		GatewayAddress, NamespacedHostname, NetworkAddress, Service, WaypointIdentity,
@@ -1067,6 +1086,62 @@ mod tests {
 		assert!(matches!(
 			result.target,
 			super::Target::Hostname(host, 8443) if host.as_str() == "mirror.example.com"
+		));
+	}
+
+	#[test]
+	fn test_named_dynamic_tunnel_backend_uses_tcp_context_and_rejects_internal() {
+		let inputs = make_proxy_inputs();
+		let target = crate::cel::Expression::new_strict(
+			r#"destination.hostname + ":" + string(destination.port)"#,
+		)
+		.unwrap();
+		let backend = super::Backend::Dynamic(
+			crate::types::agent::ResourceName::new(strng::new("proxy"), strng::new("ns")),
+			Some(Arc::new(target)),
+		);
+		let backend_name = backend.name();
+		inputs
+			.stores
+			.binds
+			.write()
+			.insert_backend(backend_name.clone(), backend.into());
+		let mut tunnel = crate::types::backend::Tunnel {
+			proxy: Arc::new(SimpleBackendReference::Backend(backend_name)),
+			mode: crate::types::backend::TunnelMode::Auto,
+			policies: vec![],
+		};
+		let destination = crate::cel::DestinationContext {
+			address: "127.0.0.1".parse().unwrap(),
+			port: 443,
+			hostname: Some(strng::new("pypi.org")),
+		};
+		let result =
+			super::resolve_tunnel_backend_call(&mut None, Some(&destination), &inputs, &tunnel).unwrap();
+		assert!(matches!(
+			result.target,
+			super::Target::Hostname(host, 443) if host.as_str() == "pypi.org"
+		));
+
+		let backend = super::Backend::Internal(
+			crate::types::agent::ResourceName::new(strng::new("internal"), strng::new("ns")),
+			crate::types::local::InternalBackend::Forward,
+		);
+		let backend_name = backend.name();
+		inputs
+			.stores
+			.binds
+			.write()
+			.insert_backend(backend_name.clone(), backend.into());
+		tunnel.proxy = Arc::new(SimpleBackendReference::Backend(backend_name));
+		let error =
+			match super::resolve_tunnel_backend_call(&mut None, Some(&destination), &inputs, &tunnel) {
+				Ok(_) => panic!("internal tunnel backend must be rejected"),
+				Err(error) => error,
+			};
+		assert!(matches!(
+			error,
+			crate::proxy::ProxyError::InvalidBackendType
 		));
 	}
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2297,7 +2297,10 @@ fn backend_policy_from_proto(
 		}),
 		Some(bps::Kind::BackendTunnel(bt)) => BackendTrafficPolicy::Tunnel(backend::Tunnel {
 			proxy: Arc::new(resolve_simple_reference(bt.proxy.as_ref())),
-			connect: bt.connect,
+			mode: match bt.mode() {
+				bps::backend_tunnel::Mode::Connect => backend::TunnelMode::Connect,
+				bps::backend_tunnel::Mode::Auto => backend::TunnelMode::Auto,
+			},
 			policies: backend_policies_from_proto(&bt.inline_policies, diagnostics)?,
 		}),
 		Some(bps::Kind::BackendTls(btls)) => {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2297,6 +2297,7 @@ fn backend_policy_from_proto(
 		}),
 		Some(bps::Kind::BackendTunnel(bt)) => BackendTrafficPolicy::Tunnel(backend::Tunnel {
 			proxy: Arc::new(resolve_simple_reference(bt.proxy.as_ref())),
+			connect: bt.connect,
 			policies: backend_policies_from_proto(&bt.inline_policies, diagnostics)?,
 		}),
 		Some(bps::Kind::BackendTls(btls)) => {

--- a/crates/agentgateway/src/types/backend.rs
+++ b/crates/agentgateway/src/types/backend.rs
@@ -67,6 +67,9 @@ impl HTTP {
 pub struct Tunnel {
 	/// Proxy backend used to tunnel the connection.
 	pub proxy: Arc<SimpleBackendReference>,
+	/// Use CONNECT even when the tunneled application transport is plaintext HTTP.
+	#[serde(default, skip_serializing_if = "std::ops::Not::not")]
+	pub connect: bool,
 	/// Policies to connect to the proxy backend
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]

--- a/crates/agentgateway/src/types/backend.rs
+++ b/crates/agentgateway/src/types/backend.rs
@@ -69,7 +69,7 @@ pub enum TunnelMode {
 	/// Use CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.
 	#[default]
 	Auto,
-	/// Always use CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.
+	/// Use CONNECT for all transports, including plaintext HTTP.
 	Connect,
 }
 
@@ -77,8 +77,7 @@ pub enum TunnelMode {
 pub struct Tunnel {
 	/// Proxy backend used to tunnel the connection.
 	pub proxy: Arc<SimpleBackendReference>,
-	/// How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend
-	/// do not run on tunneled requests; HTTP policies on the destination backend still run.
+	/// How requests are sent through the proxy.
 	#[serde(default)]
 	pub mode: TunnelMode,
 	/// Policies to connect to the proxy backend

--- a/crates/agentgateway/src/types/backend.rs
+++ b/crates/agentgateway/src/types/backend.rs
@@ -63,13 +63,24 @@ impl HTTP {
 	}
 }
 
+#[apply(schema_enum!)]
+#[derive(Default)]
+pub enum TunnelMode {
+	/// Use CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.
+	#[default]
+	Auto,
+	/// Always use CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.
+	Connect,
+}
+
 #[apply(schema!)]
 pub struct Tunnel {
 	/// Proxy backend used to tunnel the connection.
 	pub proxy: Arc<SimpleBackendReference>,
-	/// Use CONNECT even when the tunneled application transport is plaintext HTTP.
-	#[serde(default, skip_serializing_if = "std::ops::Not::not")]
-	pub connect: bool,
+	/// How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend
+	/// do not run on tunneled requests; HTTP policies on the destination backend still run.
+	#[serde(default)]
+	pub mode: TunnelMode,
 	/// Policies to connect to the proxy backend
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	#[serde(deserialize_with = "crate::types::local::de_from_local_backend_policy")]

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1358,6 +1358,11 @@ pub enum FullLocalBackendSpec {
 	/// Hostname or IP address of the upstream to route to.
 	#[serde(rename = "host")]
 	Opaque(Target),
+	/// Resolve the dial target from request metadata using a CEL expression.
+	Dynamic {
+		#[serde(default, skip_serializing_if = "Option::is_none")]
+		target: Option<Arc<crate::cel::Expression>>,
+	},
 	/// Route to the in-process admin service instead of a network upstream.
 	#[serde(rename = "internal")]
 	Internal(InternalBackend),
@@ -1373,6 +1378,7 @@ impl From<FullLocalBackendSpec> for LocalBackend {
 	fn from(spec: FullLocalBackendSpec) -> Self {
 		match spec {
 			FullLocalBackendSpec::Opaque(t) => LocalBackend::Opaque(t),
+			FullLocalBackendSpec::Dynamic { target } => LocalBackend::Dynamic { target },
 			FullLocalBackendSpec::Internal(t) => LocalBackend::Internal(t),
 			FullLocalBackendSpec::MCP(m) => LocalBackend::MCP(m),
 			FullLocalBackendSpec::AI(a) => LocalBackend::AI(a),

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -301,6 +301,30 @@ binds:
 	assert_eq!(expr.original_expression, "extproc.workerTarget");
 }
 
+#[tokio::test]
+async fn test_named_dynamic_backend_target_expression_normalizes() {
+	let normalized = normalize_test_yaml(
+		r#"
+backends:
+- name: worker
+  dynamic:
+    target: extproc.workerTarget
+"#,
+	)
+	.await
+	.expect("named dynamic backend with a target expression should normalize");
+
+	let expr = normalized
+		.backends
+		.iter()
+		.find_map(|backend| match &backend.backend {
+			Backend::Dynamic(_, expr) => expr.as_ref(),
+			_ => None,
+		})
+		.expect("named dynamic backend target expression should be set");
+	assert_eq!(expr.original_expression, "extproc.workerTarget");
+}
+
 #[test]
 fn test_local_backend_policies_reject_unknown_fields() {
 	// serde(flatten) disables deny_unknown_fields on the outer struct, but the

--- a/crates/agentgateway/tests/tests/connect.rs
+++ b/crates/agentgateway/tests/tests/connect.rs
@@ -1355,6 +1355,7 @@ async fn incoming_connect_uses_backend_tunnel_proxy() {
 			proxy: Arc::new(SimpleBackendReference::InlineBackend(Target::Address(
 				proxy_addr,
 			))),
+			connect: false,
 			policies: vec![],
 		})
 		.into(),

--- a/crates/agentgateway/tests/tests/connect.rs
+++ b/crates/agentgateway/tests/tests/connect.rs
@@ -1355,7 +1355,7 @@ async fn incoming_connect_uses_backend_tunnel_proxy() {
 			proxy: Arc::new(SimpleBackendReference::InlineBackend(Target::Address(
 				proxy_addr,
 			))),
-			connect: false,
+			mode: backend::TunnelMode::Auto,
 			policies: vec![],
 		})
 		.into(),

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1590,7 +1590,7 @@ message BackendPolicySpec {
     enum Mode {
       // Use CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.
       AUTO = 0;
-      // Always use CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.
+      // Use CONNECT for all transports, including plaintext HTTP.
       CONNECT = 1;
     }
     BackendReference proxy = 1;

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1587,11 +1587,16 @@ message BackendPolicySpec {
     google.protobuf.Duration request_timeout = 2;
   }
   message BackendTunnel {
+    enum Mode {
+      // Use CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.
+      AUTO = 0;
+      // Always use CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.
+      CONNECT = 1;
+    }
     BackendReference proxy = 1;
     // Inline backend policies (e.g. TLS, auth) for the tunnel proxy backend.
     repeated BackendPolicySpec inline_policies = 2;
-    // Use CONNECT even when the tunneled application transport is plaintext HTTP.
-    bool connect = 3;
+    Mode mode = 3;
   }
   message BackendTCP {
     KeepaliveConfig keepalive = 1;

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1590,6 +1590,8 @@ message BackendPolicySpec {
     BackendReference proxy = 1;
     // Inline backend policies (e.g. TLS, auth) for the tunnel proxy backend.
     repeated BackendPolicySpec inline_policies = 2;
+    // Use CONNECT even when the tunneled application transport is plaintext HTTP.
+    bool connect = 3;
   }
   message BackendTCP {
     KeepaliveConfig keepalive = 1;

--- a/schema/config.json
+++ b/schema/config.json
@@ -4496,9 +4496,10 @@
           "description": "Proxy backend used to tunnel the connection.",
           "$ref": "#/$defs/SimpleLocalBackendSerde"
         },
-        "connect": {
-          "description": "Use CONNECT even when the tunneled application transport is plaintext HTTP.",
-          "type": "boolean"
+        "mode": {
+          "description": "How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend\ndo not run on tunneled requests; HTTP policies on the destination backend still run.",
+          "$ref": "#/$defs/TunnelMode",
+          "default": "auto"
         },
         "policies": {
           "description": "Policies to connect to the proxy backend",
@@ -4515,6 +4516,20 @@
       "additionalProperties": false,
       "required": [
         "proxy"
+      ]
+    },
+    "TunnelMode": {
+      "oneOf": [
+        {
+          "description": "Use CONNECT for TLS and non-HTTP transports, and absolute-form requests for plaintext HTTP.",
+          "type": "string",
+          "const": "auto"
+        },
+        {
+          "description": "Always use CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.",
+          "type": "string",
+          "const": "connect"
+        }
       ]
     },
     "FailureMode": {

--- a/schema/config.json
+++ b/schema/config.json
@@ -4496,6 +4496,10 @@
           "description": "Proxy backend used to tunnel the connection.",
           "$ref": "#/$defs/SimpleLocalBackendSerde"
         },
+        "connect": {
+          "description": "Use CONNECT even when the tunneled application transport is plaintext HTTP.",
+          "type": "boolean"
+        },
         "policies": {
           "description": "Policies to connect to the proxy backend",
           "anyOf": [

--- a/schema/config.json
+++ b/schema/config.json
@@ -4497,7 +4497,7 @@
           "$ref": "#/$defs/SimpleLocalBackendSerde"
         },
         "mode": {
-          "description": "How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend\ndo not run on tunneled requests; HTTP policies on the destination backend still run.",
+          "description": "How requests are sent through the proxy.",
           "$ref": "#/$defs/TunnelMode",
           "default": "auto"
         },
@@ -4526,7 +4526,7 @@
           "const": "auto"
         },
         {
-          "description": "Always use CONNECT. HTTP policies on the proxy backend do not run on tunneled requests.",
+          "description": "Use CONNECT for all transports, including plaintext HTTP.",
           "type": "string",
           "const": "connect"
         }
@@ -10410,6 +10410,31 @@
           },
           "required": [
             "host"
+          ]
+        },
+        {
+          "description": "Resolve the dial target from request metadata using a CEL expression.",
+          "type": "object",
+          "properties": {
+            "dynamic": {
+              "type": "object",
+              "properties": {
+                "target": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/$defs/Expression"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "dynamic"
           ]
         },
         {

--- a/schema/config.md
+++ b/schema/config.md
@@ -480,7 +480,7 @@
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -816,7 +816,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -1090,7 +1090,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -1364,7 +1364,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -1636,7 +1636,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -1945,7 +1945,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -2219,7 +2219,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -2491,7 +2491,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -2544,7 +2544,7 @@
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -2938,7 +2938,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -3054,7 +3054,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -3128,7 +3128,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -3465,7 +3465,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -3749,7 +3749,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -4106,7 +4106,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -4403,7 +4403,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -4703,7 +4703,7 @@
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -4990,7 +4990,7 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -5364,7 +5364,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`binds[].listeners[].routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -5575,7 +5575,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -5691,7 +5691,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -5765,7 +5765,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -5831,7 +5831,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -6389,7 +6389,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -6698,7 +6698,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -7011,7 +7011,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -7285,7 +7285,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -7559,7 +7559,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -7831,7 +7831,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -8140,7 +8140,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -8414,7 +8414,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -8686,7 +8686,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -8927,7 +8927,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -9043,7 +9043,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -9117,7 +9117,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -9183,7 +9183,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -9741,7 +9741,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -10050,7 +10050,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -10363,7 +10363,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -10637,7 +10637,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -10911,7 +10911,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -11183,7 +11183,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -11492,7 +11492,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -11766,7 +11766,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -12038,7 +12038,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -12242,7 +12242,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -12358,7 +12358,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -12432,7 +12432,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -12498,7 +12498,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -13056,7 +13056,7 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -13365,7 +13365,7 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -13678,7 +13678,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -13952,7 +13952,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -14226,7 +14226,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -14498,7 +14498,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -14807,7 +14807,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -15081,7 +15081,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -15353,7 +15353,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -15433,7 +15433,7 @@
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -16019,7 +16019,7 @@
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -16316,7 +16316,7 @@
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -16616,7 +16616,7 @@
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -16903,7 +16903,7 @@
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`binds[].listeners[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -17292,7 +17292,7 @@
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`frontendPolicies.networkExtAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`frontendPolicies.networkExtAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.networkExtAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`frontendPolicies.networkExtAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -17602,7 +17602,7 @@
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`frontendPolicies.accessLog.otlp.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`frontendPolicies.accessLog.otlp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.accessLog.otlp.filter`|string|CEL expression that decides whether a request is exported over OTLP.|
 |`frontendPolicies.accessLog.otlp.fields`|object|OTLP-specific access log fields. If unset, the parent access log fields are used.|
@@ -17891,7 +17891,7 @@
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`frontendPolicies.logging.otlp.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`frontendPolicies.logging.otlp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.logging.otlp.filter`|string|CEL expression that decides whether a request is exported over OTLP.|
 |`frontendPolicies.logging.otlp.fields`|object|OTLP-specific access log fields. If unset, the parent access log fields are used.|
@@ -18176,7 +18176,7 @@
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`frontendPolicies.tracing.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`frontendPolicies.tracing.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`frontendPolicies.tracing.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.tracing.attributes`|object|Span attributes to add, keyed by attribute name.|
 |`frontendPolicies.tracing.resources`|object|Resource attributes to add to the tracer provider (OTel `Resource`).<br>This can be used to set things like `service.name` dynamically.|
@@ -18548,7 +18548,7 @@
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -18884,7 +18884,7 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -19158,7 +19158,7 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -19432,7 +19432,7 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -19704,7 +19704,7 @@
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -20013,7 +20013,7 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -20287,7 +20287,7 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -20559,7 +20559,7 @@
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -20612,7 +20612,7 @@
 |`policies[].policy.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`policies[].policy.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`policies[].policy.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -21006,7 +21006,7 @@
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -21122,7 +21122,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -21196,7 +21196,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -21533,7 +21533,7 @@
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`policies[].policy.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -21817,7 +21817,7 @@
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`policies[].policy.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -22174,7 +22174,7 @@
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`policies[].policy.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -22471,7 +22471,7 @@
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`policies[].policy.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -22771,7 +22771,7 @@
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -23058,7 +23058,7 @@
 |`policies[].policy.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`policies[].policy.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -23428,7 +23428,7 @@
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -23639,7 +23639,7 @@
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -23755,7 +23755,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -23829,7 +23829,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -23895,7 +23895,7 @@
 |`backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -24453,7 +24453,7 @@
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -24762,7 +24762,7 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -25075,7 +25075,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -25349,7 +25349,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -25623,7 +25623,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -25895,7 +25895,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -26204,7 +26204,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -26478,7 +26478,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -26750,7 +26750,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -26991,7 +26991,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -27107,7 +27107,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -27181,7 +27181,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -27247,7 +27247,7 @@
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -27805,7 +27805,7 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -28114,7 +28114,7 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -28427,7 +28427,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -28701,7 +28701,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -28975,7 +28975,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -29247,7 +29247,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -29556,7 +29556,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -29830,7 +29830,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -30102,7 +30102,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -30304,7 +30304,7 @@
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -30420,7 +30420,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -30494,7 +30494,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -30560,7 +30560,7 @@
 |`backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -31118,7 +31118,7 @@
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -31427,7 +31427,7 @@
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -31740,7 +31740,7 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -32014,7 +32014,7 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -32288,7 +32288,7 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -32560,7 +32560,7 @@
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -32869,7 +32869,7 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -33143,7 +33143,7 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -33415,7 +33415,7 @@
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -33806,7 +33806,7 @@
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -34142,7 +34142,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -34416,7 +34416,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -34690,7 +34690,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -34962,7 +34962,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -35271,7 +35271,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -35545,7 +35545,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -35817,7 +35817,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -35870,7 +35870,7 @@
 |`routeGroups[].routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -36264,7 +36264,7 @@
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -36380,7 +36380,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -36454,7 +36454,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -36791,7 +36791,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -37075,7 +37075,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routeGroups[].routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -37432,7 +37432,7 @@
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -37729,7 +37729,7 @@
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -38029,7 +38029,7 @@
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -38316,7 +38316,7 @@
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -38690,7 +38690,7 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`routeGroups[].routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -38901,7 +38901,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -39017,7 +39017,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -39091,7 +39091,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -39157,7 +39157,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -39715,7 +39715,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -40024,7 +40024,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -40337,7 +40337,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -40611,7 +40611,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -40885,7 +40885,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -41157,7 +41157,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -41466,7 +41466,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -41740,7 +41740,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -42012,7 +42012,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -42253,7 +42253,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -42369,7 +42369,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -42443,7 +42443,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -42509,7 +42509,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -43067,7 +43067,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -43376,7 +43376,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -43689,7 +43689,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -43963,7 +43963,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -44237,7 +44237,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -44509,7 +44509,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -44818,7 +44818,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -45092,7 +45092,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -45364,7 +45364,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -45568,7 +45568,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -45684,7 +45684,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -45758,7 +45758,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -45824,7 +45824,7 @@
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -46382,7 +46382,7 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -46691,7 +46691,7 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -47004,7 +47004,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -47278,7 +47278,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -47552,7 +47552,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -47824,7 +47824,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -48133,7 +48133,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -48407,7 +48407,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -48679,7 +48679,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -49055,7 +49055,7 @@
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.listeners[].extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -49352,7 +49352,7 @@
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.listeners[].extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`gateways.*.listeners[].extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.listeners[].extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -49652,7 +49652,7 @@
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.listeners[].extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -49939,7 +49939,7 @@
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.listeners[].extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`gateways.*.listeners[].extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.listeners[].extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -50355,7 +50355,7 @@
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`gateways.*.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -50652,7 +50652,7 @@
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`gateways.*.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -50952,7 +50952,7 @@
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`gateways.*.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -51239,7 +51239,7 @@
 |`gateways.*.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`gateways.*.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -51676,7 +51676,7 @@
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -52012,7 +52012,7 @@
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -52286,7 +52286,7 @@
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -52560,7 +52560,7 @@
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -52832,7 +52832,7 @@
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -53141,7 +53141,7 @@
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -53415,7 +53415,7 @@
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -53687,7 +53687,7 @@
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -53740,7 +53740,7 @@
 |`routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -54134,7 +54134,7 @@
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -54250,7 +54250,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -54324,7 +54324,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -54661,7 +54661,7 @@
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -54945,7 +54945,7 @@
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -55302,7 +55302,7 @@
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -55599,7 +55599,7 @@
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -55899,7 +55899,7 @@
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -56186,7 +56186,7 @@
 |`routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -56560,7 +56560,7 @@
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -56771,7 +56771,7 @@
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -56887,7 +56887,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -56961,7 +56961,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -57027,7 +57027,7 @@
 |`routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -57585,7 +57585,7 @@
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -57894,7 +57894,7 @@
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -58207,7 +58207,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -58481,7 +58481,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -58755,7 +58755,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -59027,7 +59027,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -59336,7 +59336,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -59610,7 +59610,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -59882,7 +59882,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -60123,7 +60123,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -60239,7 +60239,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -60313,7 +60313,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -60379,7 +60379,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -60937,7 +60937,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -61246,7 +61246,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -61559,7 +61559,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -61833,7 +61833,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -62107,7 +62107,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -62379,7 +62379,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -62688,7 +62688,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -62962,7 +62962,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -63234,7 +63234,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -63438,7 +63438,7 @@
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -63554,7 +63554,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -63628,7 +63628,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -63694,7 +63694,7 @@
 |`routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -64252,7 +64252,7 @@
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -64561,7 +64561,7 @@
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -64874,7 +64874,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -65148,7 +65148,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -65422,7 +65422,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -65694,7 +65694,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -66003,7 +66003,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -66277,7 +66277,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -66549,7 +66549,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -66630,7 +66630,7 @@
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`tcpRoutes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`tcpRoutes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -67099,7 +67099,7 @@
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -67215,7 +67215,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -67289,7 +67289,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -67352,7 +67352,7 @@
 |`llm.providers[].defaults.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.providers[].defaults.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.providers[].defaults.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.providers[].defaults.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`llm.providers[].defaults.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -67820,7 +67820,7 @@
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -67936,7 +67936,7 @@
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -68010,7 +68010,7 @@
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -68073,7 +68073,7 @@
 |`llm.models[].backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`llm.models[].backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`llm.models[].backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -68628,7 +68628,7 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -68902,7 +68902,7 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.models[].guardrails.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -69176,7 +69176,7 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.models[].guardrails.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -69448,7 +69448,7 @@
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.models[].guardrails.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -69757,7 +69757,7 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.models[].guardrails.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -70031,7 +70031,7 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.models[].guardrails.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -70303,7 +70303,7 @@
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.models[].guardrails.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -70669,7 +70669,7 @@
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`llm.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -70966,7 +70966,7 @@
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`llm.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -71266,7 +71266,7 @@
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`llm.policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -71553,7 +71553,7 @@
 |`llm.policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`llm.policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -71927,7 +71927,7 @@
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -72201,7 +72201,7 @@
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.policies.guardrails.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -72475,7 +72475,7 @@
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.policies.guardrails.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -72747,7 +72747,7 @@
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.policies.guardrails.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -73056,7 +73056,7 @@
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.policies.guardrails.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -73330,7 +73330,7 @@
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.policies.guardrails.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -73602,7 +73602,7 @@
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.policies.guardrails.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -73898,7 +73898,7 @@
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`llm.policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`llm.policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -74210,7 +74210,7 @@
 |`mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -74549,7 +74549,7 @@
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -74885,7 +74885,7 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -75159,7 +75159,7 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -75433,7 +75433,7 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -75705,7 +75705,7 @@
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -76014,7 +76014,7 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -76288,7 +76288,7 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -76560,7 +76560,7 @@
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -76613,7 +76613,7 @@
 |`mcp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`mcp.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`mcp.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -77007,7 +77007,7 @@
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -77123,7 +77123,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -77197,7 +77197,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -77534,7 +77534,7 @@
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`mcp.policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -77818,7 +77818,7 @@
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`mcp.policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -78175,7 +78175,7 @@
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`mcp.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -78472,7 +78472,7 @@
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`mcp.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -78772,7 +78772,7 @@
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -79059,7 +79059,7 @@
 |`mcp.policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`mcp.policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -79456,7 +79456,7 @@
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`ui.policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`ui.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`ui.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`ui.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -79753,7 +79753,7 @@
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`ui.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
+|`ui.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
 |`ui.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`ui.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`ui.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -480,7 +480,7 @@
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -816,7 +816,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -1090,7 +1090,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -1364,7 +1364,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -1636,7 +1636,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -1945,7 +1945,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -2219,7 +2219,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -2491,7 +2491,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -2544,7 +2544,7 @@
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -2938,7 +2938,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -3054,7 +3054,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -3128,7 +3128,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -3465,7 +3465,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -3749,7 +3749,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -4106,7 +4106,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -4403,7 +4403,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -4703,7 +4703,7 @@
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -4990,7 +4990,7 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -5364,7 +5364,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`binds[].listeners[].routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -5575,7 +5575,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -5691,7 +5691,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -5765,7 +5765,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -5831,7 +5831,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -6389,7 +6389,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -6698,7 +6698,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -7011,7 +7011,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -7285,7 +7285,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -7559,7 +7559,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -7831,7 +7831,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -8140,7 +8140,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -8414,7 +8414,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -8686,7 +8686,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -8927,7 +8927,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -9043,7 +9043,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -9117,7 +9117,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -9183,7 +9183,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -9741,7 +9741,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -10050,7 +10050,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -10363,7 +10363,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -10637,7 +10637,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -10911,7 +10911,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -11183,7 +11183,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -11492,7 +11492,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -11766,7 +11766,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -12038,7 +12038,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -12242,7 +12242,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -12358,7 +12358,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -12432,7 +12432,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -12498,7 +12498,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -13056,7 +13056,7 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -13365,7 +13365,7 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -13678,7 +13678,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -13952,7 +13952,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -14226,7 +14226,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -14498,7 +14498,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -14807,7 +14807,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -15081,7 +15081,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -15353,7 +15353,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -15433,7 +15433,7 @@
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -16019,7 +16019,7 @@
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -16316,7 +16316,7 @@
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -16616,7 +16616,7 @@
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -16903,7 +16903,7 @@
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`binds[].listeners[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`binds[].listeners[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -17292,7 +17292,7 @@
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`frontendPolicies.networkExtAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`frontendPolicies.networkExtAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.networkExtAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`frontendPolicies.networkExtAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -17602,7 +17602,7 @@
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`frontendPolicies.accessLog.otlp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`frontendPolicies.accessLog.otlp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.accessLog.otlp.filter`|string|CEL expression that decides whether a request is exported over OTLP.|
 |`frontendPolicies.accessLog.otlp.fields`|object|OTLP-specific access log fields. If unset, the parent access log fields are used.|
@@ -17891,7 +17891,7 @@
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`frontendPolicies.logging.otlp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`frontendPolicies.logging.otlp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.logging.otlp.filter`|string|CEL expression that decides whether a request is exported over OTLP.|
 |`frontendPolicies.logging.otlp.fields`|object|OTLP-specific access log fields. If unset, the parent access log fields are used.|
@@ -18176,7 +18176,7 @@
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`frontendPolicies.tracing.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`frontendPolicies.tracing.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`frontendPolicies.tracing.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.tracing.attributes`|object|Span attributes to add, keyed by attribute name.|
 |`frontendPolicies.tracing.resources`|object|Resource attributes to add to the tracer provider (OTel `Resource`).<br>This can be used to set things like `service.name` dynamically.|
@@ -18548,7 +18548,7 @@
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -18884,7 +18884,7 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -19158,7 +19158,7 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -19432,7 +19432,7 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -19704,7 +19704,7 @@
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -20013,7 +20013,7 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -20287,7 +20287,7 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -20559,7 +20559,7 @@
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -20612,7 +20612,7 @@
 |`policies[].policy.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`policies[].policy.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`policies[].policy.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -21006,7 +21006,7 @@
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -21122,7 +21122,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -21196,7 +21196,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -21533,7 +21533,7 @@
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`policies[].policy.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -21817,7 +21817,7 @@
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`policies[].policy.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -22174,7 +22174,7 @@
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`policies[].policy.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -22471,7 +22471,7 @@
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`policies[].policy.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -22771,7 +22771,7 @@
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -23058,7 +23058,7 @@
 |`policies[].policy.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`policies[].policy.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`policies[].policy.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -23127,6 +23127,8 @@
 |`services`|[]object|services defines the set of services that the proxy can route to. These consist of `workloads`.<br>This is an advanced feature that is mostly for testing; usage of inline `backends` on routes and<br>policies is typically preferred.|
 |`backends`|[]object|backends defines explicit backends that can be referenced by routes and policies.<br>Typically, inline backends are used on the routes/policies, but this allows re-using the same backend<br>across different configurations.|
 |`backends[].host`|string|Hostname or IP address of the upstream to route to.|
+|`backends[].dynamic`|object|Resolve the dial target from request metadata using a CEL expression.|
+|`backends[].dynamic.target`|string||
 |`backends[].internal`|string|Route to the in-process admin service instead of a network upstream.<br>Selects how an internal backend maps proxy requests to the admin API.|
 |`backends[].mcp`|object||
 |`backends[].mcp.targets`|[]object|MCP server targets to multiplex together.|
@@ -23428,7 +23430,7 @@
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -23639,7 +23641,7 @@
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -23755,7 +23757,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -23829,7 +23831,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -23895,7 +23897,7 @@
 |`backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -24453,7 +24455,7 @@
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -24762,7 +24764,7 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -25075,7 +25077,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -25349,7 +25351,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -25623,7 +25625,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -25895,7 +25897,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -26204,7 +26206,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -26478,7 +26480,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -26750,7 +26752,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -26991,7 +26993,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -27107,7 +27109,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -27181,7 +27183,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -27247,7 +27249,7 @@
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -27805,7 +27807,7 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -28114,7 +28116,7 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -28427,7 +28429,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -28701,7 +28703,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -28975,7 +28977,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -29247,7 +29249,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -29556,7 +29558,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -29830,7 +29832,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -30102,7 +30104,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -30304,7 +30306,7 @@
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -30420,7 +30422,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -30494,7 +30496,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -30560,7 +30562,7 @@
 |`backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -31118,7 +31120,7 @@
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -31427,7 +31429,7 @@
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -31740,7 +31742,7 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -32014,7 +32016,7 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -32288,7 +32290,7 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -32560,7 +32562,7 @@
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -32869,7 +32871,7 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -33143,7 +33145,7 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -33415,7 +33417,7 @@
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -33806,7 +33808,7 @@
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -34142,7 +34144,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -34416,7 +34418,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -34690,7 +34692,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -34962,7 +34964,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -35271,7 +35273,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -35545,7 +35547,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -35817,7 +35819,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -35870,7 +35872,7 @@
 |`routeGroups[].routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -36264,7 +36266,7 @@
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -36380,7 +36382,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -36454,7 +36456,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -36791,7 +36793,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -37075,7 +37077,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routeGroups[].routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -37432,7 +37434,7 @@
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -37729,7 +37731,7 @@
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -38029,7 +38031,7 @@
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -38316,7 +38318,7 @@
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -38690,7 +38692,7 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`routeGroups[].routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -38901,7 +38903,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -39017,7 +39019,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -39091,7 +39093,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -39157,7 +39159,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -39715,7 +39717,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -40024,7 +40026,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -40337,7 +40339,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -40611,7 +40613,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -40885,7 +40887,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -41157,7 +41159,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -41466,7 +41468,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -41740,7 +41742,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -42012,7 +42014,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -42253,7 +42255,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -42369,7 +42371,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -42443,7 +42445,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -42509,7 +42511,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -43067,7 +43069,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -43376,7 +43378,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -43689,7 +43691,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -43963,7 +43965,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -44237,7 +44239,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -44509,7 +44511,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -44818,7 +44820,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -45092,7 +45094,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -45364,7 +45366,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -45568,7 +45570,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -45684,7 +45686,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -45758,7 +45760,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -45824,7 +45826,7 @@
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -46382,7 +46384,7 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -46691,7 +46693,7 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -47004,7 +47006,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -47278,7 +47280,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -47552,7 +47554,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -47824,7 +47826,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -48133,7 +48135,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -48407,7 +48409,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -48679,7 +48681,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -49055,7 +49057,7 @@
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.listeners[].extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -49352,7 +49354,7 @@
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.listeners[].extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`gateways.*.listeners[].extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.listeners[].extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -49652,7 +49654,7 @@
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.listeners[].extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -49939,7 +49941,7 @@
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.listeners[].extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`gateways.*.listeners[].extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.listeners[].extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -50355,7 +50357,7 @@
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`gateways.*.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -50652,7 +50654,7 @@
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`gateways.*.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -50952,7 +50954,7 @@
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`gateways.*.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -51239,7 +51241,7 @@
 |`gateways.*.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`gateways.*.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`gateways.*.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`gateways.*.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -51676,7 +51678,7 @@
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -52012,7 +52014,7 @@
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -52286,7 +52288,7 @@
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -52560,7 +52562,7 @@
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -52832,7 +52834,7 @@
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -53141,7 +53143,7 @@
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -53415,7 +53417,7 @@
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -53687,7 +53689,7 @@
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -53740,7 +53742,7 @@
 |`routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -54134,7 +54136,7 @@
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -54250,7 +54252,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -54324,7 +54326,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -54661,7 +54663,7 @@
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -54945,7 +54947,7 @@
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -55302,7 +55304,7 @@
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -55599,7 +55601,7 @@
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -55899,7 +55901,7 @@
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -56186,7 +56188,7 @@
 |`routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -56560,7 +56562,7 @@
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -56771,7 +56773,7 @@
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -56887,7 +56889,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -56961,7 +56963,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -57027,7 +57029,7 @@
 |`routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -57585,7 +57587,7 @@
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -57894,7 +57896,7 @@
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -58207,7 +58209,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -58481,7 +58483,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -58755,7 +58757,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -59027,7 +59029,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -59336,7 +59338,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -59610,7 +59612,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -59882,7 +59884,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -60123,7 +60125,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -60239,7 +60241,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -60313,7 +60315,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -60379,7 +60381,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -60937,7 +60939,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -61246,7 +61248,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -61559,7 +61561,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -61833,7 +61835,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -62107,7 +62109,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -62379,7 +62381,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -62688,7 +62690,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -62962,7 +62964,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -63234,7 +63236,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -63438,7 +63440,7 @@
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -63554,7 +63556,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -63628,7 +63630,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -63694,7 +63696,7 @@
 |`routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -64252,7 +64254,7 @@
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -64561,7 +64563,7 @@
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -64874,7 +64876,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -65148,7 +65150,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -65422,7 +65424,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -65694,7 +65696,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -66003,7 +66005,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -66277,7 +66279,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -66549,7 +66551,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -66630,7 +66632,7 @@
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`tcpRoutes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`tcpRoutes[].backends[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -67099,7 +67101,7 @@
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -67215,7 +67217,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -67289,7 +67291,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -67352,7 +67354,7 @@
 |`llm.providers[].defaults.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.providers[].defaults.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.providers[].defaults.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.providers[].defaults.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`llm.providers[].defaults.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -67820,7 +67822,7 @@
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -67936,7 +67938,7 @@
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -68010,7 +68012,7 @@
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -68073,7 +68075,7 @@
 |`llm.models[].backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`llm.models[].backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`llm.models[].backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -68628,7 +68630,7 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -68902,7 +68904,7 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.models[].guardrails.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -69176,7 +69178,7 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.models[].guardrails.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -69448,7 +69450,7 @@
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.models[].guardrails.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -69757,7 +69759,7 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.models[].guardrails.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -70031,7 +70033,7 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.models[].guardrails.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -70303,7 +70305,7 @@
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.models[].guardrails.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -70669,7 +70671,7 @@
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`llm.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -70966,7 +70968,7 @@
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`llm.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -71266,7 +71268,7 @@
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`llm.policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -71553,7 +71555,7 @@
 |`llm.policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`llm.policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -71927,7 +71929,7 @@
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -72201,7 +72203,7 @@
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.policies.guardrails.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -72475,7 +72477,7 @@
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.policies.guardrails.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -72747,7 +72749,7 @@
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.policies.guardrails.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -73056,7 +73058,7 @@
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.policies.guardrails.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -73330,7 +73332,7 @@
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.policies.guardrails.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -73602,7 +73604,7 @@
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.policies.guardrails.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -73898,7 +73900,7 @@
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`llm.policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`llm.policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`llm.policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -74210,7 +74212,7 @@
 |`mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.targets[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -74549,7 +74551,7 @@
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -74885,7 +74887,7 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -75159,7 +75161,7 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -75433,7 +75435,7 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -75705,7 +75707,7 @@
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -76014,7 +76016,7 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -76288,7 +76290,7 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -76560,7 +76562,7 @@
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -76613,7 +76615,7 @@
 |`mcp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`mcp.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`mcp.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -77007,7 +77009,7 @@
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -77123,7 +77125,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -77197,7 +77199,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -77534,7 +77536,7 @@
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`mcp.policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -77818,7 +77820,7 @@
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.remoteRateLimit.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`mcp.policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -78175,7 +78177,7 @@
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`mcp.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -78472,7 +78474,7 @@
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`mcp.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -78772,7 +78774,7 @@
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.extProc.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -79059,7 +79061,7 @@
 |`mcp.policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`mcp.policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`mcp.policies.extProc.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -79456,7 +79458,7 @@
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`ui.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`ui.policies.extAuthz.conditional[].policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`ui.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`ui.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -79753,7 +79755,7 @@
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
-|`ui.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy. In `connect` mode, HTTP policies on the proxy backend<br>do not run on tunneled requests; HTTP policies on the destination backend still run.<br>Possible values: `auto`, `connect`.|
+|`ui.policies.extAuthz.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`ui.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`ui.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`ui.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -480,6 +480,7 @@
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -815,6 +816,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -1088,6 +1090,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -1361,6 +1364,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -1632,6 +1636,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -1940,6 +1945,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -2213,6 +2219,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -2484,6 +2491,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -2536,6 +2544,7 @@
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -2929,6 +2938,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -3044,6 +3054,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -3117,6 +3128,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -3453,6 +3465,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -3736,6 +3749,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -4092,6 +4106,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -4388,6 +4403,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -4687,6 +4703,7 @@
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -4973,6 +4990,7 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -5346,6 +5364,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`binds[].listeners[].routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -5556,6 +5575,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -5671,6 +5691,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -5744,6 +5765,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -5809,6 +5831,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -6366,6 +6389,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -6674,6 +6698,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -6986,6 +7011,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -7259,6 +7285,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -7532,6 +7559,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -7803,6 +7831,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -8111,6 +8140,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -8384,6 +8414,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -8655,6 +8686,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -8895,6 +8927,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -9010,6 +9043,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -9083,6 +9117,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -9148,6 +9183,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -9705,6 +9741,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -10013,6 +10050,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -10325,6 +10363,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -10598,6 +10637,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -10871,6 +10911,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -11142,6 +11183,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -11450,6 +11492,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -11723,6 +11766,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -11994,6 +12038,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -12197,6 +12242,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -12312,6 +12358,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -12385,6 +12432,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -12450,6 +12498,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -13007,6 +13056,7 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -13315,6 +13365,7 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -13627,6 +13678,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -13900,6 +13952,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -14173,6 +14226,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -14444,6 +14498,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -14752,6 +14807,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -15025,6 +15081,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -15296,6 +15353,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -15375,6 +15433,7 @@
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -15960,6 +16019,7 @@
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -16256,6 +16316,7 @@
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`binds[].listeners[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -16555,6 +16616,7 @@
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -16841,6 +16903,7 @@
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`binds[].listeners[].policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`binds[].listeners[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`binds[].listeners[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -17229,6 +17292,7 @@
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.networkExtAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`frontendPolicies.networkExtAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.networkExtAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`frontendPolicies.networkExtAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -17538,6 +17602,7 @@
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.accessLog.otlp.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`frontendPolicies.accessLog.otlp.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.accessLog.otlp.filter`|string|CEL expression that decides whether a request is exported over OTLP.|
 |`frontendPolicies.accessLog.otlp.fields`|object|OTLP-specific access log fields. If unset, the parent access log fields are used.|
@@ -17826,6 +17891,7 @@
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.logging.otlp.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`frontendPolicies.logging.otlp.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.logging.otlp.filter`|string|CEL expression that decides whether a request is exported over OTLP.|
 |`frontendPolicies.logging.otlp.fields`|object|OTLP-specific access log fields. If unset, the parent access log fields are used.|
@@ -18110,6 +18176,7 @@
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`frontendPolicies.tracing.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`frontendPolicies.tracing.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`frontendPolicies.tracing.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`frontendPolicies.tracing.attributes`|object|Span attributes to add, keyed by attribute name.|
 |`frontendPolicies.tracing.resources`|object|Resource attributes to add to the tracer provider (OTel `Resource`).<br>This can be used to set things like `service.name` dynamically.|
@@ -18481,6 +18548,7 @@
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -18816,6 +18884,7 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -19089,6 +19158,7 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -19362,6 +19432,7 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -19633,6 +19704,7 @@
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -19941,6 +20013,7 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -20214,6 +20287,7 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -20485,6 +20559,7 @@
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -20537,6 +20612,7 @@
 |`policies[].policy.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`policies[].policy.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`policies[].policy.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -20930,6 +21006,7 @@
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -21045,6 +21122,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -21118,6 +21196,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -21454,6 +21533,7 @@
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`policies[].policy.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -21737,6 +21817,7 @@
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`policies[].policy.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -22093,6 +22174,7 @@
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`policies[].policy.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -22389,6 +22471,7 @@
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`policies[].policy.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -22688,6 +22771,7 @@
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -22974,6 +23058,7 @@
 |`policies[].policy.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`policies[].policy.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`policies[].policy.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`policies[].policy.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`policies[].policy.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`policies[].policy.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`policies[].policy.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -23343,6 +23428,7 @@
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -23553,6 +23639,7 @@
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -23668,6 +23755,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -23741,6 +23829,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -23806,6 +23895,7 @@
 |`backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -24363,6 +24453,7 @@
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -24671,6 +24762,7 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -24983,6 +25075,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -25256,6 +25349,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -25529,6 +25623,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -25800,6 +25895,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -26108,6 +26204,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -26381,6 +26478,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -26652,6 +26750,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -26892,6 +26991,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -27007,6 +27107,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -27080,6 +27181,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -27145,6 +27247,7 @@
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -27702,6 +27805,7 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -28010,6 +28114,7 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -28322,6 +28427,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -28595,6 +28701,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -28868,6 +28975,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -29139,6 +29247,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -29447,6 +29556,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -29720,6 +29830,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -29991,6 +30102,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -30192,6 +30304,7 @@
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -30307,6 +30420,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -30380,6 +30494,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -30445,6 +30560,7 @@
 |`backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -31002,6 +31118,7 @@
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -31310,6 +31427,7 @@
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -31622,6 +31740,7 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -31895,6 +32014,7 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -32168,6 +32288,7 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -32439,6 +32560,7 @@
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -32747,6 +32869,7 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -33020,6 +33143,7 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -33291,6 +33415,7 @@
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -33681,6 +33806,7 @@
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -34016,6 +34142,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -34289,6 +34416,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -34562,6 +34690,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -34833,6 +34962,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -35141,6 +35271,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -35414,6 +35545,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -35685,6 +35817,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -35737,6 +35870,7 @@
 |`routeGroups[].routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -36130,6 +36264,7 @@
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -36245,6 +36380,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -36318,6 +36454,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -36654,6 +36791,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -36937,6 +37075,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routeGroups[].routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -37293,6 +37432,7 @@
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -37589,6 +37729,7 @@
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -37888,6 +38029,7 @@
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -38174,6 +38316,7 @@
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -38547,6 +38690,7 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`routeGroups[].routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -38757,6 +38901,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -38872,6 +39017,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -38945,6 +39091,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -39010,6 +39157,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -39567,6 +39715,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -39875,6 +40024,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -40187,6 +40337,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -40460,6 +40611,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -40733,6 +40885,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -41004,6 +41157,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -41312,6 +41466,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -41585,6 +41740,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -41856,6 +42012,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -42096,6 +42253,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -42211,6 +42369,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -42284,6 +42443,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -42349,6 +42509,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -42906,6 +43067,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -43214,6 +43376,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -43526,6 +43689,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -43799,6 +43963,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -44072,6 +44237,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -44343,6 +44509,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -44651,6 +44818,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -44924,6 +45092,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -45195,6 +45364,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -45398,6 +45568,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -45513,6 +45684,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -45586,6 +45758,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -45651,6 +45824,7 @@
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -46208,6 +46382,7 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -46516,6 +46691,7 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -46828,6 +47004,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -47101,6 +47278,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -47374,6 +47552,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -47645,6 +47824,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -47953,6 +48133,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -48226,6 +48407,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -48497,6 +48679,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -48872,6 +49055,7 @@
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.listeners[].extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -49168,6 +49352,7 @@
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`gateways.*.listeners[].extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`gateways.*.listeners[].extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.listeners[].extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -49467,6 +49652,7 @@
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.listeners[].extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -49753,6 +49939,7 @@
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`gateways.*.listeners[].extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`gateways.*.listeners[].extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.listeners[].extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.listeners[].extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -50168,6 +50355,7 @@
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`gateways.*.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`gateways.*.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -50464,6 +50652,7 @@
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`gateways.*.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`gateways.*.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`gateways.*.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -50763,6 +50952,7 @@
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`gateways.*.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`gateways.*.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -51049,6 +51239,7 @@
 |`gateways.*.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`gateways.*.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`gateways.*.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`gateways.*.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`gateways.*.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`gateways.*.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`gateways.*.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -51485,6 +51676,7 @@
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -51820,6 +52012,7 @@
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -52093,6 +52286,7 @@
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -52366,6 +52560,7 @@
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -52637,6 +52832,7 @@
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -52945,6 +53141,7 @@
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -53218,6 +53415,7 @@
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -53489,6 +53687,7 @@
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -53541,6 +53740,7 @@
 |`routes[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -53934,6 +54134,7 @@
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -54049,6 +54250,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -54122,6 +54324,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -54458,6 +54661,7 @@
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routes[].policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -54741,6 +54945,7 @@
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`routes[].policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -55097,6 +55302,7 @@
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -55393,6 +55599,7 @@
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -55692,6 +55899,7 @@
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -55978,6 +56186,7 @@
 |`routes[].policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -56351,6 +56560,7 @@
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`routes[].backends[].mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -56561,6 +56771,7 @@
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -56676,6 +56887,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -56749,6 +56961,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -56814,6 +57027,7 @@
 |`routes[].backends[].ai.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -57371,6 +57585,7 @@
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].ai.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -57679,6 +57894,7 @@
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -57991,6 +58207,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -58264,6 +58481,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -58537,6 +58755,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -58808,6 +59027,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -59116,6 +59336,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -59389,6 +59610,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -59660,6 +59882,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -59900,6 +60123,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -60015,6 +60239,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -60088,6 +60313,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -60153,6 +60379,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -60710,6 +60937,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -61018,6 +61246,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -61330,6 +61559,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -61603,6 +61833,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -61876,6 +62107,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -62147,6 +62379,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -62455,6 +62688,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -62728,6 +62962,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -62999,6 +63234,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -63202,6 +63438,7 @@
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -63317,6 +63554,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -63390,6 +63628,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -63455,6 +63694,7 @@
 |`routes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`routes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -64012,6 +64252,7 @@
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`routes[].backends[].policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -64320,6 +64561,7 @@
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -64632,6 +64874,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -64905,6 +65148,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -65178,6 +65422,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -65449,6 +65694,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -65757,6 +66003,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -66030,6 +66277,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -66301,6 +66549,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -66381,6 +66630,7 @@
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`tcpRoutes[].backends[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`tcpRoutes[].backends[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -66849,6 +67099,7 @@
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -66964,6 +67215,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -67037,6 +67289,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -67099,6 +67352,7 @@
 |`llm.providers[].defaults.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.providers[].defaults.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.providers[].defaults.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.providers[].defaults.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.providers[].defaults.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`llm.providers[].defaults.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`llm.providers[].defaults.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -67566,6 +67820,7 @@
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].auth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -67681,6 +67936,7 @@
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -67754,6 +68010,7 @@
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -67816,6 +68073,7 @@
 |`llm.models[].backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`llm.models[].backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`llm.models[].backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -68370,6 +68628,7 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -68643,6 +68902,7 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.models[].guardrails.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -68916,6 +69176,7 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.models[].guardrails.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -69187,6 +69448,7 @@
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.models[].guardrails.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -69495,6 +69757,7 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.models[].guardrails.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -69768,6 +70031,7 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.models[].guardrails.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -70039,6 +70303,7 @@
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.models[].guardrails.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.models[].guardrails.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -70404,6 +70669,7 @@
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`llm.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -70700,6 +70966,7 @@
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`llm.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -70999,6 +71266,7 @@
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`llm.policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -71285,6 +71553,7 @@
 |`llm.policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`llm.policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -71658,6 +71927,7 @@
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -71931,6 +72201,7 @@
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.policies.guardrails.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -72204,6 +72475,7 @@
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.policies.guardrails.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -72475,6 +72747,7 @@
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.policies.guardrails.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -72783,6 +73056,7 @@
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`llm.policies.guardrails.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -73056,6 +73330,7 @@
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`llm.policies.guardrails.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -73327,6 +73602,7 @@
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.guardrails.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`llm.policies.guardrails.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -73622,6 +73898,7 @@
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`llm.policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`llm.policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`llm.policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`llm.policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -73933,6 +74210,7 @@
 |`mcp.targets[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.targets[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.targets[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.targets[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.targets[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.statefulMode`|enum|Whether to keep a persistent session across requests (Stateful) or create one per request (Stateless).<br>Possible values: `stateless`, `stateful`.|
 |`mcp.prefixMode`|enum|How to namespace tool names when multiplexing: `always` prefix with the target name, or only prefix when needed (`conditional`).<br>Possible values: `conditional`, `always`, `never`.|
@@ -74271,6 +74549,7 @@
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.mcpGuardrails.processors[].failureMode`|enum|Behavior when the processor is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.mcpGuardrails.processors[].metadata`|object|CEL expressions evaluated per request and sent to the processor as metadata.|
@@ -74606,6 +74885,7 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails`|object|Use AWS Bedrock Guardrails to evaluate the prompt.<br>Configuration for AWS Bedrock Guardrails integration.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.guardrailIdentifier`|string|The unique identifier of the guardrail|
@@ -74879,6 +75159,7 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor`|object|Use Google Model Armor to evaluate the prompt.<br>Configuration for Google Cloud Model Armor integration.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -75152,6 +75433,7 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety`|object|Use Azure Content Safety to evaluate the prompt.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -75423,6 +75705,7 @@
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -75731,6 +76014,7 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor`|object|Use Google Model Armor to evaluate the response.<br>Configuration for Google Cloud Model Armor integration.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.templateId`|string|The template ID for the Model Armor configuration|
@@ -76004,6 +76288,7 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety`|object|Use Azure Content Safety to evaluate the response.<br>Configuration for Azure Content Safety integration.<br><br>Uses the Azure AI Content Safety APIs to detect harmful content<br>and jailbreak attempts. The endpoint and authentication are shared<br>across all enabled features.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.endpoint`|string|The Azure Content Safety endpoint hostname (e.g., "<resource-name>.cognitiveservices.azure.com")|
@@ -76275,6 +76560,7 @@
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.analyzeText`|object|Analyze Text configuration for detecting harmful content categories<br>(Hate, SelfHarm, Sexual, Violence) and blocklist matches.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.analyzeText.severityThreshold`|integer|Severity threshold (0-6 for FourSeverityLevels). Content at or above this level is blocked. Default: 2.|
@@ -76327,6 +76613,7 @@
 |`mcp.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.backendTunnel.policies`|object|Policies to connect to the proxy backend|
 |`mcp.policies.backendTunnel.policies.requestHeaderModifier`|object|Modify request headers before forwarding to this backend.|
 |`mcp.policies.backendTunnel.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|
@@ -76720,6 +77007,7 @@
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.oauthTokenExchange.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.oauthTokenExchange.grantType`|enum|Selects which RFC the request follows; defaults to token exchange (RFC 8693).<br>Possible values: `tokenExchange`, `jwtBearer`.|
@@ -76835,6 +77123,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -76908,6 +77197,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.path`|string|Token endpoint path on the backend; defaults to "/".|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.clientAuth`|object|Client authentication used when calling the token endpoint.|
@@ -77244,6 +77534,7 @@
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.remoteRateLimit.conditional[].descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`mcp.policies.remoteRateLimit.conditional[].descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -77527,6 +77818,7 @@
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.remoteRateLimit.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.remoteRateLimit.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.remoteRateLimit.descriptors`|[]object|Descriptors sent to the remote rate limit service.|
 |`mcp.policies.remoteRateLimit.descriptors[].entries`|[]object|Descriptor key/value entries. Values are CEL expressions evaluated from the request.|
@@ -77883,6 +78175,7 @@
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`mcp.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -78179,6 +78472,7 @@
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`mcp.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -78478,6 +78772,7 @@
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extProc.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.extProc.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extProc.conditional[].failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.extProc.conditional[].metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -78764,6 +79059,7 @@
 |`mcp.policies.extProc.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`mcp.policies.extProc.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`mcp.policies.extProc.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`mcp.policies.extProc.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`mcp.policies.extProc.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`mcp.policies.extProc.failureMode`|enum|Behavior when the external processing service is unavailable or returns an error.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.policies.extProc.metadataContext`|object|Additional metadata to send to the external processing service.<br>Maps to the `metadata_context.filter_metadata` field in ProcessingRequest, and allows dynamic CEL expressions.|
@@ -79160,6 +79456,7 @@
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`ui.policies.extAuthz.conditional[].policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`ui.policies.extAuthz.conditional[].policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`ui.policies.extAuthz.conditional[].protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`ui.policies.extAuthz.conditional[].protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|
@@ -79456,6 +79753,7 @@
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.service.port`|integer|Port on the target Service to route to.|
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.host`|string|Hostname or IP address|
 |`ui.policies.extAuthz.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
+|`ui.policies.extAuthz.policies.backendTunnel.connect`|boolean|Use CONNECT even when the tunneled application transport is plaintext HTTP.|
 |`ui.policies.extAuthz.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
 |`ui.policies.extAuthz.protocol`|object|Protocol used to call the authorization service. Use gRPC unless the service only supports HTTP.<br>Exactly one of grpc or http may be set.|
 |`ui.policies.extAuthz.protocol.grpc`|object|Call the authorization service using the gRPC authorization protocol.|


### PR DESCRIPTION
## Summary

- add `backendTunnel.connect` to force CONNECT for plaintext HTTP
- resolve named dynamic proxy targets from request-time CEL metadata
- preserve the Actor target as CONNECT authority while applying proxy policies

## Tests

- HTTP/1.1 and h2c dynamic CONNECT integration test
- existing absolute-form tunnel regression test
- `cargo check -p agentgateway`
- `go test ./controller/pkg/agentgateway/plugins`