### PR TITLE
fix(llm): convert OpenAI file content parts on the Vertex Gemini path

### DIFF
--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -9,6 +9,10 @@ use tracing::debug;
 
 use crate::{StreamingUsageGuard, logged_response_parsing, parse, types};
 
+#[cfg(test)]
+#[path = "completions_tests.rs"]
+mod tests;
+
 /// Parse a Google error response, handling both single object and array-wrapped formats.
 /// Google's OpenAI-compatible endpoints consistently return `[{"error": {...}}]`
 /// rather than `{"error": {...}}` when using the Vertex AI shim.
@@ -66,10 +70,14 @@ pub fn translate_google_error(bytes: &Bytes) -> Result<Bytes, crate::AIError> {
 pub(crate) fn parse_data_url(url: &str) -> Option<(&str, &str)> {
 	let raw = url.strip_prefix("data:")?;
 	let (meta, data) = raw.split_once(',')?;
-	let (media_type, encoding) = meta.split_once(';')?;
-	if !encoding.eq_ignore_ascii_case("base64") {
+	// RFC 2397 allows media-type parameters before the encoding marker:
+	// data:<mediatype>[;param=value]*;base64,<data>
+	let idx = meta.len().checked_sub(";base64".len())?;
+	if !meta.get(idx..)?.eq_ignore_ascii_case(";base64") {
 		return None;
 	}
+	// Parameters such as charset are not part of the media type.
+	let media_type = meta.get(..idx)?.split(';').next().unwrap_or_default();
 	Some((media_type, data))
 }
 

--- a/crates/llm/src/conversion/completions_tests.rs
+++ b/crates/llm/src/conversion/completions_tests.rs
@@ -1,0 +1,39 @@
+use super::parse_data_url;
+
+#[test]
+fn plain_base64_data_url() {
+	assert_eq!(
+		parse_data_url("data:application/pdf;base64,JVBERi0xLjQK"),
+		Some(("application/pdf", "JVBERi0xLjQK"))
+	);
+}
+
+#[test]
+fn media_type_parameters_are_dropped() {
+	// RFC 2397 permits parameters before the encoding marker. Rejecting these used to
+	// push callers onto their raw-base64 fallback, sending the header as payload.
+	assert_eq!(
+		parse_data_url("data:text/plain;charset=utf-8;base64,dGVzdA=="),
+		Some(("text/plain", "dGVzdA=="))
+	);
+}
+
+#[test]
+fn empty_media_type_is_preserved() {
+	assert_eq!(
+		parse_data_url("data:;base64,dGVzdA=="),
+		Some(("", "dGVzdA=="))
+	);
+}
+
+#[test]
+fn non_base64_encodings_are_rejected() {
+	assert_eq!(parse_data_url("data:image/png,iVBORw0KGgo="), None);
+	assert_eq!(parse_data_url("data:text/plain;charset=utf-8,hi"), None);
+}
+
+#[test]
+fn non_data_urls_are_rejected() {
+	assert_eq!(parse_data_url("https://example.com/cat.png"), None);
+	assert_eq!(parse_data_url("data:no-comma"), None);
+}

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -393,6 +393,9 @@ pub mod from_completions {
 						"image_url" => {
 							parts.push(image_part(p.rest.get("image_url"))?);
 						},
+						"file" => {
+							parts.push(file_part(p.rest.get("file"))?);
+						},
 						_ => {},
 					}
 				}
@@ -402,6 +405,28 @@ pub mod from_completions {
 		Ok(parts)
 	}
 
+	fn inline_data_part(mime: &str, data: &str) -> vg::Part {
+		vg::Part::InlineData(vg::InlineDataPart {
+			inline_data: vg::Blob {
+				mime_type: canonical_mime(mime).to_string(),
+				data: data.to_string(),
+				rest: Value::Null,
+			},
+			rest: Value::Null,
+		})
+	}
+
+	fn file_data_part(mime: &str, uri: &str) -> vg::Part {
+		vg::Part::FileData(vg::FileDataPart {
+			file_data: vg::FileData {
+				mime_type: Some(canonical_mime(mime).to_string()),
+				file_uri: uri.to_string(),
+				rest: Value::Null,
+			},
+			rest: Value::Null,
+		})
+	}
+
 	fn image_part(image_url: Option<&Value>) -> Result<vg::Part, AIError> {
 		let url = image_url
 			.and_then(|u| u.get("url"))
@@ -409,14 +434,7 @@ pub mod from_completions {
 			.unwrap_or_default();
 
 		if let Some((mime, data)) = parse_data_url(url) {
-			return Ok(vg::Part::InlineData(vg::InlineDataPart {
-				inline_data: vg::Blob {
-					mime_type: canonical_mime(mime).to_string(),
-					data: data.to_string(),
-					rest: Value::Null,
-				},
-				rest: Value::Null,
-			}));
+			return Ok(inline_data_part(mime, data));
 		}
 
 		if url.starts_with("gs://") {
@@ -428,20 +446,59 @@ pub mod from_completions {
 					"gs:// image_url ({url}) has no recognised extension or MIME hint; pass image_url.format (or mime_type/content_type), or use an object with a known extension"
 				))));
 			};
