### PR TITLE
llm: rewrite multipart model fields for routed models

### DIFF
--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -1,3 +1,4 @@
+use std::ops::Range;
 use std::sync::Arc;
 
 use agent_core::strng;
@@ -293,7 +294,8 @@ impl ModelRouter {
 				}
 			},
 		};
-		if let Err(resp) = rewrite_request_model(req, location, &target) {
+
+		if let Err(resp) = Box::pin(rewrite_request_model(req, location, &target)).await {
 			return ResolveResult::DirectResponse(*resp);
 		}
 		match self.resolve_concrete_model(&target, true, req) {
@@ -532,7 +534,7 @@ async fn requested_model(req: &mut Request) -> RouterResult<RequestedModel> {
 	})
 }
 
-fn rewrite_request_model(
+async fn rewrite_request_model(
 	req: &mut Request,
 	location: RequestedModelLocation,
 	target: &str,
@@ -540,8 +542,7 @@ fn rewrite_request_model(
 	match location {
 		RequestedModelLocation::Body(body) => rewrite_body_model(req, body, target),
 		RequestedModelLocation::Path => rewrite_uri_model(req, target),
-		// TODO: Rewrite multipart model fields for virtual model routing.
-		RequestedModelLocation::Multipart => Ok(()),
+		RequestedModelLocation::Multipart => rewrite_multipart_request_model(req, target).await,
 	}
 }
 
@@ -663,6 +664,24 @@ fn multipart_boundary(req: &Request) -> Option<String> {
 		.and_then(|content_type| multer::parse_boundary(content_type).ok())
 }
 
+pub(crate) async fn rewrite_multipart_request_model(
+	req: &mut Request,
+	target: &str,
+) -> Result<(), Box<Response>> {
+	let Some(boundary) = multipart_boundary(req) else {
+		return Ok(());
+	};
+	let body = body_bytes(req).await?;
+	let Some(body) = rewrite_multipart_body_model(&body, &boundary, target).await? else {
+		return Ok(());
+	};
+	*req.body_mut() = http::Body::from(body);
+	req.headers_mut().remove(::http::header::CONTENT_LENGTH);
+	req.headers_mut().remove(::http::header::TRANSFER_ENCODING);
+	req.extensions_mut().remove::<cel::BufferedBody>();
+	Ok(())
+}
+
 async fn multipart_model(body: &Bytes, boundary: &str) -> RouterResult<String> {
 	let stream = stream::once(std::future::ready(Ok::<Bytes, multer::Error>(body.clone())));
 	let mut multipart = multer::Multipart::new(stream, boundary);
@@ -690,6 +709,117 @@ async fn multipart_model(body: &Bytes, boundary: &str) -> RouterResult<String> {
 		"LLM multipart request body is missing string field 'model'",
 		"missing_model",
 	)))
+}
+
+
+async fn rewrite_multipart_body_model(
+	body: &Bytes,
+	boundary: &str,
+	target: &str,
+) -> RouterResult<Option<Bytes>> {
+	let fields = multipart_field_ranges(body, boundary).ok_or_else(|| {
+		Box::new(llm_error_response(
+			::http::StatusCode::BAD_REQUEST,
+			"LLM multipart request body must be valid multipart/form-data",
+			"invalid_request_body",
+		))
+	})?;
+	let stream = stream::once(std::future::ready(Ok::<Bytes, multer::Error>(body.clone())));
+	let mut multipart = multer::Multipart::new(stream, boundary);
+	let mut model_ranges = Vec::new();
+	while let Some((index, field)) = multipart.next_field_with_idx().await.map_err(|err| {
+		tracing::debug!(%err, "failed to parse LLM multipart request body for model rewrite");
+		Box::new(llm_error_response(
+			::http::StatusCode::BAD_REQUEST,
+			"LLM multipart request body must be valid multipart/form-data",
+			"invalid_request_body",
+		))
+	})? {
+		if field.name() != Some("model") {
+			continue;
+		}
+		field.text().await.map_err(|err| {
+			tracing::debug!(%err, "failed to parse LLM multipart model field for rewrite");
+			Box::new(llm_error_response(
+				::http::StatusCode::BAD_REQUEST,
+				"LLM multipart request body has invalid string field 'model'",
+				"invalid_model",
+			))
+		})?;
+		model_ranges.push(fields.get(index).cloned().ok_or_else(|| {
+			Box::new(llm_error_response(
+				::http::StatusCode::BAD_REQUEST,
+				"LLM multipart request body must be valid multipart/form-data",
+				"invalid_request_body",
+			))
+		})?);
+	}
+	if model_ranges.is_empty() {
+		return Ok(None);
+	}
+	if model_ranges
+		.iter()
+		.all(|range| &body[range.clone()] == target.as_bytes())
+	{
+		return Ok(None);
+	}
+
+	let removed = model_ranges.iter().map(Range::len).sum::<usize>();
+	let mut rewritten = Vec::with_capacity(
+		body
+			.len()
+			.saturating_sub(removed)
+			.saturating_add(target.len().saturating_mul(model_ranges.len())),
+	);
+	let mut copied = 0;
+	for range in model_ranges {
+		rewritten.extend_from_slice(&body[copied..range.start]);
+		rewritten.extend_from_slice(target.as_bytes());
+		copied = range.end;
+	}
+	rewritten.extend_from_slice(&body[copied..]);
+	Ok(Some(Bytes::from(rewritten)))
+}
+
+fn multipart_field_ranges(body: &[u8], boundary: &str) -> Option<Vec<Range<usize>>> {
+	// Multer identifies field names but does not expose source offsets. Mirror its boundary
+	// framing here so model data can be spliced without reserializing files or headers.
+	let delimiter = format!("--{boundary}").into_bytes();
+	let field_delimiter = format!("\r\n--{boundary}").into_bytes();
+	let mut cursor = find_bytes(body, &delimiter)?;
+	let mut fields = Vec::new();
+
+	loop {
+		if !body.get(cursor..)?.starts_with(&delimiter) {
+			return None;
+		}
+		cursor += delimiter.len();
+		if body.get(cursor..)?.starts_with(b"--") {
+			return Some(fields);
+		}
+		while matches!(body.get(cursor), Some(b' ' | b'\t')) {
+			cursor += 1;
+		}
+		if !body.get(cursor..)?.starts_with(b"\r\n") {
+			return None;
+		}
+		cursor += 2;
+
+		let headers_end = cursor + find_bytes(body.get(cursor..)?, b"\r\n\r\n")?;
+		let field_start = headers_end + 4;
+		let field_end = field_start + find_bytes(body.get(field_start..)?, &field_delimiter)?;
+		fields.push(field_start..field_end);
+		cursor = field_end + 2;
+	}
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+	if needle.is_empty() {
+		return Some(0);
+	}
+	haystack
+		.windows(needle.len())
+		.position(|window| window == needle)
 }
 
 async fn body_bytes(req: &mut Request) -> RouterResult<Bytes> {
@@ -1047,6 +1177,123 @@ mod tests {
 			req.uri().to_string(),
 			"http://example.com/model/real%2Fmodel/converse?trace=true"
 		);
+	}
+
+
+	#[tokio::test]
+	async fn rewrite_multipart_body_model_preserves_non_model_bytes() {
+		let body = Bytes::from_static(
+			concat!(
+				"--audio-boundary\r\n",
+				"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
+				"Content-Type: audio/wav\r\n",
+				"\r\n",
+				"audio--audio-boundary-public-model-bytes\r\n",
+				"--audio-boundary\r\n",
+				"Content-Disposition: form-data; name=\"model\"\r\n",
+				"\r\n",
+				"public-model\r\n",
+				"--audio-boundary\r\n",
+				"Content-Disposition: form-data; name=\"model\"\r\n",
+				"X-Field-Metadata: preserved\r\n",
+				"\r\n",
+				"stale-duplicate\r\n",
+				"--audio-boundary--\r\n",
+			)
+			.as_bytes(),
+		);
+		let expected = Bytes::from_static(
+			concat!(
+				"--audio-boundary\r\n",
+				"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
+				"Content-Type: audio/wav\r\n",
+				"\r\n",
+				"audio--audio-boundary-public-model-bytes\r\n",
+				"--audio-boundary\r\n",
+				"Content-Disposition: form-data; name=\"model\"\r\n",
+				"\r\n",
+				"upstream-model\r\n",
+				"--audio-boundary\r\n",
+				"Content-Disposition: form-data; name=\"model\"\r\n",
+				"X-Field-Metadata: preserved\r\n",
+				"\r\n",
+				"upstream-model\r\n",
+				"--audio-boundary--\r\n",
+			)
+			.as_bytes(),
+		);
+
+		let rewritten = rewrite_multipart_body_model(&body, "audio-boundary", "upstream-model")
+			.await
+			.expect("multipart body should parse")
+			.expect("model fields should change");
+		assert_eq!(rewritten, expected);
+	}
+
+	#[tokio::test]
+	async fn rewrite_multipart_request_model_clears_stale_body_metadata() {
+		let body = Bytes::from_static(
+			concat!(
+				"--quoted-boundary\r\n",
+				"Content-Disposition: form-data; name=\"model\"\r\n",
+				"\r\n",
+				"short\r\n",
+				"--quoted-boundary--\r\n",
+			)
+			.as_bytes(),
+		);
+		let mut req = ::http::Request::builder()
+			.uri("http://example.com/v1/audio/transcriptions")
+			.header(
+				::http::header::CONTENT_TYPE,
+				"multipart/form-data; boundary=\"quoted-boundary\"",
+			)
+			.header(::http::header::CONTENT_LENGTH, body.len())
+			.header(::http::header::TRANSFER_ENCODING, "chunked")
+			.body(http::Body::from(body.clone()))
+			.expect("valid request");
+		req
+			.extensions_mut()
+			.insert(cel::BufferedBody::complete(body));
+
+		rewrite_multipart_request_model(&mut req, "a-much-longer-model")
+			.await
+			.expect("multipart model rewrite");
+
+		assert!(!req.headers().contains_key(::http::header::CONTENT_LENGTH));
+		assert!(
+			!req
+				.headers()
+				.contains_key(::http::header::TRANSFER_ENCODING)
+		);
+		assert!(req.extensions().get::<cel::BufferedBody>().is_none());
+		let rewritten = http::read_body_with_limit(req.into_body(), 1024)
+			.await
+			.expect("rewritten request body");
+		assert!(
+			rewritten
+				.windows(b"a-much-longer-model".len())
+				.any(|window| window == b"a-much-longer-model")
+		);
+	}
+
+	#[tokio::test]
+	async fn rewrite_multipart_body_model_without_model_is_unchanged() {
+		let body = Bytes::from_static(
+			concat!(
+				"--audio-boundary\r\n",
+				"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
+				"\r\n",
+				"audio-bytes\r\n",
+				"--audio-boundary--\r\n",
+			)
+			.as_bytes(),
+		);
+
+		let rewritten = rewrite_multipart_body_model(&body, "audio-boundary", "upstream-model")
+			.await
+			.expect("multipart body should parse");
+		assert!(rewritten.is_none());
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -711,7 +711,6 @@ async fn multipart_model(body: &Bytes, boundary: &str) -> RouterResult<String> {
 	)))
 }
 
