### PR TITLE
Show warning UI for duplicate port binds

### DIFF
--- a/ui/src/pages/TrafficListeners.tsx
+++ b/ui/src/pages/TrafficListeners.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { Network, Pencil, Plus, Route as RouteIcon, Trash2 } from 'lucide-react';
+import { AlertTriangle, Network, Pencil, Plus, Route as RouteIcon, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { ConfigDiffSaveActions } from '@/components/ConfigDiffDrawer';
@@ -26,7 +26,7 @@ import {
 } from '@/pages/traffic/TrafficConfigDumpPanel';
 import { TrafficPolicySection } from '@/pages/traffic/TrafficPolicySection';
 import { type SchemaHelp, useSchemaHelp } from '@/schemaHelp';
-import { listenerContexts, listenerDisplayName, trafficStats } from '@/traffic';
+import { findDuplicatePorts, listenerContexts, listenerDisplayName, trafficStats } from '@/traffic';
 import type { GatewayConfig, TrafficBind, TrafficListener } from '@/types';
 
 const protocols = ['HTTP', 'HTTPS', 'TCP', 'TLS', 'HBONE'] as const;
@@ -67,6 +67,10 @@ function TrafficListenersEditorPage() {
 	const help = useSchemaHelp();
 	const listeners = useMemo(() => listenerContexts(config.data), [config.data]);
 	const stats = trafficStats(config.data);
+	const duplicatePorts = useMemo(
+		() => findDuplicatePorts(config.data?.binds ?? []),
+		[config.data]
+	);
 	const [bindEditor, setBindEditor] = useState<TrafficBind | null>(null);
 	const [listenerEditor, setListenerEditor] = useState<{
 		bindIndex: number;
@@ -158,6 +162,15 @@ function TrafficListenersEditorPage() {
 					Edit those listeners through raw YAML or split the routes across separate listeners.
 				</StatusBanner>
 			) : null}
+			{duplicatePorts.size ? (
+				<StatusBanner
+					state="warn"
+					title={`Port conflict: ${duplicatePorts.size === 1 ? 'port' : 'ports'} ${[...duplicatePorts].join(', ')} used by multiple binds`}
+				>
+					Each port should only be bound once. The gateway will reject this configuration.
+					Remove or reassign duplicate binds to resolve the conflict.
+				</StatusBanner>
+			) : null}
 
 			<Panel>
 				{config.isLoading ? (
@@ -189,7 +202,18 @@ function TrafficListenersEditorPage() {
 								<section className="traffic-bind" key={`${bind.port}-${bindIndex}`}>
 									<div className="traffic-bind-header">
 										<div>
-											<h3>Port {bind.port}</h3>
+											<h3>
+												{duplicatePorts.has(bind.port) ? (
+													<Tooltip content="Port conflict: another bind uses this port">
+														<AlertTriangle
+															size={16}
+															className="inline-icon warn"
+															aria-label="Port conflict"
+														/>
+													</Tooltip>
+												) : null}
+												Port {bind.port}
+											</h3>
 											<p>
 												{bindListeners.length} listeners · {listenerRouteCount(bind)} routes ·{' '}
 												{backendCount} backends

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -5195,6 +5195,14 @@ textarea {
 .traffic-bind-header h3 {
 	margin: 0;
 	font-size: 16px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.traffic-bind-header h3 .inline-icon.warn {
+	color: var(--warn);
+	flex-shrink: 0;
 }
 
 .traffic-bind-header p {

--- a/ui/src/traffic.ts
+++ b/ui/src/traffic.ts
@@ -23,6 +23,16 @@ export interface RouteContext extends ListenerContext {
 	routeIndex: number;
 }
 
+export function findDuplicatePorts(binds: TrafficBind[]): Set<number> {
+	const seen = new Set<number>();
+	const duplicates = new Set<number>();
+	for (const bind of binds) {
+		if (seen.has(bind.port)) duplicates.add(bind.port);
+		else seen.add(bind.port);
+	}
+	return duplicates;
+}
+
 export function trafficStats(config: GatewayConfig | undefined) {
 	const binds = config?.binds ?? [];
 	const gateways = Object.values(config?.gateways ?? {});
@@ -33,6 +43,7 @@ export function trafficStats(config: GatewayConfig | undefined) {
 	let tcpRoutes = 0;
 	let backends = 0;
 	let invalidListeners = 0;
+	const portConflicts = findDuplicatePorts(binds).size;
 	for (const bind of binds) {
 		for (const listener of bind.listeners ?? []) {
 			listeners += 1;
@@ -59,7 +70,8 @@ export function trafficStats(config: GatewayConfig | undefined) {
 		httpRoutes,
 		tcpRoutes,
 		backends,
-		invalidListeners
+		invalidListeners,
+		portConflicts
 	};
 }
 


### PR DESCRIPTION
## Summary

Fixes #891

- Added `findDuplicatePorts()` utility in `traffic.ts` that returns a `Set<number>` of ports used by multiple binds
- Added `portConflicts` to `trafficStats()` for dashboard visibility
- Traffic Listeners page now shows a `StatusBanner` warning when duplicate ports are detected, with guidance to resolve
- Individual bind sections with conflicting ports display an `AlertTriangle` icon with tooltip
- CSS updated for flex layout and warn-color styling on bind headers

## Test plan

- [x] Warning banner appears when two or more binds share a port
- [x] Per-bind alert icon appears only on conflicting binds
- [x] No warnings shown when all ports are unique
- [x] Mirrors existing `invalidListeners` pattern for consistency