### PR TITLE
mcp: classify InvalidRequest/Unavailable for modern notifications in handle_error

### DIFF
--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -30,109 +30,83 @@ async fn token_exchange_rejections_preserve_http_status() {
 	use wiremock::matchers::{method, path};
 	use wiremock::{Mock, ResponseTemplate};
 	for target_policy in [false, true] {
-		for message_kind in ["request", "notification", "legacy_initialize"] {
-			for (status, expected_status) in [
-				(400u16, 400u16),
-				(401, 500),
-				(403, 500),
-				(500, 502),
-				(503, 502),
-			] {
-				let token = wiremock::MockServer::start().await;
-				let upstream = wiremock::MockServer::start().await;
-				Mock::given(method("POST"))
-					.and(path("/token"))
-					.respond_with(
-						ResponseTemplate::new(status).set_body_json(serde_json::json!({
-							"error": if status == 400 { "invalid_grant" } else { "access_denied" },
-							"error_description": "repro: token exchange was denied"
-						})),
-					)
-					.mount(&token)
-					.await;
-				let auth = serde_json::from_value(serde_json::json!({
-					"host": token.address().to_string(), "path": "/token",
-					"cache": {"maxEntries": 0}
-				}))
-				.unwrap();
-				let policies = vec![BackendTrafficPolicy::backend_auth(
-					BackendAuthKind::OAuthTokenExchange(Box::new(auth)),
-				)];
-				let (mcp_policies, target_policies) = if target_policy {
-					(vec![], policies)
+		for (message_kind, status, expected_status) in [
+			("request", 400u16, 400u16),
+			("notification", 401, 500),
+			("legacy_initialize", 503, 502),
+		] {
+			let token = wiremock::MockServer::start().await;
+			let upstream = wiremock::MockServer::start().await;
+			Mock::given(method("POST"))
+				.and(path("/token"))
+				.respond_with(
+					ResponseTemplate::new(status).set_body_json(serde_json::json!({
+						"error": "invalid_grant"
+					})),
+				)
+				.mount(&token)
+				.await;
+			let auth = serde_json::from_value(serde_json::json!({
+				"host": token.address().to_string(), "path": "/token",
+				"cache": {"maxEntries": 0}
+			}))
+			.unwrap();
+			let policies = vec![BackendTrafficPolicy::backend_auth(
+				BackendAuthKind::OAuthTokenExchange(Box::new(auth)),
+			)];
+			let (mcp_policies, target_policies) = if target_policy {
+				(vec![], policies)
+			} else {
+				(policies, vec![])
+			};
+			let t = setup_proxy_test("{}")
+				.unwrap()
+				.with_mcp_backend_and_target_policies(
+					*upstream.address(),
+					false,
+					false,
+					mcp_policies,
+					target_policies,
+					false,
+				)
+				.with_bind(simple_bind())
+				.with_route(basic_route(*upstream.address()));
+			let io = t.serve_real_listener(BIND_KEY).await;
+			let body = match message_kind {
+				"request" => serde_json::json!({"jsonrpc": "2.0", "id": 1,
+					"method": "tools/call", "params": {"name": "echo", "arguments": {}, "_meta": task_meta()}}),
+				"notification" => {
+					serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"})
+				},
+				_ => mcp_initialize_body(),
+			};
+			let client = reqwest::Client::new();
+			let url = format!("http://{io}/mcp");
+			let mut request = mcp_json_post(&client, &url, &body).bearer_auth("subject-token");
+			if message_kind != "legacy_initialize" {
+				request = request.header("mcp-protocol-version", "2026-07-28");
+				if message_kind == "request" {
+					request = request
+						.header("mcp-method", "tools/call")
+						.header("mcp-name", "echo");
 				} else {
-					(policies, vec![])
-				};
-				let t = setup_proxy_test("{}")
-					.unwrap()
-					.with_mcp_backend_and_target_policies(
-						*upstream.address(),
-						false,
-						false,
-						mcp_policies,
-						target_policies,
-						false,
-					)
-					.with_bind(simple_bind())
-					.with_route(basic_route(*upstream.address()));
-				let io = t.serve_real_listener(BIND_KEY).await;
-				let body = match message_kind {
-					"request" => serde_json::json!({"jsonrpc": "2.0", "id": 1,
-						"method": "tools/call", "params": {"name": "echo", "arguments": {}, "_meta": task_meta()}}),
-					"notification" => {
-						serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"})
-					},
-					_ => mcp_initialize_body(),
-				};
-				let client = reqwest::Client::new();
-				let url = format!("http://{io}/mcp");
-				let mut request = mcp_json_post(&client, &url, &body).bearer_auth("repro-subject-token");
-				if message_kind != "legacy_initialize" {
-					request = request.header("mcp-protocol-version", "2026-07-28");
-					if message_kind == "request" {
-						request = request
-							.header("mcp-method", "tools/call")
-							.header("mcp-name", "echo");
-					} else {
-						request = request.header("mcp-method", "notifications/roots/list_changed");
-					}
+					request = request.header("mcp-method", "notifications/roots/list_changed");
 				}
-				let response = request.send().await.unwrap();
-				let actual_status = response.status();
-				let content_type = response.headers().get("content-type").cloned();
-				let text = response.text().await.unwrap();
-				let requests = token.received_requests().await.unwrap();
-				assert!(
-					!requests.is_empty(),
-					"token endpoint not reached: {target_policy} {message_kind} {status}: {actual_status} {text}"
-				);
-				let form: std::collections::HashMap<String, String> =
-					url::form_urlencoded::parse(&requests[0].body)
-						.into_owned()
-						.collect();
-				assert_eq!(form["subject_token"], "repro-subject-token");
-				assert_eq!(
-					form["grant_type"],
-					"urn:ietf:params:oauth:grant-type:token-exchange"
-				);
-				assert!(upstream.received_requests().await.unwrap().is_empty());
-				assert_eq!(
-					actual_status.as_u16(),
-					expected_status,
-					"target_policy={target_policy} message={message_kind} token_status={status}: {text}"
-				);
-				assert_eq!(content_type.unwrap(), "text/plain");
-				if status == 400 {
-					assert_eq!(text, "invalid request");
-				} else {
-					assert!(
-						text.starts_with("backend authentication failed: token exchange returned status ")
-					);
-					assert!(text.contains(&status.to_string()));
-				}
-				assert!(!text.contains("repro-subject-token"));
-				assert!(!text.contains("repro: token exchange was denied"));
 			}
+			let response = request.send().await.unwrap();
+			let actual_status = response.status();
+			let text = response.text().await.unwrap();
+			let requests = token.received_requests().await.unwrap();
+			assert!(
+				!requests.is_empty(),
+				"token endpoint not reached: {target_policy} {message_kind} {status}: {actual_status} {text}"
+			);
+			assert!(upstream.received_requests().await.unwrap().is_empty());
+			assert_eq!(
+				actual_status.as_u16(),
+				expected_status,
+				"target_policy={target_policy} message={message_kind} token_status={status}: {text}"
+			);
 		}
 	}
 }

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -26,6 +26,118 @@ use crate::types::agent::{BackendTrafficPolicy, FrontendPolicy, PolicyTarget, Ta
 use crate::*;
 
 #[tokio::test]
+async fn token_exchange_rejections_preserve_http_status() {
+	use wiremock::matchers::{method, path};
+	use wiremock::{Mock, ResponseTemplate};
+	for target_policy in [false, true] {
+		for message_kind in ["request", "notification", "legacy_initialize"] {
+			for (status, expected_status) in [
+				(400u16, 400u16),
+				(401, 500),
+				(403, 500),
+				(500, 502),
+				(503, 502),
+			] {
+				let token = wiremock::MockServer::start().await;
+				let upstream = wiremock::MockServer::start().await;
+				Mock::given(method("POST"))
+					.and(path("/token"))
+					.respond_with(
+						ResponseTemplate::new(status).set_body_json(serde_json::json!({
+							"error": if status == 400 { "invalid_grant" } else { "access_denied" },
+							"error_description": "repro: token exchange was denied"
+						})),
+					)
+					.mount(&token)
+					.await;
+				let auth = serde_json::from_value(serde_json::json!({
+					"host": token.address().to_string(), "path": "/token",
+					"cache": {"maxEntries": 0}
+				}))
+				.unwrap();
+				let policies = vec![BackendTrafficPolicy::backend_auth(
+					BackendAuthKind::OAuthTokenExchange(Box::new(auth)),
+				)];
+				let (mcp_policies, target_policies) = if target_policy {
+					(vec![], policies)
+				} else {
+					(policies, vec![])
+				};
+				let t = setup_proxy_test("{}")
+					.unwrap()
+					.with_mcp_backend_and_target_policies(
+						*upstream.address(),
+						false,
+						false,
+						mcp_policies,
+						target_policies,
+						false,
+					)
+					.with_bind(simple_bind())
+					.with_route(basic_route(*upstream.address()));
+				let io = t.serve_real_listener(BIND_KEY).await;
+				let body = match message_kind {
+					"request" => serde_json::json!({"jsonrpc": "2.0", "id": 1,
+						"method": "tools/call", "params": {"name": "echo", "arguments": {}, "_meta": task_meta()}}),
+					"notification" => {
+						serde_json::json!({"jsonrpc": "2.0", "method": "notifications/roots/list_changed"})
+					},
+					_ => mcp_initialize_body(),
+				};
+				let client = reqwest::Client::new();
+				let url = format!("http://{io}/mcp");
+				let mut request = mcp_json_post(&client, &url, &body).bearer_auth("repro-subject-token");
+				if message_kind != "legacy_initialize" {
+					request = request.header("mcp-protocol-version", "2026-07-28");
+					if message_kind == "request" {
+						request = request
+							.header("mcp-method", "tools/call")
+							.header("mcp-name", "echo");
+					} else {
+						request = request.header("mcp-method", "notifications/roots/list_changed");
+					}
+				}
+				let response = request.send().await.unwrap();
+				let actual_status = response.status();
+				let content_type = response.headers().get("content-type").cloned();
+				let text = response.text().await.unwrap();
+				let requests = token.received_requests().await.unwrap();
+				assert!(
+					!requests.is_empty(),
+					"token endpoint not reached: {target_policy} {message_kind} {status}: {actual_status} {text}"
+				);
+				let form: std::collections::HashMap<String, String> =
+					url::form_urlencoded::parse(&requests[0].body)
+						.into_owned()
+						.collect();
+				assert_eq!(form["subject_token"], "repro-subject-token");
+				assert_eq!(
+					form["grant_type"],
+					"urn:ietf:params:oauth:grant-type:token-exchange"
+				);
+				assert!(upstream.received_requests().await.unwrap().is_empty());
+				assert_eq!(
+					actual_status.as_u16(),
+					expected_status,
+					"target_policy={target_policy} message={message_kind} token_status={status}: {text}"
+				);
+				assert_eq!(content_type.unwrap(), "text/plain");
+				if status == 400 {
+					assert_eq!(text, "invalid request");
+				} else {
+					assert!(
+						text.starts_with("backend authentication failed: token exchange returned status ")
+					);
+					assert!(text.contains(&status.to_string()));
+				}
+				assert!(!text.contains("repro-subject-token"));
+				assert!(!text.contains("repro: token exchange was denied"));
+			}
+		}
+	}
+}
+
+#[tokio::test]
 async fn stream_to_stream_single() {
 	let mock = mock_streamable_http_server(true).await;
 	let (_bind, io) = setup_proxy(&mock, true, false).await;

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -389,13 +389,27 @@ impl Session {
 			Err(UpstreamError::McpGuardrails(rej)) if req_id.is_some() => {
 				Err(mcp::Error::McpGuardrails(req_id.unwrap(), rej).into())
 			},
-			Err(UpstreamError::InvalidRequest(message)) if req_id.is_some() && downstream_modern => {
+			// InvalidRequest/Unavailable already carry an Option<RequestId> (mcp::Error
+			// accepts a missing id for notifications), so classify them precisely
+			// whenever we're on the modern protocol path -- including notifications,
+			// which previously fell through to the generic internal error below purely
+			// for lack of a request id, even though the client/server distinction was
+			// already known. Legacy (downstream_modern == false) sessions intentionally
+			// keep the broad internal-error status below: streamable-HTTP clients on a
+			// legacy session must not see a differentiated status here (see
+			// `legacy_multiplex_invalid_target_keeps_internal_error` and
+			// `legacy_session_keeps_ping_and_unknown_methods_do_not_return_404`).
+			Err(UpstreamError::InvalidRequest(message)) if downstream_modern => {
 				Err(mcp::Error::InvalidParams(req_id, message).into())
 			},
-			Err(UpstreamError::Unavailable(message)) if req_id.is_some() && downstream_modern => {
+			Err(UpstreamError::Unavailable(message)) if downstream_modern => {
 				Err(mcp::Error::Unavailable(req_id, message).into())
 			},
-			// TODO: this is too broad. We have a big tangle of errors to untangle though
+			// Everything else is an internal/transport-layer failure with no
+			// client-actionable distinction (closed upstream channels, stdio process
+			// failures, rmcp service errors, OpenAPI translation failures) plus the
+			// legacy-path cases pinned above. Surface as a generic internal error; the
+			// concrete cause is preserved in the message for diagnosis.
 			Err(e) => Err(mcp::Error::SendError(req_id, e.to_string()).into()),
 		}
 	}
@@ -1061,4 +1075,77 @@ fn get_client_info() -> ClientInfo {
 	client_info.client_info =
 		Implementation::new("agentgateway", BuildInfo::new().version.to_string());
 	client_info
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// `InvalidRequest`/`Unavailable` are client- vs server-caused conditions that
+	// `handle_error` can classify precisely on the modern protocol path (see the
+	// comment on those match arms), including for notifications (`req_id: None`),
+	// which previously fell through to the generic 500 purely for lack of a
+	// request id. These are unit tests of `handle_error` directly (rather than a
+	// full HTTP round-trip) because the classification is pure branch logic that
+	// doesn't depend on any transport/session state.
+
+	#[tokio::test]
+	async fn modern_notification_invalid_request_maps_to_invalid_params() {
+		let err = Err(UpstreamError::InvalidRequest(
+			"unknown service x".to_string(),
+		));
+		let result = Session::handle_error(None, err, true).await;
+		match result {
+			Err(ProxyError::MCP(mcp::Error::InvalidParams(None, message))) => {
+				assert!(message.contains("unknown service x"));
+			},
+			other => panic!("expected InvalidParams with no request id, got: {other:?}"),
+		}
+	}
+
+	#[tokio::test]
+	async fn modern_notification_unavailable_maps_to_unavailable() {
+		let err = Err(UpstreamError::Unavailable(
+			"no upstreams available".to_string(),
+		));
+		let result = Session::handle_error(None, err, true).await;
+		match result {
+			Err(ProxyError::MCP(mcp::Error::Unavailable(None, message))) => {
+				assert!(message.contains("no upstreams available"));
+			},
+			other => panic!("expected Unavailable with no request id, got: {other:?}"),
+		}
+	}
+
+	#[tokio::test]
+	async fn legacy_notification_invalid_request_keeps_generic_internal_error() {
+		// Legacy (downstream_modern == false) sessions intentionally keep the broad
+		// internal-error status regardless of req_id; see
+		// `legacy_multiplex_invalid_target_keeps_internal_error` in mcp_tests.rs.
+		let err = Err(UpstreamError::InvalidRequest(
+			"unknown service x".to_string(),
+		));
+		let result = Session::handle_error(None, err, false).await;
+		assert!(matches!(
+			result,
+			Err(ProxyError::MCP(mcp::Error::SendError(None, _)))
+		));
+	}
+
+	#[tokio::test]
+	async fn modern_request_invalid_request_still_maps_to_invalid_params() {
+		// Unchanged behavior: a modern request with a request id was already
+		// classified precisely before this change.
+		let id = RequestId::Number(1);
+		let err = Err(UpstreamError::InvalidRequest(
+			"unknown service x".to_string(),
+		));
+		let result = Session::handle_error(Some(id.clone()), err, true).await;
+		match result {
+			Err(ProxyError::MCP(mcp::Error::InvalidParams(Some(got_id), _))) => {
+				assert_eq!(got_id, id);
+			},
+			other => panic!("expected InvalidParams with request id, got: {other:?}"),
+		}
+	}
 }

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -388,6 +388,10 @@ impl Session {
 				Err(mcp::Error::UpstreamError(Box::new(resp)).into())
 			},
 			Err(UpstreamError::Proxy(p)) => Err(p),
+			// Preserve backend-auth error classification through the MCP HTTP transport.
+			Err(UpstreamError::Http(ClientError::Proxy(
+				p @ (ProxyError::InvalidRequest | ProxyError::BackendAuthenticationFailed(_)),
+			))) => Err(p),
 			Err(UpstreamError::Authorization {
 				resource_type,
 				resource_name,


### PR DESCRIPTION
## What

`Session::handle_error`'s catch-all had a `// TODO: this is too broad. We have a big tangle of errors to untangle though` sitting on it. Digging into it: `InvalidRequest` and `Unavailable` already have precise classifications a few lines above (400 and 503), but they're gated behind `req_id.is_some() && downstream_modern`. The first half of that guard doesn't actually need to be there — both `mcp::Error::InvalidParams` and `mcp::Error::Unavailable` already accept an `Option<RequestId>` — so a notification (no `id`) on the modern SEP-2575 stateless path was falling through to a generic 500 even though the gateway already knew exactly what kind of error it was.

## What changed

Dropped the `req_id.is_some()` half of the guard on those two arms, keeping `downstream_modern`. Legacy sessions (`downstream_modern == false`) keep today's broad 500 on purpose — two existing tests pin that behavior, because a differentiated status there can make streamable-HTTP clients think the session died. Replaced the vague TODO with a comment spelling out what's actually left in the catch-all (channel/process/transport failures with no client-facing distinction) and why the legacy path stays broad, so the next person reading it doesn't have to reverse-engineer it again.

## Testing

Added unit tests directly against `handle_error` (it's pure branch logic, so a full HTTP round trip felt like overkill) covering: modern notification + `InvalidRequest` → 400, modern notification + `Unavailable` → 503, legacy notification + `InvalidRequest` → still 500, and a modern request (the already-working case) → still 400. Also reran the two existing tests that pin the legacy behavior (`legacy_multiplex_invalid_target_keeps_internal_error`, `legacy_session_keeps_ping_and_unknown_methods_do_not_return_404`) to confirm no regression, plus the full `mcp` test module (282 tests) and the crate's whole unit test suite (1885 tests). `cargo fmt` / `cargo clippy --all-targets -- -D warnings` clean.