### PR TITLE
adding a standalone dashboard

### DIFF
--- a/controller/install/dashboards/README.md
+++ b/controller/install/dashboards/README.md
@@ -1,11 +1,14 @@
 # Dashboards
 
-`agentgateway-dashboard.py` generates the AgentGateway Grafana dashboard from the Grafana Foundation SDK.
+`agentgateway-dashboard.py` generates the Agentgateway Grafana dashboards from the Grafana Foundation SDK. Edit this generator rather than the generated JSON files.
 
 By default it emits a `dashboard.grafana.app/v1beta1` `Dashboard` manifest. Use `--legacy` to emit the raw dashboard JSON used by the Helm chart's Grafana sidecar ConfigMap.
 
-To update the Helm chart copy:
+The default dashboard uses Kubernetes namespace, gateway, and pod filters. Use `--standalone` for deployments without these labels.
+
+To update the Helm chart copies:
 
 ```bash
 controller/install/dashboards/agentgateway-dashboard.py --legacy > controller/install/helm/agentgateway/files/agentgateway-dashboard.json
+controller/install/dashboards/agentgateway-dashboard.py --standalone --legacy > controller/install/helm/agentgateway-standalone/files/agentgateway-dashboard.json
 ```

--- a/controller/install/dashboards/agentgateway-dashboard.py
+++ b/controller/install/dashboards/agentgateway-dashboard.py
@@ -186,7 +186,7 @@ def filter_pods(expr: str) -> str:
   return (
     f"{expr} "
     f"* on(pod, namespace) group_left(gateway_networking_k8s_io_gateway_name) "
-    f"agentgateway_build_info{{namespace=~\"$namespace\",gateway_networking_k8s_io_gateway_name=~\"$gateway_name\"}}"
+    f'agentgateway_build_info{{namespace=~"$namespace",gateway_networking_k8s_io_gateway_name=~"$gateway_name"}}'
   )
 
 
@@ -489,10 +489,7 @@ def build_dashboard() -> Dashboard:
     .with_row(Row("MCP").collapsed(True).with_panel(mcp_tools).with_panel(mcp_list))
     .with_row(Row("Latency").collapsed(True).with_panel(latency_by_route))
     .with_row(
-      Row("XDS")
-      .collapsed(True)
-      .with_panel(xds_messages)
-      .with_panel(xds_average_size)
+      Row("XDS").collapsed(True).with_panel(xds_messages).with_panel(xds_average_size)
     )
     .with_row(
       Row("Runtime")
@@ -503,6 +500,157 @@ def build_dashboard() -> Dashboard:
       .with_panel(build_info)
     )
   )
