### PR TITLE
feat: operator-resolved Bedrock request metadata for per-prompt attribution

### DIFF
--- a/crates/agentgateway/src/llm/bedrock_metadata.rs
+++ b/crates/agentgateway/src/llm/bedrock_metadata.rs
@@ -1,0 +1,481 @@
+//! Operator-resolved Bedrock request metadata.
+//!
+//! Amazon Bedrock accepts per-call key/value metadata on `InvokeModel`,
+//! `InvokeModelWithResponseStream`, `Converse`, and `ConverseStream`. The
+//! values are recorded in the model invocation logs (not on the bill), so they
+//! are the per-prompt attribution layer: which user, app, or feature a specific
+//! call belonged to, queryable in CloudWatch Logs Insights or Athena.
+//!
+//! Bedrock does not enforce metadata: a request that omits it succeeds, and
+//! AWS's own guidance is to set it in a shared client or LLM gateway. This
+//! module lets the operator do that with the same shape as STS session tags
+//! (`assumeRole.tags`): a static `value`, or a CEL `expression` evaluated
+//! against the request, for example `jwt.sub` or `request.headers["x-app"]`.
+//! Resolution fails closed: an expression that cannot produce a valid value
+//! rejects the request before it reaches Bedrock.
+//!
+//! Operator entries take precedence over any caller-supplied metadata
+//! (the `x-bedrock-metadata` escape hatch): a key the operator claims cannot be
+//! overridden by the caller, matching how session tags and pinned attribution
+//! values behave elsewhere in the gateway.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, LazyLock};
+
+use regex::Regex;
+
+use crate::llm::AIError;
+use crate::*;
+
+/// Maximum number of metadata entries Bedrock accepts per request.
+pub const MAX_REQUEST_METADATA_ENTRIES: usize = 16;
+/// Maximum length of a metadata key or value, in characters.
+pub const MAX_REQUEST_METADATA_LEN: usize = 256;
+
+/// Header carrying request metadata on the `InvokeModel` family of APIs. It is
+/// SigV4-signed like every other `x-amzn-*` header the gateway sends.
+pub const REQUEST_METADATA_HEADER: &str = "x-amzn-bedrock-request-metadata";
+/// Body field carrying request metadata on `Converse` and `ConverseStream`.
+pub const REQUEST_METADATA_FIELD: &str = "requestMetadata";
+
+/// Bedrock documents "a restricted set of alphanumeric and punctuation
+/// characters" without enumerating it. This is the STS tag character set,
+/// which is the conservative subset shared with session tags, so a value that
+/// is valid as a tag is valid here too.
+static ALLOWED_CHARS: LazyLock<Regex> =
+	LazyLock::new(|| Regex::new(r"^[\p{L}\p{Z}\p{N}_.:/=+\-@]+$").expect("static regex"));
+
+/// One request-metadata entry in configuration form. Exactly one of `value`
+/// and `expression` must be set.
+#[apply(schema!)]
+pub struct BedrockRequestMetadataEntry {
+	/// Metadata key.
+	pub key: String,
+	/// Static metadata value.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub value: Option<String>,
+	/// CEL expression evaluated against each request to produce the value, for
+	/// example `jwt.sub` or `request.headers["x-app"]`. If the expression does not
+	/// produce a valid value at request time, the request is rejected.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub expression: Option<Arc<cel::Expression>>,
+}
+
+/// Request metadata in runtime form: static values pre-validated, dynamic (CEL)
+/// values compiled and evaluated per request.
+#[derive(Debug, Clone, Default)]
+pub struct BedrockRequestMetadata {
+	// Sorted by key so serialization and tests are deterministic.
+	static_entries: Arc<[(String, String)]>,
+	dynamic_entries: Arc<[(String, Arc<cel::Expression>)]>,
+}
+
+impl PartialEq for BedrockRequestMetadata {
+	fn eq(&self, other: &Self) -> bool {
+		self.static_entries == other.static_entries
+			&& self.dynamic_entries.len() == other.dynamic_entries.len()
+			&& self
+				.dynamic_entries
+				.iter()
+				.zip(other.dynamic_entries.iter())
+				.all(|((ka, ea), (kb, eb))| ka == kb && ea.original_expression == eb.original_expression)
+	}
+}
+
+impl BedrockRequestMetadata {
+	/// Validates and splits configured entries into static and dynamic sets.
+	/// Everything Bedrock would reject that can be checked without a request is
+	/// checked here, so config errors surface at load time rather than per call.
+	pub fn try_new(entries: Vec<BedrockRequestMetadataEntry>) -> anyhow::Result<Self> {
+		if entries.len() > MAX_REQUEST_METADATA_ENTRIES {
+			anyhow::bail!(
+				"at most {MAX_REQUEST_METADATA_ENTRIES} request metadata entries are allowed, got {}",
+				entries.len()
+			);
+		}
+		let mut keys = HashSet::with_capacity(entries.len());
+		let mut static_entries = Vec::new();
+		let mut dynamic_entries = Vec::new();
+		for entry in entries {
+			validate_key(&entry.key)?;
+			if !keys.insert(entry.key.clone()) {
+				anyhow::bail!("duplicate request metadata key {:?}", entry.key);
+			}
+			match (entry.value, entry.expression) {
+				(Some(value), None) => {
+					validate_value(&entry.key, &value)?;
+					static_entries.push((entry.key, value));
+				},
+				(None, Some(expression)) => dynamic_entries.push((entry.key, expression)),
+				_ => anyhow::bail!(
+					"request metadata {:?} must set exactly one of 'value' or 'expression'",
+					entry.key
+				),
+			}
+		}
+		static_entries.sort();
+		dynamic_entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+		Ok(Self {
+			static_entries: static_entries.into(),
+			dynamic_entries: dynamic_entries.into(),
+		})
+	}
+
+	pub fn is_empty(&self) -> bool {
+		self.static_entries.is_empty() && self.dynamic_entries.is_empty()
+	}
+
+	/// Expressions to register with the CEL context so the request snapshot
+	/// captures what they read (JWT claims, headers).
+	pub fn expressions(&self) -> impl Iterator<Item = &cel::Expression> {
+		self.dynamic_entries.iter().map(|(_, e)| e.as_ref())
+	}
+
+	/// Evaluates dynamic entries and merges them with the static ones. Fails
+	/// closed: an expression that cannot produce a valid value is an error.
+	pub fn resolve(&self, exec: &cel::Executor<'_>) -> Result<Vec<(String, String)>, AIError> {
+		let mut resolved: Vec<(String, String)> =
+			Vec::with_capacity(self.static_entries.len() + self.dynamic_entries.len());
+		resolved.extend(self.static_entries.iter().cloned());
+		for (key, expr) in self.dynamic_entries.iter() {
+			let value = exec
+				.eval(expr)
+				.map_err(anyhow::Error::from)
+				.and_then(cel_value_to_string)
+				.and_then(|value| {
+					if value.is_empty() {
+						anyhow::bail!("expression produced an empty value");
+					}
+					validate_value(key, &value)?;
+					Ok(value)
+				})
+				.map_err(|e| {
+					AIError::RequestMetadata(strng::format!(
+						"{key:?} (expression {:?}): {e}",
+						expr.original_expression
+					))
+				})?;
+			resolved.push((key.clone(), value));
+		}
+		Ok(resolved)
+	}
+
+	/// Applies the resolved metadata to a `Converse`/`ConverseStream` body.
+	///
+	/// Operator entries override caller-supplied keys of the same name. Caller
+	/// keys the operator did not claim are kept, up to Bedrock's entry limit;
+	/// operator attribution is never the part that gets dropped.
+	pub fn apply_to_body(
+		&self,
+		body: &mut serde_json::Map<String, serde_json::Value>,
+		exec: &cel::Executor<'_>,
+	) -> Result<(), AIError> {
+		let resolved = self.resolve(exec)?;
+		self.merge_resolved_into_body(body, resolved);
+		Ok(())
+	}
+
+	/// Merges already-resolved entries into a `Converse` body; see
+	/// [`Self::apply_to_body`] for the precedence rules.
+	pub fn merge_resolved_into_body(
+		&self,
+		body: &mut serde_json::Map<String, serde_json::Value>,
+		resolved: Vec<(String, String)>,
+	) {
+		let mut merged: serde_json::Map<String, serde_json::Value> = resolved
+			.into_iter()
+			.map(|(k, v)| (k, serde_json::Value::String(v)))
+			.collect();
+		if let Some(serde_json::Value::Object(existing)) = body.remove(REQUEST_METADATA_FIELD) {
+			for (k, v) in existing {
+				if merged.len() >= MAX_REQUEST_METADATA_ENTRIES {
+					warn!(
+						"bedrock request metadata: dropping caller-supplied key {k:?}, entry limit reached"
+					);
+					continue;
+				}
+				merged.entry(k).or_insert(v);
+			}
+		}
+		body.insert(
+			REQUEST_METADATA_FIELD.to_string(),
+			serde_json::Value::Object(merged),
+		);
+	}
+
+	/// Renders the resolved metadata as the header value for the `InvokeModel`
+	/// family of APIs.
+	pub fn header_value(&self, exec: &cel::Executor<'_>) -> Result<http::HeaderValue, AIError> {
+		let resolved: HashMap<String, String> = self.resolve(exec)?.into_iter().collect();
+		let json = serde_json::to_string(&resolved).map_err(AIError::RequestMarshal)?;
+		http::HeaderValue::from_str(&json)
+			.map_err(|e| AIError::RequestMetadata(strng::format!("header value: {e}")))
+	}
+
+	pub(crate) fn static_entries(&self) -> &[(String, String)] {
+		&self.static_entries
+	}
+
+	pub(crate) fn dynamic_entries(&self) -> &[(String, Arc<cel::Expression>)] {
+		&self.dynamic_entries
+	}
+}
+
+fn validate_key(key: &str) -> anyhow::Result<()> {
+	if key.is_empty() {
+		anyhow::bail!("request metadata key must not be empty");
+	}
+	if key.chars().count() > MAX_REQUEST_METADATA_LEN {
+		anyhow::bail!("request metadata key {key:?} exceeds {MAX_REQUEST_METADATA_LEN} characters");
+	}
+	if !ALLOWED_CHARS.is_match(key) {
+		anyhow::bail!("request metadata key {key:?} contains characters outside the allowed set");
+	}
+	Ok(())
+}
+
+fn validate_value(key: &str, value: &str) -> anyhow::Result<()> {
+	if value.chars().count() > MAX_REQUEST_METADATA_LEN {
+		anyhow::bail!(
+			"request metadata value for {key:?} exceeds {MAX_REQUEST_METADATA_LEN} characters"
+		);
+	}
+	if !ALLOWED_CHARS.is_match(value) {
+		anyhow::bail!("request metadata value for {key:?} contains characters outside the allowed set");
+	}
+	Ok(())
+}
+
+/// Strings, numbers, and booleans (common JWT claim types) stringify; anything
+/// else (null, lists, maps) is an error so misattribution fails closed.
+fn cel_value_to_string(v: cel::Value) -> anyhow::Result<String> {
+	v.always_materialize_owned()
+		.as_string()
+		.map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<BedrockRequestMetadata, D::Error>
+where
+	D: serde::Deserializer<'de>,
+{
+	let entries = Vec::<BedrockRequestMetadataEntry>::deserialize(deserializer)?;
+	BedrockRequestMetadata::try_new(entries).map_err(serde::de::Error::custom)
+}
+
+pub(crate) fn serialize<S>(
+	metadata: &BedrockRequestMetadata,
+	serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+	S: serde::Serializer,
+{
+	let static_entries =
+		metadata
+			.static_entries()
+			.iter()
+			.map(|(key, value)| BedrockRequestMetadataEntry {
+				key: key.clone(),
+				value: Some(value.clone()),
+				expression: None,
+			});
+	let dynamic_entries =
+		metadata
+			.dynamic_entries()
+			.iter()
+			.map(|(key, expression)| BedrockRequestMetadataEntry {
+				key: key.clone(),
+				value: None,
+				expression: Some(expression.clone()),
+			});
+	serializer.collect_seq(static_entries.chain(dynamic_entries))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn entry(
+		key: &str,
+		value: Option<&str>,
+		expression: Option<&str>,
+	) -> BedrockRequestMetadataEntry {
+		BedrockRequestMetadataEntry {
+			key: key.to_string(),
+			value: value.map(str::to_string),
+			expression: expression
+				.map(|e| Arc::new(cel::Expression::new_strict(e).expect("expression should compile"))),
+		}
+	}
+
+	fn metadata(entries: Vec<BedrockRequestMetadataEntry>) -> BedrockRequestMetadata {
+		BedrockRequestMetadata::try_new(entries).expect("metadata should validate")
+	}
+
+	fn request_with_headers(headers: &[(&str, &str)]) -> crate::http::Request {
+		let mut builder = ::http::Request::builder().uri("http://example.com/v1/chat/completions");
+		for (k, v) in headers {
+			builder = builder.header(*k, *v);
+		}
+		builder.body(crate::http::Body::empty()).unwrap()
+	}
+
+	#[test]
+	fn rejects_more_than_sixteen_entries() {
+		let entries = (0..17)
+			.map(|i| entry(&format!("k{i}"), Some("v"), None))
+			.collect();
+		let err = BedrockRequestMetadata::try_new(entries).unwrap_err();
+		assert!(err.to_string().contains("at most 16"), "{err}");
+	}
+
+	#[test]
+	fn rejects_duplicate_keys_and_ambiguous_entries() {
+		let err = BedrockRequestMetadata::try_new(vec![
+			entry("team", Some("a"), None),
+			entry("team", Some("b"), None),
+		])
+		.unwrap_err();
+		assert!(err.to_string().contains("duplicate"), "{err}");
+
+		let err = BedrockRequestMetadata::try_new(vec![entry("team", None, None)]).unwrap_err();
+		assert!(err.to_string().contains("exactly one"), "{err}");
+
+		let err =
+			BedrockRequestMetadata::try_new(vec![entry("team", Some("a"), Some("jwt.sub"))]).unwrap_err();
+		assert!(err.to_string().contains("exactly one"), "{err}");
+	}
+
+	#[test]
+	fn rejects_invalid_characters_and_lengths_at_load() {
+		let err = BedrockRequestMetadata::try_new(vec![entry("te{am}", Some("a"), None)]).unwrap_err();
+		assert!(err.to_string().contains("allowed set"), "{err}");
+
+		let err = BedrockRequestMetadata::try_new(vec![entry("team", Some("a\"b"), None)]).unwrap_err();
+		assert!(err.to_string().contains("allowed set"), "{err}");
+
+		let long = "x".repeat(MAX_REQUEST_METADATA_LEN + 1);
+		let err = BedrockRequestMetadata::try_new(vec![entry("team", Some(&long), None)]).unwrap_err();
+		assert!(err.to_string().contains("exceeds"), "{err}");
+	}
+
+	#[test]
+	fn resolves_static_and_dynamic_entries() {
+		let md = metadata(vec![
+			entry("CostCenter", Some("12345"), None),
+			entry("App", None, Some(r#"request.headers["x-app"]"#)),
+		]);
+		let req = request_with_headers(&[("x-app", "checkout")]);
+		let exec = cel::Executor::new_request(&req);
+		let resolved = md.resolve(&exec).unwrap();
+		assert_eq!(
+			resolved,
+			vec![
+				("CostCenter".to_string(), "12345".to_string()),
+				("App".to_string(), "checkout".to_string()),
+			]
+		);
+	}
+
+	#[test]
+	fn fails_closed_when_expression_cannot_resolve() {
+		let md = metadata(vec![entry(
+			"App",
+			None,
+			Some(r#"request.headers["x-app"]"#),
+		)]);
+		let req = request_with_headers(&[]);
+		let exec = cel::Executor::new_request(&req);
+		let err = md.resolve(&exec).unwrap_err();
+		assert!(matches!(err, AIError::RequestMetadata(_)), "{err}");
+	}
+
+	#[test]
+	fn fails_closed_on_empty_or_invalid_dynamic_value() {
+		let md = metadata(vec![entry(
+			"App",
+			None,
+			Some(r#"request.headers["x-app"]"#),
+		)]);
+		let req = request_with_headers(&[("x-app", "")]);
+		let exec = cel::Executor::new_request(&req);
+		let err = md.resolve(&exec).unwrap_err();
+		assert!(err.to_string().contains("empty value"), "{err}");
+
+		let req = request_with_headers(&[("x-app", "bad\"quote")]);
+		let exec = cel::Executor::new_request(&req);
+		let err = md.resolve(&exec).unwrap_err();
+		assert!(err.to_string().contains("allowed set"), "{err}");
+	}
+
+	#[test]
+	fn operator_entries_override_caller_supplied_keys_and_keep_the_rest() {
+		let md = metadata(vec![
+			entry("team", Some("platform"), None),
+			entry("user", None, Some(r#"request.headers["x-user"]"#)),
+		]);
+		let req = request_with_headers(&[("x-user", "alice")]);
+		let exec = cel::Executor::new_request(&req);
+		let mut body = serde_json::json!({
+			"messages": [],
+			"requestMetadata": {"team": "caller-says-so", "experiment": "b"}
+		});
+		md.apply_to_body(body.as_object_mut().unwrap(), &exec)
+			.unwrap();
+		assert_eq!(
+			body["requestMetadata"],
+			serde_json::json!({"team": "platform", "user": "alice", "experiment": "b"})
+		);
+	}
+
+	#[test]
+	fn caller_keys_are_dropped_before_operator_keys_at_the_limit() {
+		let entries = (0..15)
+			.map(|i| entry(&format!("op{i}"), Some("v"), None))
+			.collect();
+		let md = metadata(entries);
+		let req = request_with_headers(&[]);
+		let exec = cel::Executor::new_request(&req);
+		let mut body = serde_json::json!({
+			"requestMetadata": {"c1": "1", "c2": "2", "c3": "3"}
+		});
+		md.apply_to_body(body.as_object_mut().unwrap(), &exec)
+			.unwrap();
+		let merged = body["requestMetadata"].as_object().unwrap();
+		assert_eq!(merged.len(), MAX_REQUEST_METADATA_ENTRIES);
+		assert!((0..15).all(|i| merged.contains_key(&format!("op{i}"))));
+	}
+
+	#[test]
+	fn header_value_is_json_object() {
+		let md = metadata(vec![
+			entry("team", Some("platform"), None),
+			entry("user", None, Some(r#"request.headers["x-user"]"#)),
+		]);
+		let req = request_with_headers(&[("x-user", "alice")]);
+		let exec = cel::Executor::new_request(&req);
+		let value = md.header_value(&exec).unwrap();
+		let parsed: HashMap<String, String> = serde_json::from_str(value.to_str().unwrap()).unwrap();
+		assert_eq!(parsed["team"], "platform");
+		assert_eq!(parsed["user"], "alice");
+	}
+
+	#[test]
+	fn round_trips_through_serde() {
+		let md = metadata(vec![
+			entry("team", Some("platform"), None),
+			entry("user", None, Some("jwt.sub")),
+		]);
+		#[derive(serde::Serialize, serde::Deserialize)]
+		struct Wrapper {
+			#[serde(serialize_with = "serialize", deserialize_with = "deserialize")]
+			md: BedrockRequestMetadata,
+		}
+		let json = serde_json::to_string(&Wrapper { md: md.clone() }).unwrap();
+		assert_eq!(
+			json,
+			r#"{"md":[{"key":"team","value":"platform"},{"key":"user","expression":"jwt.sub"}]}"#
+		);
+		let back: Wrapper = serde_json::from_str(&json).unwrap();
+		assert_eq!(back.md, md);
+	}
+}

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -30,6 +30,7 @@ use crate::telemetry::log::{AsyncLog, RequestLog};
 use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference, Target};
 use crate::types::loadbalancer::{ActiveHandle, EndpointWithInfo};
 use crate::*;
+pub mod bedrock_metadata;
 pub mod model_router;
 pub use agent_llm::{azure, bedrock, vertex};
 
@@ -137,6 +138,19 @@ pub enum AIProvider {
 pub struct BedrockProvider {
 	#[serde(flatten)]
 	pub provider: bedrock::Provider,
+	/// Request metadata attached to every Bedrock call, recorded in the model
+	/// invocation logs (not on the bill) for per-prompt attribution. Each entry is
+	/// a static `value` or a CEL `expression` evaluated against the request, the
+	/// same shape as `assumeRole.tags`. Operator entries override caller-supplied
+	/// `x-bedrock-metadata` keys of the same name; an expression that cannot
+	/// produce a valid value rejects the request.
+	#[serde(
+		default,
+		skip_serializing_if = "bedrock_metadata::BedrockRequestMetadata::is_empty",
+		deserialize_with = "bedrock_metadata::deserialize",
+		serialize_with = "bedrock_metadata::serialize"
+	)]
+	pub request_metadata: bedrock_metadata::BedrockRequestMetadata,
 	#[serde(skip)]
 	pub source_credentials_cache: crate::http::auth::aws::AwsCredentialsCache,
 	#[serde(skip)]
@@ -147,9 +161,16 @@ impl BedrockProvider {
 	pub fn new(provider: bedrock::Provider) -> Self {
 		Self {
 			provider,
+			request_metadata: Default::default(),
 			source_credentials_cache: Default::default(),
 			assume_role_cache: Default::default(),
 		}
+	}
+
+	/// CEL expressions this provider evaluates per request, registered with the
+	/// request context so the snapshot captures what they read.
+	pub fn cel_expressions(&self) -> impl Iterator<Item = &cel::Expression> {
+		self.request_metadata.expressions()
 	}
 }
 
@@ -160,7 +181,28 @@ impl schemars::JsonSchema for BedrockProvider {
 	}
 
 	fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
-		<bedrock::Provider as schemars::JsonSchema>::json_schema(generator)
+		// The inner provider's schema, plus the gateway-side field that carries CEL
+		// and therefore cannot live in the provider crate.
+		let mut schema = <bedrock::Provider as schemars::JsonSchema>::json_schema(generator);
+		let entries = generator.subschema_for::<Vec<bedrock_metadata::BedrockRequestMetadataEntry>>();
+		let mut entries = entries.to_value();
+		if let Some(obj) = entries.as_object_mut() {
+			obj.insert(
+				"description".to_string(),
+				serde_json::Value::String(
+					"Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.".to_string(),
+				),
+			);
+		}
+		if let Some(properties) = schema
+			.ensure_object()
+			.entry("properties")
+			.or_insert_with(|| serde_json::json!({}))
+			.as_object_mut()
+		{
+			properties.insert("requestMetadata".to_string(), entries);
+		}
+		schema
 	}
 }
 
@@ -221,9 +263,37 @@ impl std::ops::DerefMut for AzureProvider {
 	}
 }
 
+/// Where Bedrock accepts request metadata for a given upstream API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BedrockMetadataPlacement {
+	/// `Converse` / `ConverseStream`: the `requestMetadata` body field.
+	Body,
+	/// `InvokeModel` / `InvokeModelWithResponseStream`: the signed header.
+	Header,
+	/// APIs that do not accept request metadata.
+	None,
+}
+
 impl AIProvider {
 	pub fn bedrock(provider: bedrock::Provider) -> Self {
 		Self::Bedrock(BedrockProvider::new(provider))
+	}
+
+	/// CEL expressions the provider evaluates per request.
+	pub fn cel_expressions(&self) -> Box<dyn Iterator<Item = &cel::Expression> + '_> {
+		match self {
+			AIProvider::Bedrock(b) => Box::new(b.cel_expressions()),
+			_ => Box::new(std::iter::empty()),
+		}
+	}
+
+	/// Operator-resolved Bedrock request metadata, if this is a Bedrock provider
+	/// with any configured.
+	fn bedrock_request_metadata(&self) -> Option<&bedrock_metadata::BedrockRequestMetadata> {
+		match self {
+			AIProvider::Bedrock(b) if !b.request_metadata.is_empty() => Some(&b.request_metadata),
+			_ => None,
+		}
 	}
 
 	pub fn azure(provider: azure::Provider) -> Self {
@@ -2073,6 +2143,12 @@ impl AIProvider {
 			Some(p) => p.apply_final_transformations(rendered.body, log)?,
 			None => rendered.body,
 		};
+		let body = self.apply_bedrock_request_metadata(
+			body,
+			&mut parts,
+			Some(provider_format.route_type()),
+			log,
+		)?;
 		parts.headers.remove(header::CONTENT_LENGTH);
 		let req = Request::from_parts(parts, Body::from(body));
 		Ok(RequestResult::Success {
@@ -2080,6 +2156,71 @@ impl AIProvider {
 			llm_request: llm_info,
 			upstream_route_type: provider_format.route_type(),
 		})
+	}
+
+	/// Attaches operator-resolved request metadata to a Bedrock-bound request.
+	///
+	/// `Converse`/`ConverseStream` carry it in the body; the `InvokeModel` family
+	/// carries it in a signed header. Routes Bedrock does not accept metadata on
+	/// (count-tokens, rerank) are left untouched. Fails closed on an expression
+	/// that cannot resolve, before the request reaches Bedrock.
+	fn apply_bedrock_request_metadata(
+		&self,
+		body: Vec<u8>,
+		parts: &mut Parts,
+		route_type: Option<RouteType>,
+		log: &mut Option<&mut RequestLog>,
+	) -> Result<Vec<u8>, AIError> {
+		let Some(metadata) = self.bedrock_request_metadata() else {
+			return Ok(body);
+		};
+		let path = parts.uri.path();
+		let placement = match route_type {
+			Some(RouteType::Embeddings) => BedrockMetadataPlacement::Header,
+			Some(RouteType::AnthropicTokenCount) | Some(RouteType::Rerank) => {
+				BedrockMetadataPlacement::None
+			},
+			Some(_) => BedrockMetadataPlacement::Body,
+			// Raw passthrough: decide from the upstream path the caller addressed.
+			None if path.ends_with("/converse") || path.ends_with("/converse-stream") => {
+				BedrockMetadataPlacement::Body
+			},
+			None if path.ends_with("/invoke") || path.ends_with("/invoke-with-response-stream") => {
+				BedrockMetadataPlacement::Header
+			},
+			None => BedrockMetadataPlacement::None,
+		};
+		let snapshot = log.as_ref().and_then(|x| x.request_snapshot.as_deref());
+		match placement {
+			BedrockMetadataPlacement::None => Ok(body),
+			BedrockMetadataPlacement::Header => {
+				let empty = serde_json::Value::Null;
+				let exec = Executor::new_llm(snapshot, &empty);
+				let value = metadata.header_value(&exec)?;
+				parts
+					.headers
+					.insert(bedrock_metadata::REQUEST_METADATA_HEADER, value);
+				Ok(body)
+			},
+			BedrockMetadataPlacement::Body => {
+				let mut v: serde_json::Value =
+					serde_json::from_slice(body.as_slice()).map_err(AIError::RequestParsing)?;
+				{
+					let exec = Executor::new_llm(snapshot, &v);
+					// Resolve against the body first, then mutate it. The executor borrows the
+					// value, so the resolved entries are materialized before the edit.
+					let resolved = metadata.resolve(&exec)?;
+					drop(exec);
+					let serde_json::Value::Object(map) = &mut v else {
+						return Err(AIError::MissingField(
+							"converted request must be an object".into(),
+						));
+					};
+					metadata.merge_resolved_into_body(map, resolved);
+				}
+				serde_json::to_vec(&v).map_err(AIError::RequestMarshal)
+			},
+		}
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -2152,6 +2293,12 @@ impl AIProvider {
 			},
 			_ => body,
 		};
+		let body = self.apply_bedrock_request_metadata(
+			body,
+			&mut parts,
+			provider_format.map(|f| f.route_type()),
+			log,
+		)?;
 		parts.headers.remove(header::CONTENT_LENGTH);
 		let req = Request::from_parts(parts, Body::from(body));
 		Ok(RequestResult::Success {

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -3623,3 +3623,211 @@ fn query_requests_sse_matches_alt_query_parameter() {
 		"/v1beta/models/gemini-2.5-flash:streamGenerateContent?halt=sse"
 	)));
 }
+
+fn bedrock_provider_with_request_metadata(
+	entries: Vec<bedrock_metadata::BedrockRequestMetadataEntry>,
+) -> AIProvider {
+	let mut provider = BedrockProvider::new(bedrock::Provider {
+		model: Some(strng::new("amazon.nova-micro-v1:0")),
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	});
+	provider.request_metadata =
+		bedrock_metadata::BedrockRequestMetadata::try_new(entries).expect("metadata should validate");
+	AIProvider::Bedrock(provider)
+}
+
+fn bedrock_test_backend_info() -> crate::http::auth::BackendInfo {
+	use crate::test_helpers::proxymock::setup_proxy_test;
+	use crate::types::agent::BackendTarget;
+	crate::http::auth::BackendInfo {
+		target: BackendTarget::Invalid,
+		call_target: Target::from(("bedrock-runtime.us-east-1.amazonaws.com", 443)),
+		inputs: setup_proxy_test("{}").unwrap().pi,
+	}
+}
+
+fn metadata_entry(key: &str, value: &str) -> bedrock_metadata::BedrockRequestMetadataEntry {
+	bedrock_metadata::BedrockRequestMetadataEntry {
+		key: key.to_string(),
+		value: Some(value.to_string()),
+		expression: None,
+	}
+}
+
+#[tokio::test]
+async fn bedrock_request_metadata_lands_in_converse_body_and_overrides_caller_keys() {
+	let provider = bedrock_provider_with_request_metadata(vec![
+		metadata_entry("team", "platform"),
+		metadata_entry("environment", "prod"),
+	]);
+	let req = ::http::Request::builder()
+		.uri("https://gateway.example.com/v1/chat/completions")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		// Caller-supplied metadata: the operator's `team` wins, `experiment` survives.
+		.header(
+			"x-bedrock-metadata",
+			r#"{"team": "caller-says-so", "experiment": "b"}"#,
+		)
+		.body(Body::from(
+			json!({
+				"model": "amazon.nova-micro-v1:0",
+				"messages": [{"role": "user", "content": "hello"}],
+			})
+			.to_string(),
+		))
+		.unwrap();
+
+	let RequestResult::Success {
+		request: forwarded,
+		upstream_route_type,
+		..
+	} = provider
+		.process_completions_request(
+			&bedrock_test_backend_info(),
+			None,
+			req,
+			false,
+			&mut None,
+			None,
+		)
+		.await
+		.expect("Bedrock completions request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+	assert_eq!(upstream_route_type, RouteType::Completions);
+	assert!(
+		forwarded
+			.headers()
+			.get(bedrock_metadata::REQUEST_METADATA_HEADER)
+			.is_none(),
+		"Converse carries metadata in the body, not the header"
+	);
+
+	let body = forwarded.into_body().collect().await.unwrap().to_bytes();
+	let json: Value = serde_json::from_slice(&body).expect("forwarded body should be JSON");
+	assert_eq!(
+		json["requestMetadata"],
+		json!({"team": "platform", "environment": "prod", "experiment": "b"}),
+		"{json}"
+	);
+}
+
+#[tokio::test]
+async fn bedrock_request_metadata_rides_signed_header_on_invoke_model() {
+	let provider = bedrock_provider_with_request_metadata(vec![metadata_entry("team", "platform")]);
+	let req = ::http::Request::builder()
+		.uri("https://gateway.example.com/v1/embeddings")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			json!({"model": "amazon.titan-embed-text-v2:0", "input": "hello"}).to_string(),
+		))
+		.unwrap();
+
+	let RequestResult::Success {
+		request: forwarded,
+		upstream_route_type,
+		..
+	} = provider
+		.process_embeddings_request(&bedrock_test_backend_info(), None, req, false, &mut None)
+		.await
+		.expect("Bedrock embeddings request should process")
+	else {
+		panic!("expected forwarded request");
+	};
+	assert_eq!(upstream_route_type, RouteType::Embeddings);
+
+	let header = forwarded
+		.headers()
+		.get(bedrock_metadata::REQUEST_METADATA_HEADER)
+		.expect("InvokeModel carries metadata in the signed header")
+		.to_str()
+		.unwrap()
+		.to_string();
+	let parsed: Value = serde_json::from_str(&header).unwrap();
+	assert_eq!(parsed, json!({"team": "platform"}));
+
+	let body = forwarded.into_body().collect().await.unwrap().to_bytes();
+	let json: Value = serde_json::from_slice(&body).expect("forwarded body should be JSON");
+	assert!(json.get("requestMetadata").is_none(), "{json}");
+}
+
+#[tokio::test]
+async fn bedrock_request_metadata_fails_closed_when_identity_is_unavailable() {
+	// A dynamic entry with no request context to resolve it from: the request is
+	// rejected before it reaches Bedrock, rather than forwarded unattributed.
+	let provider =
+		bedrock_provider_with_request_metadata(vec![bedrock_metadata::BedrockRequestMetadataEntry {
+			key: "user".to_string(),
+			value: None,
+			expression: Some(std::sync::Arc::new(
+				crate::cel::Expression::new_strict("jwt.sub").unwrap(),
+			)),
+		}]);
+	let req = ::http::Request::builder()
+		.uri("https://gateway.example.com/v1/chat/completions")
+		.header(::http::header::CONTENT_TYPE, "application/json")
+		.body(Body::from(
+			json!({
+				"model": "amazon.nova-micro-v1:0",
+				"messages": [{"role": "user", "content": "hello"}],
+			})
+			.to_string(),
+		))
+		.unwrap();
+
+	let err = provider
+		.process_completions_request(
+			&bedrock_test_backend_info(),
+			None,
+			req,
+			false,
+			&mut None,
+			None,
+		)
+		.await
+		.expect_err("unresolvable metadata must reject the request");
+	assert!(matches!(err, AIError::RequestMetadata(_)), "{err}");
+}
+
+#[test]
+fn bedrock_request_metadata_round_trips_through_provider_config() {
+	let provider: AIProvider = serde_json::from_value(json!({
+		"bedrock": {
+			"region": "us-east-1",
+			"model": "amazon.nova-micro-v1:0",
+			"requestMetadata": [
+				{"key": "environment", "value": "prod"},
+				{"key": "user", "expression": "jwt.sub"}
+			]
+		}
+	}))
+	.expect("bedrock provider with request metadata should deserialize");
+	let AIProvider::Bedrock(bedrock) = &provider else {
+		panic!("expected bedrock provider");
+	};
+	assert_eq!(bedrock.region, "us-east-1");
+	assert!(!bedrock.request_metadata.is_empty());
+	assert_eq!(bedrock.cel_expressions().count(), 1);
+
+	let serialized = serde_json::to_value(&provider).unwrap();
+	assert_eq!(
+		serialized["bedrock"]["requestMetadata"],
+		json!([
+			{"key": "environment", "value": "prod"},
+			{"key": "user", "expression": "jwt.sub"}
+		])
+	);
+
+	// Invalid entries are rejected at config load, not at request time.
+	let err = serde_json::from_value::<AIProvider>(json!({
+		"bedrock": {
+			"region": "us-east-1",
+			"requestMetadata": [{"key": "team", "value": "a", "expression": "jwt.sub"}]
+		}
+	}))
+	.unwrap_err();
+	assert!(err.to_string().contains("exactly one"), "{err}");
+}

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -251,7 +251,8 @@ fn classify_ai_request(error: &llm::AIError) -> AIErrorClassification {
 		| llm::AIError::UnsupportedModel
 		| llm::AIError::UnsupportedContent
 		| llm::AIError::UnsupportedConversion(_)
-		| llm::AIError::RequestParsing(_) => AIErrorClassification {
+		| llm::AIError::RequestParsing(_)
+		| llm::AIError::RequestMetadata(_) => AIErrorClassification {
 			status: StatusCode::BAD_REQUEST,
 			reason: ProxyResponseReason::InvalidRequest,
 		},
@@ -310,7 +311,8 @@ fn classify_ai_response(error: &llm::AIError) -> AIErrorClassification {
 		| llm::AIError::RequestMarshal(_)
 		| llm::AIError::ResponseMarshal(_)
 		| llm::AIError::Encoding(_)
-		| llm::AIError::JoinError(_) => AIErrorClassification {
+		| llm::AIError::JoinError(_)
+		| llm::AIError::RequestMetadata(_) => AIErrorClassification {
 			status: StatusCode::INTERNAL_SERVER_ERROR,
 			reason: ProxyResponseReason::Internal,
 		},

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -354,6 +354,11 @@ impl BackendPolicies {
 				ctx.register_expression(expr);
 			}
 		}
+		if let Some(provider) = self.llm_provider.as_ref() {
+			for expr in provider.provider.cel_expressions() {
+				ctx.register_expression(expr);
+			}
+		}
 		if let Some(health) = self.health.as_ref() {
 			health.register_expressions(ctx);
 		}

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -507,6 +507,8 @@ pub enum AIError {
 	Encoding(axum_core::Error),
 	#[error("error computing tokens")]
 	JoinError(#[from] tokio::task::JoinError),
+	#[error("bedrock request metadata could not be resolved: {0}")]
+	RequestMetadata(Strng),
 }
 
 #[apply(schema!)]

--- a/examples/llm-bedrock-attribution/README.md
+++ b/examples/llm-bedrock-attribution/README.md
@@ -1,0 +1,42 @@
+## Bedrock attribution: the bill and the logs
+
+This example carries a caller's identity from the gateway into both places AWS records Amazon Bedrock usage, using one set of CEL expressions:
+
+- **The bill.** `assumeRole.sessionName` and `assumeRole.tags` ride the per-request STS `AssumeRole` call. The session name lands in CloudTrail and in the Cost and Usage Report's IAM principal column; the tags surface as cost allocation tags in Cost Explorer and the CUR once you activate the keys.
+- **The logs.** `requestMetadata` is attached to every Bedrock call and recorded in the model invocation logs, which is where per-prompt attribution lives (CloudWatch Logs Insights, Athena). Bedrock does not enforce metadata and records whatever a caller sends; setting it at the gateway is what makes it mandatory and trustworthy.
+
+Each entry is either a static `value` or a CEL `expression` evaluated against the request. Values derived from `jwt.*` come from a token the gateway validated; operator-set values come from this file. A caller cannot override an operator entry: if a client sends its own `x-bedrock-metadata` header, keys the operator claimed are replaced and the rest are kept, up to Bedrock's limit of 16 entries. An expression that errors, or produces an empty or invalid value, rejects the request before it reaches AWS.
+
+Limits are checked at config load for static values and per request for dynamic ones: at most 16 entries, keys and values up to 256 characters, and the character set shared with STS tags.
+
+### Running the example
+
+The AWS credentials in the environment must be allowed to assume the configured role with `sts:AssumeRole` and `sts:TagSession`. Replace the role ARN and, if you use another model, the model ID.
+
+```bash
+cargo run -- -f examples/llm-bedrock-attribution/config.yaml
+```
+
+Send a request with a token (see `examples/mcp-authentication` for a signed test token):
+
+```bash
+curl http://localhost:4000/v1/chat/completions \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-team: platform" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "amazon.nova-micro-v1:0", "messages": [{"role": "user", "content": "hello"}]}'
+```
+
+Then:
+
+- **CloudTrail**, filter by event name `Converse`: `userIdentity.arn` ends with the caller's `jwt.sub`, not one shared session name.
+- **Model invocation logs** (once enabled in the region): each record carries `requestMetadata.user`, `requestMetadata.team`, and `requestMetadata.environment`.
+- **Cost Explorer**, after activating `user`, `team`, and `environment` as cost allocation tags and waiting for the next billing data: Bedrock spend grouped by any of them.
+
+### Where the metadata goes on the wire
+
+| Upstream API | Placement |
+|---|---|
+| `Converse`, `ConverseStream` (chat routes) | `requestMetadata` field in the request body |
+| `InvokeModel`, `InvokeModelWithResponseStream` (embeddings, passthrough) | `x-amzn-bedrock-request-metadata` header, SigV4-signed |
+| `CountTokens`, `Rerank` | not supported by Bedrock; left untouched |

--- a/examples/llm-bedrock-attribution/config.yaml
+++ b/examples/llm-bedrock-attribution/config.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Attribution for Amazon Bedrock traffic, resolved once at the gateway from a
+# validated identity and carried to the two places AWS records it:
+#
+#   * the bill: STS session tags and the role session name on the per-request
+#     AssumeRole, which surface in Cost Explorer and the Cost and Usage Report
+#     (after the tag keys are activated as cost allocation tags); and
+#   * the invocation logs: Bedrock request metadata, recorded per call in the
+#     model invocation logs for per-prompt attribution.
+#
+# Both use the same CEL expressions, so a caller's JWT subject becomes the same
+# value on the bill and in the logs. A caller cannot set either: the values come
+# from a token the gateway validated or from operator configuration, and a
+# request whose expressions cannot resolve is rejected before it reaches AWS.
+config: {}
+binds:
+- port: 4000
+  listeners:
+  - name: default
+    protocol: HTTP
+    routes:
+    - name: bedrock
+      policies:
+        jwtAuth:
+          issuer: agentgateway.dev
+          audiences: [test.agentgateway.dev]
+          jwks:
+            # Relative to the folder the binary runs from, not the config file
+            file: ./manifests/jwt/pub-key
+      backends:
+      - ai:
+          name: bedrock
+          provider:
+            bedrock:
+              region: us-east-1
+              model: amazon.nova-micro-v1:0
+              # Per-call metadata, recorded in the model invocation logs.
+              requestMetadata:
+              - key: user
+                expression: jwt.sub
+              - key: team
+                expression: request.headers["x-team"]
+              - key: environment
+                value: prod
+          policies:
+            backendAuth:
+              aws:
+                assumeRole:
+                  roleArn: arn:aws:iam::123456789012:role/bedrock-invoke
+                  # Per-caller session identity, visible in CloudTrail and in
+                  # the Cost and Usage Report's IAM principal column.
+                  sessionName:
+                    expression: jwt.sub
+                  # Session tags, surfacing as cost allocation tags on the bill.
+                  tags:
+                  - key: user
+                    expression: jwt.sub
+                  - key: team
+                    expression: request.headers["x-team"]
+                  - key: environment
+                    value: prod

--- a/schema/config.json
+++ b/schema/config.json
@@ -8418,11 +8418,50 @@
             "string",
             "null"
           ]
+        },
+        "requestMetadata": {
+          "description": "Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/BedrockRequestMetadataEntry"
+          }
         }
       },
       "additionalProperties": false,
       "required": [
         "region"
+      ]
+    },
+    "BedrockRequestMetadataEntry": {
+      "description": "One request-metadata entry in configuration form. Exactly one of `value`\nand `expression` must be set.",
+      "type": "object",
+      "properties": {
+        "key": {
+          "description": "Metadata key.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Static metadata value.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expression": {
+          "description": "CEL expression evaluated against each request to produce the value, for\nexample `jwt.sub` or `request.headers[\"x-app\"]`. If the expression does not\nproduce a valid value at request time, the request is rejected.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expression"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "key"
       ]
     },
     "AzureProvider": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -5376,6 +5376,10 @@
 |`binds[].listeners[].routes[].backends[].ai.provider.bedrock.region`|string|AWS region for the Bedrock endpoint.|
 |`binds[].listeners[].routes[].backends[].ai.provider.bedrock.guardrailIdentifier`|string|Identifier of the Bedrock guardrail to apply.|
 |`binds[].listeners[].routes[].backends[].ai.provider.bedrock.guardrailVersion`|string|Version of the Bedrock guardrail to apply.|
+|`binds[].listeners[].routes[].backends[].ai.provider.bedrock.requestMetadata`|[]object|Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.|
+|`binds[].listeners[].routes[].backends[].ai.provider.bedrock.requestMetadata[].key`|string|Metadata key.|
+|`binds[].listeners[].routes[].backends[].ai.provider.bedrock.requestMetadata[].value`|string|Static metadata value.|
+|`binds[].listeners[].routes[].backends[].ai.provider.bedrock.requestMetadata[].expression`|string|CEL expression evaluated against each request to produce the value, for<br>example `jwt.sub` or `request.headers["x-app"]`. If the expression does not<br>produce a valid value at request time, the request is rejected.|
 |`binds[].listeners[].routes[].backends[].ai.provider.azure`|object||
 |`binds[].listeners[].routes[].backends[].ai.provider.azure.model`|string|Model ID to send to Azure, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.provider.azure.resourceName`|string|The Azure resource name used to construct the endpoint host.|
@@ -8715,6 +8719,10 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.bedrock.region`|string|AWS region for the Bedrock endpoint.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.bedrock.guardrailIdentifier`|string|Identifier of the Bedrock guardrail to apply.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.bedrock.guardrailVersion`|string|Version of the Bedrock guardrail to apply.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata`|[]object|Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].key`|string|Metadata key.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].value`|string|Static metadata value.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].expression`|string|CEL expression evaluated against each request to produce the value, for<br>example `jwt.sub` or `request.headers["x-app"]`. If the expression does not<br>produce a valid value at request time, the request is rejected.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.azure`|object||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.azure.model`|string|Model ID to send to Azure, overriding the model in the client request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].provider.azure.resourceName`|string|The Azure resource name used to construct the endpoint host.|
@@ -23373,6 +23381,10 @@
 |`backends[].ai.provider.bedrock.region`|string|AWS region for the Bedrock endpoint.|
 |`backends[].ai.provider.bedrock.guardrailIdentifier`|string|Identifier of the Bedrock guardrail to apply.|
 |`backends[].ai.provider.bedrock.guardrailVersion`|string|Version of the Bedrock guardrail to apply.|
+|`backends[].ai.provider.bedrock.requestMetadata`|[]object|Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.|
+|`backends[].ai.provider.bedrock.requestMetadata[].key`|string|Metadata key.|
+|`backends[].ai.provider.bedrock.requestMetadata[].value`|string|Static metadata value.|
+|`backends[].ai.provider.bedrock.requestMetadata[].expression`|string|CEL expression evaluated against each request to produce the value, for<br>example `jwt.sub` or `request.headers["x-app"]`. If the expression does not<br>produce a valid value at request time, the request is rejected.|
 |`backends[].ai.provider.azure`|object||
 |`backends[].ai.provider.azure.model`|string|Model ID to send to Azure, overriding the model in the client request.|
 |`backends[].ai.provider.azure.resourceName`|string|The Azure resource name used to construct the endpoint host.|
@@ -26712,6 +26724,10 @@
 |`backends[].ai.groups[].providers[].provider.bedrock.region`|string|AWS region for the Bedrock endpoint.|
 |`backends[].ai.groups[].providers[].provider.bedrock.guardrailIdentifier`|string|Identifier of the Bedrock guardrail to apply.|
 |`backends[].ai.groups[].providers[].provider.bedrock.guardrailVersion`|string|Version of the Bedrock guardrail to apply.|
+|`backends[].ai.groups[].providers[].provider.bedrock.requestMetadata`|[]object|Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.|
+|`backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].key`|string|Metadata key.|
+|`backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].value`|string|Static metadata value.|
+|`backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].expression`|string|CEL expression evaluated against each request to produce the value, for<br>example `jwt.sub` or `request.headers["x-app"]`. If the expression does not<br>produce a valid value at request time, the request is rejected.|
 |`backends[].ai.groups[].providers[].provider.azure`|object||
 |`backends[].ai.groups[].providers[].provider.azure.model`|string|Model ID to send to Azure, overriding the model in the client request.|
 |`backends[].ai.groups[].providers[].provider.azure.resourceName`|string|The Azure resource name used to construct the endpoint host.|
@@ -38577,6 +38593,10 @@
 |`routeGroups[].routes[].backends[].ai.provider.bedrock.region`|string|AWS region for the Bedrock endpoint.|
 |`routeGroups[].routes[].backends[].ai.provider.bedrock.guardrailIdentifier`|string|Identifier of the Bedrock guardrail to apply.|
 |`routeGroups[].routes[].backends[].ai.provider.bedrock.guardrailVersion`|string|Version of the Bedrock guardrail to apply.|
+|`routeGroups[].routes[].backends[].ai.provider.bedrock.requestMetadata`|[]object|Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.|
+|`routeGroups[].routes[].backends[].ai.provider.bedrock.requestMetadata[].key`|string|Metadata key.|
+|`routeGroups[].routes[].backends[].ai.provider.bedrock.requestMetadata[].value`|string|Static metadata value.|
+|`routeGroups[].routes[].backends[].ai.provider.bedrock.requestMetadata[].expression`|string|CEL expression evaluated against each request to produce the value, for<br>example `jwt.sub` or `request.headers["x-app"]`. If the expression does not<br>produce a valid value at request time, the request is rejected.|
 |`routeGroups[].routes[].backends[].ai.provider.azure`|object||
 |`routeGroups[].routes[].backends[].ai.provider.azure.model`|string|Model ID to send to Azure, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.provider.azure.resourceName`|string|The Azure resource name used to construct the endpoint host.|