-			return Ok(vg::Part::FileData(vg::FileDataPart {
-				file_data: vg::FileData {
-					mime_type: Some(canonical_mime(&mime).to_string()),
-					file_uri: url.to_string(),
-					rest: Value::Null,
-				},
-				rest: Value::Null,
-			}));
+			return Ok(file_data_part(&mime, url));
 		}
 
 		// http(s) and anything else are not fetchable by Vertex.
 		Err(AIError::InvalidResponse(strng::new(format!(
 			"native Gemini path rejects http(s) image_url ({url}); upload to gs:// or send inline data:"
 		))))
+	}
+
+	/// Convert an OpenAI `file` content part into a Gemini part.
+	///
+	/// Mirrors [`image_part`]: inline `data:` payloads become `inlineData`, `gs://`
+	/// objects become `fileData`, and anything Vertex cannot fetch is rejected rather
+	/// than dropped.
+	fn file_part(file: Option<&Value>) -> Result<vg::Part, AIError> {
+		let field = |k: &str| {
+			file
+				.and_then(|f| f.get(k))
+				.and_then(Value::as_str)
+				.unwrap_or_default()
+		};
+		let file_data = field("file_data");
+		let file_id = field("file_id");
+
+		if let Some((mime, data)) = parse_data_url(file_data) {
+			return Ok(inline_data_part(mime, data));
+		}
+
+		// Clients carry a gs:// object in either field; Vertex fetches those directly.
+		if let Some(uri) = [file_data, file_id]
+			.into_iter()
+			.find(|u| u.starts_with("gs://"))
+		{
+			let Some(mime) = explicit_mime_hint(file)
+				.or_else(|| mime_from_extension(field("filename")).map(str::to_string))
+				.or_else(|| mime_from_extension(uri).map(str::to_string))
+			else {
+				return Err(AIError::InvalidResponse(strng::new(format!(
+					"gs:// file ({uri}) has no recognised extension or MIME hint; pass file.filename (or mime_type/content_type), or use an object with a known extension"
+				))));
+			};
+			return Ok(file_data_part(&mime, uri));
+		}
+
+		if !file_id.is_empty() {
+			return Err(AIError::InvalidResponse(strng::new(format!(
+				"native Gemini path cannot resolve OpenAI file_id ({file_id}); Vertex has no OpenAI Files store. Send file.file_data as an inline data: URI, or reference a gs:// object"
+			))));
+		}
+
+		Err(AIError::InvalidResponse(strng::new(
+			"file content part has neither an inline data: file_data nor a gs:// reference",
+		)))
 	}
 
 	fn text_part(text: &str) -> vg::Part {

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -471,7 +471,18 @@ pub mod from_completions {
 		let file_id = field("file_id");
 
 		if let Some((mime, data)) = parse_data_url(file_data) {
-			return Ok(inline_data_part(mime, data));
+			if !mime.is_empty() {
+				return Ok(inline_data_part(mime, data));
+			}
+			// RFC 2397 allows an absent media type; Vertex rejects an empty mimeType.
+			let Some(mime) = explicit_mime_hint(file)
+				.or_else(|| mime_from_extension(field("filename")).map(str::to_string))
+			else {
+				return Err(AIError::UnsupportedConversion(strng::literal!(
+					"data: file_data has no media type; pass file.filename with a known extension (or mime_type/content_type)"
+				)));
+			};
+			return Ok(inline_data_part(&mime, data));
 		}
 
 		// Clients carry a gs:// object in either field; Vertex fetches those directly.

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -490,6 +490,18 @@ pub mod from_completions {
 			return Ok(file_data_part(&mime, uri));
 		}
 
+		// Raw base64 without a data URL wrapper, as bedrock.rs also accepts; mime from filename.
+		if !file_data.is_empty() && !file_data.contains("://") {
+			let Some(mime) = explicit_mime_hint(file)
+				.or_else(|| mime_from_extension(field("filename")).map(str::to_string))
+			else {
+				return Err(AIError::UnsupportedConversion(strng::literal!(
+					"raw base64 file_data has no MIME source; pass file.filename with a known extension (or mime_type/content_type), or wrap it in a data: URI"
+				)));
+			};
+			return Ok(inline_data_part(&mime, file_data));
+		}
+
 		if !file_id.is_empty() {
 			return Err(AIError::UnsupportedConversion(strng::new(format!(
 				"native Gemini path cannot resolve OpenAI file_id ({file_id}); Vertex has no OpenAI Files store. Send file.file_data as an inline data: URI, or reference a gs:// object"

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -491,7 +491,8 @@ pub mod from_completions {
 		}
 
 		// Raw base64 without a data URL wrapper, as bedrock.rs also accepts; mime from filename.
-		if !file_data.is_empty() && !file_data.contains("://") {
+		// A malformed `data:` value must not reach here, or its header becomes payload.
+		if !file_data.is_empty() && !file_data.contains("://") && !file_data.starts_with("data:") {
 			let Some(mime) = explicit_mime_hint(file)
 				.or_else(|| mime_from_extension(field("filename")).map(str::to_string))
 			else {

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -442,7 +442,7 @@ pub mod from_completions {
 			let Some(mime) =
 				explicit_mime_hint(image_url).or_else(|| mime_from_extension(url).map(str::to_string))
 			else {
-				return Err(AIError::InvalidResponse(strng::new(format!(
+				return Err(AIError::UnsupportedConversion(strng::new(format!(
 					"gs:// image_url ({url}) has no recognised extension or MIME hint; pass image_url.format (or mime_type/content_type), or use an object with a known extension"
 				))));
 			};
@@ -450,7 +450,7 @@ pub mod from_completions {
 		}
 
 		// http(s) and anything else are not fetchable by Vertex.
-		Err(AIError::InvalidResponse(strng::new(format!(
+		Err(AIError::UnsupportedConversion(strng::new(format!(
 			"native Gemini path rejects http(s) image_url ({url}); upload to gs:// or send inline data:"
 		))))
 	}
@@ -483,7 +483,7 @@ pub mod from_completions {
 				.or_else(|| mime_from_extension(field("filename")).map(str::to_string))
 				.or_else(|| mime_from_extension(uri).map(str::to_string))
 			else {
-				return Err(AIError::InvalidResponse(strng::new(format!(
+				return Err(AIError::UnsupportedConversion(strng::new(format!(
 					"gs:// file ({uri}) has no recognised extension or MIME hint; pass file.filename (or mime_type/content_type), or use an object with a known extension"
 				))));
 			};
@@ -491,12 +491,12 @@ pub mod from_completions {
 		}
 
 		if !file_id.is_empty() {
-			return Err(AIError::InvalidResponse(strng::new(format!(
+			return Err(AIError::UnsupportedConversion(strng::new(format!(
 				"native Gemini path cannot resolve OpenAI file_id ({file_id}); Vertex has no OpenAI Files store. Send file.file_data as an inline data: URI, or reference a gs:// object"
 			))));
 		}
 
-		Err(AIError::InvalidResponse(strng::new(
+		Err(AIError::UnsupportedConversion(strng::new(
 			"file content part has neither an inline data: file_data nor a gs:// reference",
 		)))
 	}

--- a/crates/llm/src/conversion/vertex_gemini_tests.rs
+++ b/crates/llm/src/conversion/vertex_gemini_tests.rs
@@ -160,10 +160,15 @@ fn file_id_is_rejected_rather_than_dropped() {
 		&req(file_content(json!({ "file_id": "file-abc123" }))),
 		None,
 	);
-	let msg = format!("{:?}", err.expect_err("opaque file_id must be rejected"));
+	let err = err.expect_err("opaque file_id must be rejected");
+	// Load-bearing: classify_ai_request maps UnsupportedConversion to 400, InvalidResponse to 503.
 	assert!(
-		msg.contains("file_id"),
-		"error should name the field: {msg}"
+		matches!(err, crate::AIError::UnsupportedConversion(_)),
+		"bad client input must be a request error, got {err:?}"
+	);
+	assert!(
+		format!("{err:?}").contains("file_id"),
+		"error should name the field: {err:?}"
 	);
 }
 

--- a/crates/llm/src/conversion/vertex_gemini_tests.rs
+++ b/crates/llm/src/conversion/vertex_gemini_tests.rs
@@ -143,6 +143,32 @@ fn file_gs_uri_without_extension_or_hint_is_rejected() {
 }
 
 #[test]
+fn data_url_without_media_type_falls_back_to_filename() {
+	let g = to_gemini(file_content(json!({
+		"filename": "report.pdf",
+		"file_data": "data:;base64,JVBERi0xLjQK"
+	})));
+	assert_eq!(
+		g["contents"][0]["parts"][1]["inlineData"]["mimeType"],
+		"application/pdf"
+	);
+}
+
+#[test]
+fn data_url_without_media_type_or_filename_is_rejected() {
+	let err = from_completions::translate(
+		&req(file_content(
+			json!({ "file_data": "data:;base64,JVBERi0xLjQK" }),
+		)),
+		None,
+	);
+	assert!(
+		err.is_err(),
+		"an empty mimeType is rejected by Vertex, so it must not be sent"
+	);
+}
+
+#[test]
 fn raw_base64_file_data_takes_mime_from_filename() {
 	let g = to_gemini(file_content(json!({
 		"filename": "report.pdf",

--- a/crates/llm/src/conversion/vertex_gemini_tests.rs
+++ b/crates/llm/src/conversion/vertex_gemini_tests.rs
@@ -93,6 +93,92 @@ fn gs_url_uses_explicit_mime_hint() {
 	);
 }
 
+// ---------- Request: content parts / files ----------
+
+fn file_content(file: Value) -> Value {
+	json!({
+		"model": "gemini-2.5-flash",
+		"messages": [{ "role": "user", "content": [
+			{ "type": "text", "text": "What is this document about?" },
+			{ "type": "file", "file": file }
+		]}]
+	})
+}
+
+#[test]
+fn file_data_url_becomes_inline_data() {
+	let g = to_gemini(file_content(json!({
+		"filename": "report.pdf",
+		"file_data": "data:application/pdf;base64,JVBERi0xLjQK"
+	})));
+	let part = &g["contents"][0]["parts"][1];
+	assert_eq!(part["inlineData"]["mimeType"], "application/pdf");
+	assert_eq!(part["inlineData"]["data"], "JVBERi0xLjQK");
+}
+
+#[test]
+fn file_gs_uri_takes_mime_from_filename() {
+	// The gs:// object has no extension, so the mime can only come from `filename`.
+	let g = to_gemini(file_content(json!({
+		"filename": "report.pdf",
+		"file_data": "gs://bucket/object"
+	})));
+	let part = &g["contents"][0]["parts"][1];
+	assert_eq!(part["fileData"]["fileUri"], "gs://bucket/object");
+	assert_eq!(part["fileData"]["mimeType"], "application/pdf");
+}
+
+#[test]
+fn file_gs_uri_without_extension_or_hint_is_rejected() {
+	let err = from_completions::translate(
+		&req(file_content(json!({
+			"file_data": "gs://bucket/object"
+		}))),
+		None,
+	);
+	assert!(
+		err.is_err(),
+		"extension-less gs:// file with no MIME hint must be rejected before egress"
+	);
+}
+
+#[test]
+fn file_id_holding_a_gs_uri_becomes_file_data() {
+	// Some clients put a bucket URI in `file_id` rather than `file_data`; Vertex can fetch
+	// that directly, so it is honoured instead of being treated as an opaque OpenAI id.
+	let g = to_gemini(file_content(json!({ "file_id": "gs://bucket/report.pdf" })));
+	let part = &g["contents"][0]["parts"][1];
+	assert_eq!(part["fileData"]["fileUri"], "gs://bucket/report.pdf");
+	assert_eq!(part["fileData"]["mimeType"], "application/pdf");
+}
+
+#[test]
+fn file_id_is_rejected_rather_than_dropped() {
+	// Vertex has no OpenAI Files store, so an opaque file_id cannot be resolved. It must
+	// error rather than silently vanish from the request (#3117).
+	let err = from_completions::translate(
+		&req(file_content(json!({ "file_id": "file-abc123" }))),
+		None,
+	);
+	let msg = format!("{:?}", err.expect_err("opaque file_id must be rejected"));
+	assert!(
+		msg.contains("file_id"),
+		"error should name the field: {msg}"
+	);
+}
+
+#[test]
+fn file_part_without_data_or_id_is_rejected() {
+	let err = from_completions::translate(
+		&req(file_content(json!({ "filename": "report.pdf" }))),
+		None,
+	);
+	assert!(
+		err.is_err(),
+		"a file part carrying no payload must be rejected"
+	);
+}
+
 #[test]
 fn empty_string_user_content_is_preserved() {
 	let g = to_gemini(json!({

--- a/crates/llm/src/conversion/vertex_gemini_tests.rs
+++ b/crates/llm/src/conversion/vertex_gemini_tests.rs
@@ -143,6 +143,29 @@ fn file_gs_uri_without_extension_or_hint_is_rejected() {
 }
 
 #[test]
+fn raw_base64_file_data_takes_mime_from_filename() {
+	let g = to_gemini(file_content(json!({
+		"filename": "report.pdf",
+		"file_data": "JVBERi0xLjQK"
+	})));
+	let part = &g["contents"][0]["parts"][1];
+	assert_eq!(part["inlineData"]["mimeType"], "application/pdf");
+	assert_eq!(part["inlineData"]["data"], "JVBERi0xLjQK");
+}
+
+#[test]
+fn raw_base64_file_data_without_a_mime_source_is_rejected() {
+	let err = from_completions::translate(
+		&req(file_content(json!({ "file_data": "JVBERi0xLjQK" }))),
+		None,
+	);
+	assert!(
+		err.is_err(),
+		"raw base64 with no filename or hint cannot yield the mimeType Vertex requires"
+	);
+}
+
+#[test]
 fn file_id_holding_a_gs_uri_becomes_file_data() {
 	// Some clients put a bucket URI in `file_id` rather than `file_data`; Vertex can fetch
 	// that directly, so it is honoured instead of being treated as an opaque OpenAI id.

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -146,6 +146,7 @@ mod requests {
 		("image-url", &[ANTHROPIC]),
 		("image-inline", &[VERTEX_GEMINI]),
 		("image-file", &[VERTEX_GEMINI]),
+		("file-inline", &[VERTEX_GEMINI]),
 		("structured-output", &[VERTEX_GEMINI]),
 		("multi-turn-tools", &[VERTEX_GEMINI]),
 		// Stands in for `full`, whose remote HTTP image the Gemini path rejects.

--- a/crates/llm/src/tests/requests/completions/file-inline.json
+++ b/crates/llm/src/tests/requests/completions/file-inline.json
@@ -1,0 +1,18 @@
+{
+  "model": "gemini-2.5-pro",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "text": "What is this document about?" },
+        {
+          "type": "file",
+          "file": {
+            "filename": "report.pdf",
+            "file_data": "data:application/pdf;base64,JVBERi0xLjQK"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/crates/llm/src/tests/requests/completions/file-inline.vertex-gemini.snap
+++ b/crates/llm/src/tests/requests/completions/file-inline.vertex-gemini.snap
@@ -1,0 +1,49 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/completions/file-inline.json
+info:
+  model: gemini-2.5-pro
+  messages:
+    - role: user
+      content:
+        - type: text
+          text: What is this document about?
+        - type: file
+          file:
+            filename: report.pdf
+            file_data: "data:application/pdf;base64,JVBERi0xLjQK"
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "What is this document about?"
+          },
+          {
+            "inlineData": {
+              "mimeType": "application/pdf",
+              "data": "JVBERi0xLjQK"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "parsed": {
+    "input_format": "Completions",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gemini-2.5-pro",
+    "provider": "vertex",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "user",
+        "content": "What is this document about?"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
`user_parts` handled `text` and `image_url` only, so an OpenAI `file` content part
fell through and was discarded — the model answered as if nothing was attached and
the request still returned 200.

`file` is now converted like `image_url`: inline `data:` payloads become `inlineData`,
`gs://` objects become `fileData`. Opaque `file_id`s and empty parts error rather than
being dropped silently.

Verified against real Vertex (`gemini-2.5-flash`) with a 1-page PDF: both paths
returned 200 with `DOCUMENT 1290 / TEXT 16` prompt tokens, the inverse of the reported
symptom.

Fixes #3117