+
+
+def build_standalone_dashboard() -> Dashboard:
+  dashboard = (
+    new_dashboard("Agentgateway (Standalone)", "agentgateway-standalone")
+    .description(
+      "Request, LLM, MCP, and runtime metrics for standalone Agentgateway deployments."
+    )
+    .tags(["agentgateway", "standalone"])
+    .time("now-1h", "now")
+    .with_row(Row("Requests"))
+    .with_panel(
+      rps_timeseries("Request Rate").with_target(
+        query(prom_sum(rate("agentgateway_requests_total")), "requests/s")
+      )
+    )
+  )
+  for label in ["status", "route", "reason"]:
+    dashboard.with_panel(
+      rps_timeseries(f"Requests (by {label.title()})").with_target(
+        query(
+          prom_sum(rate("agentgateway_requests_total"), by=[label]),
+          "{{" + label + "}}",
+        )
+      )
+    )
+
+  dashboard.with_row(
+    Row("Latency")
+    .collapsed(True)
+    .with_panel(
+      add_targets(
+        seconds_timeseries("Latency by Route"),
+        [
+          (
+            quantile(
+              value,
+              prom_sum(
+                rate("agentgateway_request_duration_seconds_bucket"),
+                by=["le", "route"],
+              ),
+            ),
+            "{{route}} " + percentile,
+          )
+          for value, percentile in [("0.50", "p50"), ("0.95", "p95"), ("0.99", "p99")]
+        ],
+      )
+    )
+  )
+  llm = (
+    Row("LLM")
+    .collapsed(True)
+    .with_panel(
+      tps_timeseries("Token Consumption").with_target(
+        query(
+          prom_sum(
+            rate("agentgateway_gen_ai_client_token_usage_sum"),
+            by=["gen_ai_token_type", "gen_ai_request_model"],
+          ),
+          "{{gen_ai_request_model}} ({{gen_ai_token_type}})",
+        )
+      )
+    )
+    .with_panel(
+      usd_timeseries("USD Cost per Interval").with_target(
+        query(
+          prom_sum(
+            increase("agentgateway_gen_ai_client_cost_usd_total"),
+            by=["gen_ai_request_model"],
+          ),
+          "{{gen_ai_request_model}}",
+        )
+      )
+    )
+  )
+  for title, metric, tokens_per_second in [
+    (
+      "Time to First Token (p50)",
+      "agentgateway_gen_ai_server_time_to_first_token_bucket",
+      False,
+    ),
+    (
+      "Request Duration (p50)",
+      "agentgateway_gen_ai_server_request_duration_bucket",
+      False,
+    ),
+    (
+      "Tokens per Second (p50)",
+      "agentgateway_gen_ai_server_time_per_output_token_bucket",
+      True,
+    ),
+  ]:
+    expr = quantile("0.5", prom_sum(rate(metric), by=["le", "gen_ai_request_model"]))
+    panel = tps_timeseries(title) if tokens_per_second else seconds_timeseries(title)
+    llm.with_panel(
+      panel.with_target(
+        query("1 / " + expr if tokens_per_second else expr, "{{gen_ai_request_model}}")
+      )
+    )
+  dashboard.with_row(llm)
+  dashboard.with_row(
+    Row("MCP")
+    .collapsed(True)
+    .with_panel(
+      rps_timeseries("MCP Calls (by Method)").with_target(
+        query(
+          prom_sum(rate("agentgateway_mcp_requests_total"), by=["method"]), "{{method}}"
+        )
+      )
+    )
+    .with_panel(
+      rps_timeseries("Tool Calls (by Tool)").with_target(
+        query(
+          prom_sum(
+            rate(labels("agentgateway_mcp_requests_total", {"method": "tools/call"})),
+            by=["server", "resource"],
+          ),
+          "{{server}}/{{resource}}",
+        )
+      )
+    )
+  )
+  dashboard.with_row(
+    Row("Runtime")
+    .collapsed(True)
+    .with_panel(
+      base_timeseries("Build Versions").with_target(
+        query(prom_sum("agentgateway_build_info", by=["tag"]), "{{tag}}")
+      )
+    )
+    .with_panel(
+      add_targets(
+        base_timeseries("Tokio Runtime"),
+        [
+          ("agentgateway_tokio_num_workers", "workers"),
+          ("agentgateway_tokio_num_alive_tasks", "alive tasks"),
+          ("agentgateway_tokio_global_queue_depth", "queue depth"),
+        ],
+      )
+    )
+    .with_panel(
+      add_targets(
+        bytes_timeseries("Process Memory"),
+        [
+          ("agentgateway_process_rss", "rss"),
+          ("agentgateway_process_pss", "pss"),
+        ],
+      )
+    )
+  )
+  return dashboard
 
 
 class Manifest:
@@ -522,14 +670,18 @@ class Manifest:
     )
 
 
-def encode_dashboard() -> str:
-  dashboard = build_dashboard().build()
+def encode_dashboard(standalone: bool = False) -> str:
+  dashboard = (
+    build_standalone_dashboard() if standalone else build_dashboard()
+  ).build()
   encoder = JSONEncoder(sort_keys=True, indent=2)
   return encoder.encode(dashboard)
 
 
-def encode_manifest() -> str:
-  dashboard = build_dashboard().build()
+def encode_manifest(standalone: bool = False) -> str:
+  dashboard = (
+    build_standalone_dashboard() if standalone else build_dashboard()
+  ).build()
   manifest = Manifest.dashboard(dashboard)
   encoder = JSONEncoder(sort_keys=True, indent=2)
   return encoder.encode(manifest)
