### PR TITLE
warn on post-request MCP authorization fields

### DIFF
--- a/architecture/cel.md
+++ b/architecture/cel.md
@@ -7,7 +7,11 @@ A simple example of an expression that could be used for MCP authorization: `jwt
 
 For post-request logging, tracing, and metrics CEL, MCP tool calls also expose payload fields such as
 `mcp.methodName`, `mcp.sessionId`, `mcp.tool.arguments`, `mcp.tool.result`, and `mcp.tool.error`.
-Request-time authorization keeps the `mcp` context identity-only, so those payload fields are absent during RBAC evaluation.
+Request-time authorization keeps the `mcp` context identity-only: `mcp.tool.target`, `mcp.tool.name`,
+and the target/name fields of prompts, resources, and tasks are available, but the post-request fields
+listed above are absent during RBAC evaluation. An `mcpAuthorization` expression that references one
+of those fields is retained with the existing authorization semantics and produces a configuration warning;
+the reference cannot enforce a condition on a value that is not available at authorization time.
 
 While CEL is not as powerful as alternatives like Lua or WASM, it is pretty fast and good enough for many use cases.
 

--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -310,6 +310,18 @@ impl Expression {
 		self.expression.expression()
 	}
 
+	pub(crate) fn references_property(&self, property: &[&str]) -> bool {
+		let mut properties = Vec::with_capacity(5);
+		properties::properties(
+			&self.expression.expression().expr,
+			&mut properties,
+			&mut Vec::default(),
+		);
+		properties
+			.iter()
+			.any(|referenced| referenced.starts_with(property))
+	}
+
 	pub fn needs_llm_request(&self) -> bool {
 		self.attributes.contains(Attributes::LlmRequest)
 	}

--- a/crates/agentgateway/src/cel/tests.rs
+++ b/crates/agentgateway/src/cel/tests.rs
@@ -606,6 +606,19 @@ fn test_properties() {
 }
 
 #[test]
+fn expression_references_property_prefix() {
+	let expression = Expression::new_strict(
+		r#"mcp.tool.name == "echo" && has(mcp.tool.arguments.a) && !has(mcp.tool.result)"#,
+	)
+	.unwrap();
+
+	assert!(expression.references_property(&["mcp", "tool", "name"]));
+	assert!(expression.references_property(&["mcp", "tool", "arguments"]));
+	assert!(expression.references_property(&["mcp", "tool", "result"]));
+	assert!(!expression.references_property(&["mcp", "tool", "error"]));
+}
+
+#[test]
 fn map() {
 	let expr = r#"request.headers.map(v, v)"#;
 	let v = eval(expr).unwrap();

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -292,13 +292,13 @@ pub struct MCPTool {
 	pub target: String,
 	/// The resolved tool name sent to the upstream target.
 	pub name: String,
-	/// The JSON arguments passed to the tool call.
+	/// The JSON arguments passed to the tool call. Available only in post-request CEL.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub arguments: Option<serde_json::Map<String, serde_json::Value>>,
-	/// The terminal tool result payload, if available.
+	/// The terminal tool result payload, if available. Available only in post-request CEL.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub result: Option<serde_json::Value>,
-	/// The terminal JSON-RPC error payload, if available.
+	/// The terminal JSON-RPC error payload, if available. Available only in post-request CEL.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub error: Option<serde_json::Value>,
 }
@@ -339,8 +339,10 @@ impl MCPTask {
 #[dynamic(rename_all = "camelCase")]
 pub struct MCPInfo {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	/// Available only in post-request CEL; absent during MCP authorization.
 	pub method_name: Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
+	/// Available only in post-request CEL; absent during MCP authorization.
 	pub session_id: Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub tool: Option<MCPTool>,

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -279,8 +279,7 @@ fn mcp_authorization_cel_expression(
 		.collect::<Vec<_>>();
 	if !fields.is_empty() {
 		diagnostics.add_warning(format!(
-			"{context} expression {:?} references post-request-only MCP fields [{}]; these fields are unavailable during request-time authorization, so references to their values cannot enforce the intended condition",
-			expression.original_expression,
+			"{context} expression references post-request-only MCP fields [{}]; these fields are unavailable during request-time authorization, so references to their values cannot enforce the intended condition",
 			fields.join(", ")
 		));
 	}
@@ -4305,6 +4304,12 @@ mod tests {
 			let warnings = diagnostics.into_warnings();
 			assert_eq!(warnings.len(), 1, "expression: {expression}");
 			assert!(warnings[0].contains(fields), "warning: {}", warnings[0]);
+			assert!(
+				!warnings[0].contains(expression),
+				"warning: {}",
+				warnings[0]
+			);
+			assert!(!warnings[0].contains("secret"), "warning: {}", warnings[0]);
 		}
 	}
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -258,6 +258,35 @@ pub(crate) fn permissive_cel_expression_arc(
 	))
 }
 
+const MCP_POST_REQUEST_FIELDS: &[(&[&str], &str)] = &[
+	(&["mcp", "methodName"], "mcp.methodName"),
+	(&["mcp", "sessionId"], "mcp.sessionId"),
+	(&["mcp", "tool", "arguments"], "mcp.tool.arguments"),
+	(&["mcp", "tool", "result"], "mcp.tool.result"),
+	(&["mcp", "tool", "error"], "mcp.tool.error"),
+];
+
+fn mcp_authorization_cel_expression(
+	diagnostics: &mut Diagnostics,
+	context: impl AsRef<str>,
+	original_expression: &str,
+) -> Arc<cel::Expression> {
+	let context = context.as_ref();
+	let expression = permissive_cel_expression_arc(diagnostics, context, original_expression);
+	let fields = MCP_POST_REQUEST_FIELDS
+		.iter()
+		.filter_map(|(path, name)| expression.references_property(path).then_some(*name))
+		.collect::<Vec<_>>();
+	if !fields.is_empty() {
+		diagnostics.add_warning(format!(
+			"{context} expression {:?} references post-request-only MCP fields [{}]; these fields are unavailable during request-time authorization, so references to their values cannot enforce the intended condition",
+			expression.original_expression,
+			fields.join(", ")
+		));
+	}
+	expression
+}
+
 fn regex_or_warn_invalid(
 	diagnostics: &mut Diagnostics,
 	context: impl AsRef<str>,
@@ -514,7 +543,7 @@ fn mcp_authorization_from_proto(
 	let mut allow_exprs = Vec::new();
 	// We do NOT want to NACK invalid CEL expressions. Instead, we ensure they always evaluate to errors.
 	for allow_rule in &rbac.allow {
-		allow_exprs.push(permissive_cel_expression_arc(
+		allow_exprs.push(mcp_authorization_cel_expression(
 			diagnostics,
 			"backend.mcpAuthorization.allow",
 			allow_rule,
@@ -523,7 +552,7 @@ fn mcp_authorization_from_proto(
 
 	let mut deny_exprs = Vec::new();
 	for deny_rule in &rbac.deny {
-		deny_exprs.push(permissive_cel_expression_arc(
+		deny_exprs.push(mcp_authorization_cel_expression(
 			diagnostics,
 			"backend.mcpAuthorization.deny",
 			deny_rule,
@@ -532,7 +561,7 @@ fn mcp_authorization_from_proto(
 
 	let mut require_exprs = Vec::new();
 	for require_rule in &rbac.require {
-		require_exprs.push(permissive_cel_expression_arc(
+		require_exprs.push(mcp_authorization_cel_expression(
 			diagnostics,
 			"backend.mcpAuthorization.require",
 			require_rule,
@@ -4249,6 +4278,47 @@ mod tests {
 				BackendReference::Invalid
 			));
 		}
+	}
+
+	#[test]
+	fn mcp_authorization_warns_on_post_request_fields() {
+		let expressions = [
+			(
+				r#"mcp.tool.name == "echo" && mcp.tool.arguments.value == "secret""#,
+				"mcp.tool.arguments",
+			),
+			(
+				r#"has(mcp.methodName) && has(mcp.sessionId) && has(mcp.tool.result) && has(mcp.tool.error)"#,
+				"mcp.methodName, mcp.sessionId, mcp.tool.result, mcp.tool.error",
+			),
+		];
+
+		for (expression, fields) in expressions {
+			let mut diagnostics = Diagnostics::default();
+			mcp_authorization_from_proto(
+				&proto::agent::backend_policy_spec::McpAuthorization {
+					allow: vec![expression.to_string()],
+					..Default::default()
+				},
+				&mut diagnostics,
+			);
+			let warnings = diagnostics.into_warnings();
+			assert_eq!(warnings.len(), 1, "expression: {expression}");
+			assert!(warnings[0].contains(fields), "warning: {}", warnings[0]);
+		}
+	}
+
+	#[test]
+	fn mcp_authorization_does_not_warn_on_request_identity_fields() {
+		let mut diagnostics = Diagnostics::default();
+		mcp_authorization_from_proto(
+			&proto::agent::backend_policy_spec::McpAuthorization {
+				allow: vec![r#"mcp.tool.target == "server" && mcp.tool.name == "echo""#.to_string()],
+				..Default::default()
+			},
+			&mut diagnostics,
+		);
+		assert!(diagnostics.into_warnings().is_empty());
 	}
 
 	fn jwt_sign_from_proto_for_test(

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -935,12 +935,14 @@
       ],
       "properties": {
         "methodName": {
+          "description": "Available only in post-request CEL; absent during MCP authorization.",
           "type": [
             "string",
             "null"
           ]
         },
         "sessionId": {
+          "description": "Available only in post-request CEL; absent during MCP authorization.",
           "type": [
             "string",
             "null"
@@ -961,7 +963,7 @@
               "type": "string"
             },
             "arguments": {
-              "description": "The JSON arguments passed to the tool call.",
+              "description": "The JSON arguments passed to the tool call. Available only in post-request CEL.",
               "type": [
                 "object",
                 "null"
@@ -969,10 +971,10 @@
               "additionalProperties": true
             },
             "result": {
-              "description": "The terminal tool result payload, if available."
+              "description": "The terminal tool result payload, if available. Available only in post-request CEL."
             },
             "error": {
-              "description": "The terminal JSON-RPC error payload, if available."
+              "description": "The terminal JSON-RPC error payload, if available. Available only in post-request CEL."
             }
           },
           "additionalProperties": false,

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -129,14 +129,14 @@
 |`destination.port`|integer|The port of the downstream request destination at agentgateway.|
 |`destination.hostname`|string|The requested destination hostname, when known. For TLS connections this is the sniffed SNI.|
 |`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.<br>Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.|