-
 async fn rewrite_multipart_body_model(
 	body: &Bytes,
 	boundary: &str,
@@ -1178,7 +1177,6 @@ mod tests {
 			"http://example.com/model/real%2Fmodel/converse?trace=true"
 		);
 	}
-
 
 	#[tokio::test]
 	async fn rewrite_multipart_body_model_preserves_non_model_bytes() {

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -1,4 +1,3 @@
-use std::ops::Range;
 use std::sync::Arc;
 
 use agent_core::strng;
@@ -716,17 +715,12 @@ async fn rewrite_multipart_body_model(
 	boundary: &str,
 	target: &str,
 ) -> RouterResult<Option<Bytes>> {
-	let fields = multipart_field_ranges(body, boundary).ok_or_else(|| {
-		Box::new(llm_error_response(
-			::http::StatusCode::BAD_REQUEST,
-			"LLM multipart request body must be valid multipart/form-data",
-			"invalid_request_body",
-		))
-	})?;
+	// Parse once to avoid rebuilding an already-correct body. Comparing decoded text also
+	// respects a model field's declared charset.
 	let stream = stream::once(std::future::ready(Ok::<Bytes, multer::Error>(body.clone())));
 	let mut multipart = multer::Multipart::new(stream, boundary);
-	let mut model_ranges = Vec::new();
-	while let Some((index, field)) = multipart.next_field_with_idx().await.map_err(|err| {
+	let mut needs_rewrite = false;
+	while let Some(field) = multipart.next_field().await.map_err(|err| {
 		tracing::debug!(%err, "failed to parse LLM multipart request body for model rewrite");
 		Box::new(llm_error_response(
 			::http::StatusCode::BAD_REQUEST,
@@ -737,7 +731,7 @@ async fn rewrite_multipart_body_model(
 		if field.name() != Some("model") {
 			continue;
 		}
-		field.text().await.map_err(|err| {
+		let model = field.text().await.map_err(|err| {
 			tracing::debug!(%err, "failed to parse LLM multipart model field for rewrite");
 			Box::new(llm_error_response(
 				::http::StatusCode::BAD_REQUEST,
@@ -745,80 +739,73 @@ async fn rewrite_multipart_body_model(
 				"invalid_model",
 			))
 		})?;
-		model_ranges.push(fields.get(index).cloned().ok_or_else(|| {
-			Box::new(llm_error_response(
-				::http::StatusCode::BAD_REQUEST,
-				"LLM multipart request body must be valid multipart/form-data",
-				"invalid_request_body",
-			))
-		})?);
+		if model != target {
+			needs_rewrite = true;
+		}
 	}
-	if model_ranges.is_empty() {
-		return Ok(None);
-	}
-	if model_ranges
-		.iter()
-		.all(|range| &body[range.clone()] == target.as_bytes())
-	{
+	if !needs_rewrite {
 		return Ok(None);
 	}
 
-	let removed = model_ranges.iter().map(Range::len).sum::<usize>();
-	let mut rewritten = Vec::with_capacity(
-		body
-			.len()
-			.saturating_sub(removed)
-			.saturating_add(target.len().saturating_mul(model_ranges.len())),
-	);
-	let mut copied = 0;
-	for range in model_ranges {
-		rewritten.extend_from_slice(&body[copied..range.start]);
-		rewritten.extend_from_slice(target.as_bytes());
-		copied = range.end;
+	// Multer does not expose raw offsets, so rebuild the multipart envelope from the fields it
+	// parsed. File and non-model field bytes are preserved; header formatting is normalized.
+	let stream = stream::once(std::future::ready(Ok::<Bytes, multer::Error>(body.clone())));
+	let mut multipart = multer::Multipart::new(stream, boundary);
+	let mut rewritten = Vec::with_capacity(body.len());
+	while let Some(field) = multipart.next_field().await.map_err(|err| {
+		tracing::debug!(%err, "failed to parse LLM multipart request body for model rewrite");
+		Box::new(llm_error_response(
+			::http::StatusCode::BAD_REQUEST,
+			"LLM multipart request body must be valid multipart/form-data",
+			"invalid_request_body",
+		))
+	})? {
+		let is_model = field.name() == Some("model");
+		rewritten.extend_from_slice(b"--");
+		rewritten.extend_from_slice(boundary.as_bytes());
+		rewritten.extend_from_slice(b"\r\n");
+		for (name, value) in field.headers() {
+			rewritten.extend_from_slice(name.as_str().as_bytes());
+			rewritten.extend_from_slice(b": ");
+			if is_model && name == ::http::header::CONTENT_TYPE {
+				// The replacement is UTF-8 regardless of the source field's charset.
+				rewritten.extend_from_slice(b"text/plain; charset=utf-8");
+			} else if is_model && name == ::http::header::CONTENT_LENGTH {
+				rewritten.extend_from_slice(target.len().to_string().as_bytes());
+			} else {
+				rewritten.extend_from_slice(value.as_bytes());
+			}
+			rewritten.extend_from_slice(b"\r\n");
+		}
+		rewritten.extend_from_slice(b"\r\n");
+		if is_model {
+			// Consume the original field so multer validates the complete body.
+			field.bytes().await.map_err(|err| {
+				tracing::debug!(%err, "failed to read LLM multipart model field for rewrite");
+				Box::new(llm_error_response(
+					::http::StatusCode::BAD_REQUEST,
+					"LLM multipart request body must be valid multipart/form-data",
+					"invalid_request_body",
+				))
+			})?;
+			rewritten.extend_from_slice(target.as_bytes());
+		} else {
+			let data = field.bytes().await.map_err(|err| {
+				tracing::debug!(%err, "failed to read LLM multipart field for model rewrite");
+				Box::new(llm_error_response(
+					::http::StatusCode::BAD_REQUEST,
+					"LLM multipart request body must be valid multipart/form-data",
+					"invalid_request_body",
+				))
+			})?;
+			rewritten.extend_from_slice(&data);
+		}
+		rewritten.extend_from_slice(b"\r\n");
 	}
-	rewritten.extend_from_slice(&body[copied..]);
+	rewritten.extend_from_slice(b"--");
+	rewritten.extend_from_slice(boundary.as_bytes());
+	rewritten.extend_from_slice(b"--\r\n");
 	Ok(Some(Bytes::from(rewritten)))
-}
-
-fn multipart_field_ranges(body: &[u8], boundary: &str) -> Option<Vec<Range<usize>>> {
-	// Multer identifies field names but does not expose source offsets. Mirror its boundary
-	// framing here so model data can be spliced without reserializing files or headers.
-	let delimiter = format!("--{boundary}").into_bytes();
-	let field_delimiter = format!("\r\n--{boundary}").into_bytes();
-	let mut cursor = find_bytes(body, &delimiter)?;
-	let mut fields = Vec::new();
-
-	loop {
-		if !body.get(cursor..)?.starts_with(&delimiter) {
-			return None;
-		}
-		cursor += delimiter.len();
-		if body.get(cursor..)?.starts_with(b"--") {
-			return Some(fields);
-		}
-		while matches!(body.get(cursor), Some(b' ' | b'\t')) {
-			cursor += 1;
-		}
-		if !body.get(cursor..)?.starts_with(b"\r\n") {
-			return None;
-		}
-		cursor += 2;
-
-		let headers_end = cursor + find_bytes(body.get(cursor..)?, b"\r\n\r\n")?;
-		let field_start = headers_end + 4;
-		let field_end = field_start + find_bytes(body.get(field_start..)?, &field_delimiter)?;
-		fields.push(field_start..field_end);
-		cursor = field_end + 2;
-	}
-}
-
-fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-	if needle.is_empty() {
-		return Some(0);
-	}
-	haystack
-		.windows(needle.len())
-		.position(|window| window == needle)
 }
 
 async fn body_bytes(req: &mut Request) -> RouterResult<Bytes> {
@@ -1189,6 +1176,7 @@ mod tests {
 				"audio--audio-boundary-public-model-bytes\r\n",
 				"--audio-boundary\r\n",
 				"Content-Disposition: form-data; name=\"model\"\r\n",
+				"Content-Length: 12\r\n",
 				"\r\n",
 				"public-model\r\n",
 				"--audio-boundary\r\n",
@@ -1200,32 +1188,94 @@ mod tests {
 			)
 			.as_bytes(),
 		);
-		let expected = Bytes::from_static(
-			concat!(
-				"--audio-boundary\r\n",
-				"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
-				"Content-Type: audio/wav\r\n",
-				"\r\n",
-				"audio--audio-boundary-public-model-bytes\r\n",
-				"--audio-boundary\r\n",
-				"Content-Disposition: form-data; name=\"model\"\r\n",
-				"\r\n",
-				"upstream-model\r\n",
-				"--audio-boundary\r\n",
-				"Content-Disposition: form-data; name=\"model\"\r\n",
-				"X-Field-Metadata: preserved\r\n",
-				"\r\n",
-				"upstream-model\r\n",
-				"--audio-boundary--\r\n",
-			)
-			.as_bytes(),
-		);
 
 		let rewritten = rewrite_multipart_body_model(&body, "audio-boundary", "upstream-model")
 			.await
 			.expect("multipart body should parse")
 			.expect("model fields should change");
-		assert_eq!(rewritten, expected);
+		let stream = stream::once(std::future::ready(Ok::<Bytes, multer::Error>(rewritten)));
+		let mut multipart = multer::Multipart::new(stream, "audio-boundary");
+		let mut model_fields = 0;
+		while let Some(field) = multipart
+			.next_field()
+			.await
+			.expect("rewritten multipart body should parse")
+		{
+			match field.name() {
+				Some("file") => assert_eq!(
+					field
+						.bytes()
+						.await
+						.expect("file field should read")
+						.as_ref(),
+					b"audio--audio-boundary-public-model-bytes"
+				),
+				Some("model") => {
+					if model_fields == 0 {
+						assert_eq!(
+							field
+								.headers()
+								.get(::http::header::CONTENT_LENGTH)
+								.and_then(|value| value.to_str().ok()),
+							Some("14")
+						);
+					}
+					if model_fields == 1 {
+						assert_eq!(
+							field
+								.headers()
+								.get("x-field-metadata")
+								.and_then(|value| value.to_str().ok()),
+							Some("preserved")
+						);
+					}
+					assert_eq!(
+						field.text().await.expect("model field should read"),
+						"upstream-model"
+					);
+					model_fields += 1;
+				},
+				name => panic!("unexpected multipart field {name:?}"),
+			}
+		}
+		assert_eq!(model_fields, 2);
+	}
+
+	#[tokio::test]
+	async fn rewrite_multipart_body_model_normalizes_model_charset() {
+		let mut body = concat!(
+			"--charset-boundary\r\n",
+			"Content-Disposition: form-data; name=\"model\"\r\n",
+			"Content-Type: text/plain; charset=utf-16le\r\n",
+			"\r\n",
+		)
+		.as_bytes()
+		.to_vec();
+		for code_unit in "public-model".encode_utf16() {
+			body.extend_from_slice(&code_unit.to_le_bytes());
+		}
+		body.extend_from_slice(b"\r\n--charset-boundary--\r\n");
+
+		let rewritten =
+			rewrite_multipart_body_model(&Bytes::from(body), "charset-boundary", "upstream-model")
+				.await
+				.expect("multipart body should parse")
+				.expect("model field should change");
+		let stream = stream::once(std::future::ready(Ok::<Bytes, multer::Error>(rewritten)));
+		let mut multipart = multer::Multipart::new(stream, "charset-boundary");
+		let field = multipart
+			.next_field()
+			.await
+			.expect("rewritten multipart body should parse")
+			.expect("rewritten multipart body should contain a model field");
+		assert_eq!(
+			field.content_type().map(|value| value.as_ref()),
+			Some("text/plain; charset=utf-8")
+		);
+		assert_eq!(
+			field.text().await.expect("model field should read"),
+			"upstream-model"
+		);
 	}
 
 	#[tokio::test]

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2381,6 +2381,16 @@ async fn make_backend_call(
 				.as_ref()
 				.map(|policy| policy.resolve_route(req.uri().path()))
 				.unwrap_or(llm::RouteType::Completions);
+			if matches!(route_type, RouteType::Detect | RouteType::Passthrough)
+				&& let Some(provider_model) = llm.provider.override_model()
+			{
+				Box::pin(model_router::rewrite_multipart_request_model(
+					&mut req,
+					provider_model.as_str(),
+				))
+				.await
+				.map_err(ProxyResponse::DirectResponse)?;
+			}
 			trace!("llm: route {} to {route_type:?}", req.uri().path());
 			let llm_provider = llm.provider.provider().to_string();
 			dtrace::trace(|trace| {

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -755,6 +755,7 @@ impl Store {
 			"/v1/images/generations",
 			"/v1/images/edits",
 			"/v1/images/variations",
+			"/v1/audio/transcriptions",
 			"/v1/embeddings",
 			"/v1/rerank",
 			"/v2/rerank",

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -475,7 +475,7 @@ llm:
 	let io = t.serve_http(strng::literal!("bind/0"));
 	let body = multipart_audio_body("real-model");
 
-	let res = send_multipart_audio(io.clone(), body.clone()).await;	
+	let res = send_multipart_audio(io.clone(), body.clone()).await;
 	assert_eq!(res.status(), StatusCode::OK);
 	let _ = read_body_raw(res.into_body()).await;
 
@@ -489,6 +489,7 @@ llm:
 	let log = agent_core::telemetry::testing::eventually_find(&[
 		("scope", "request"),
 		("http.path", "/v1/audio/transcriptions"),
+		("gen_ai.provider.name", "openai"),
 	])
 	.await
 	.unwrap();

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -540,7 +540,7 @@ llm:
 		.await
 		.expect("request recording should be enabled");
 	assert_eq!(requests.len(), 1);
-	assert_eq!(requests[0].body, multipart_audio_body("real-model"));
+	assert_multipart_audio_body(&requests[0].body, "real-model").await;
 }
 
 #[tokio::test]
@@ -575,7 +575,7 @@ llm:
 		.await
 		.expect("request recording should be enabled");
 	assert_eq!(requests.len(), 1);
-	assert_eq!(requests[0].body, multipart_audio_body("upstream-model"));
+	assert_multipart_audio_body(&requests[0].body, "upstream-model").await;
 }
 
 #[tokio::test]
@@ -617,7 +617,7 @@ llm:
 		.await
 		.expect("request recording should be enabled");
 	assert_eq!(requests.len(), 1);
-	assert_eq!(requests[0].body, multipart_audio_body("upstream-model"));
+	assert_multipart_audio_body(&requests[0].body, "upstream-model").await;
 }
 
 #[tokio::test]
@@ -659,7 +659,7 @@ llm:
 		.await
 		.expect("request recording should be enabled");
 	assert_eq!(requests.len(), 1);
-	assert_eq!(requests[0].body, multipart_audio_body("real-model"));
+	assert_multipart_audio_body(&requests[0].body, "real-model").await;
 }
 
 #[tokio::test]
@@ -1000,6 +1000,46 @@ fn multipart_audio_body(model: &str) -> Vec<u8> {
 		model,
 	)
 	.into_bytes()
+}
+
+async fn assert_multipart_audio_body(body: &[u8], expected_model: &str) {
+	let stream = futures_util::stream::once(std::future::ready(Ok::<bytes::Bytes, multer::Error>(
+		bytes::Bytes::copy_from_slice(body),
+	)));
+	let mut multipart = multer::Multipart::new(stream, "audio-boundary");
+	let mut saw_file = false;
+	let mut saw_model = false;
+	while let Some(field) = multipart
+		.next_field()
+		.await
+		.expect("upstream multipart body should parse")
+	{
+		match field.name() {
+			Some("file") => {
+				assert_eq!(field.file_name(), Some("audio.wav"));
+				assert_eq!(field.content_type().map(|v| v.as_ref()), Some("audio/wav"));
+				assert_eq!(
+					field
+						.bytes()
+						.await
+						.expect("file field should read")
+						.as_ref(),
+					b"fake-audio-public-model-bytes"
+				);
+				saw_file = true;
+			},
+			Some("model") => {
+				assert_eq!(
+					field.text().await.expect("model field should read"),
+					expected_model
+				);
+				saw_model = true;
+			},
+			name => panic!("unexpected multipart field {name:?}"),
+		}
+	}
+	assert!(saw_file, "multipart body should include the file field");
+	assert!(saw_model, "multipart body should include the model field");
 }
 
 async fn send_multipart_audio(io: MemoryClient, body: Vec<u8>) -> Response {

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -473,29 +473,9 @@ llm:
 	);
 	let t = setup_local_llm_config(&config).await;
 	let io = t.serve_http(strng::literal!("bind/0"));
-	let body = concat!(
-		"--audio-boundary\r\n",
-		"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
-		"Content-Type: audio/wav\r\n",
-		"\r\n",
-		"fake-audio-bytes\r\n",
-		"--audio-boundary\r\n",
-		"Content-Disposition: form-data; name=\"model\"\r\n",
-		"\r\n",
-		"real-model\r\n",
-		"--audio-boundary--\r\n",
-	)
-	.as_bytes();
+	let body = multipart_audio_body("real-model");
 
-	let res = RequestBuilder::new(Method::POST, "http://lo/v1/audio/transcriptions")
-		.header(
-			header::CONTENT_TYPE,
-			"multipart/form-data; boundary=audio-boundary",
-		)
-		.body(Body::from(body.to_vec()))
-		.send(io.clone())
-		.await
-		.unwrap();
+	let res = send_multipart_audio(io.clone(), body.clone()).await;	
 	assert_eq!(res.status(), StatusCode::OK);
 	let _ = read_body_raw(res.into_body()).await;
 
@@ -519,6 +499,166 @@ llm:
 		"gen_ai.usage.output_tokens": 23
 	});
 	assert!(is_json_subset(&want, &log), "want={want:#?} got={log:#?}");
+}
+
+#[tokio::test]
+async fn llm_model_router_rewrites_multipart_virtual_model() {
+	let mock = body_mock(include_bytes!(
+		"../../../llm/src/tests/response/completions/basic.json"
+	))
+	.await;
+	let config = format!(
+		r#"
+llm:
+  port: 0
+  models:
+  - name: real-model
+    visibility: internal
+    provider: openAI
+    params:
+      baseUrl: http://{}
+    passthrough: detect
+  virtualModels:
+  - name: public-model
+    routing:
+      weighted:
+        targets:
+        - model: real-model
+"#,
+		mock.address()
+	);
+	let t = setup_local_llm_config(&config).await;
+	let io = t.serve_http(strng::literal!("bind/0"));
+
+	let res = send_multipart_audio(io, multipart_audio_body("public-model")).await;
+	assert_eq!(res.status(), StatusCode::OK);
+	let _ = read_body_raw(res.into_body()).await;
+
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(requests[0].body, multipart_audio_body("real-model"));
+}
+
+#[tokio::test]
+async fn llm_model_router_applies_provider_model_to_opaque_multipart() {
+	let mock = body_mock(include_bytes!(
+		"../../../llm/src/tests/response/completions/basic.json"
+	))
+	.await;
+	let config = format!(
+		r#"
+llm:
+  port: 0
+  models:
+  - name: public-model
+    provider: openAI
+    params:
+      baseUrl: http://{}
+      model: upstream-model
+    passthrough: opaque
+"#,
+		mock.address()
+	);
+	let t = setup_local_llm_config(&config).await;
+	let io = t.serve_http(strng::literal!("bind/0"));
+
+	let res = send_multipart_audio(io, multipart_audio_body("public-model")).await;
+	assert_eq!(res.status(), StatusCode::OK);
+	let _ = read_body_raw(res.into_body()).await;
+
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(requests[0].body, multipart_audio_body("upstream-model"));
+}
+
+#[tokio::test]
+async fn llm_model_router_prefers_provider_model_after_multipart_virtual_routing() {
+	let mock = body_mock(include_bytes!(
+		"../../../llm/src/tests/response/completions/basic.json"
+	))
+	.await;
+	let config = format!(
+		r#"
+llm:
+  port: 0
+  models:
+  - name: routed-model
+    visibility: internal
+    provider: openAI
+    params:
+      baseUrl: http://{}
+      model: upstream-model
+    passthrough: detect
+  virtualModels:
+  - name: public-model
+    routing:
+      weighted:
+        targets:
+        - model: routed-model
+"#,
+		mock.address()
+	);
+	let t = setup_local_llm_config(&config).await;
+	let io = t.serve_http(strng::literal!("bind/0"));
+
+	let res = send_multipart_audio(io, multipart_audio_body("public-model")).await;
+	assert_eq!(res.status(), StatusCode::OK);
+	let _ = read_body_raw(res.into_body()).await;
+
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(requests[0].body, multipart_audio_body("upstream-model"));
+}
+
+#[tokio::test]
+async fn llm_model_router_rewrites_failover_virtual_multipart_model() {
+	let mock = body_mock(include_bytes!(
+		"../../../llm/src/tests/response/completions/basic.json"
+	))
+	.await;
+	let config = format!(
+		r#"
+llm:
+  port: 0
+  models:
+  - name: real-model
+    visibility: internal
+    provider: openAI
+    params:
+      baseUrl: http://{}
+    passthrough: opaque
+  virtualModels:
+  - name: public-model
+    routing:
+      failover:
+        targets:
+        - model: real-model
+          priority: 0
+"#,
+		mock.address()
+	);
+	let t = setup_local_llm_config(&config).await;
+	let io = t.serve_http(strng::literal!("bind/0"));
+
+	let res = send_multipart_audio(io, multipart_audio_body("public-model")).await;
+	assert_eq!(res.status(), StatusCode::OK);
+	let _ = read_body_raw(res.into_body()).await;
+
+	let requests = mock
+		.received_requests()
+		.await
+		.expect("request recording should be enabled");
+	assert_eq!(requests.len(), 1);
+	assert_eq!(requests[0].body, multipart_audio_body("real-model"));
 }
 
 #[tokio::test]
@@ -840,6 +980,37 @@ fn completions_request_body_with_model(model: &str) -> Vec<u8> {
 		.expect("request fixture should be valid JSON");
 	body["model"] = json!(model);
 	serde_json::to_vec(&body).expect("request fixture should serialize")
+}
+
+fn multipart_audio_body(model: &str) -> Vec<u8> {
+	format!(
+		concat!(
+			"--audio-boundary\r\n",
+			"Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n",
+			"Content-Type: audio/wav\r\n",
+			"\r\n",
+			"fake-audio-public-model-bytes\r\n",
+			"--audio-boundary\r\n",
+			"Content-Disposition: form-data; name=\"model\"\r\n",
+			"\r\n",
+			"{}\r\n",
+			"--audio-boundary--\r\n",
+		),
+		model,
+	)
+	.into_bytes()
+}
+
+async fn send_multipart_audio(io: MemoryClient, body: Vec<u8>) -> Response {
+	RequestBuilder::new(Method::POST, "http://lo/v1/audio/transcriptions")
+		.header(
+			header::CONTENT_TYPE,
+			"multipart/form-data; boundary=audio-boundary",
+		)
+		.body(Body::from(body))
+		.send(io)
+		.await
+		.expect("multipart audio request")
 }
 
 async fn send_completions_with_model(


### PR DESCRIPTION
## Summary

Multipart requests can already be routed using the `model` form field, but the
resolved model was not written back to the multipart body. As a result, aliases
and virtual models were forwarded to the upstream provider without right changes.

This change:

- rewrites multipart `model` fields after virtual model resolution
- applies provider `params.model` overrides to multipart requests
- preserves file contents, multipart headers, and all non-model fields
- removes stale body metadata after rewriting
- registers `/v1/audio/transcriptions` as an implicit model-router path for
  Kubernetes configuration

The endpoint addition is intentionally limited to `/v1/audio/transcriptions`.
Other multipart endpoints can be considered separately when their routing
behavior is defined. Ref https://github.com/agentgateway/agentgateway/issues/2292.

## Testing

Added coverage for:

- weighted virtual model routing
- failover virtual model routing
- provider model overrides
- multipart file and metadata preservation
- duplicate model fields
- missing model fields
- Kubernetes implicit routing for `/v1/audio/transcriptions`

Also verified on EKS using an `AgentgatewayModel` and a capture backend:

- client model: `issue-2942-weighted`
- forwarded model: `issue-2942-upstream-model`

Fixes #2942.