@@ -538,6 +690,11 @@ def encode_manifest() -> str:
 def main() -> None:
   parser = argparse.ArgumentParser()
   parser.add_argument(
+    "--standalone",
+    action="store_true",
+    help="generate the dashboard for standalone deployments",
+  )
+  parser.add_argument(
     "--legacy",
     action="store_true",
     help="emit the raw dashboard JSON instead of the dashboard.grafana.app manifest",
@@ -545,9 +702,9 @@ def main() -> None:
   args = parser.parse_args()
 
   if args.legacy:
-    print(encode_dashboard())
+    print(encode_dashboard(args.standalone))
   else:
-    print(encode_manifest())
+    print(encode_manifest(args.standalone))
 
 
 if __name__ == "__main__":

--- a/controller/install/helm/agentgateway-standalone/files/agentgateway-dashboard.json
+++ b/controller/install/helm/agentgateway-standalone/files/agentgateway-dashboard.json
@@ -1,0 +1,957 @@
+{
+  "uid": "agentgateway-standalone",
+  "title": "agentgateway (standalone)",
+  "description": "Local/standalone agentgateway metrics. k8s label filters removed; pick your Prometheus in the Data source dropdown.",
+  "tags": [
+    "agentgateway",
+    "standalone"
+  ],
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "templating": {
+    "list": [
+      {
+        "type": "datasource",
+        "name": "datasource",
+        "label": "Data source",
+        "query": "prometheus",
+        "refresh": 1,
+        "hide": 0,
+        "current": {},
+        "regex": ""
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "type": "row",
+      "title": "Traffic",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Request rate (total)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 3,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(agentgateway_requests_total[$__rate_interval]))",
+          "legendFormat": "requests/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Requests by status",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 4,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (status) (rate(agentgateway_requests_total[$__rate_interval]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Requests by route",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 5,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (route) (rate(agentgateway_requests_total[$__rate_interval]))",
+          "legendFormat": "{{route}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Requests by reason (errors)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 6,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (reason) (rate(agentgateway_requests_total[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "HTTP latency",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 7,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Request latency by route (p50 / p95 / p99)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 8,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50 {{route}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95 {{route}}",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99 {{route}}",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "LLM (gen_ai) \u2014 populated when the LLM lane is used",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 9,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Token consumption",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 10,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (gen_ai_token_type,gen_ai_request_model) (rate(agentgateway_gen_ai_client_token_usage_sum[$__rate_interval]))",
+          "legendFormat": "{{gen_ai_request_model}} {{gen_ai_token_type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "USD cost per interval",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 11,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (gen_ai_request_model) (increase(agentgateway_gen_ai_client_cost_usd_total[$__rate_interval]))",
+          "legendFormat": "{{gen_ai_request_model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Time to first token (p50)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 12,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_to_first_token_bucket[$__rate_interval])))",
+          "legendFormat": "{{gen_ai_request_model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "LLM request duration (p50)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 13,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_request_duration_bucket[$__rate_interval])))",
+          "legendFormat": "{{gen_ai_request_model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokens per second (p50)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 14,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "1 / histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_per_output_token_bucket[$__rate_interval])))",
+          "legendFormat": "{{gen_ai_request_model}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "MCP",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 15,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "MCP calls by method",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 16,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (method) (rate(agentgateway_mcp_requests_total[$__rate_interval]))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "MCP tool calls by tool",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 17,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (server,resource) (rate(agentgateway_mcp_requests_total{method=\"tools/call\"}[$__rate_interval]))",
+          "legendFormat": "{{server}}/{{resource}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Runtime & build (may be empty on macOS / non-Linux hosts)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "id": 18,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "title": "Build info",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 19,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum by (tag) (agentgateway_build_info)",
+          "legendFormat": "{{tag}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokio runtime",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 20,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "agentgateway_tokio_num_workers",
+          "legendFormat": "workers",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "agentgateway_tokio_num_alive_tasks",
+          "legendFormat": "alive tasks",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "agentgateway_tokio_global_queue_depth",
+          "legendFormat": "queue depth",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Process memory",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "id": 21,
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": true
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "agentgateway_process_rss",
+          "legendFormat": "rss",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "agentgateway_process_pss",
+          "legendFormat": "pss",
+          "refId": "B"
+        }
+      ]
+    }
+  ]
+}