@@ -41916,6 +41936,10 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.bedrock.region`|string|AWS region for the Bedrock endpoint.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.bedrock.guardrailIdentifier`|string|Identifier of the Bedrock guardrail to apply.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.bedrock.guardrailVersion`|string|Version of the Bedrock guardrail to apply.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata`|[]object|Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].key`|string|Metadata key.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].value`|string|Static metadata value.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].expression`|string|CEL expression evaluated against each request to produce the value, for<br>example `jwt.sub` or `request.headers["x-app"]`. If the expression does not<br>produce a valid value at request time, the request is rejected.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.azure`|object||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.azure.model`|string|Model ID to send to Azure, overriding the model in the client request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].provider.azure.resourceName`|string|The Azure resource name used to construct the endpoint host.|
@@ -56381,6 +56405,10 @@
 |`routes[].backends[].ai.provider.bedrock.region`|string|AWS region for the Bedrock endpoint.|
 |`routes[].backends[].ai.provider.bedrock.guardrailIdentifier`|string|Identifier of the Bedrock guardrail to apply.|
 |`routes[].backends[].ai.provider.bedrock.guardrailVersion`|string|Version of the Bedrock guardrail to apply.|
+|`routes[].backends[].ai.provider.bedrock.requestMetadata`|[]object|Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.|
+|`routes[].backends[].ai.provider.bedrock.requestMetadata[].key`|string|Metadata key.|
+|`routes[].backends[].ai.provider.bedrock.requestMetadata[].value`|string|Static metadata value.|
+|`routes[].backends[].ai.provider.bedrock.requestMetadata[].expression`|string|CEL expression evaluated against each request to produce the value, for<br>example `jwt.sub` or `request.headers["x-app"]`. If the expression does not<br>produce a valid value at request time, the request is rejected.|
 |`routes[].backends[].ai.provider.azure`|object||
 |`routes[].backends[].ai.provider.azure.model`|string|Model ID to send to Azure, overriding the model in the client request.|
 |`routes[].backends[].ai.provider.azure.resourceName`|string|The Azure resource name used to construct the endpoint host.|
