### PR TITLE
Bump rust to 1.98

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CI: true
-  RUST_VERSION: "1.97.0"
+  RUST_VERSION: "1.98.0"
   CARGO_BUILD_WARNINGS: deny
   GO_VERSION: "1.26.6"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CI: true
-  RUST_VERSION: "1.97.0"
+  RUST_VERSION: "1.98.0"
   CARGO_BUILD_WARNINGS: deny
   GO_VERSION: "1.26.6"
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/agentgateway

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,id=agentgateway-ui-pnpm,target=/pnpm/store \
 
 RUN pnpm build
 
-FROM docker.io/library/rust:1.97.0-trixie AS musl-builder
+FROM docker.io/library/rust:1.98.0-trixie AS musl-builder
 
 ARG TARGETARCH
 
@@ -37,7 +37,7 @@ else
 fi
 EOF
 
-FROM docker.io/library/rust:1.97.0-trixie AS base-builder
+FROM docker.io/library/rust:1.98.0-trixie AS base-builder
 
 ARG TARGETARCH
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -26,7 +26,7 @@
 # (a rust image with node/npm copied in, so napi has both toolchains)
 # Temporary: drop once parcel-bundler/lightningcss#1294 ships a s390x prebuilt.
 # ─────────────────────────────────────────────────────────────────────────────
-FROM docker.io/library/rust:1.97.0-bookworm AS lightningcss-s390x
+FROM docker.io/library/rust:1.98.0-bookworm AS lightningcss-s390x
 
 COPY --from=docker.io/library/node:24.17.0-bookworm /usr/local/bin/node /usr/local/bin/node
 COPY --from=docker.io/library/node:24.17.0-bookworm /usr/local/include/node /usr/local/include/node
@@ -81,7 +81,7 @@ RUN pnpm build
 # ─────────────────────────────────────────────────────────────────────────────
 # Stage: build the agentgateway binary for s390x.
 # ─────────────────────────────────────────────────────────────────────────────
-FROM docker.io/library/rust:1.97.0-bookworm AS builder
+FROM docker.io/library/rust:1.98.0-bookworm AS builder
 ARG PROFILE=release
 ARG VERSION
 ARG GIT_REVISION

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -6289,6 +6289,7 @@ async fn mcp_extauth_deny() {
 	);
 }
 
+#[allow(clippy::result_large_err)]
 async fn try_mcp_streamable_client(
 	s: SocketAddr,
 ) -> Result<RunningService<RoleClient, InitializeRequestParams>, rmcp::service::ClientInitializeError>

--- a/crates/pool/src/client.rs
+++ b/crates/pool/src/client.rs
@@ -201,6 +201,7 @@ where
 		}
 	}
 
+	#[allow(clippy::result_large_err)]
 	async fn try_send_request(
 		&self,
 		req: Request<RequestBody>,

--- a/crates/pool/src/pool.rs
+++ b/crates/pool/src/pool.rs
@@ -355,6 +355,7 @@ impl HttpConnection {
 			HttpConnection::Http2(h) => h.load.remaining_capacity(),
 		}
 	}
+	#[allow(clippy::result_large_err)]
 	pub fn try_send_request(
 		&mut self,
 		req: Request<RequestBody>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.97"
+channel = "1.98"
 components = ["rustc", "rust-std", "cargo", "clippy", "rustfmt", "rust-docs"]


### PR DESCRIPTION
Adds a few ignores due to async returns that are meant to be retriable.
These are exposed due to asyncs being inspected by the linter now.
https://github.com/rust-lang/rust-clippy/pull/17130



https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/

I did look at https://blog.rust-lang.org/2026/08/20/Rust-1.98.0/#buffered-integer-formatting
It was interesting as it did remove itoa from a package but the replacement would only be for telemetry date string conversion and techincally the linked benchmarks show that while it is similar in performance to itoa it is marginally worse in terms of speed. If people are interested ive added the patch for what the extra commit would look like in the first comment and am happy to add it back in if we prefer the ability to scrub another dependency.