--- a/controller/install/helm/agentgateway-standalone/files/agentgateway-dashboard.json
+++ b/controller/install/helm/agentgateway-standalone/files/agentgateway-dashboard.json
@@ -1,41 +1,11 @@
 {
-  "uid": "agentgateway-standalone",
-  "title": "agentgateway (standalone)",
-  "description": "Local/standalone agentgateway metrics. k8s label filters removed; pick your Prometheus in the Data source dropdown.",
-  "tags": [
-    "agentgateway",
-    "standalone"
-  ],
+  "annotations": {},
+  "description": "Request, LLM, MCP, and runtime metrics for standalone Agentgateway deployments.",
   "editable": true,
-  "schemaVersion": 39,
-  "version": 1,
-  "refresh": "15s",
-  "time": {
-    "from": "now-1h",
-    "to": "now"
-  },
-  "timezone": "browser",
-  "templating": {
-    "list": [
-      {
-        "type": "datasource",
-        "name": "datasource",
-        "label": "Data source",
-        "query": "prometheus",
-        "refresh": 1,
-        "hide": 0,
-        "current": {},
-        "regex": ""
-      }
-    ]
-  },
-  "annotations": {
-    "list": []
-  },
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
   "panels": [
     {
-      "type": "row",
-      "title": "Traffic",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -43,915 +13,930 @@
         "x": 0,
         "y": 0
       },
-      "id": 2,
-      "panels": []
+      "id": 0,
+      "panels": [],
+      "title": "Requests",
+      "type": "row"
     },
     {
-      "type": "timeseries",
-      "title": "Request rate (total)",
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
+        "uid": "$datasource"
       },
-      "id": 3,
-      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 0,
         "y": 1
       },
+      "interval": "5s",
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "asc"
+        }
+      },
+      "repeatDirection": "h",
+      "targets": [
+        {
+          "expr": "sum (rate(agentgateway_requests_total[$__rate_interval]))",
+          "legendFormat": "requests/s",
+          "refId": ""
+        }
+      ],
+      "title": "Request Rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps",
           "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "reqps"
         },
         "overrides": []
       },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum(rate(agentgateway_requests_total[$__rate_interval]))",
-          "legendFormat": "requests/s",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "Requests by status",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 4,
-      "description": "",
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 12,
         "y": 1
       },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
+      "interval": "5s",
       "options": {
         "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
+          "mode": "single",
+          "sort": "asc"
         }
       },
+      "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
           "expr": "sum by (status) (rate(agentgateway_requests_total[$__rate_interval]))",
           "legendFormat": "{{status}}",
-          "refId": "A"
+          "refId": ""
         }
-      ]
+      ],
+      "title": "Requests (by Status)",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Requests by route",
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 5,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 9
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps",
           "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "reqps"
         },
         "overrides": []
       },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "interval": "5s",
       "options": {
         "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
+          "mode": "single",
+          "sort": "asc"
         }
       },
+      "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
           "expr": "sum by (route) (rate(agentgateway_requests_total[$__rate_interval]))",
           "legendFormat": "{{route}}",
-          "refId": "A"
+          "refId": ""
         }
-      ]
+      ],
+      "title": "Requests (by Route)",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
     },
     {
-      "type": "timeseries",
-      "title": "Requests by reason (errors)",
       "datasource": {
         "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 6,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 9
+        "uid": "$datasource"
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "reqps",
           "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "showPoints": "never"
+          },
+          "unit": "reqps"
         },
         "overrides": []
       },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "interval": "5s",
       "options": {
         "legend": {
+          "calcs": [
+            "last",
+            "max",
+            "mean"
+          ],
           "displayMode": "table",
           "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
         },
         "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
+          "mode": "single",
+          "sort": "asc"
         }
       },
+      "repeatDirection": "h",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
           "expr": "sum by (reason) (rate(agentgateway_requests_total[$__rate_interval]))",
           "legendFormat": "{{reason}}",
-          "refId": "A"
+          "refId": ""
         }
-      ]
+      ],
+      "title": "Requests (by Reason)",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
     },
     {
-      "type": "row",
-      "title": "HTTP latency",
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 21
       },
