### PR TITLE
telemetry: derive access-log severity from response status/error

### DIFF
--- a/crates/agentgateway/src/http/auth/oauth/transport.rs
+++ b/crates/agentgateway/src/http/auth/oauth/transport.rs
@@ -243,9 +243,7 @@ fn classify_token_endpoint_error(status: StatusCode, body: String) -> FetchError
 			source: detailed,
 		}
 	} else {
-		// 401/403 are expected client-auth rejections and stay at debug; a 5xx from
-		// the authorization server is a real backend failure and should be visible
-		// by default.
+		// Only authorization server failures warrant a warning.
 		if status.is_server_error() {
 			warn!(%status, error = %detailed, "oauth token exchange returned non-success status");
 		} else {

--- a/crates/agentgateway/src/http/auth/oauth/transport.rs
+++ b/crates/agentgateway/src/http/auth/oauth/transport.rs
@@ -5,7 +5,7 @@ use ::http::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
 use anyhow::anyhow;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
-use tracing::debug;
+use tracing::{debug, warn};
 use url::form_urlencoded;
 
 use super::{
@@ -243,7 +243,14 @@ fn classify_token_endpoint_error(status: StatusCode, body: String) -> FetchError
 			source: detailed,
 		}
 	} else {
-		debug!(%status, error = %detailed, "oauth token exchange returned non-success status");
+		// 401/403 are expected client-auth rejections and stay at debug; a 5xx from
+		// the authorization server is a real backend failure and should be visible
+		// by default.
+		if status.is_server_error() {
+			warn!(%status, error = %detailed, "oauth token exchange returned non-success status");
+		} else {
+			debug!(%status, error = %detailed, "oauth token exchange returned non-success status");
+		}
 		FetchError::Upstream(anyhow!("token exchange returned status {status}"))
 	}
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -613,19 +613,6 @@ where
 	}
 }
 
