### PR TITLE
delegation: require reference grant for Route<-->Route

### DIFF
--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -90,6 +90,7 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 			wellknown.ServiceGVK.GroupKind(),
 			wellknown.SecretGVK.GroupKind(),
 			wellknown.AgentgatewayBackendGVK.GroupKind(),
+			wellknown.HTTPRouteGVK.GroupKind(),
 		),
 		// AgentgatewayPolicy targets
 		PolicyTargets: func(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName, port *gwv1.PortNumber) ([]*api.PolicyTarget, error) {

--- a/controller/pkg/agentgateway/translator/references_collection.go
+++ b/controller/pkg/agentgateway/translator/references_collection.go
@@ -146,15 +146,47 @@ func (refs ReferenceGrants) BackendAllowed(
 		return true
 	}
 	if refKind == wellknown.HTTPRouteGVK.GroupKind() {
-		// ReferenceGrant not required for route delegation
+		// Delegation authorization is evaluated against each matched child by
+		// ParentlessHTTPRouteAllowed. A route-group selector is not itself an
+		// HTTPRoute object name and cannot be authorized here.
 		return true
 	}
-	from := Reference{Kind: k.GroupKind(), Namespace: gwv1b1.Namespace(routeNamespace)}
-	to := Reference{Kind: refKind, Namespace: backendNamespace}
+	return refs.referenceAllowed(ctx, k.GroupKind(), gwv1b1.Namespace(routeNamespace), refKind, backendNamespace, string(backendName))
+}
+
+// ParentlessHTTPRouteAllowed checks whether a parent HTTPRoute may adopt a
+// parentless HTTPRoute from another namespace. The actual child name is used
+// for the lookup so named grants continue to work with wildcard and label
+// route-group selectors.
+func (refs ReferenceGrants) ParentlessHTTPRouteAllowed(
+	ctx krt.HandlerContext,
+	parentNamespace string,
+	child types.NamespacedName,
+) bool {
+	return refs.referenceAllowed(
+		ctx,
+		wellknown.HTTPRouteGVK.GroupKind(),
+		gwv1b1.Namespace(parentNamespace),
+		wellknown.HTTPRouteGVK.GroupKind(),
+		gwv1b1.Namespace(child.Namespace),
+		child.Name,
+	)
+}
+
+func (refs ReferenceGrants) referenceAllowed(
+	ctx krt.HandlerContext,
+	fromKind schema.GroupKind,
+	fromNamespace gwv1b1.Namespace,
+	toKind schema.GroupKind,
+	toNamespace gwv1b1.Namespace,
+	toName string,
+) bool {
+	from := Reference{Kind: fromKind, Namespace: fromNamespace}
+	to := Reference{Kind: toKind, Namespace: toNamespace}
 	pair := ReferencePair{From: from, To: to}
 	grants := krt.Fetch(ctx, refs.collection, krt.FilterIndex(refs.index, pair))
 	for _, g := range grants {
-		if g.AllowAll || g.AllowedName == string(backendName) {
+		if g.AllowAll || g.AllowedName == toName {
 			return true
 		}
 	}

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -117,7 +117,19 @@ func isDelegatedChildHTTPRoute(obj *gwv1.HTTPRoute) bool {
 	}
 	return false
 }
-func childAllowsParent(obj *gwv1.HTTPRoute, parentRef resolvedBinding) bool {
+func childAllowsParent(
+	krtctx krt.HandlerContext,
+	obj *gwv1.HTTPRoute,
+	parentRef resolvedBinding,
+	grants ReferenceGrants,
+	grantMode apisettings.BackendRefGrantMode,
+) bool {
+	if len(obj.Spec.ParentRefs) == 0 {
+		if obj.Namespace == parentRef.Parent.Namespace || !grantMode.RequireRouteBackendGrant() {
+			return true
+		}
+		return grants.ParentlessHTTPRouteAllowed(krtctx, parentRef.Parent.Namespace, config.NamespacedName(obj))
+	}
 	allowedParents := slices.MapFilter(obj.Spec.ParentRefs, func(ref gwv1.ParentReference) *types.NamespacedName {
 		if NormalizeReference(ref.Group, ref.Kind, wellknown.GatewayGVK.GroupKind()) != wellknown.HTTPRouteGVK.GroupKind() {
 			return nil
@@ -127,9 +139,6 @@ func childAllowsParent(obj *gwv1.HTTPRoute, parentRef resolvedBinding) bool {
 			Name:      string(ref.Name),
 		})
 	})
-	if len(allowedParents) == 0 {
-		return true
-	}
 	return slices.Contains(allowedParents, parentRef.Parent)
 }
 
@@ -250,6 +259,9 @@ func buildDelegatedHTTPRoutes(
 		}
 		gateways := sets.New[types.NamespacedName]()
 		for _, parentBinding := range findMatchingBindings(krtctx, sourceRoute) {
+			if !childAllowsParent(krtctx, sourceRoute, resolvedBinding{Parent: parentBinding.Source}, inputs.Grants, inputs.BackendRefGrantMode) {
+				continue
+			}
 			gateways.InsertAll(resolveGateways(krtctx, parentBinding, seen.Copy())...)
 		}
 		return slices.SortBy(gateways.UnsortedList(), types.NamespacedName.String)
@@ -290,7 +302,7 @@ func buildDelegatedHTTPRoutes(
 		ctx := inputs.WithCtx(krtctx)
 		var resources []agwir.AgwResource
 		for _, binding := range matchingBindings(krtctx, obj) {
-			if !childAllowsParent(obj, binding) {
+			if !childAllowsParent(krtctx, obj, binding, inputs.Grants, inputs.BackendRefGrantMode) {
 				continue
 			}
 			for n, rule := range obj.Spec.Rules {
@@ -328,7 +340,7 @@ func buildDelegatedHTTPRoutes(
 		}
 		gateways := sets.New[types.NamespacedName]()
 		for _, binding := range matchingBindings(krtctx, obj) {
-			if !childAllowsParent(obj, binding) {
+			if !childAllowsParent(krtctx, obj, binding, inputs.Grants, inputs.BackendRefGrantMode) {
 				continue
 			}
 			gateways.Insert(binding.Gateway)

--- a/controller/pkg/agentgateway/translator/route_delegation_authorization_test.go
+++ b/controller/pkg/agentgateway/translator/route_delegation_authorization_test.go
@@ -1,0 +1,141 @@
+package translator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/kube/krt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	apisettings "github.com/agentgateway/agentgateway/controller/api/settings"
+	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
+	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
+)
+
+func TestChildAllowsParent(t *testing.T) {
+	parent := resolvedBinding{Parent: types.NamespacedName{Namespace: "parent-ns", Name: "parent"}}
+	matchingParentRef := httpRouteParentRef("parent-ns", "parent")
+	nonMatchingParentRef := httpRouteParentRef("parent-ns", "other")
+
+	tests := []struct {
+		name       string
+		child      *gwv1.HTTPRoute
+		grants     []ReferenceGrant
+		grantMode  apisettings.BackendRefGrantMode
+		wantAllows bool
+	}{
+		{
+			name:       "parentless child in same namespace",
+			child:      httpRoute("parent-ns", "child"),
+			wantAllows: true,
+		},
+		{
+			name:  "parentless child in another namespace without grant",
+			child: httpRoute("child-ns", "child"),
+		},
+		{
+			name:       "parentless child in another namespace without grant when grants disabled",
+			child:      httpRoute("child-ns", "child"),
+			grantMode:  apisettings.BackendRefGrantModeNone,
+			wantAllows: true,
+		},
+		{
+			name:       "parentless child in another namespace with kind-wide grant",
+			child:      httpRoute("child-ns", "child"),
+			grants:     []ReferenceGrant{httpRouteGrant("")},
+			wantAllows: true,
+		},
+		{
+			name:       "parentless child in another namespace with named grant",
+			child:      httpRoute("child-ns", "child"),
+			grants:     []ReferenceGrant{httpRouteGrant("child")},
+			wantAllows: true,
+		},
+		{
+			name:   "named grant applies to actual child name",
+			child:  httpRoute("child-ns", "other-child"),
+			grants: []ReferenceGrant{httpRouteGrant("child")},
+		},
+		{
+			name: "explicit matching parent does not need a grant",
+			child: func() *gwv1.HTTPRoute {
+				route := httpRoute("child-ns", "child")
+				route.Spec.ParentRefs = []gwv1.ParentReference{matchingParentRef}
+				return route
+			}(),
+			wantAllows: true,
+		},
+		{
+			name: "grant does not override a nonmatching explicit parent",
+			child: func() *gwv1.HTTPRoute {
+				route := httpRoute("child-ns", "child")
+				route.Spec.ParentRefs = []gwv1.ParentReference{nonMatchingParentRef}
+				return route
+			}(),
+			grants: []ReferenceGrant{httpRouteGrant("")},
+		},
+		{
+			name: "disabled grants do not override a nonmatching explicit parent",
+			child: func() *gwv1.HTTPRoute {
+				route := httpRoute("child-ns", "child")
+				route.Spec.ParentRefs = []gwv1.ParentReference{nonMatchingParentRef}
+				return route
+			}(),
+			grantMode: apisettings.BackendRefGrantModeNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantAllows, childAllowsParent(
+				krt.TestingDummyContext{},
+				tt.child,
+				parent,
+				buildTestGrants(t, tt.grants),
+				tt.grantMode,
+			))
+		})
+	}
+}
+
+func buildTestGrants(t *testing.T, grants []ReferenceGrant) ReferenceGrants {
+	t.Helper()
+	opts := krtutil.NewKrtOptions(t.Context().Done(), nil)
+	collection := krt.NewStaticCollection(nil, grants, opts.ToOptions("TestReferenceGrants")...)
+	return BuildReferenceGrants(collection)
+}
+
+func httpRoute(namespace, name string) *gwv1.HTTPRoute {
+	return &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}
+}
+
+func httpRouteParentRef(namespace, name string) gwv1.ParentReference {
+	group := gwv1.Group(wellknown.GatewayGroup)
+	kind := gwv1.Kind(wellknown.HTTPRouteKind)
+	ns := gwv1.Namespace(namespace)
+	return gwv1.ParentReference{
+		Group:     &group,
+		Kind:      &kind,
+		Namespace: &ns,
+		Name:      gwv1.ObjectName(name),
+	}
+}
+
+func httpRouteGrant(childName string) ReferenceGrant {
+	grant := ReferenceGrant{
+		Source: types.NamespacedName{Namespace: "child-ns", Name: "grant-" + childName},
+		From: Reference{
+			Kind:      wellknown.HTTPRouteGVK.GroupKind(),
+			Namespace: "parent-ns",
+		},
+		To: Reference{
+			Kind:      wellknown.HTTPRouteGVK.GroupKind(),
+			Namespace: "child-ns",
+		},
+		AllowedName: childName,
+	}
+	grant.AllowAll = childName == ""
+	return grant
+}

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-all-references.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-all-references.yaml
@@ -124,6 +124,36 @@ spec:
         group: agentgateway.dev
         kind: AgentgatewayBackend
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-parent
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: child-team1-foo
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-child
+  namespace: grandchild
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: team1
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: grandchild
+---
 # Output
 output:
 - gateway:

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-backend-references.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-backend-references.yaml
@@ -81,6 +81,21 @@ spec:
         group: agentgateway.dev
         kind: AgentgatewayBackend
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-parent
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: child-team1-foo
+---
 # Output
 output:
 - gateway:

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-child-filter.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-child-filter.yaml
@@ -74,6 +74,21 @@ spec:
         - name: httpbin
           port: 8000
 ---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: child-team1-ungranted
+  namespace: team1
+spec:
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /anything/team1/ungranted
+      backendRefs:
+        - name: httpbin
+          port: 8000
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -81,7 +96,22 @@ metadata:
   namespace: team1
 spec:
   ports:
-    - port: 8000
+  - port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-implicit-child
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: child-team1-implicit
 ---
 # Output
 output:
@@ -230,3 +260,11 @@ status:
         kind: HTTPRoute
         name: not-parent
         namespace: default
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: HTTPRoute
+  metadata:
+    name: child-team1-ungranted
+    namespace: team1
+  spec: null
+  status:
+    parents: []

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-labels.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-labels.yaml
@@ -62,6 +62,21 @@ spec:
   ports:
   - port: 8000
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-primary-child
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: child-team1-primary
+---
 # Output
 output:
 - gateway:

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-policy-references.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-policy-references.yaml
@@ -73,6 +73,21 @@ spec:
         group: agentgateway.dev
         kind: AgentgatewayBackend
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-parent
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: child-team1-foo
+---
 # Output
 output:
 - gateway:

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-precise.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-precise.yaml
@@ -56,7 +56,22 @@ metadata:
   namespace: team1
 spec:
   ports:
-    - port: 8000
+  - port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-primary-child
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: child-team1-primary
 ---
 # Output
 output:

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-scopes-gateway.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-scopes-gateway.yaml
@@ -72,6 +72,21 @@ spec:
   ports:
   - port: 8000
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-parent
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: child-team1-foo
+---
 # Output
 output:
 - gateway:

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation.yaml
@@ -59,6 +59,21 @@ spec:
   ports:
   - port: 8000
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-parent
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: child-team1-foo
+---
 # Output
 output:
 - gateway:

--- a/controller/pkg/agentgateway/translator/testdata/routes/multi-delegation.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/multi-delegation.yaml
@@ -89,6 +89,20 @@ spec:
   ports:
   - port: 8000
 ---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-parent
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: default
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+---
 # Output
 output:
 - gateway:

--- a/controller/test/e2e/testdata/delegation/setup.yaml
+++ b/controller/test/e2e/testdata/delegation/setup.yaml
@@ -37,3 +37,31 @@ spec:
   static:
     host: backend.agentgateway-base.svc.cluster.local
     port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-infra-route-delegation
+  namespace: team1
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: infra
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-team2-root-route-delegation
+  namespace: team2
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: team2-root
+  to:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute


### PR DESCRIPTION
There are a few attachments, but the parentless attachment for route
means the child route did not authorize the parent to attach to it. When
cross namespace, require a ref grant.

Signed-off-by: John Howard <john.howard@solo.io>