-      "id": 7,
-      "panels": []
+      "id": 0,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 22
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.50, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "{{route}} p50",
+              "refId": ""
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "{{route}} p95",
+              "refId": ""
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
+              "legendFormat": "{{route}} p99",
+              "refId": ""
+            }
+          ],
+          "title": "Latency by Route",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        }
+      ],
+      "title": "Latency",
+      "type": "row"
     },
     {
-      "type": "timeseries",
-      "title": "Request latency by route (p50 / p95 / p99)",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 8,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 18
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.50, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
-          "legendFormat": "p50 {{route}}",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.95, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
-          "legendFormat": "p95 {{route}}",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "histogram_quantile(0.99, sum by (le,route) (rate(agentgateway_request_duration_seconds_bucket[$__rate_interval])))",
-          "legendFormat": "p99 {{route}}",
-          "refId": "C"
-        }
-      ]
-    },
-    {
-      "type": "row",
-      "title": "LLM (gen_ai) \u2014 populated when the LLM lane is used",
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 32
       },
-      "id": 9,
-      "panels": []
+      "id": 0,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "tps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 33
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (gen_ai_token_type,gen_ai_request_model) (rate(agentgateway_gen_ai_client_token_usage_sum[$__rate_interval]))",
+              "legendFormat": "{{gen_ai_request_model}} ({{gen_ai_token_type}})",
+              "refId": ""
+            }
+          ],
+          "title": "Token Consumption",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 33
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (gen_ai_request_model) (increase(agentgateway_gen_ai_client_cost_usd_total[$__rate_interval]))",
+              "legendFormat": "{{gen_ai_request_model}}",
+              "refId": ""
+            }
+          ],
+          "title": "USD Cost per Interval",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_to_first_token_bucket[$__rate_interval])))",
+              "legendFormat": "{{gen_ai_request_model}}",
+              "refId": ""
+            }
+          ],
+          "title": "Time to First Token (p50)",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_request_duration_bucket[$__rate_interval])))",
+              "legendFormat": "{{gen_ai_request_model}}",
+              "refId": ""
+            }
+          ],
+          "title": "Request Duration (p50)",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "tps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "1 / histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_per_output_token_bucket[$__rate_interval])))",
+              "legendFormat": "{{gen_ai_request_model}}",
+              "refId": ""
+            }
+          ],
+          "title": "Tokens per Second (p50)",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
+        }
+      ],
+      "title": "LLM",
+      "type": "row"
     },
     {
-      "type": "timeseries",
-      "title": "Token consumption",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 10,
-      "description": "",
+      "collapsed": true,
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 1,
+        "w": 24,
         "x": 0,
-        "y": 27
+        "y": 63
       },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
+      "id": 0,
+      "panels": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$datasource"
           },
-          "expr": "sum by (gen_ai_token_type,gen_ai_request_model) (rate(agentgateway_gen_ai_client_token_usage_sum[$__rate_interval]))",
-          "legendFormat": "{{gen_ai_request_model}} {{gen_ai_token_type}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "USD cost per interval",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 11,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 27
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "currencyUSD",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 64
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (method) (rate(agentgateway_mcp_requests_total[$__rate_interval]))",
+              "legendFormat": "{{method}}",
+              "refId": ""
+            }
+          ],
+          "title": "MCP Calls (by Method)",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
         },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$datasource"
           },
-          "expr": "sum by (gen_ai_request_model) (increase(agentgateway_gen_ai_client_cost_usd_total[$__rate_interval]))",
-          "legendFormat": "{{gen_ai_request_model}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "Time to first token (p50)",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 12,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 35
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
           },
-          "expr": "histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_to_first_token_bucket[$__rate_interval])))",
-          "legendFormat": "{{gen_ai_request_model}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "LLM request duration (p50)",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 13,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 35
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "s",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 64
           },
-          "expr": "histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_request_duration_bucket[$__rate_interval])))",
-          "legendFormat": "{{gen_ai_request_model}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "Tokens per second (p50)",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 14,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 43
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
           },
-          "expr": "1 / histogram_quantile(0.5, sum by (le,gen_ai_request_model) (rate(agentgateway_gen_ai_server_time_per_output_token_bucket[$__rate_interval])))",
-          "legendFormat": "{{gen_ai_request_model}}",
-          "refId": "A"
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (server,resource) (rate(agentgateway_mcp_requests_total{method=\"tools/call\"}[$__rate_interval]))",
+              "legendFormat": "{{server}}/{{resource}}",
+              "refId": ""
+            }
+          ],
+          "title": "Tool Calls (by Tool)",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
         }