@@ -59720,6 +59748,10 @@
 |`routes[].backends[].ai.groups[].providers[].provider.bedrock.region`|string|AWS region for the Bedrock endpoint.|
 |`routes[].backends[].ai.groups[].providers[].provider.bedrock.guardrailIdentifier`|string|Identifier of the Bedrock guardrail to apply.|
 |`routes[].backends[].ai.groups[].providers[].provider.bedrock.guardrailVersion`|string|Version of the Bedrock guardrail to apply.|
+|`routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata`|[]object|Request metadata attached to every Bedrock call, recorded in the model invocation logs (not on the bill) for per-prompt attribution. Each entry is a static `value` or a CEL `expression` evaluated against the request, the same shape as `assumeRole.tags`. Operator entries override caller-supplied `x-bedrock-metadata` keys of the same name; an expression that cannot produce a valid value rejects the request.|
+|`routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].key`|string|Metadata key.|
+|`routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].value`|string|Static metadata value.|
+|`routes[].backends[].ai.groups[].providers[].provider.bedrock.requestMetadata[].expression`|string|CEL expression evaluated against each request to produce the value, for<br>example `jwt.sub` or `request.headers["x-app"]`. If the expression does not<br>produce a valid value at request time, the request is rejected.|
 |`routes[].backends[].ai.groups[].providers[].provider.azure`|object||
 |`routes[].backends[].ai.groups[].providers[].provider.azure.model`|string|Model ID to send to Azure, overriding the model in the client request.|
 |`routes[].backends[].ai.groups[].providers[].provider.azure.resourceName`|string|The Azure resource name used to construct the endpoint host.|


