### PR TITLE
feat(api): expose custom provider override

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_backend_types.go
@@ -327,6 +327,11 @@ type CustomProviderSettings struct {
 	// +optional
 	BackendRef *LocalBackendObjectReference `json:"backendRef,omitempty"`
 
+	// Provider identity used for cost-catalog lookup and telemetry.
+	// Defaults to "custom" when unset.
+	// +optional
+	ProviderOverride *ShortString `json:"providerOverride,omitempty"`
+
 	// Provider-native API formats this provider supports.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=6

--- a/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
+++ b/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
@@ -2284,6 +2284,11 @@ func (in *CustomProviderSettings) DeepCopyInto(out *CustomProviderSettings) {
 		*out = new(LocalBackendObjectReference)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ProviderOverride != nil {
+		in, out := &in.ProviderOverride, &out.ProviderOverride
+		*out = new(ShortString)
+		**out = **in
+	}
 	if in.Formats != nil {
 		in, out := &in.Formats, &out.Formats
 		*out = make([]ProviderFormatConfig, len(*in))

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -330,6 +330,13 @@ spec:
                                     maxLength: 256
                                     minLength: 1
                                     type: string
+                                  providerOverride:
+                                    description: |-
+                                      Provider identity used for cost-catalog lookup and telemetry.
+                                      Defaults to "custom" when unset.
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
                                 required:
                                 - formats
                                 type: object
@@ -7176,6 +7183,13 @@ spec:
                             description: |-
                               Model name override, such as `gpt-oss`.
                               If unset, the model name is taken from the request.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          providerOverride:
+                            description: |-
+                              Provider identity used for cost-catalog lookup and telemetry.
+                              Defaults to "custom" when unset.
                             maxLength: 256
                             minLength: 1
                             type: string

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -221,6 +221,13 @@ spec:
                     x-kubernetes-list-map-keys:
                     - type
                     x-kubernetes-list-type: map
+                  providerOverride:
+                    description: |-
+                      Provider identity used for cost-catalog lookup and telemetry.
+                      Defaults to "custom" when unset.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
                 required:
                 - formats
                 type: object

--- a/controller/pkg/agentgateway/translator/model_collections.go
+++ b/controller/pkg/agentgateway/translator/model_collections.go
@@ -640,8 +640,9 @@ func translateModelLLMProvider(ctx RouteContext, namespace string, model *agentg
 			return nil, err
 		}
 		provider.Provider = &api.AIBackend_Provider_Custom{Custom: &api.AIBackend_Custom{
-			Formats: formats,
-			Model:   providerModel(selectedModel, llm.Custom.Model),
+			Formats:          formats,
+			Model:            providerModel(selectedModel, llm.Custom.Model),
+			ProviderOverride: llm.Custom.ProviderOverride,
 		}}
 		if llm.Custom.BackendRef != nil {
 			ref, err := plugins.TranslateCustomProviderBackendRef(ctx.Krt, ctx.References.RouteBackend, namespace, *llm.Custom.BackendRef)

--- a/controller/pkg/agentgateway/translator/testdata/models/custom-inferencepool.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/models/custom-inferencepool.yaml
@@ -61,6 +61,7 @@ spec:
     sectionName: llm
   provider: Custom
   custom:
+    providerOverride: team-a
     backendRef:
       group: inference.networking.k8s.io
       kind: InferencePool
@@ -82,6 +83,7 @@ output:
           - custom:
               formats:
               - format: COMPLETIONS
+              providerOverride: team-a
             name: backend
             providerBackend:
               port: 8000

--- a/controller/pkg/syncer/backend/backend_plugin.go
+++ b/controller/pkg/syncer/backend/backend_plugin.go
@@ -559,8 +559,9 @@ func translateLLMProvider(ctx plugins.PolicyCtx, namespace string, llm *agentgat
 		}
 		provider.Provider = &api.AIBackend_Provider_Custom{
 			Custom: &api.AIBackend_Custom{
-				Formats: formats,
-				Model:   llm.Custom.Model,
+				Formats:          formats,
+				Model:            llm.Custom.Model,
+				ProviderOverride: llm.Custom.ProviderOverride,
 			},
 		}
 		if llm.Custom.BackendRef != nil {

--- a/controller/pkg/syncer/backend/backend_plugin_test.go
+++ b/controller/pkg/syncer/backend/backend_plugin_test.go
@@ -463,6 +463,7 @@ func TestBuildAIBackend(t *testing.T) {
 					AI: &agentgateway.AIBackend{
 						LLM: &agentgateway.LLMProvider{
 							Custom: &agentgateway.CustomProvider{
+								ProviderOverride: new("team-a"),
 								Formats: []agentgateway.ProviderFormatConfig{
 									{Type: agentgateway.ProviderFormatCompletions},
 									{Type: agentgateway.ProviderFormatResponses, Path: "/v1/responses"},

--- a/controller/pkg/syncer/backend/testdata/Valid_custom_backend_with_host_target.yaml
+++ b/controller/pkg/syncer/backend/testdata/Valid_custom_backend_with_host_target.yaml
@@ -6,6 +6,7 @@ ai:
         - format: COMPLETIONS
         - format: RESPONSES
           path: /v1/responses
+        providerOverride: team-a
       hostOverride:
         host: llm.example.com
         port: 443


### PR DESCRIPTION
Closes #2752

## Summary
Expose `providerOverride` for custom providers in the Kubernetes API and pass it through the controller translator.

This allows an `AgentgatewayModel` to specify the provider identity used for cost-catalog lookup and telemetry. When omitted, the existing "custom" fallback remains unchanged.

## Changes
- Add optional `providerOverride` to `CustomProviderSettings`.
- Forward it through the `AgentgatewayModel` translator.
- Forward it through the `AgentgatewayBackend` translator, which shares the same settings type.
- Regenerate the deepcopy code and CRD schemas.
- Extend the existing model and backend golden test cases to cover `providerOverride`.

## Testing

  ```bash
  cd controller

  go test ./pkg/agentgateway/translator \
    -run '^TestModels$/^custom-inferencepool\.yaml$' \
    -count=1

  go test ./pkg/syncer/backend \
    -run '^TestBuildAIBackend$/^Valid_custom_backend_with_host_target$' \
    -count=1
```
Both targeted tests pass.