-      ]
-    },
-    {
-      "type": "row",
+      ],
       "title": "MCP",
-      "collapsed": false,
+      "type": "row"
+    },
+    {
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 74
       },
-      "id": 15,
-      "panels": []
-    },
-    {
-      "type": "timeseries",
-      "title": "MCP calls by method",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 16,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 52
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
+      "id": 0,
+      "panels": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$datasource"
           },
-          "expr": "sum by (method) (rate(agentgateway_mcp_requests_total[$__rate_interval]))",
-          "legendFormat": "{{method}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "MCP tool calls by tool",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 17,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 52
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "reqps",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
           },
-          "expr": "sum by (server,resource) (rate(agentgateway_mcp_requests_total{method=\"tools/call\"}[$__rate_interval]))",
-          "legendFormat": "{{server}}/{{resource}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "row",
-      "title": "Runtime & build (may be empty on macOS / non-Linux hosts)",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 60
-      },
-      "id": 18,
-      "panels": []
-    },
-    {
-      "type": "timeseries",
-      "title": "Build info",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 19,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 61
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 75
           },
-          "expr": "sum by (tag) (agentgateway_build_info)",
-          "legendFormat": "{{tag}}",
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "Tokio runtime",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 20,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 61
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
           },
-          "expr": "agentgateway_tokio_num_workers",
-          "legendFormat": "workers",
-          "refId": "A"
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "sum by (tag) (agentgateway_build_info)",
+              "legendFormat": "{{tag}}",
+              "refId": ""
+            }
+          ],
+          "title": "Build Versions",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$datasource"
           },
-          "expr": "agentgateway_tokio_num_alive_tasks",
-          "legendFormat": "alive tasks",
-          "refId": "B"
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "agentgateway_tokio_num_workers",
+              "legendFormat": "workers",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_tokio_num_alive_tasks",
+              "legendFormat": "alive tasks",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_tokio_global_queue_depth",
+              "legendFormat": "queue depth",
+              "refId": ""
+            }
+          ],
+          "title": "Tokio Runtime",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
         },
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${datasource}"
+            "uid": "$datasource"
           },
-          "expr": "agentgateway_tokio_global_queue_depth",
-          "legendFormat": "queue depth",
-          "refId": "C"
-        }
-      ]
-    },
-    {
-      "type": "timeseries",
-      "title": "Process memory",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "id": 21,
-      "description": "",
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 69
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "bytes",
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ]
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "fillOpacity": 10,
+                "gradientMode": "opacity",
+                "showPoints": "never"
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
           },
-          "expr": "agentgateway_process_rss",
-          "legendFormat": "rss",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 85
           },
-          "expr": "agentgateway_process_pss",
-          "legendFormat": "pss",
-          "refId": "B"
+          "interval": "5s",
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true,
+              "sortBy": "Last",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "asc"
+            }
+          },
+          "repeatDirection": "h",
+          "targets": [
+            {
+              "expr": "agentgateway_process_rss",
+              "legendFormat": "rss",
+              "refId": ""
+            },
+            {
+              "expr": "agentgateway_process_pss",
+              "legendFormat": "pss",
+              "refId": ""
+            }
+          ],
+          "title": "Process Memory",
+          "transformations": [],
+          "transparent": false,
+          "type": "timeseries"
         }
-      ]
+      ],
+      "title": "Runtime",
+      "type": "row"
     }
-  ]
+  ],
+  "refresh": "15s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "agentgateway",
+    "standalone"
+  ],
+  "templating": {
+    "list": [
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "hide": 0,
+        "id": "00000000-0000-0000-0000-000000000000",
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "query": "prometheus",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Agentgateway (Standalone)",
+  "uid": "agentgateway-standalone"
 }


### PR DESCRIPTION
Our standalone doc(https://agentgateway.dev/docs/standalone/latest/integrations/observability/grafana/#import-the-agentgateway-dashboard) currently asks users to import the k8s dashboard which doesn't work at all.

This dashboard seems to work okay for me:

<img width="1712" height="843" alt="image" src="https://github.com/user-attachments/assets/71a73e52-77ad-465a-a3bf-1c67842a1c76" />