-|`mcp.methodName`|string||
-|`mcp.sessionId`|string||
+|`mcp.methodName`|string|Available only in post-request CEL; absent during MCP authorization.|
+|`mcp.sessionId`|string|Available only in post-request CEL; absent during MCP authorization.|
 |`mcp.tool`|object||
 |`mcp.tool.target`|string|The target handling the tool call after multiplexing resolution.|
 |`mcp.tool.name`|string|The resolved tool name sent to the upstream target.|
-|`mcp.tool.arguments`|object|The JSON arguments passed to the tool call.|
-|`mcp.tool.result`|any|The terminal tool result payload, if available.|
-|`mcp.tool.error`|any|The terminal JSON-RPC error payload, if available.|
+|`mcp.tool.arguments`|object|The JSON arguments passed to the tool call. Available only in post-request CEL.|
+|`mcp.tool.result`|any|The terminal tool result payload, if available. Available only in post-request CEL.|
+|`mcp.tool.error`|any|The terminal JSON-RPC error payload, if available. Available only in post-request CEL.|
 |`mcp.prompt`|object||
 |`mcp.prompt.target`|string|The target of the resource|
 |`mcp.prompt.name`|string|The name of the resource|


### PR DESCRIPTION
## Summary

`mcpAuthorization` CEL is evaluated before MCP payload fields are populated. Expressions that reference `mcp.methodName`, `mcp.sessionId`, `mcp.tool.arguments`, `mcp.tool.result`, or `mcp.tool.error` can therefore be accepted while failing to enforce the intended condition.

This change:

- reuses the CEL AST property extraction to detect those post-request-only field references;
- emits an existing XDS configuration warning for allow, deny, and require MCP authorization rules;
- keeps the current policy evaluation behavior unchanged; and
- documents the field phases in the architecture and generated CEL schema docs.

Closes #3092.

## Validation

- `cargo fmt --all`
- `cargo xtask schema`
- `cargo test -p agentgateway mcp_authorization --lib` (8 passed)
- `cargo test -p agentgateway expression_references_property --lib` (1 passed)
- `cargo clippy -p agentgateway --lib -- -D warnings`
- Full `agentgateway` library suite: 1918 passed; 5 existing MCP access-log telemetry tests failed while waiting for global log records in `eventually_find`, reproduced with one test thread. The new CEL/XDS tests pass.