### PR TITLE
feat: reload backendAuth secrets when the file changes

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -2276,16 +2276,15 @@ where
 enum BackendAuthCompat {
 	PlainKey {
 		#[cfg_attr(feature = "schema", schemars(with = "FileOrInline"))]
-		#[serde(deserialize_with = "deser_key_from_file")]
-		key: SecretString,
+		key: FileOrInline,
 	},
 	FullWithCredentials {
 		#[serde(flatten)]
 		auth: LocalBackendAuthKind,
-		credentials: Vec<crate::http::auth::BackendAuthCredential>,
+		credentials: Vec<LocalBackendAuthCredential>,
 	},
 	CredentialsOnly {
-		credentials: Vec<crate::http::auth::BackendAuthCredential>,
+		credentials: Vec<LocalBackendAuthCredential>,
 	},
 	Full(LocalBackendAuthKind),
 }
@@ -2293,7 +2292,21 @@ enum BackendAuthCompat {
 #[derive(Debug, Clone)]
 pub struct LocalBackendAuth {
 	kind: Option<LocalBackendAuthKind>,
-	credentials: Vec<crate::http::auth::BackendAuthCredential>,
+	credentials: Vec<LocalBackendAuthCredential>,
+}
+
+// Mirrors BackendAuthCredential but holds the credential unresolved, so a
+// file-backed value is loaded through the resource manager rather than at
+// deserialization time.
+/// An additional credential to inject on the backend request.
+#[apply(schema_de!)]
+#[cfg_attr(feature = "schema", schemars(rename = "BackendAuthCredential"))]
+pub struct LocalBackendAuthCredential {
+	/// Where the credential is inserted on the backend request.
+	pub location: crate::http::auth::AuthorizationLocation,
+	/// Credential value.
+	#[cfg_attr(feature = "schema", schemars(with = "FileOrInline"))]
+	pub key: FileOrInline,
 }
 
 impl LocalBackendAuth {
@@ -2305,9 +2318,10 @@ impl LocalBackendAuth {
 			Some(LocalBackendAuthKind::Passthrough { location }) => {
 				Some(BackendAuthKind::Passthrough { location })
 			},
-			Some(LocalBackendAuthKind::Key { value, location }) => {
-				Some(BackendAuthKind::Key { value, location })
-			},
+			Some(LocalBackendAuthKind::Key { value, location }) => Some(BackendAuthKind::Key {
+				value: load_secret(&value, resources).await?,
+				location,
+			}),
 			Some(LocalBackendAuthKind::Gcp(auth)) => Some(BackendAuthKind::Gcp(auth)),
 			Some(LocalBackendAuthKind::Aws(auth)) => Some(BackendAuthKind::Aws(auth)),
 			Some(LocalBackendAuthKind::Azure(auth)) => Some(BackendAuthKind::Azure(auth)),
@@ -2323,11 +2337,28 @@ impl LocalBackendAuth {
 			},
 			None => None,
 		};
-		Ok(BackendAuth {
-			kind,
-			credentials: self.credentials,
-		})
+		let mut credentials = Vec::with_capacity(self.credentials.len());
+		for credential in self.credentials {
+			credentials.push(crate::http::auth::BackendAuthCredential {
+				location: credential.location,
+				key: load_secret(&credential.key, resources).await?,
+			});
+		}
+		Ok(BackendAuth { kind, credentials })
 	}
+}
+
+/// Loads a secret through the resource manager, so a file-backed one is watched
+/// and a change to it triggers a config reload rather than being read once at
+/// parse time. Values are trimmed, matching the previous deserialize-time
+/// behaviour: a file written by `echo` or a Kubernetes Secret commonly carries a
+/// trailing newline.
+async fn load_secret(
+	value: &FileOrInline,
+	resources: &crate::resource_manager::ResourceFetcher,
+) -> anyhow::Result<SecretString> {
+	let loaded = crate::serdes::load_file_or_inline(value, resources).await?;
+	Ok(SecretString::from(loaded.trim().to_string()))
 }
 
 #[apply(schema_de!)]
