### PR TITLE
llm: allow limiting authorized models on an API key

### DIFF
--- a/crates/agentgateway/src/http/apikey.rs
+++ b/crates/agentgateway/src/http/apikey.rs
@@ -145,15 +145,178 @@ where
 
 #[apply(schema_ser!)]
 pub struct APIKeyAuthentication {
-	// A map of API keys to the metadata for that key
+	// A map of API keys to the policy for that key.
 	#[serde(serialize_with = "ser_redact")]
-	pub users: Arc<HashMap<APIKeyHash, UserMetadata>>,
+	pub users: Arc<HashMap<APIKeyHash, APIKeyPolicy>>,
 
 	/// Validation mode for API Key authentication
 	pub mode: Mode,
 
 	#[serde(default)]
 	pub location: AuthorizationLocation,
+}
+
+#[derive(Debug, Clone)]
+pub struct APIKeyPolicy {
+	pub metadata: UserMetadata,
+	pub allowed_models: AllowedModels,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AllowedModels(Option<Vec<AllowedModelPattern>>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AllowedModelPattern {
+	Exact(String),
+	Prefix(String),
+	Suffix(String),
+	All,
+}
+
+impl AllowedModels {
+	fn compile(patterns: Option<Vec<String>>) -> anyhow::Result<Self> {
+		let Some(patterns) = patterns else {
+			return Ok(Self(None));
+		};
+		if patterns.len() > 1 && patterns.iter().any(|pattern| pattern == "*") {
+			anyhow::bail!("allowedModels cannot combine '*' with other values");
+		}
+
+		let mut compiled = Vec::with_capacity(patterns.len());
+		for pattern in patterns {
+			if pattern.is_empty() {
+				anyhow::bail!("allowedModels cannot contain an empty model name");
+			}
+			let wildcard_count = pattern.bytes().filter(|byte| *byte == b'*').count();
+			let pattern = match wildcard_count {
+				0 => AllowedModelPattern::Exact(pattern),
+				1 if pattern == "*" => AllowedModelPattern::All,
+				1 if pattern.ends_with('*') => {
+					AllowedModelPattern::Prefix(pattern.trim_end_matches('*').to_string())
+				},
+				1 if pattern.starts_with('*') => {
+					AllowedModelPattern::Suffix(pattern.trim_start_matches('*').to_string())
+				},
+				_ => anyhow::bail!(
+					"allowedModels pattern {pattern:?} must contain at most one wildcard, at the beginning or end"
+				),
+			};
+			if !compiled.contains(&pattern) {
+				compiled.push(pattern);
+			}
+		}
+		Ok(Self(Some(compiled)))
+	}
+
+	pub fn allows(&self, model: &str) -> bool {
+		self
+			.0
+			.as_ref()
+			.is_none_or(|patterns| patterns.iter().any(|pattern| pattern.allows(model)))
+	}
+}
+
+impl AllowedModelPattern {
+	fn allows(&self, model: &str) -> bool {
+		match self {
+			Self::Exact(exact) => model == exact,
+			Self::Prefix(prefix) => model.starts_with(prefix),
+			Self::Suffix(suffix) => model.ends_with(suffix),
+			Self::All => true,
+		}
+	}
+
+	fn intersects(&self, configured_model: &str) -> bool {
+		match self {
+			Self::All => true,
+			Self::Exact(model) => configured_model_pattern_matches(configured_model, model),
+			Self::Prefix(allowed) => {
+				if configured_model == "*" {
+					return true;
+				}
+				if let Some(configured) = configured_model.strip_suffix('*') {
+					return allowed.starts_with(configured) || configured.starts_with(allowed);
+				}
+				configured_model.starts_with('*') || configured_model.starts_with(allowed)
+			},
+			Self::Suffix(allowed) => {
+				if configured_model == "*" {
+					return true;
+				}
+				if let Some(configured) = configured_model.strip_prefix('*') {
+					return allowed.ends_with(configured) || configured.ends_with(allowed);
+				}
+				configured_model.ends_with('*') || configured_model.ends_with(allowed)
+			},
+		}
+	}
+}
+
+fn configured_model_pattern_matches(pattern: &str, model: &str) -> bool {
+	if pattern == "*" {
+		return true;
+	}
+	if let Some(prefix) = pattern.strip_suffix('*') {
+		return model.starts_with(prefix);
+	}
+	if let Some(suffix) = pattern.strip_prefix('*') {
+		return model.ends_with(suffix);
+	}
+	pattern == model
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelAccessPolicy {
+	allowed_models: AllowedModels,
+}
+
+impl ModelAccessPolicy {
+	pub fn allows(&self, model: &str) -> bool {
+		self.allowed_models.allows(model)
+	}
+}
+
+pub fn discoverable_models<'a>(
+	policy: Option<&'a ModelAccessPolicy>,
+	configured_model: &'a str,
+) -> impl Iterator<Item = &'a str> + 'a {
+	let patterns = policy.and_then(|policy| policy.allowed_models.0.as_deref());
+	let configured_is_pattern = configured_model.contains('*');
+	let configured = std::iter::once(configured_model).filter(move |_| {
+		if configured_is_pattern {
+			patterns.is_none()
+		} else {
+			patterns.is_none_or(|patterns| {
+				patterns
+					.iter()
+					.any(|pattern| pattern.allows(configured_model))
+			})
+		}
+	});
+	let mut emitted_configured = false;
+	let intersections = patterns.into_iter().flatten().filter_map(move |pattern| {
+		if !configured_is_pattern {
+			return None;
+		}
+		match pattern {
+			AllowedModelPattern::Exact(model)
+				if configured_model_pattern_matches(configured_model, model) =>
+			{
+				Some(model.as_str())
+			},
+			pattern if pattern.intersects(configured_model) && !emitted_configured => {
+				emitted_configured = true;
+				Some(configured_model)
+			},
+			_ => None,
+		}
+	});
+	configured.chain(intersections)
+}
+
+struct AuthenticatedAPIKey {
+	claims: Claims,
+	model_access: ModelAccessPolicy,
 }
 
 impl APIKeyAuthentication {
@@ -166,14 +329,22 @@ impl APIKeyAuthentication {
 			users: Arc::new(
 				keys
 					.into_iter()
-					.map(|(key, meta)| (key.sha256(), meta))
+					.map(|(key, metadata)| {
+						(
+							key.sha256(),
+							APIKeyPolicy {
+								metadata,
+								allowed_models: AllowedModels::default(),
+							},
+						)
+					})
 					.collect(),
 			),
 			mode,
 			location,
 		}
 	}
-	async fn verify(&self, req: &mut Request) -> Result<Option<Claims>, ProxyError> {
+	async fn verify(&self, req: &mut Request) -> Result<Option<AuthenticatedAPIKey>, ProxyError> {
 		let Some(key) = self.location.extract(req) else {
 			// In strict mode, we require credentials
 			if self.mode == Mode::Strict {
@@ -194,18 +365,22 @@ impl APIKeyAuthentication {
 		};
 
 		let key = APIKey::new(key);
-		if let Some(meta) = self.users.get(&key.sha256()) {
+		if let Some(policy) = self.users.get(&key.sha256()) {
 			pol_result!(
 				dtrace::Info,
 				Apply,
 				"authenticated request with API key with metadata {}",
-				serde_json::to_string(meta).unwrap_or_default()
+				serde_json::to_string(&policy.metadata).unwrap_or_default()
 			);
-			let claims = Claims {
-				key,
-				metadata: meta.clone(),
-			};
-			Ok(Some(claims))
+			Ok(Some(AuthenticatedAPIKey {
+				claims: Claims {
+					key,
+					metadata: policy.metadata.clone(),
+				},
+				model_access: ModelAccessPolicy {
+					allowed_models: policy.allowed_models.clone(),
+				},
+			}))
 		} else if self.mode == Mode::Permissive {
 			pol_result!(
 				dtrace::Warn,
@@ -234,10 +409,11 @@ impl crate::store::RequestPolicyTrait for APIKeyAuthentication {
 		req: &mut Request,
 	) -> Result<crate::http::PolicyResponse, ProxyResponse> {
 		let res = self.verify(req).await.map_err(ProxyResponse::from)?;
-		if let Some(claims) = res {
+		if let Some(authenticated) = res {
 			self.location.remove(req).map_err(ProxyResponse::from)?;
 			// Insert the claims into extensions so we can reference it later
-			req.extensions_mut().insert(claims);
+			req.extensions_mut().insert(authenticated.claims);
+			req.extensions_mut().insert(authenticated.model_access);
 		}
 		Ok(crate::http::PolicyResponse::default())
 	}
@@ -269,6 +445,10 @@ pub enum LocalAPIKey {
 		key: APIKey,
 		/// Optional metadata attached to requests authenticated with this key.
 		metadata: Option<UserMetadata>,
+		/// Model patterns this key is allowed to access.
+		/// Omitted means no additional constraint; an empty list denies all models.
+		#[serde(rename = "allowedModels", default)]
+		allowed_models: Option<Vec<String>>,
 	},
 	Sha256 {
 		/// SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.
@@ -276,24 +456,55 @@ pub enum LocalAPIKey {
 		key_hash: APIKeyHash,
 		/// Optional metadata attached to requests authenticated with this key.
 		metadata: Option<UserMetadata>,
+		/// Model patterns this key is allowed to access.
+		/// Omitted means no additional constraint; an empty list denies all models.
+		#[serde(rename = "allowedModels", default)]
+		allowed_models: Option<Vec<String>>,
 	},
 }
 
 impl LocalAPIKey {
-	fn into_parts(self) -> (APIKeyHash, UserMetadata) {
-		match self {
-			LocalAPIKey::Key { key, metadata } => (key.sha256(), metadata.unwrap_or_default()),
-			LocalAPIKey::Sha256 { key_hash, metadata } => (key_hash, metadata.unwrap_or_default()),
-		}
+	fn into_parts(self) -> anyhow::Result<(APIKeyHash, APIKeyPolicy)> {
+		let (key_hash, metadata, allowed_models) = match self {
+			LocalAPIKey::Key {
+				key,
+				metadata,
+				allowed_models,
+			} => (key.sha256(), metadata, allowed_models),
+			LocalAPIKey::Sha256 {
+				key_hash,
+				metadata,
+				allowed_models,
+			} => (key_hash, metadata, allowed_models),
+		};
+		Ok((
+			key_hash,
+			APIKeyPolicy {
+				metadata: metadata.unwrap_or_default(),
+				allowed_models: AllowedModels::compile(allowed_models)?,
+			},
+		))
 	}
 }
 
 impl LocalAPIKeys {
-	pub fn into(self) -> APIKeyAuthentication {
-		APIKeyAuthentication {
-			users: Arc::new(self.keys.into_iter().map(LocalAPIKey::into_parts).collect()),
+	pub fn compile(self) -> anyhow::Result<APIKeyAuthentication> {
+		Ok(APIKeyAuthentication {
+			users: Arc::new(
+				self
+					.keys
+					.into_iter()
+					.map(LocalAPIKey::into_parts)
+					.collect::<anyhow::Result<_>>()?,
+			),
 			mode: self.mode,
 			location: self.location,
-		}
+		})
+	}
+
+	pub fn into(self) -> APIKeyAuthentication {
+		self
+			.compile()
+			.expect("API key allowedModels configuration must be valid")
 	}
 }

--- a/crates/agentgateway/src/http/apikey_tests.rs
+++ b/crates/agentgateway/src/http/apikey_tests.rs
@@ -20,6 +20,153 @@ fn test_apikey_equality() {
 	assert!(!map.contains_key(&APIKey::new("other-key")));
 }
 
+#[test]
+fn test_allowed_models_matching() {
+	let cases: &[(&str, Option<&[&str]>, &str, bool)] = &[
+		("omitted allows all", None, "gpt-4o", true),
+		("empty denies all", Some(&[]), "gpt-4o", false),
+		("exact match", Some(&["gpt-4o"]), "gpt-4o", true),
+		("exact mismatch", Some(&["gpt-4o"]), "gpt-4.1", false),
+		("prefix match", Some(&["openai/*"]), "openai/gpt-4o", true),
+		(
+			"prefix mismatch",
+			Some(&["openai/*"]),
+			"anthropic/claude",
+			false,
+		),
+		("suffix match", Some(&["*-latest"]), "gpt-4-latest", true),
+		(
+			"suffix mismatch",
+			Some(&["*-latest"]),
+			"gpt-4-preview",
+			false,
+		),
+		("all wildcard", Some(&["*"]), "any/model", true),
+		(
+			"any pattern may match",
+			Some(&["gpt-4o", "anthropic/*"]),
+			"anthropic/claude",
+			true,
+		),
+		(
+			"matching is case sensitive",
+			Some(&["GPT-*"]),
+			"gpt-4o",
+			false,
+		),
+	];
+
+	for (name, patterns, model, want) in cases {
+		let allowed = AllowedModels::compile(
+			patterns.map(|patterns| patterns.iter().map(|pattern| pattern.to_string()).collect()),
+		)
+		.unwrap();
+		assert_eq!(allowed.allows(model), *want, "{name}");
+	}
+}
+
+#[test]
+fn test_allowed_models_discovery_intersections() {
+	#[allow(clippy::type_complexity)]
+	let cases: &[(&str, Option<&[&str]>, &str, &[&str])] = &[
+		(
+			"omitted preserves configured pattern",
+			None,
+			"provider/*",
+			&["provider/*"],
+		),
+		("empty discovers nothing", Some(&[]), "provider/*", &[]),
+		(
+			"exact model is advertised through configured pattern",
+			Some(&["provider/model"]),
+			"provider/*",
+			&["provider/model"],
+		),
+		(
+			"nonmatching exact is hidden",
+			Some(&["other/model"]),
+			"provider/*",
+			&[],
+		),
+		(
+			"disjoint prefixes are hidden",
+			Some(&["other/*"]),
+			"provider/*",
+			&[],
+		),
+		(
+			"disjoint suffixes are hidden",
+			Some(&["*-preview"]),
+			"*-latest",
+			&[],
+		),
+		(
+			"narrower allowed pattern includes configured pattern",
+			Some(&["provider/gpt-*"]),
+			"provider/*",
+			&["provider/*"],
+		),
+		(
+			"narrower configured pattern is preserved",
+			Some(&["provider/*"]),
+			"provider/gpt-*",
+			&["provider/gpt-*"],
+		),
+		(
+			"overlapping prefix and suffix include configured pattern",
+			Some(&["provider/*"]),
+			"*-latest",
+			&["*-latest"],
+		),
+		(
+			"multiple exact models are advertised and deduplicated",
+			Some(&["provider/one", "provider/two", "provider/one"]),
+			"provider/*",
+			&["provider/one", "provider/two"],
+		),
+		(
+			"concrete configured models are filtered",
+			Some(&["provider/*"]),
+			"other/model",
+			&[],
+		),
+	];
+
+	for (name, patterns, configured, want) in cases {
+		let allowed = AllowedModels::compile(
+			patterns.map(|patterns| patterns.iter().map(|pattern| pattern.to_string()).collect()),
+		)
+		.unwrap();
+		let policy = ModelAccessPolicy {
+			allowed_models: allowed,
+		};
+		assert_eq!(
+			discoverable_models(Some(&policy), configured).collect::<Vec<_>>(),
+			*want,
+			"{name}"
+		);
+	}
+}
+
+#[test]
+fn test_allowed_models_rejects_invalid_patterns() {
+	let cases = [
+		(vec![""], "empty model name"),
+		(vec!["provider/*/model"], "at the beginning or end"),
+		(vec!["**"], "at most one wildcard"),
+		(vec!["*", "provider/model"], "cannot combine '*'"),
+	];
+
+	for (patterns, want) in cases {
+		let err =
+			AllowedModels::compile(Some(patterns.into_iter().map(str::to_string).collect())).unwrap_err();
+		assert!(
+			err.to_string().contains(want),
+			"error {err:?} did not contain {want:?}"
+		);
+	}
+}
+
 #[tokio::test]
 async fn test_apikey_query_parameter_extracts_and_strips() {
 	let auth = APIKeyAuthentication::new(

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -178,6 +178,9 @@ impl ModelRouter {
 			Ok(requested_model) => requested_model,
 			Err(resp) => return ResolveResult::DirectResponse(*resp),
 		};
+		if !api_key_model_authorized(req, &requested_model.model) {
+			return ResolveResult::DirectResponse(api_key_model_authorization_denied_response());
+		}
 		req
 			.extensions_mut()
 			.get_or_insert_with(TransformationMetadata::default)
@@ -214,11 +217,15 @@ impl ModelRouter {
 			.iter()
 			.filter(|model| model.visibility == ModelVisibility::Public)
 			.filter(|model| model_authorized(model, req))
-			.map(|model| model_list_entry(&model.name, model.created))
+			.flat_map(|model| {
+				api_key_discoverable_models(req, &model.name)
+					.map(|name| model_list_entry(name, model.created))
+			})
 			.chain(
 				self
 					.virtual_models
 					.iter()
+					.filter(|model| api_key_model_authorized(req, &model.name))
 					.map(|model| model_list_entry(&model.name, model.created)),
 			)
 			.collect::<Vec<_>>();
@@ -356,6 +363,14 @@ fn model_authorization_denied_response() -> Response {
 	)
 }
 
+fn api_key_model_authorization_denied_response() -> Response {
+	llm_error_response(
+		::http::StatusCode::FORBIDDEN,
+		"Model is not allowed for this API key",
+		"model_not_allowed",
+	)
+}
+
 fn request_body_too_large_response() -> Response {
 	llm_error_response(
 		::http::StatusCode::PAYLOAD_TOO_LARGE,
@@ -396,6 +411,32 @@ fn model_authorized(model: &ModelRoute, req: &Request) -> bool {
 	)
 	.apply(req)
 	.is_ok()
+}
+
+fn api_key_model_authorized(req: &Request, model: &str) -> bool {
+	let Some(policy) = req
+		.extensions()
+		.get::<crate::http::apikey::ModelAccessPolicy>()
+	else {
+		return true;
+	};
+	let allowed = policy.allows(model);
+	if !allowed {
+		tracing::debug!(model, "requested model is not allowed for API key");
+	}
+	allowed
+}
+
+fn api_key_discoverable_models<'a>(
+	req: &'a Request,
+	configured_model: &'a str,
+) -> impl Iterator<Item = &'a str> + 'a {
+	crate::http::apikey::discoverable_models(
+		req
+			.extensions()
+			.get::<crate::http::apikey::ModelAccessPolicy>(),
+		configured_model,
+	)
 }
 
 fn model_list_entry(id: &str, created: u64) -> serde_json::Value {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2979,7 +2979,13 @@ fn traffic_policy_from_proto(
 							));
 						},
 					};
-					Ok::<_, ProtoError>((key, meta))
+					Ok::<_, ProtoError>((
+						key,
+						http::apikey::APIKeyPolicy {
+							metadata: meta,
+							allowed_models: Default::default(),
+						},
+					))
 				})
 				.collect::<Result<Vec<_>, _>>()?;
 			TrafficPolicy::APIKey(RequestPolicy::single(http::apikey::APIKeyAuthentication {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -5282,7 +5282,7 @@ pub(crate) async fn split_policies_for_target(
 		)));
 	}
 	if let Some(p) = api_key {
-		route_policies.push(TrafficPolicy::APIKey(RequestPolicy::single(p.into())));
+		route_policies.push(TrafficPolicy::APIKey(RequestPolicy::single(p.compile()?)));
 	}
 	if let Some(p) = transformations {
 		if backend_target {

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -212,6 +212,55 @@ async fn setup_local_llm_config(yaml: &str) -> TestBind {
 }
 
 #[tokio::test]
+async fn llm_api_key_allowed_models_filters_discovery_and_requests() {
+	let mock = body_mock(llm_body!("response/completions/basic.json")).await;
+	let config = format!(
+		r#"
+llm:
+  port: 0
+  policies:
+    apiKey:
+      keys:
+      - key: sk-restricted
+        metadata:
+          name: restricted
+        allowedModels:
+        - openai/gpt-*
+        - direct-model
+      mode: strict
+  models:
+  - name: openai/*
+    provider: openAI
+    params:
+      baseUrl: http://{}
+  - name: direct-model
+    provider: openAI
+    params:
+      baseUrl: http://{}
+"#,
+		mock.address(),
+		mock.address(),
+	);
+	let t = setup_local_llm_config(&config).await;
+	let io = t.serve_http(strng::literal!("bind/0"));
+	let authorization = [("authorization", "Bearer sk-restricted")];
+
+	let mut models = list_models(io.clone(), &authorization).await;
+	models.sort();
+	assert_eq!(models, vec!["direct-model", "openai/*"]);
+
+	let response = send_completions_with_model(io.clone(), "openai/gpt-4o", &authorization).await;
+	assert_eq!(response.status(), StatusCode::OK);
+	let _ = read_body_raw(response.into_body()).await;
+
+	let response = send_completions_with_model(io, "openai/claude", &authorization).await;
+	assert_eq!(response.status(), StatusCode::FORBIDDEN);
+	let body: Value = serde_json::from_slice(&read_body_raw(response.into_body()).await).unwrap();
+	assert_eq!(body["error"]["code"], "model_not_allowed");
+	assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
 async fn llm_local_router_handles_models_virtual_model_and_missing_model() {
 	let mock = body_mock(llm_body!("response/completions/basic.json")).await;
 	let config = format!(

--- a/schema/config.json
+++ b/schema/config.json
@@ -6317,6 +6317,17 @@
             },
             "metadata": {
               "description": "Optional metadata attached to requests authenticated with this key."
+            },
+            "allowedModels": {
+              "description": "Model patterns this key is allowed to access.\nOmitted means no additional constraint; an empty list denies all models.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "default": null
             }
           },
           "additionalProperties": false,
@@ -6333,6 +6344,17 @@
             },
             "metadata": {
               "description": "Optional metadata attached to requests authenticated with this key."
+            },
+            "allowedModels": {
+              "description": "Model patterns this key is allowed to access.\nOmitted means no additional constraint; an empty list denies all models.",
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "default": null
             }
           },
           "additionalProperties": false,

--- a/schema/config.md
+++ b/schema/config.md
@@ -3786,6 +3786,7 @@
 |`binds[].listeners[].routes[].policies.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`binds[].listeners[].routes[].policies.apiKey.keys[].key`|string|API key value to accept.|
 |`binds[].listeners[].routes[].policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`binds[].listeners[].routes[].policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`binds[].listeners[].routes[].policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`binds[].listeners[].routes[].policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`binds[].listeners[].routes[].policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -16837,6 +16838,7 @@
 |`binds[].listeners[].policies.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`binds[].listeners[].policies.apiKey.keys[].key`|string|API key value to accept.|
 |`binds[].listeners[].policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`binds[].listeners[].policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`binds[].listeners[].policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`binds[].listeners[].policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`binds[].listeners[].policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -21712,6 +21714,7 @@
 |`policies[].policy.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`policies[].policy.apiKey.keys[].key`|string|API key value to accept.|
 |`policies[].policy.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`policies[].policy.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`policies[].policy.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`policies[].policy.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`policies[].policy.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -36849,6 +36852,7 @@
 |`routeGroups[].routes[].policies.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`routeGroups[].routes[].policies.apiKey.keys[].key`|string|API key value to accept.|
 |`routeGroups[].routes[].policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`routeGroups[].routes[].policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`routeGroups[].routes[].policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`routeGroups[].routes[].policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`routeGroups[].routes[].policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -49613,6 +49617,7 @@
 |`gateways.*.listeners[].apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`gateways.*.listeners[].apiKey.keys[].key`|string|API key value to accept.|
 |`gateways.*.listeners[].apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`gateways.*.listeners[].apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`gateways.*.listeners[].apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`gateways.*.listeners[].apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`gateways.*.listeners[].apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -50903,6 +50908,7 @@
 |`gateways.*.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`gateways.*.apiKey.keys[].key`|string|API key value to accept.|
 |`gateways.*.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`gateways.*.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`gateways.*.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`gateways.*.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`gateways.*.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -54578,6 +54584,7 @@
 |`routes[].policies.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`routes[].policies.apiKey.keys[].key`|string|API key value to accept.|
 |`routes[].policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`routes[].policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`routes[].policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`routes[].policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`routes[].policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -71048,6 +71055,7 @@
 |`llm.policies.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`llm.policies.apiKey.keys[].key`|string|API key value to accept.|
 |`llm.policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`llm.policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`llm.policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`llm.policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`llm.policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -77264,6 +77272,7 @@
 |`mcp.policies.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`mcp.policies.apiKey.keys[].key`|string|API key value to accept.|
 |`mcp.policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`mcp.policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`mcp.policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`mcp.policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`mcp.policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -79159,6 +79168,7 @@
 |`ui.policies.apiKey.keys`|[]object|API keys that are accepted by this policy.|
 |`ui.policies.apiKey.keys[].key`|string|API key value to accept.|
 |`ui.policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
+|`ui.policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
 |`ui.policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`ui.policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`ui.policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|


### PR DESCRIPTION
This is a popular feature on other gateways.

Signed-off-by: John Howard <john.howard@solo.io>
