### PR TITLE
fix: cache InferencePool status to suppress redundant writes

### DIFF
--- a/controller/pkg/agentgateway/translator/builtin_helpers.go
+++ b/controller/pkg/agentgateway/translator/builtin_helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/durationpb"
 	"istio.io/istio/pkg/ptr"
+	infv1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/api"
@@ -110,6 +111,8 @@ func GetStatus[I, IS any](spec I) IS {
 	case *agentgateway.AgentgatewayBackend:
 		return any(t.Status).(IS)
 	case *agentgateway.AgentgatewayModel:
+		return any(t.Status).(IS)
+	case *infv1.InferencePool:
 		return any(t.Status).(IS)
 	default:
 		// For external resources (registered via extraGVKs), we don't introspect the object here.


### PR DESCRIPTION
When checking for InferencePool status changes, no changes were ever suppressed because the live status was never read into the cache. This causes continuous redundant writes. The suppression check at compares live against desired status and skips the write when they match, but GetStatus was missing the *infv1.InferencePool case, so it always returned a zero value.

https://github.com/agentgateway/agentgateway/blob/0d510695da62d9c6f3ff326039519e8c1e9214a2/controller/pkg/agentgateway/translator/builtin_helpers.go#L115-L117
https://github.com/agentgateway/agentgateway/blob/0d510695da62d9c6f3ff326039519e8c1e9214a2/controller/pkg/syncer/status/collection.go#L84-L90

We found this while investigating an external controller managing both an HTTPRoute and an InferencePool via agentgateway. Only the InferencePool showed continuous resourceVersion churn. Tracing the inconsistency led to this missing case, and fixing it resolved the issue.