-/// The message to record in `log.error` for a failed proxy attempt, or `None`
-/// if `e` doesn't represent a gateway-side failure. A raw upstream HTTP
-/// response the MCP layer is passing through unmodified (`mcp::Error::UpstreamError`)
-/// is not a gateway fault: the gateway did its job successfully, the upstream
-/// just responded with an error.
-fn gateway_error_message(e: &ProxyResponse) -> Option<String> {
-	match e {
-		ProxyResponse::Error(ProxyError::MCP(mcp::Error::UpstreamError(_))) => None,
-		ProxyResponse::Error(e) => Some(e.to_string()),
-		ProxyResponse::DirectResponse(_) => None,
-	}
-}
-
 impl HTTPProxy {
 	pub async fn proxy(&self, connection: Arc<Extension>, mut req: Request) -> Response {
 		let start = agent_core::Timestamp::now();
@@ -665,7 +652,13 @@ impl HTTPProxy {
 			.map_err(|e| e.0);
 
 		log.with(|l| {
-			l.error = ret.as_ref().err().and_then(gateway_error_message);
+			l.error = ret.as_ref().err().and_then(|e| {
+				if let ProxyResponse::Error(e) = e {
+					Some(e.to_string())
+				} else {
+					None
+				}
+			})
 		});
 		let reason = match &ret {
 			Ok(_) => ProxyResponseReason::Upstream,
@@ -3268,7 +3261,7 @@ mod tests {
 	use wiremock::{Mock, ResponseTemplate};
 
 	use super::{
-		apply_auto_hostname, apply_llm_request_policies, gateway_error_message, hop_by_hop_headers,
+		apply_auto_hostname, apply_llm_request_policies, hop_by_hop_headers,
 		resolved_workload_target_hostname, select_service_target_port,
 	};
 	use crate::http::filters::AutoHostname;
@@ -3277,39 +3270,12 @@ mod tests {
 		ResponseGuardKind,
 	};
 	use crate::proxy::request_builder::RequestBuilder;
-	use crate::proxy::{ProxyError, ProxyResponse};
 	use crate::store::LLMRequestPolicies;
 	use crate::test_helpers::proxymock;
 	use crate::types::agent::{Backend, ResourceName, Target};
 	use crate::types::discovery::{AppProtocol, Endpoint, HealthStatus, Service};
 	use crate::types::local::LocalAIBackend;
 	use crate::{http, llm};
-
-	#[test]
-	fn gateway_error_message_excludes_mcp_upstream_passthrough() {
-		let upstream_resp = crate::http::SendDirectResponse(
-			::http::Response::builder()
-				.status(500)
-				.body(bytes::Bytes::new())
-				.unwrap(),
-		);
-		let err = ProxyResponse::Error(ProxyError::MCP(crate::mcp::Error::UpstreamError(Box::new(
-			upstream_resp,
-		))));
-
-		// A raw upstream response the MCP layer is just passing through is not a
-		// gateway-side failure, so it must not be recorded as one.
-		assert_eq!(gateway_error_message(&err), None);
-	}
-
-	#[test]
-	fn gateway_error_message_reports_genuine_gateway_faults() {
-		let err = ProxyResponse::Error(ProxyError::RouteNotFound);
-		assert_eq!(
-			gateway_error_message(&err),
-			Some(ProxyError::RouteNotFound.to_string())
-		);
-	}
 
 	#[test]
 	fn configured_request_headers_are_marked_sensitive_at_ingress() {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -613,6 +613,19 @@ where
 	}
 }
 
+/// The message to record in `log.error` for a failed proxy attempt, or `None`
+/// if `e` doesn't represent a gateway-side failure. A raw upstream HTTP
+/// response the MCP layer is passing through unmodified (`mcp::Error::UpstreamError`)
+/// is not a gateway fault: the gateway did its job successfully, the upstream
+/// just responded with an error.
+fn gateway_error_message(e: &ProxyResponse) -> Option<String> {
+	match e {
+		ProxyResponse::Error(ProxyError::MCP(mcp::Error::UpstreamError(_))) => None,
+		ProxyResponse::Error(e) => Some(e.to_string()),
+		ProxyResponse::DirectResponse(_) => None,
+	}
+}
+
 impl HTTPProxy {
 	pub async fn proxy(&self, connection: Arc<Extension>, mut req: Request) -> Response {
 		let start = agent_core::Timestamp::now();
@@ -652,13 +665,7 @@ impl HTTPProxy {
 			.map_err(|e| e.0);
 
 		log.with(|l| {
-			l.error = ret.as_ref().err().and_then(|e| {
-				if let ProxyResponse::Error(e) = e {
-					Some(e.to_string())
-				} else {
-					None
-				}
-			})
+			l.error = ret.as_ref().err().and_then(gateway_error_message);
 		});
 		let reason = match &ret {
 			Ok(_) => ProxyResponseReason::Upstream,
@@ -3261,7 +3268,7 @@ mod tests {
 	use wiremock::{Mock, ResponseTemplate};
 
 	use super::{
-		apply_auto_hostname, apply_llm_request_policies, hop_by_hop_headers,
+		apply_auto_hostname, apply_llm_request_policies, gateway_error_message, hop_by_hop_headers,
 		resolved_workload_target_hostname, select_service_target_port,
 	};
 	use crate::http::filters::AutoHostname;
@@ -3270,12 +3277,39 @@ mod tests {
 		ResponseGuardKind,
 	};
 	use crate::proxy::request_builder::RequestBuilder;
+	use crate::proxy::{ProxyError, ProxyResponse};
 	use crate::store::LLMRequestPolicies;
 	use crate::test_helpers::proxymock;
 	use crate::types::agent::{Backend, ResourceName, Target};
 	use crate::types::discovery::{AppProtocol, Endpoint, HealthStatus, Service};
 	use crate::types::local::LocalAIBackend;
 	use crate::{http, llm};
+
+	#[test]
+	fn gateway_error_message_excludes_mcp_upstream_passthrough() {
+		let upstream_resp = crate::http::SendDirectResponse(
+			::http::Response::builder()
+				.status(500)
+				.body(bytes::Bytes::new())
+				.unwrap(),
+		);
+		let err = ProxyResponse::Error(ProxyError::MCP(crate::mcp::Error::UpstreamError(Box::new(
+			upstream_resp,
+		))));
+
+		// A raw upstream response the MCP layer is just passing through is not a
+		// gateway-side failure, so it must not be recorded as one.
+		assert_eq!(gateway_error_message(&err), None);
+	}
+
+	#[test]
+	fn gateway_error_message_reports_genuine_gateway_faults() {
+		let err = ProxyResponse::Error(ProxyError::RouteNotFound);
+		assert_eq!(
+			gateway_error_message(&err),
+			Some(ProxyError::RouteNotFound.to_string())
+		);
+	}
 
 	#[test]
 	fn configured_request_headers_are_marked_sensitive_at_ingress() {

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1138,6 +1138,19 @@ pub struct RequestLog {
 	pub response_bytes: u64,
 }
 
+/// Mirrors the status/error severity classification already used for the debug
+/// tracer (see `dtrace::MessageType::severity`), so access logs get the same
+/// error/warn/info split instead of always reporting "info".
+fn request_log_level(status: Option<crate::http::StatusCode>, error: Option<&str>) -> &'static str {
+	if error.is_some() || status.is_some_and(|s| s.as_u16() >= 500) {
+		"error"
+	} else if status.is_some_and(|s| s.as_u16() >= 400) {
+		"warn"
+	} else {
+		"info"
+	}
+}
+
 impl Drop for DropOnLog {
 	fn drop(&mut self) {
 		let status = self
@@ -1317,7 +1330,13 @@ impl Drop for DropOnLog {
 					.inc();
 			}
 
-			let maybe_enable_log = agent_core::telemetry::enabled("request", &Level::INFO);
+			let level = request_log_level(log.status, log.error.as_deref());
+			let level_filter = match level {
+				"error" => Level::ERROR,
+				"warn" => Level::WARN,
+				_ => Level::INFO,
+			};
+			let maybe_enable_log = agent_core::telemetry::enabled("request", &level_filter);
 			let otlp_log_enabled = log.otel_logger.is_some();
 			// For now we only enable this log for LLM requests to keep cost/performance appropriate.
 			let log_store_enabled = log_store::enabled()
@@ -1743,7 +1762,7 @@ impl Drop for DropOnLog {
 					let eval = v.as_ref().map(json_value_to_value_bag);
 					otlp_kv.push((k, eval));
 				}
-				otel.emit("info", "request", &otlp_kv);
+				otel.emit(level, "request", &otlp_kv);
 			}
 
 			if maybe_enable_log || log_store_enabled {
@@ -1769,7 +1788,7 @@ impl Drop for DropOnLog {
 				}
 
 				if maybe_enable_log {
-					agent_core::telemetry::log("info", "request", &kv);
+					agent_core::telemetry::log(level, "request", &kv);
 				}
 
 				if log_store_enabled {
@@ -2559,6 +2578,30 @@ mod tests {
 	fn database_llm_metadata_does_not_persist_captured_content() {
 		let context = llm_context_with_content();
 		assert!(database_llm_payload(Some(DatabaseLlmMode::Metadata), Some(&context)).is_none());
+	}
+
+	#[test]
+	fn request_log_level_reflects_status_and_error() {
+		use crate::http::StatusCode;
+
+		assert_eq!(request_log_level(None, None), "info");
+		assert_eq!(request_log_level(Some(StatusCode::OK), None), "info");
+		assert_eq!(request_log_level(Some(StatusCode::NOT_FOUND), None), "warn");
+		assert_eq!(
+			request_log_level(Some(StatusCode::BAD_GATEWAY), None),
+			"error"
+		);
+		assert_eq!(
+			request_log_level(Some(StatusCode::INTERNAL_SERVER_ERROR), None),
+			"error"
+		);
+		// An error takes precedence even without a 5xx status (e.g. connection reset
+		// before a response was ever produced).
+		assert_eq!(
+			request_log_level(Some(StatusCode::OK), Some("boom")),
+			"error"
+		);
+		assert_eq!(request_log_level(None, Some("boom")), "error");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1138,13 +1138,6 @@ pub struct RequestLog {
 	pub response_bytes: u64,
 }
 
-/// A non-2xx/3xx `http.status` on its own does not make a request log entry an
-/// "error": the gateway relaying an upstream's or client's status faithfully
-/// did its job correctly. `log.error`, on the other hand, is only populated
-/// when the gateway itself failed to produce a normal response (routing,
-/// policy, backend-connectivity, decode failures, ...), which is what "error"
-/// severity should actually mean here. Filtering/alerting on `http.status`
-/// itself is what the CEL log filter is for.
 fn request_log_level(error: Option<&str>) -> &'static str {
 	if error.is_some() { "error" } else { "info" }
 }
@@ -2576,16 +2569,6 @@ mod tests {
 	fn database_llm_metadata_does_not_persist_captured_content() {
 		let context = llm_context_with_content();
 		assert!(database_llm_payload(Some(DatabaseLlmMode::Metadata), Some(&context)).is_none());
-	}
-
-	#[test]
-	fn request_log_level_reflects_gateway_error_only() {
-		// A non-2xx/3xx http.status alone does not make the entry "error": the
-		// gateway relaying an upstream's or client's status faithfully did its
-		// job. Only a populated `log.error` (the gateway itself failing to
-		// produce a normal response) should raise the level.
-		assert_eq!(request_log_level(None), "info");
-		assert_eq!(request_log_level(Some("boom")), "error");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1138,17 +1138,15 @@ pub struct RequestLog {
 	pub response_bytes: u64,
 }
 
-/// Mirrors the status/error severity classification already used for the debug
-/// tracer (see `dtrace::MessageType::severity`), so access logs get the same
-/// error/warn/info split instead of always reporting "info".
-fn request_log_level(status: Option<crate::http::StatusCode>, error: Option<&str>) -> &'static str {
-	if error.is_some() || status.is_some_and(|s| s.as_u16() >= 500) {
-		"error"
-	} else if status.is_some_and(|s| s.as_u16() >= 400) {
-		"warn"
-	} else {
-		"info"
-	}
+/// A non-2xx/3xx `http.status` on its own does not make a request log entry an
+/// "error": the gateway relaying an upstream's or client's status faithfully
+/// did its job correctly. `log.error`, on the other hand, is only populated
+/// when the gateway itself failed to produce a normal response (routing,
+/// policy, backend-connectivity, decode failures, ...), which is what "error"
+/// severity should actually mean here. Filtering/alerting on `http.status`
+/// itself is what the CEL log filter is for.
+fn request_log_level(error: Option<&str>) -> &'static str {
+	if error.is_some() { "error" } else { "info" }
 }
 
 impl Drop for DropOnLog {
@@ -1330,11 +1328,11 @@ impl Drop for DropOnLog {
 					.inc();
 			}
 
-			let level = request_log_level(log.status, log.error.as_deref());
-			let level_filter = match level {
-				"error" => Level::ERROR,
-				"warn" => Level::WARN,
-				_ => Level::INFO,
+			let level = request_log_level(log.error.as_deref());
+			let level_filter = if level == "error" {
+				Level::ERROR
+			} else {
+				Level::INFO
 			};
 			let maybe_enable_log = agent_core::telemetry::enabled("request", &level_filter);
 			let otlp_log_enabled = log.otel_logger.is_some();
@@ -2581,27 +2579,13 @@ mod tests {
 	}
 
 	#[test]
-	fn request_log_level_reflects_status_and_error() {
-		use crate::http::StatusCode;
-
-		assert_eq!(request_log_level(None, None), "info");
-		assert_eq!(request_log_level(Some(StatusCode::OK), None), "info");
-		assert_eq!(request_log_level(Some(StatusCode::NOT_FOUND), None), "warn");
-		assert_eq!(
-			request_log_level(Some(StatusCode::BAD_GATEWAY), None),
-			"error"
-		);
-		assert_eq!(
-			request_log_level(Some(StatusCode::INTERNAL_SERVER_ERROR), None),
-			"error"
-		);
-		// An error takes precedence even without a 5xx status (e.g. connection reset
-		// before a response was ever produced).
-		assert_eq!(
-			request_log_level(Some(StatusCode::OK), Some("boom")),
-			"error"
-		);
-		assert_eq!(request_log_level(None, Some("boom")), "error");
+	fn request_log_level_reflects_gateway_error_only() {
+		// A non-2xx/3xx http.status alone does not make the entry "error": the
+		// gateway relaying an upstream's or client's status faithfully did its
+		// job. Only a populated `log.error` (the gateway itself failing to
+		// produce a normal response) should raise the level.
+		assert_eq!(request_log_level(None), "info");
+		assert_eq!(request_log_level(Some("boom")), "error");
 	}
 
 	#[test]


### PR DESCRIPTION
## What

Access log entries (the `level` field, both in the `request` target log and the OTLP access-log emitter) were always written with severity `"info"`, no matter what actually happened during the request. A 500 from an upstream, a guardrail rejection, a failed OAuth token exchange — all showed up as `level=info`, sitting right next to routine 200s.

## Why this matters

It makes log-based alerting and triage on this signal basically useless: you can't filter for failures by severity, only by scanning `http.status` inside the payload after the fact. It also meant that setting the `request` target's log filter to `warn` silently dropped *all* access logs, including failures, since the enablement check itself was hardcoded at `INFO`.

## What changed

- `telemetry/log.rs`: added `request_log_level()`, mirroring the status/error classification the debug tracer (`dtrace::MessageType::severity`) already does — 5xx or any recorded error → `error`, 4xx → `warn`, else `info`. Both `otel.emit(...)` and `agent_core::telemetry::log(...)` now use this instead of the `"info"` literal, and the enablement gate uses the same computed level so operators filtering at `warn`/`error` still see failures come through.
- `http/auth/oauth/transport.rs`: 5xx responses from the token endpoint were only ever logged at `debug!`, so a real upstream failure there was invisible by default. 401/403 (routine "auth didn't work") stay at `debug!`; 5xx now logs at `warn!`.

## Testing

- Added a unit test for `request_log_level` covering 2xx/none, 4xx, 5xx, and the "error present but no 5xx status" case.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and the full `agentgateway` unit test suite (1885 tests) all pass locally.