### PR DESCRIPTION
## What

Adds `requestMetadata` to the Bedrock provider: operator-resolved per-call metadata, attached to every Bedrock request and recorded in the model invocation logs.

```yaml
provider:
  bedrock:
    region: us-east-1
    requestMetadata:
    - key: user
      expression: jwt.sub
    - key: team
      expression: request.headers["x-team"]
    - key: environment
      value: prod
```

Same shape and semantics as `assumeRole.tags` (#2435, #2447, #2508): a static `value` or a CEL `expression` evaluated against the request, so one identity resolved at the gateway now reaches all three places AWS records it — the bill (session tags, IAM principal), the invocation logs (request metadata), and CloudTrail (session name).

## Why

AWS published per-request metadata for Bedrock on 2026-08-21 ([Per-request metadata tagging](https://docs.aws.amazon.com/bedrock/latest/userguide/request-metadata.html)). It is the per-prompt layer: session tags surface only as aggregated billing data, while request metadata is recorded per call, so it is where "which user / app / feature was this specific request" lives (CloudWatch Logs Insights, Athena).

The docs are explicit that Bedrock does not enforce it:

> Request metadata is supplied per call and is not enforced by Amazon Bedrock. Requests that omit it still succeed, and there is no service-side policy to require it. To guarantee coverage across an organization, set request metadata in a shared client or LLM gateway.

This PR is that gateway-side setting. Today the gateway only forwards a caller-supplied `x-bedrock-metadata` header, which is the caller naming itself; an operator has no way to make attribution mandatory or to derive it from a validated identity.

## Behavior

- **Validated at load**, like session tags: at most 16 entries, keys and values up to 256 characters, unique keys, exactly one of `value` / `expression`. The character set is the STS tag set (Bedrock documents "a restricted set of alphanumeric and punctuation characters" without enumerating it; the STS set is the conservative shared subset, so anything valid as a tag is valid here).
- **Fails closed** per request: an expression that errors, or produces an empty or invalid value, rejects the request (400, `bedrock request metadata could not be resolved: ...`) before it reaches Bedrock.
- **Placement follows the upstream API:**

  | Upstream API | Placement |
  |---|---|
  | `Converse`, `ConverseStream` (all chat routes) | `requestMetadata` body field |
  | `InvokeModel`, `InvokeModelWithResponseStream` (embeddings, passthrough) | `x-amzn-bedrock-request-metadata` header — already SigV4-signed via `should_sign_header` |
  | `CountTokens`, `Rerank` | not supported by Bedrock; untouched |

- **Precedence:** operator entries override caller-supplied `x-bedrock-metadata` keys of the same name. Caller keys the operator did not claim are kept, up to the 16-entry limit; if the limit is hit, caller keys are what gets dropped (with a warning), never operator attribution. This matches how session tags and pinned values behave elsewhere.
- Expressions are registered with the request CEL context (`BackendPolicies::register_cel_expressions`) so the snapshot captures what they read.

## Why not `finalTransformations`?

An operator can already set `requestMetadata` on the Converse body through the generic `finalTransformations` policy. That path has no limit validation, no fail-closed behavior (a missing claim silently yields nothing), no header placement for the InvokeModel family, and no precedence rule over the caller's `x-bedrock-metadata`. Since this is attribution — the same class of value as session tags — it should have the same guarantees, and be discoverable next to them in the provider config.

## Not in scope

- xDS / CRD plumbing (session tags are local-config only today as well).
- The caller-supplied `x-bedrock-metadata` passthrough is unchanged except for the precedence rule above.
- Observation while writing the round-trip test: because `BedrockProvider` `#[serde(flatten)]`s the inner provider, the inner `deny_unknown_fields` is inert, so typos in a `bedrock:` block are accepted. Pre-existing; left alone here.

## Testing

- `bedrock_metadata.rs`: validation (count, chars, lengths, duplicates, value/expression exclusivity), static + dynamic resolution, fail-closed on missing/empty/invalid values, caller-override precedence, entry-limit behavior, header rendering, serde round trip.
- `llm/tests.rs`: through `process_completions_request` — metadata lands in the rendered Converse body with the operator's key overriding the caller's; through `process_embeddings_request` — rides the signed header and not the body; a dynamic entry with no identity rejects the request; provider config round trip.
- `cargo test -p agentgateway -- llm:: http::auth:: store::` (670 tests), `cargo clippy --all-targets -D warnings`, strict `cargo fmt --check`, `cargo xtask schema` (schema diff is the one property plus one definition).
- Example: `examples/llm-bedrock-attribution` configures the bill and log layers together and documents where to look (CloudTrail, invocation logs, Cost Explorer).