@@ -2341,10 +2372,10 @@ enum LocalBackendAuthKind {
 	},
 	/// Send a configured secret value to the backend.
 	Key {
-		/// Secret value to send to the backend.
+		/// Secret value to send to the backend. File references are watched, so
+		/// rotating the file reloads it without a restart.
 		#[cfg_attr(feature = "schema", schemars(with = "FileOrInline"))]
-		#[serde(deserialize_with = "deser_key_from_file")]
-		value: SecretString,
+		value: FileOrInline,
 		/// Where to place the secret in the backend request.
 		#[serde(default, skip_serializing_if = "Option::is_none")]
 		location: Option<crate::http::auth::AuthorizationLocation>,

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -2459,3 +2459,63 @@ fn test_de_backend_auth_accepts_each_shape() {
 	assert!(credentials_only.kind.is_none());
 	assert_eq!(credentials_only.credentials.len(), 1);
 }
+
+/// A file-backed `backendAuth` key has to participate in config reloads, the
+/// same way `backendTLS` files and `jwtSign.signingKey` already do. Before this
+/// was resolved through the resource manager, the path was consumed during
+/// deserialization: the value was correct at startup and then frozen, so a
+/// rotated Kubernetes Secret was never picked up and the gateway kept
+/// presenting a retired credential until something else forced a reload.
+#[tokio::test]
+async fn backend_auth_key_file_is_a_tracked_resource() {
+	let dir = tempfile::tempdir().unwrap();
+	let token = dir.path().join("token");
+	// Trailing newline on purpose: `echo` and Kubernetes Secrets both add one,
+	// and the value must still be trimmed.
+	fs::write(&token, "first-token\n").unwrap();
+
+	let manager = crate::resource_manager::ResourceManager::new(test_client()).unwrap();
+	let resources = crate::resource_manager::ResourceFetcher::managed(manager.clone());
+	let mut changes = manager.subscribe_changes();
+
+	let yaml = format!(
+		r#"
+binds:
+- port: 3000
+  listeners:
+  - routes:
+    - backends:
+      - host: 127.0.0.1:8080
+        policies:
+          backendAuth:
+            key:
+              file: {}
+"#,
+		token.display()
+	);
+	NormalizedLocalConfig::from(
+		&test_config(),
+		&resources,
+		ListenerTarget {
+			gateway_name: "name".into(),
+			gateway_namespace: "ns".into(),
+			listener_name: None,
+			port: None,
+		},
+		&yaml,
+	)
+	.await
+	.expect("config with a file-backed backendAuth key should load");
+
+	// Mark whatever the initial fetch produced as seen, so the assertion below
+	// can only pass on a notification caused by the rewrite.
+	let _ = changes.borrow_and_update();
+
+	// Rewriting the file must reach the manager, which is what triggers a
+	// reload and re-reads the credential.
+	fs::write(&token, "second-token\n").unwrap();
+	tokio::time::timeout(std::time::Duration::from_secs(10), changes.changed())
+		.await
+		.expect("a change to the key file should notify the resource manager")
+		.expect("resource change channel should stay open");
+}

--- a/schema/config.json
+++ b/schema/config.json
@@ -3013,7 +3013,7 @@
                   "type": "object",
                   "properties": {
                     "value": {
-                      "description": "Secret value to send to the backend.",
+                      "description": "Secret value to send to the backend. File references are watched, so\nrotating the file reloads it without a restart.",
                       "$ref": "#/$defs/FileOrInline"
                     },
                     "location": {
@@ -4339,7 +4339,7 @@
               "type": "object",
               "properties": {
                 "value": {
-                  "description": "Secret value to send to the backend.",
+                  "description": "Secret value to send to the backend. File references are watched, so\nrotating the file reloads it without a restart.",
                   "$ref": "#/$defs/FileOrInline"
                 },
                 "location": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -257,7 +257,7 @@
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -592,7 +592,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -865,7 +865,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -1138,7 +1138,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -1409,7 +1409,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -1717,7 +1717,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -1990,7 +1990,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -2261,7 +2261,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -2581,7 +2581,7 @@
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -2812,7 +2812,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -3230,7 +3230,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -3513,7 +3513,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -3869,7 +3869,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -4165,7 +4165,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -4464,7 +4464,7 @@
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -4750,7 +4750,7 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -5123,7 +5123,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -5439,7 +5439,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -5854,7 +5854,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -6143,7 +6143,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -6451,7 +6451,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -6763,7 +6763,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -7036,7 +7036,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -7309,7 +7309,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -7580,7 +7580,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -7888,7 +7888,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -8161,7 +8161,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -8432,7 +8432,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -8778,7 +8778,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -9193,7 +9193,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -9482,7 +9482,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -9790,7 +9790,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -10102,7 +10102,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -10375,7 +10375,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -10648,7 +10648,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -10919,7 +10919,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -11227,7 +11227,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -11500,7 +11500,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -11771,7 +11771,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -12080,7 +12080,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -12495,7 +12495,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -12784,7 +12784,7 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -13092,7 +13092,7 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -13404,7 +13404,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -13677,7 +13677,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -13950,7 +13950,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -14221,7 +14221,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -14529,7 +14529,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -14802,7 +14802,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -15073,7 +15073,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -15420,7 +15420,7 @@
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -15737,7 +15737,7 @@
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -16033,7 +16033,7 @@
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -16332,7 +16332,7 @@
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -16618,7 +16618,7 @@
 |`binds[].listeners[].policies.extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`binds[].listeners[].policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -17006,7 +17006,7 @@
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`frontendPolicies.networkExtAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`frontendPolicies.networkExtAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -17315,7 +17315,7 @@
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`frontendPolicies.accessLog.otlp.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -17603,7 +17603,7 @@
 |`frontendPolicies.logging.otlp.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`frontendPolicies.logging.otlp.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -17887,7 +17887,7 @@
 |`frontendPolicies.tracing.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`frontendPolicies.tracing.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`frontendPolicies.tracing.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`frontendPolicies.tracing.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`frontendPolicies.tracing.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`frontendPolicies.tracing.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`frontendPolicies.tracing.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`frontendPolicies.tracing.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -18258,7 +18258,7 @@
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -18593,7 +18593,7 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -18866,7 +18866,7 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -19139,7 +19139,7 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -19410,7 +19410,7 @@
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -19718,7 +19718,7 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -19991,7 +19991,7 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -20262,7 +20262,7 @@
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -20582,7 +20582,7 @@
 |`policies[].policy.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -20813,7 +20813,7 @@
 |`policies[].policy.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -21231,7 +21231,7 @@
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -21514,7 +21514,7 @@
 |`policies[].policy.remoteRateLimit.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -21870,7 +21870,7 @@
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -22166,7 +22166,7 @@
 |`policies[].policy.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -22465,7 +22465,7 @@
 |`policies[].policy.extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -22751,7 +22751,7 @@
 |`policies[].policy.extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`policies[].policy.extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`policies[].policy.extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`policies[].policy.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`policies[].policy.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`policies[].policy.extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`policies[].policy.extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -23120,7 +23120,7 @@
 |`backends[].mcp.targets[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].mcp.targets[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].mcp.targets[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].mcp.targets[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].mcp.targets[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].mcp.targets[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -23436,7 +23436,7 @@
 |`backends[].ai.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -23851,7 +23851,7 @@
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -24140,7 +24140,7 @@
 |`backends[].ai.policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -24448,7 +24448,7 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -24760,7 +24760,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -25033,7 +25033,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -25306,7 +25306,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -25577,7 +25577,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -25885,7 +25885,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -26158,7 +26158,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -26429,7 +26429,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -26775,7 +26775,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -27190,7 +27190,7 @@
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -27479,7 +27479,7 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -27787,7 +27787,7 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -28099,7 +28099,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -28372,7 +28372,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -28645,7 +28645,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -28916,7 +28916,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -29224,7 +29224,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -29497,7 +29497,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -29768,7 +29768,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -30075,7 +30075,7 @@
 |`backends[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -30490,7 +30490,7 @@
 |`backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -30779,7 +30779,7 @@
 |`backends[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -31087,7 +31087,7 @@
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -31399,7 +31399,7 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -31672,7 +31672,7 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -31945,7 +31945,7 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -32216,7 +32216,7 @@
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -32524,7 +32524,7 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -32797,7 +32797,7 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -33068,7 +33068,7 @@
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -33458,7 +33458,7 @@
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -33793,7 +33793,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -34066,7 +34066,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -34339,7 +34339,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -34610,7 +34610,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -34918,7 +34918,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -35191,7 +35191,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -35462,7 +35462,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -35782,7 +35782,7 @@
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -36013,7 +36013,7 @@
 |`routeGroups[].routes[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -36431,7 +36431,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -36714,7 +36714,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -37070,7 +37070,7 @@
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -37366,7 +37366,7 @@
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -37665,7 +37665,7 @@
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -37951,7 +37951,7 @@
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -38324,7 +38324,7 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -38640,7 +38640,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -39055,7 +39055,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -39344,7 +39344,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -39652,7 +39652,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -39964,7 +39964,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -40237,7 +40237,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -40510,7 +40510,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -40781,7 +40781,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -41089,7 +41089,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -41362,7 +41362,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -41633,7 +41633,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -41979,7 +41979,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -42394,7 +42394,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -42683,7 +42683,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -42991,7 +42991,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -43303,7 +43303,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -43576,7 +43576,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -43849,7 +43849,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -44120,7 +44120,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -44428,7 +44428,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -44701,7 +44701,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -44972,7 +44972,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -45281,7 +45281,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -45696,7 +45696,7 @@
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -45985,7 +45985,7 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -46293,7 +46293,7 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -46605,7 +46605,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -46878,7 +46878,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -47151,7 +47151,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -47422,7 +47422,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -47730,7 +47730,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -48003,7 +48003,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -48274,7 +48274,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -48649,7 +48649,7 @@
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -48945,7 +48945,7 @@
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`gateways.*.listeners[].extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`gateways.*.listeners[].extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -49244,7 +49244,7 @@
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -49530,7 +49530,7 @@
 |`gateways.*.listeners[].extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`gateways.*.listeners[].extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`gateways.*.listeners[].extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -49945,7 +49945,7 @@
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`gateways.*.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`gateways.*.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -50241,7 +50241,7 @@
 |`gateways.*.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`gateways.*.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`gateways.*.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`gateways.*.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`gateways.*.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`gateways.*.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`gateways.*.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -50540,7 +50540,7 @@
 |`gateways.*.extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`gateways.*.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`gateways.*.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -50826,7 +50826,7 @@
 |`gateways.*.extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`gateways.*.extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`gateways.*.extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`gateways.*.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`gateways.*.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`gateways.*.extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`gateways.*.extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`gateways.*.extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -51262,7 +51262,7 @@
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -51597,7 +51597,7 @@
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -51870,7 +51870,7 @@
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -52143,7 +52143,7 @@
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -52414,7 +52414,7 @@
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -52722,7 +52722,7 @@
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -52995,7 +52995,7 @@
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -53266,7 +53266,7 @@
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -53586,7 +53586,7 @@
 |`routes[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -53817,7 +53817,7 @@
 |`routes[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -54235,7 +54235,7 @@
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -54518,7 +54518,7 @@
 |`routes[].policies.remoteRateLimit.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -54874,7 +54874,7 @@
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -55170,7 +55170,7 @@
 |`routes[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -55469,7 +55469,7 @@
 |`routes[].policies.extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -55755,7 +55755,7 @@
 |`routes[].policies.extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].policies.extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].policies.extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].policies.extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].policies.extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -56128,7 +56128,7 @@
 |`routes[].backends[].mcp.targets[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -56444,7 +56444,7 @@
 |`routes[].backends[].ai.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -56859,7 +56859,7 @@
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -57148,7 +57148,7 @@
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -57456,7 +57456,7 @@
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -57768,7 +57768,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -58041,7 +58041,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -58314,7 +58314,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -58585,7 +58585,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -58893,7 +58893,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -59166,7 +59166,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -59437,7 +59437,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -59783,7 +59783,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -60198,7 +60198,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -60487,7 +60487,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -60795,7 +60795,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -61107,7 +61107,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -61380,7 +61380,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -61653,7 +61653,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -61924,7 +61924,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -62232,7 +62232,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -62505,7 +62505,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -62776,7 +62776,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -63085,7 +63085,7 @@
 |`routes[].backends[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -63500,7 +63500,7 @@
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -63789,7 +63789,7 @@
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -64097,7 +64097,7 @@
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -64409,7 +64409,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -64682,7 +64682,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -64955,7 +64955,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -65226,7 +65226,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -65534,7 +65534,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -65807,7 +65807,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -66078,7 +66078,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -66426,7 +66426,7 @@
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -66732,7 +66732,7 @@
 |`llm.providers[].defaults.auth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.providers[].defaults.auth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.providers[].defaults.auth.key`|object|Send a configured secret value to the backend.|
-|`llm.providers[].defaults.auth.key.value`|object|Secret value to send to the backend.|
+|`llm.providers[].defaults.auth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.providers[].defaults.auth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.providers[].defaults.auth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.providers[].defaults.auth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -67144,7 +67144,7 @@
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.providers[].defaults.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.providers[].defaults.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -67449,7 +67449,7 @@
 |`llm.models[].auth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].auth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].auth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].auth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].auth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].auth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].auth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].auth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -67861,7 +67861,7 @@
 |`llm.models[].backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -68147,7 +68147,7 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -68420,7 +68420,7 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -68693,7 +68693,7 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -68964,7 +68964,7 @@
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -69272,7 +69272,7 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -69545,7 +69545,7 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -69816,7 +69816,7 @@
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -70181,7 +70181,7 @@
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -70477,7 +70477,7 @@
 |`llm.policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -70776,7 +70776,7 @@
 |`llm.policies.extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -71062,7 +71062,7 @@
 |`llm.policies.extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -71435,7 +71435,7 @@
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -71708,7 +71708,7 @@
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -71981,7 +71981,7 @@
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -72252,7 +72252,7 @@
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -72560,7 +72560,7 @@
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -72833,7 +72833,7 @@
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -73104,7 +73104,7 @@
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -73399,7 +73399,7 @@
 |`llm.policies.remoteRateLimit.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`llm.policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -73710,7 +73710,7 @@
 |`mcp.targets[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.targets[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.targets[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.targets[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.targets[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.targets[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.targets[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -74048,7 +74048,7 @@
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -74383,7 +74383,7 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -74656,7 +74656,7 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -74929,7 +74929,7 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -75200,7 +75200,7 @@
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -75508,7 +75508,7 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -75781,7 +75781,7 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -76052,7 +76052,7 @@
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -76372,7 +76372,7 @@
 |`mcp.policies.backendTunnel.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.backendTunnel.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.backendTunnel.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.backendTunnel.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.backendTunnel.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.backendTunnel.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.backendTunnel.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -76603,7 +76603,7 @@
 |`mcp.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -77021,7 +77021,7 @@
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -77304,7 +77304,7 @@
 |`mcp.policies.remoteRateLimit.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -77660,7 +77660,7 @@
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -77956,7 +77956,7 @@
 |`mcp.policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -78255,7 +78255,7 @@
 |`mcp.policies.extProc.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -78541,7 +78541,7 @@
 |`mcp.policies.extProc.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`mcp.policies.extProc.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`mcp.policies.extProc.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`mcp.policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`mcp.policies.extProc.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`mcp.policies.extProc.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.extProc.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`mcp.policies.extProc.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -78937,7 +78937,7 @@
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`ui.policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`ui.policies.extAuthz.conditional[].policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|
@@ -79233,7 +79233,7 @@
 |`ui.policies.extAuthz.policies.backendAuth.passthrough.location.cookie.name`|string|Cookie name containing the credential.|
 |`ui.policies.extAuthz.policies.backendAuth.passthrough.location.expression`|string|Read the credential from a CEL expression evaluated against the incoming request.<br>CEL expression that returns the credential string. This location can extract credentials but cannot insert them.|
 |`ui.policies.extAuthz.policies.backendAuth.key`|object|Send a configured secret value to the backend.|
-|`ui.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend.|
+|`ui.policies.extAuthz.policies.backendAuth.key.value`|object|Secret value to send to the backend. File references are watched, so<br>rotating the file reloads it without a restart.|
 |`ui.policies.extAuthz.policies.backendAuth.key.value.file`|string|Path to a file on disk to load the value from.|
 |`ui.policies.extAuthz.policies.backendAuth.key.location`|object|Where to place the secret in the backend request.|
 |`ui.policies.extAuthz.policies.backendAuth.key.location.header`|object|Read the credential from an HTTP header.|


### PR DESCRIPTION
`backendAuth.key` with a `file:` reference is read during deserialization, so the path never reaches the resource manager. This means a token rotation currently requires either a restart or a separate config change to force a reload.

`backendTLS.cert/key/root` and `jwtSign.signingKey` hold `FileOrInline` and resolve it in `try_into(resources)` instead, so they pick up a rotated file on their own — `examples/traffic-jwt-sign/README.md` documents exactly that. This extends the same behaviour to `backendAuth`, via the existing `load_file_or_inline` helper.

### Reproduction

One target with `backendAuth.key.file`, upstream echoing the `Authorization` header:

```
before: rewrite the key file, wait 35s -> old token still sent, no reload
        append a comment to the config -> new token sent
after:  rewrite the key file, wait 20s -> new token sent, config untouched
```

### Docs

The field's schema description now records the behaviour, phrased like the note in `examples/traffic-jwt-sign/README.md`. Most of the diff is `schema/config.json` and `schema/config.md` regenerated by `make generate-schema` — that one description repeats at every config path where `backendAuth.key` can appear.

### Test

`backend_auth_key_file_is_a_tracked_resource` rewrites a file-backed key and asserts the resource manager is notified. It marks the initial fetch as seen first, so it can only pass on the rewrite. Reverting `local.rs` and keeping the test makes it fail with `Elapsed(())`.

Five `deser_key_from_file` sites in `http/auth/oauth/client_auth.rs` have the same issue; left out to keep this reviewable, happy to add them.
