### PR TITLE
feat(auth): support forward proxy authentication via the `Proxy_Authorization` header

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -618,6 +618,9 @@ impl Client {
 			transport,
 		} = call;
 		async move {
+      req
+        .headers_mut()
+        .remove(http::header::PROXY_AUTHORIZATION);
 			let dest = connector
 				.resolve_target(transport.skip_dns_resolution(), &target)
 				.await?;

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -618,9 +618,10 @@ impl Client {
 			transport,
 		} = call;
 		async move {
-      req
-        .headers_mut()
-        .remove(http::header::PROXY_AUTHORIZATION);
+			// `Proxy-Authorization` is hop-by-hop: it authenticates the client to this gateway and
+			// must never reach the upstream. Request policies have already consumed it by now. This
+			// runs before the tunnel branch below, which inserts our own upstream proxy credential.
+			req.headers_mut().remove(http::header::PROXY_AUTHORIZATION);
 			let dest = connector
 				.resolve_target(transport.skip_dns_resolution(), &target)
 				.await?;

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -618,10 +618,6 @@ impl Client {
 			transport,
 		} = call;
 		async move {
-			// `Proxy-Authorization` is hop-by-hop: it authenticates the client to this gateway and
-			// must never reach the upstream. Request policies have already consumed it by now. This
-			// runs before the tunnel branch below, which inserts our own upstream proxy credential.
-			req.headers_mut().remove(http::header::PROXY_AUTHORIZATION);
 			let dest = connector
 				.resolve_target(transport.skip_dns_resolution(), &target)
 				.await?;

--- a/crates/agentgateway/src/http/auth/mod.rs
+++ b/crates/agentgateway/src/http/auth/mod.rs
@@ -369,6 +369,15 @@ impl AuthorizationLocation {
 		}
 	}
 
+	/// Returns true if credentials are read from the `Proxy-Authorization` header.
+	///
+	/// Per RFC 9110, credentials sent in `Proxy-Authorization` are addressed to the proxy itself,
+	/// so failures must be challenged with `407` + `Proxy-Authenticate` rather than
+	/// `401` + `WWW-Authenticate`.
+	pub fn is_proxy_header(&self) -> bool {
+		matches!(self, AuthorizationLocation::Header { name, .. } if name == http::header::PROXY_AUTHORIZATION)
+	}
+
 	pub fn extract<'a>(&self, req: &'a Request) -> Option<Cow<'a, str>> {
 		match self {
 			AuthorizationLocation::Header { name, prefix } => {

--- a/crates/agentgateway/src/http/basicauth.rs
+++ b/crates/agentgateway/src/http/basicauth.rs
@@ -14,10 +14,28 @@ mod tests;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
 	#[error("no basic authentication credentials found")]
-	Missing { realm: String },
+	Missing { realm: String, proxy: bool },
 
 	#[error("invalid credentials")]
-	InvalidCredentials { realm: String },
+	InvalidCredentials { realm: String, proxy: bool },
+}
+
+impl Error {
+	pub fn realm(&self) -> &str {
+		match self {
+			Error::Missing { realm, .. } => realm,
+			Error::InvalidCredentials { realm, .. } => realm,
+		}
+	}
+
+	/// Whether the credentials were addressed to the gateway acting as a forward proxy, which
+	/// requires a `407` + `Proxy-Authenticate` challenge instead of `401` + `WWW-Authenticate`.
+	pub fn is_proxy(&self) -> bool {
+		match self {
+			Error::Missing { proxy, .. } => *proxy,
+			Error::InvalidCredentials { proxy, .. } => *proxy,
+		}
+	}
 }
 
 /// Validation mode for Basic Auth.
@@ -85,6 +103,7 @@ impl BasicAuthentication {
 	}
 
 	async fn verify(&self, req: &mut Request) -> Result<Option<Claims>, ProxyError> {
+		let proxy = self.authorization_location.is_proxy_header();
 		let Some(encoded_credentials) = self.authorization_location.extract(req) else {
 			// In strict mode, we require credentials
 			if self.mode == Mode::Strict {
@@ -95,6 +114,7 @@ impl BasicAuthentication {
 				);
 				return Err(ProxyError::BasicAuthenticationFailure(Error::Missing {
 					realm: self.realm.clone().unwrap_or_else(default_realm),
+					proxy,
 				}));
 			}
 			// Otherwise without credentials, don't attempt to authenticate
@@ -109,6 +129,7 @@ impl BasicAuthentication {
 		let invalid_credentials = || {
 			ProxyError::BasicAuthenticationFailure(Error::InvalidCredentials {
 				realm: self.realm.clone().unwrap_or_else(default_realm),
+				proxy,
 			})
 		};
 		let (username, password) = base64::engine::general_purpose::STANDARD

--- a/crates/agentgateway/src/http/basicauth_tests.rs
+++ b/crates/agentgateway/src/http/basicauth_tests.rs
@@ -115,3 +115,143 @@ async fn test_query_parameter_credentials() {
 	assert_eq!(req.uri().to_string(), "http://example.com/?keep=yes");
 	assert!(req.extensions().get::<Claims>().is_some());
 }
+
+fn proxy_authorization_location() -> AuthorizationLocation {
+	AuthorizationLocation::Header {
+		name: ::http::header::PROXY_AUTHORIZATION,
+		prefix: Some("Basic ".into()),
+	}
+}
+
+/// A forward proxy reading `Proxy-Authorization` must challenge with 407 + `Proxy-Authenticate`,
+/// otherwise browsers will not prompt for credentials or retry.
+#[tokio::test]
+async fn test_proxy_authorization_missing_returns_407() {
+	let auth = BasicAuthentication::new(
+		&create_test_htpasswd(),
+		Some("proxy".to_string()),
+		Mode::Strict,
+		proxy_authorization_location(),
+	);
+
+	let mut req = ::http::Request::builder()
+		.method(::http::Method::CONNECT)
+		.uri("example.com:443")
+		.body(axum::body::Body::empty())
+		.unwrap();
+
+	let err = auth.verify(&mut req).await.expect_err("should reject");
+	let resp = err.into_response_with_grpc(false);
+	assert_eq!(
+		resp.status(),
+		::http::StatusCode::PROXY_AUTHENTICATION_REQUIRED
+	);
+	assert_eq!(
+		resp
+			.headers()
+			.get(::http::header::PROXY_AUTHENTICATE)
+			.unwrap(),
+		"Basic realm=\"proxy\""
+	);
+	assert!(
+		resp
+			.headers()
+			.get(::http::header::WWW_AUTHENTICATE)
+			.is_none()
+	);
+}
+
+#[tokio::test]
+async fn test_proxy_authorization_invalid_returns_407() {
+	let auth = BasicAuthentication::new(
+		&create_test_htpasswd(),
+		None,
+		Mode::Strict,
+		proxy_authorization_location(),
+	);
+
+	let mut req = ::http::Request::builder()
+		.method(::http::Method::CONNECT)
+		.uri("example.com:443")
+		// testuser:wrongpass
+		.header("Proxy-Authorization", "Basic dGVzdHVzZXI6d3JvbmdwYXNz")
+		.body(axum::body::Body::empty())
+		.unwrap();
+
+	let err = auth.verify(&mut req).await.expect_err("should reject");
+	let resp = err.into_response_with_grpc(false);
+	assert_eq!(
+		resp.status(),
+		::http::StatusCode::PROXY_AUTHENTICATION_REQUIRED
+	);
+	assert_eq!(
+		resp
+			.headers()
+			.get(::http::header::PROXY_AUTHENTICATE)
+			.unwrap(),
+		"Basic realm=\"Restricted\""
+	);
+}
+
+#[tokio::test]
+async fn test_proxy_authorization_valid_credentials() {
+	let auth = BasicAuthentication::new(
+		&create_test_htpasswd(),
+		None,
+		Mode::Strict,
+		proxy_authorization_location(),
+	);
+
+	let mut req = ::http::Request::builder()
+		.method(::http::Method::CONNECT)
+		.uri("example.com:443")
+		// testuser:test123
+		.header("Proxy-Authorization", "Basic dGVzdHVzZXI6dGVzdDEyMw==")
+		.body(axum::body::Body::empty())
+		.unwrap();
+
+	let _ = crate::test_helpers::test_policy(&auth, &mut req)
+		.await
+		.expect("basic auth should validate");
+	assert!(req.extensions().get::<Claims>().is_some());
+	// The credential is consumed by the policy and must not survive into the upstream request.
+	assert!(
+		req
+			.headers()
+			.get(::http::header::PROXY_AUTHORIZATION)
+			.is_none()
+	);
+}
+
+/// Ordinary API requests must keep the existing 401 + `WWW-Authenticate` behavior.
+#[tokio::test]
+async fn test_ordinary_request_still_returns_401() {
+	let auth = BasicAuthentication::new(
+		&create_test_htpasswd(),
+		None,
+		Mode::Strict,
+		super::default_authorization_location(),
+	);
+
+	let mut req = ::http::Request::builder()
+		.uri("http://example.com")
+		.body(axum::body::Body::empty())
+		.unwrap();
+
+	let err = auth.verify(&mut req).await.expect_err("should reject");
+	let resp = err.into_response_with_grpc(false);
+	assert_eq!(resp.status(), ::http::StatusCode::UNAUTHORIZED);
+	assert_eq!(
+		resp
+			.headers()
+			.get(::http::header::WWW_AUTHENTICATE)
+			.unwrap(),
+		"Basic realm=\"Restricted\""
+	);
+	assert!(
+		resp
+			.headers()
+			.get(::http::header::PROXY_AUTHENTICATE)
+			.is_none()
+	);
+}

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -41,7 +41,8 @@ pub use recordbody::{RecordedBody, RecordedBodyHandle};
 
 pub(crate) fn mark_sensitive_headers(req: &mut Request, configured: &[HeaderName]) {
 	for (name, value) in req.headers_mut() {
-		if name == header::AUTHORIZATION || configured.contains(name) {
+    if name == header::AUTHORIZATION || name == header::PROXY_AUTHORIZATION ||
+        configured.contains(name) {
 			value.set_sensitive(true)
 		}
 	}

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -41,8 +41,10 @@ pub use recordbody::{RecordedBody, RecordedBodyHandle};
 
 pub(crate) fn mark_sensitive_headers(req: &mut Request, configured: &[HeaderName]) {
 	for (name, value) in req.headers_mut() {
-    if name == header::AUTHORIZATION || name == header::PROXY_AUTHORIZATION ||
-        configured.contains(name) {
+		if name == header::AUTHORIZATION
+			|| name == header::PROXY_AUTHORIZATION
+			|| configured.contains(name)
+		{
 			value.set_sensitive(true)
 		}
 	}

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -3813,9 +3813,10 @@ async fn send_mirror(
 // obsoleted RFC 2616 (section 13.5.1) and are used for backward
 // compatibility.
 //
-// NOTE: `Proxy-Authorization` is hop-by-hop but is deliberately absent here. It is stripped at the
-// outbound boundary (`client::Client::call`) instead, so that request policies such as `basicAuth`
-// can read it when the gateway acts as an authenticated forward proxy.
+// NOTE: `Proxy-Authorization` is considered hop-by-hop according to
+// RFC 2616, but is deliberately absent here. It is not stripped so
+// that request policies such as `basicAuth` can read it when the
+// gateway acts as an authenticated forward proxy.
 static HOP_HEADERS: [HeaderName; 8] = [
 	header::CONNECTION,
 	// non-standard but still sent by libcurl and rejected by e.g. google

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -3812,6 +3812,10 @@ async fn send_mirror(
 // Connection header field. These are the headers defined by the
 // obsoleted RFC 2616 (section 13.5.1) and are used for backward
 // compatibility.
+//
+// NOTE: `Proxy-Authorization` is hop-by-hop but is deliberately absent here. It is stripped at the
+// outbound boundary (`client::Client::call`) instead, so that request policies such as `basicAuth`
+// can read it when the gateway acts as an authenticated forward proxy.
 static HOP_HEADERS: [HeaderName; 8] = [
 	header::CONNECTION,
 	// non-standard but still sent by libcurl and rejected by e.g. google

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -3812,13 +3812,12 @@ async fn send_mirror(
 // Connection header field. These are the headers defined by the
 // obsoleted RFC 2616 (section 13.5.1) and are used for backward
 // compatibility.
-static HOP_HEADERS: [HeaderName; 9] = [
+static HOP_HEADERS: [HeaderName; 8] = [
 	header::CONNECTION,
 	// non-standard but still sent by libcurl and rejected by e.g. google
 	HeaderName::from_static("proxy-connection"),
 	HeaderName::from_static("keep-alive"),
 	header::PROXY_AUTHENTICATE,
-	header::PROXY_AUTHORIZATION,
 	header::TE,
 	header::TRAILER,
 	header::TRANSFER_ENCODING,

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -364,7 +364,13 @@ impl ProxyError {
 				| http::oidc::Error::Config(_)
 				| http::oidc::Error::Http(_) => StatusCode::INTERNAL_SERVER_ERROR,
 			},
-			ProxyError::BasicAuthenticationFailure(_) => StatusCode::UNAUTHORIZED,
+			ProxyError::BasicAuthenticationFailure(ref e) => {
+				if e.is_proxy() {
+					StatusCode::PROXY_AUTHENTICATION_REQUIRED
+				} else {
+					StatusCode::UNAUTHORIZED
+				}
+			},
 			ProxyError::APIKeyAuthenticationFailure(_) => StatusCode::UNAUTHORIZED,
 			ProxyError::McpJwtAuthenticationFailure(_, _) => StatusCode::UNAUTHORIZED,
 			ProxyError::AuthorizationFailed => StatusCode::FORBIDDEN,
@@ -437,15 +443,18 @@ impl ProxyError {
 			http::x_headers::set_ratelimit_headers(hm, limit, remaining, reset_seconds);
 		}
 
-		// Add WWW-Authenticate header for basic auth failures
+		// Add an authentication challenge for basic auth failures. Requests authenticating to the
+		// gateway as a forward proxy are challenged with `Proxy-Authenticate` (paired with 407);
+		// ordinary requests use `WWW-Authenticate` (paired with 401).
 		if let ProxyError::BasicAuthenticationFailure(err) = &self {
-			let realm = match err {
-				http::basicauth::Error::Missing { realm } => realm,
-				http::basicauth::Error::InvalidCredentials { realm } => realm,
+			let auth_header = format!("Basic realm=\"{}\"", err.realm());
+			let challenge = if err.is_proxy() {
+				hyper::header::PROXY_AUTHENTICATE
+			} else {
+				hyper::header::WWW_AUTHENTICATE
 			};
-			let auth_header = format!("Basic realm=\"{}\"", realm);
 			if let Ok(hv) = HeaderValue::try_from(auth_header) {
-				rb = rb.header(hyper::header::WWW_AUTHENTICATE, hv);
+				rb = rb.header(challenge, hv);
 			}
 		}
 
@@ -505,6 +514,7 @@ fn http_status_to_grpc_status(status: StatusCode) -> Code {
 		StatusCode::OK => Code::Ok,
 		StatusCode::BAD_REQUEST => Code::Internal,
 		StatusCode::UNAUTHORIZED => Code::Unauthenticated,
+		StatusCode::PROXY_AUTHENTICATION_REQUIRED => Code::Unauthenticated,
 		StatusCode::FORBIDDEN => Code::PermissionDenied,
 		// HTTP 404 maps to UNIMPLEMENTED, not gRPC NOT_FOUND.
 		StatusCode::NOT_FOUND => Code::Unimplemented,


### PR DESCRIPTION
fixes #3074 

* Removes the `Proxy_Authorization` header from `HOP_HEADERS`, instead stripping the header on the outbound Client::call so it not sent upstream.
   * `Proxy_Authorization` is added to `mark_sensitive_headers` to avoid logging it.
* Return the correct `407 + Proxy-Authenticate` response for proxy CONNECT authentication failures, when reading the credential from the `Proxy_Authorization` header instead of `Authorization`.
   * Checking the method did not seem relevant in the case that `Proxy_Authorization` is used, so we don't check it explicitly to equal `CONNECT`.

Gen AI usage: Used Claude Opus 5 for most of the implementation work and to understand the codebase better. I reviewed the logic.