### PR TITLE
feat: support following proxy debug traces

### DIFF
--- a/controller/pkg/cli/proxy/trace/cmd.go
+++ b/controller/pkg/cli/proxy/trace/cmd.go
@@ -17,8 +17,7 @@ type traceFlags struct {
 	proxyAdminPort int
 	traceFile      string
 	expression     string
-	follow         bool
-	maxDuration    time.Duration
+	followDuration time.Duration
 	raw            bool
 	port           int
 	local          bool
@@ -56,7 +55,7 @@ func Command() flag.Command {
   agctl proxy trace --expression 'request.path == "/healthz"'
 
   # Follow matching requests for up to 10 minutes (JSONL includes requestId).
-  agctl proxy trace --follow --max-duration 10m --raw --expression 'request.path == "/v1/responses"'
+  agctl proxy trace --follow=10m --raw --expression 'request.path == "/v1/responses"'
   
   # Enable tracing and send a request to the gateway, with some curl arguments.
   agctl proxy trace gateway/my-gateway --raw --port 80 -- http://host/some/path -H "Authorization: Bearer sk-123"`,
@@ -82,8 +81,8 @@ func (f *traceFlags) attach(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.proxyAdminPort, "proxy-admin-port", f.proxyAdminPort, "Agentgateway admin port")
 	cmd.Flags().StringVarP(&f.traceFile, "file", "f", "", "Trace JSONL file to render, or - for stdin")
 	cmd.Flags().StringVar(&f.expression, "expression", "", "CEL expression for selecting which request to trace")
-	cmd.Flags().BoolVar(&f.follow, "follow", false, "Continue tracing matching requests until the maximum duration or interruption")
-	cmd.Flags().DurationVar(&f.maxDuration, "max-duration", defaultFollowMaxDuration, "Maximum duration for --follow (maximum 1h)")
+	cmd.Flags().DurationVar(&f.followDuration, "follow", defaultFollowMaxDuration, "Continue tracing matching requests for this duration (maximum 1h)")
+	cmd.Flags().Lookup("follow").NoOptDefVal = defaultFollowMaxDuration.String()
 	cmd.Flags().BoolVar(&f.raw, "raw", false, "Print trace events as JSONL instead of opening the TUI")
 	cmd.Flags().IntVar(&f.port, "port", 0, "Gateway listener port to use when triggering a request")
 	cmd.Flags().BoolVar(&f.local, "local", false, "Trace against a local agentgateway instance on 127.0.0.1")
@@ -100,14 +99,12 @@ func parseArgs(cmd *cobra.Command, args []string, flags *traceFlags) (string, []
 	if flags.local && len(resourceArgs) > 0 {
 		return "", nil, fmt.Errorf("--local does not accept a resource argument")
 	}
-	if flags.maxDuration < time.Millisecond {
-		return "", nil, fmt.Errorf("--max-duration must be at least 1ms")
+	follow := cmd.Flags().Changed("follow")
+	if follow && flags.followDuration < time.Millisecond {
+		return "", nil, fmt.Errorf("--follow duration must be at least 1ms")
 	}
-	if flags.maxDuration > time.Hour {
-		return "", nil, fmt.Errorf("--max-duration must not exceed 1h")
-	}
-	if !flags.follow && cmd.Flags().Changed("max-duration") {
-		return "", nil, fmt.Errorf("--max-duration requires --follow")
+	if follow && flags.followDuration > time.Hour {
+		return "", nil, fmt.Errorf("--follow duration must not exceed 1h")
 	}
 	if flags.traceFile != "" {
 		if len(resourceArgs) > 0 {
@@ -119,7 +116,7 @@ func parseArgs(cmd *cobra.Command, args []string, flags *traceFlags) (string, []
 		if flags.expression != "" {
 			return "", nil, fmt.Errorf("--file does not accept --expression")
 		}
-		if flags.follow {
+		if follow {
 			return "", nil, fmt.Errorf("--file does not accept --follow")
 		}
 		if len(requestArgs) > 0 {

--- a/controller/pkg/cli/proxy/trace/cmd.go
+++ b/controller/pkg/cli/proxy/trace/cmd.go
@@ -14,6 +14,7 @@ type traceFlags struct {
 	proxyAdminPort int
 	traceFile      string
 	expression     string
+	follow         bool
 	raw            bool
 	port           int
 	local          bool
@@ -26,7 +27,7 @@ func Command() flag.Command {
 
 	return flag.Command{
 		Use:   "trace [resource] [-- <curl args...>]",
-		Short: "Trace the next request handled by an agentgateway pod or local instance.",
+		Short: "Trace requests handled by an agentgateway pod or local instance.",
 		Long:  "Start an agentgateway debug trace, render it in a TUI or JSONL, and optionally trigger the traced request against a pod or a local instance.",
 		Example: `  agctl proxy trace
   
@@ -49,6 +50,9 @@ func Command() flag.Command {
   
   # Watch for the next request matching a CEL expression.
   agctl proxy trace --expression 'request.path == "/healthz"'
+
+  # Follow all matching requests until interrupted (JSONL includes requestId).
+  agctl proxy trace --follow --raw --expression 'request.path == "/v1/responses"'
   
   # Enable tracing and send a request to the gateway, with some curl arguments.
   agctl proxy trace gateway/my-gateway --raw --port 80 -- http://host/some/path -H "Authorization: Bearer sk-123"`,
@@ -74,6 +78,7 @@ func (f *traceFlags) attach(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.proxyAdminPort, "proxy-admin-port", f.proxyAdminPort, "Agentgateway admin port")
 	cmd.Flags().StringVarP(&f.traceFile, "file", "f", "", "Trace JSONL file to render, or - for stdin")
 	cmd.Flags().StringVar(&f.expression, "expression", "", "CEL expression for selecting which request to trace")
+	cmd.Flags().BoolVar(&f.follow, "follow", false, "Continue tracing all matching requests until interrupted")
 	cmd.Flags().BoolVar(&f.raw, "raw", false, "Print trace events as JSONL instead of opening the TUI")
 	cmd.Flags().IntVar(&f.port, "port", 0, "Gateway listener port to use when triggering a request")
 	cmd.Flags().BoolVar(&f.local, "local", false, "Trace against a local agentgateway instance on 127.0.0.1")
@@ -99,6 +104,9 @@ func parseArgs(cmd *cobra.Command, args []string, flags *traceFlags) (string, []
 		}
 		if flags.expression != "" {
 			return "", nil, fmt.Errorf("--file does not accept --expression")
+		}
+		if flags.follow {
+			return "", nil, fmt.Errorf("--file does not accept --follow")
 		}
 		if len(requestArgs) > 0 {
 			return "", nil, fmt.Errorf("--file does not accept a request URL after --")

--- a/controller/pkg/cli/proxy/trace/cmd.go
+++ b/controller/pkg/cli/proxy/trace/cmd.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -9,12 +10,15 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
 
+const defaultFollowMaxDuration = 5 * time.Second
+
 type traceFlags struct {
 	namespace      string
 	proxyAdminPort int
 	traceFile      string
 	expression     string
 	follow         bool
+	maxDuration    time.Duration
 	raw            bool
 	port           int
 	local          bool
@@ -51,8 +55,8 @@ func Command() flag.Command {
   # Watch for the next request matching a CEL expression.
   agctl proxy trace --expression 'request.path == "/healthz"'
 
-  # Follow all matching requests until interrupted (JSONL includes requestId).
-  agctl proxy trace --follow --raw --expression 'request.path == "/v1/responses"'
+  # Follow matching requests for up to 10 minutes (JSONL includes requestId).
+  agctl proxy trace --follow --max-duration 10m --raw --expression 'request.path == "/v1/responses"'
   
   # Enable tracing and send a request to the gateway, with some curl arguments.
   agctl proxy trace gateway/my-gateway --raw --port 80 -- http://host/some/path -H "Authorization: Bearer sk-123"`,
@@ -78,7 +82,8 @@ func (f *traceFlags) attach(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&f.proxyAdminPort, "proxy-admin-port", f.proxyAdminPort, "Agentgateway admin port")
 	cmd.Flags().StringVarP(&f.traceFile, "file", "f", "", "Trace JSONL file to render, or - for stdin")
 	cmd.Flags().StringVar(&f.expression, "expression", "", "CEL expression for selecting which request to trace")
-	cmd.Flags().BoolVar(&f.follow, "follow", false, "Continue tracing all matching requests until interrupted")
+	cmd.Flags().BoolVar(&f.follow, "follow", false, "Continue tracing matching requests until the maximum duration or interruption")
+	cmd.Flags().DurationVar(&f.maxDuration, "max-duration", defaultFollowMaxDuration, "Maximum duration for --follow (maximum 1h)")
 	cmd.Flags().BoolVar(&f.raw, "raw", false, "Print trace events as JSONL instead of opening the TUI")
 	cmd.Flags().IntVar(&f.port, "port", 0, "Gateway listener port to use when triggering a request")
 	cmd.Flags().BoolVar(&f.local, "local", false, "Trace against a local agentgateway instance on 127.0.0.1")
@@ -94,6 +99,15 @@ func parseArgs(cmd *cobra.Command, args []string, flags *traceFlags) (string, []
 	}
 	if flags.local && len(resourceArgs) > 0 {
 		return "", nil, fmt.Errorf("--local does not accept a resource argument")
+	}
+	if flags.maxDuration < time.Millisecond {
+		return "", nil, fmt.Errorf("--max-duration must be at least 1ms")
+	}
+	if flags.maxDuration > time.Hour {
+		return "", nil, fmt.Errorf("--max-duration must not exceed 1h")
+	}
+	if !flags.follow && cmd.Flags().Changed("max-duration") {
+		return "", nil, fmt.Errorf("--max-duration requires --follow")
 	}
 	if flags.traceFile != "" {
 		if len(resourceArgs) > 0 {

--- a/controller/pkg/cli/proxy/trace/trace.go
+++ b/controller/pkg/cli/proxy/trace/trace.go
@@ -17,7 +17,6 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -155,8 +154,9 @@ func run(cmd *cobra.Command, flags *traceFlags, resourceArg string, requestArgs 
 		}
 		return runTUI(cmd, target, body, nil, 0)
 	}
-	if flags.follow {
-		writeFollowWarning(cmd, flags.maxDuration)
+	follow := cmd.Flags().Changed("follow")
+	if follow {
+		writeFollowWarning(cmd, flags.followDuration)
 	}
 
 	var (
@@ -178,7 +178,7 @@ func run(cmd *cobra.Command, flags *traceFlags, resourceArg string, requestArgs 
 	}
 	defer closeAdmin()
 
-	traceResp, err := openTraceStream(cmd.Context(), adminAddress, flags.expression, flags.follow, flags.maxDuration)
+	traceResp, err := openTraceStream(cmd.Context(), adminAddress, flags.expression, follow, flags.followDuration)
 	if err != nil {
 		return err
 	}
@@ -277,8 +277,7 @@ func traceStreamURL(adminAddress, expression string, follow bool, maxDuration ti
 	}
 	if follow {
 		q := u.Query()
-		q.Set("follow", "true")
-		q.Set("maxDurationMs", strconv.FormatInt(maxDuration.Milliseconds(), 10))
+		q.Set("follow", maxDuration.String())
 		u.RawQuery = q.Encode()
 	}
 	return u.String()

--- a/controller/pkg/cli/proxy/trace/trace.go
+++ b/controller/pkg/cli/proxy/trace/trace.go
@@ -17,6 +17,7 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -154,6 +155,9 @@ func run(cmd *cobra.Command, flags *traceFlags, resourceArg string, requestArgs 
 		}
 		return runTUI(cmd, target, body, nil, 0)
 	}
+	if flags.follow {
+		writeFollowWarning(cmd, flags.maxDuration)
+	}
 
 	var (
 		target *traceTarget
@@ -174,7 +178,7 @@ func run(cmd *cobra.Command, flags *traceFlags, resourceArg string, requestArgs 
 	}
 	defer closeAdmin()
 
-	traceResp, err := openTraceStream(cmd.Context(), adminAddress, flags.expression, flags.follow)
+	traceResp, err := openTraceStream(cmd.Context(), adminAddress, flags.expression, flags.follow, flags.maxDuration)
 	if err != nil {
 		return err
 	}
@@ -184,6 +188,14 @@ func run(cmd *cobra.Command, flags *traceFlags, resourceArg string, requestArgs 
 		return runRaw(cmd, target, traceResp.Body, requestArgs, flags.port)
 	}
 	return runTUI(cmd, target, traceResp.Body, requestArgs, flags.port)
+}
+
+func writeFollowWarning(cmd *cobra.Command, maxDuration time.Duration) {
+	fmt.Fprintf(
+		cmd.ErrOrStderr(),
+		"Warning: --follow continuously traces matching requests and may impact gateway performance; tracing will stop after %s.\n",
+		maxDuration,
+	)
 }
 
 type traceTarget struct {
@@ -252,7 +264,7 @@ func traceAdminAddress(target *traceTarget, adminPort int) (string, func(), erro
 	return adminForwarder.Address(), adminForwarder.Close, nil
 }
 
-func traceStreamURL(adminAddress, expression string, follow bool) string {
+func traceStreamURL(adminAddress, expression string, follow bool, maxDuration time.Duration) string {
 	u := url.URL{
 		Scheme: "http",
 		Host:   adminAddress,
@@ -266,13 +278,14 @@ func traceStreamURL(adminAddress, expression string, follow bool) string {
 	if follow {
 		q := u.Query()
 		q.Set("follow", "true")
+		q.Set("maxDurationMs", strconv.FormatInt(maxDuration.Milliseconds(), 10))
 		u.RawQuery = q.Encode()
 	}
 	return u.String()
 }
 
-func openTraceStream(ctx context.Context, adminAddress, expression string, follow bool) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, traceStreamURL(adminAddress, expression, follow), nil)
+func openTraceStream(ctx context.Context, adminAddress, expression string, follow bool, maxDuration time.Duration) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, traceStreamURL(adminAddress, expression, follow, maxDuration), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct trace request: %w", err)
 	}

--- a/controller/pkg/cli/proxy/trace/trace.go
+++ b/controller/pkg/cli/proxy/trace/trace.go
@@ -53,6 +53,7 @@ var (
 )
 
 type traceEnvelope struct {
+	RequestID  uint64     `json:"requestId"`
 	EventStart *uint64    `json:"eventStart"`
 	EventEnd   uint64     `json:"eventEnd"`
 	Severity   string     `json:"severity"`
@@ -173,7 +174,7 @@ func run(cmd *cobra.Command, flags *traceFlags, resourceArg string, requestArgs 
 	}
 	defer closeAdmin()
 
-	traceResp, err := openTraceStream(cmd.Context(), adminAddress, flags.expression)
+	traceResp, err := openTraceStream(cmd.Context(), adminAddress, flags.expression, flags.follow)
 	if err != nil {
 		return err
 	}
@@ -251,7 +252,7 @@ func traceAdminAddress(target *traceTarget, adminPort int) (string, func(), erro
 	return adminForwarder.Address(), adminForwarder.Close, nil
 }
 
-func traceStreamURL(adminAddress, expression string) string {
+func traceStreamURL(adminAddress, expression string, follow bool) string {
 	u := url.URL{
 		Scheme: "http",
 		Host:   adminAddress,
@@ -262,11 +263,16 @@ func traceStreamURL(adminAddress, expression string) string {
 		q.Set("expression", expression)
 		u.RawQuery = q.Encode()
 	}
+	if follow {
+		q := u.Query()
+		q.Set("follow", "true")
+		u.RawQuery = q.Encode()
+	}
 	return u.String()
 }
 
-func openTraceStream(ctx context.Context, adminAddress, expression string) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, traceStreamURL(adminAddress, expression), nil)
+func openTraceStream(ctx context.Context, adminAddress, expression string, follow bool) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, traceStreamURL(adminAddress, expression, follow), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct trace request: %w", err)
 	}
@@ -609,23 +615,28 @@ func consumeTrace(body io.Reader, readErrorsAsEvents bool, onEvent func(raw stri
 }
 
 func streamTraceRows(body io.Reader, onRow func(traceRow)) error {
-	var currentSnapshot json.RawMessage
-	var previousSnapshot json.RawMessage
+	type snapshotState struct {
+		current  json.RawMessage
+		previous json.RawMessage
+	}
+	states := map[uint64]snapshotState{}
 
 	return consumeTrace(body, true, func(raw string, envelope traceEnvelope) error {
+		state := states[envelope.RequestID]
 		row := traceRow{
 			RawJSON:          raw,
 			Envelope:         envelope,
 			Summary:          summarizeEnvelope(envelope),
-			CurrentSnapshot:  currentSnapshot,
-			PreviousSnapshot: previousSnapshot,
+			CurrentSnapshot:  state.current,
+			PreviousSnapshot: state.previous,
 		}
 
 		if snapshot := eventSnapshot(envelope.Message); len(snapshot) > 0 {
 			row.CurrentSnapshot = cloneRaw(snapshot)
-			row.PreviousSnapshot = cloneRaw(currentSnapshot)
-			previousSnapshot = cloneRaw(currentSnapshot)
-			currentSnapshot = cloneRaw(snapshot)
+			row.PreviousSnapshot = cloneRaw(state.current)
+			state.previous = cloneRaw(state.current)
+			state.current = cloneRaw(snapshot)
+			states[envelope.RequestID] = state
 		}
 
 		onRow(row)
@@ -1373,7 +1384,7 @@ func (m *traceModel) root() tview.Primitive {
 }
 
 func (m *traceModel) setHeader() {
-	headers := []string{"#", "Type", "Summary"}
+	headers := []string{"#", "Request", "Type", "Summary"}
 	for col, header := range headers {
 		m.table.SetCell(
 			0,
@@ -1395,6 +1406,7 @@ func (m *traceModel) addRow(row traceRow) {
 	textColor := traceSeverityColor(row.Envelope.Severity)
 	for col, text := range []string{
 		fmt.Sprintf("%d", rowIndex+1),
+		fmt.Sprintf("%d", row.Envelope.RequestID),
 		displayEventType(row.Envelope.Message.Type),
 		row.Summary,
 	} {

--- a/controller/pkg/cli/proxy/trace/trace_test.go
+++ b/controller/pkg/cli/proxy/trace/trace_test.go
@@ -227,9 +227,40 @@ func TestTraceStreamURLEncodesExpression(t *testing.T) {
 
 func TestTraceStreamURLIncludesFollowDuration(t *testing.T) {
 	got := traceStreamURL("127.0.0.1:15000", "", true, 10*time.Minute)
-	want := "http://127.0.0.1:15000/debug/trace?follow=true&maxDurationMs=600000"
+	want := "http://127.0.0.1:15000/debug/trace?follow=10m0s"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFollowOptionalDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want time.Duration
+	}{
+		{name: "default", args: []string{"--follow"}, want: defaultFollowMaxDuration},
+		{name: "explicit", args: []string{"--follow=10m"}, want: 10 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags := &traceFlags{proxyAdminPort: 15000}
+			cmd := &cobra.Command{}
+			flags.attach(cmd)
+			if err := cmd.ParseFlags(tt.args); err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := parseArgs(cmd, cmd.Flags().Args(), flags); err != nil {
+				t.Fatal(err)
+			}
+			if !cmd.Flags().Changed("follow") {
+				t.Fatal("follow flag was not marked as changed")
+			}
+			if flags.followDuration != tt.want {
+				t.Fatalf("got %s, want %s", flags.followDuration, tt.want)
+			}
+		})
 	}
 }
 

--- a/controller/pkg/cli/proxy/trace/trace_test.go
+++ b/controller/pkg/cli/proxy/trace/trace_test.go
@@ -217,7 +217,7 @@ func TestSummarizeFrontendPolicySelection(t *testing.T) {
 }
 
 func TestTraceStreamURLEncodesExpression(t *testing.T) {
-	got := traceStreamURL("127.0.0.1:15000", `request.path == "/healthz"`)
+	got := traceStreamURL("127.0.0.1:15000", `request.path == "/healthz"`, false)
 	want := "http://127.0.0.1:15000/debug/trace?expression=request.path+%3D%3D+%22%2Fhealthz%22"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)

--- a/controller/pkg/cli/proxy/trace/trace_test.go
+++ b/controller/pkg/cli/proxy/trace/trace_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 	"testing/iotest"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -217,8 +218,16 @@ func TestSummarizeFrontendPolicySelection(t *testing.T) {
 }
 
 func TestTraceStreamURLEncodesExpression(t *testing.T) {
-	got := traceStreamURL("127.0.0.1:15000", `request.path == "/healthz"`, false)
+	got := traceStreamURL("127.0.0.1:15000", `request.path == "/healthz"`, false, defaultFollowMaxDuration)
 	want := "http://127.0.0.1:15000/debug/trace?expression=request.path+%3D%3D+%22%2Fhealthz%22"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestTraceStreamURLIncludesFollowDuration(t *testing.T) {
+	got := traceStreamURL("127.0.0.1:15000", "", true, 10*time.Minute)
+	want := "http://127.0.0.1:15000/debug/trace?follow=true&maxDurationMs=600000"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}

--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -353,6 +353,10 @@ pub async fn handle_debug_trace(req: Request) -> Response {
 			.find(|(key, _)| key == "expression")
 			.map(|(_, value)| value.into_owned())
 	});
+	let follow = req.uri().query().is_some_and(|query| {
+		url::form_urlencoded::parse(query.as_bytes())
+			.any(|(key, value)| key == "follow" && value == "true")
+	});
 	let expression = match expression {
 		Some(expression) => match crate::cel::Expression::new_strict(&expression) {
 			Ok(expression) => Some(expression),
@@ -365,7 +369,11 @@ pub async fn handle_debug_trace(req: Request) -> Response {
 		},
 		None => None,
 	};
-	let rx = crate::proxy::dtrace::track_expression(expression);
+	let rx = if follow {
+		crate::proxy::dtrace::track_expression_follow(expression)
+	} else {
+		crate::proxy::dtrace::track_expression(expression)
+	};
 	let sse_stream = trace_sse_stream(rx);
 	::http::Response::builder()
 		.status(hyper::StatusCode::OK)

--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -41,6 +41,8 @@ const PPROF_DEFAULT_SECONDS: u64 = 10;
 const PPROF_MIN_SECONDS: u64 = 1;
 #[cfg(target_os = "linux")]
 const PPROF_MAX_SECONDS: u64 = 300;
+const TRACE_FOLLOW_DEFAULT_DURATION: Duration = Duration::from_secs(5);
+const TRACE_FOLLOW_MAX_DURATION: Duration = Duration::from_secs(60 * 60);
 // Default matches Go's CPU profiler. Higher rates severely under-report on a
 // multi-core-busy process: SIGPROF is non-queuing, so expirations coalesce, and
 // pprof-rs's handler serializes all threads through one lock and drops samples
@@ -348,15 +350,44 @@ async fn handle_server_shutdown(AxumState(state): AxumState<Arc<AdminState>>) ->
 }
 
 pub async fn handle_debug_trace(req: Request) -> Response {
-	let expression = req.uri().query().and_then(|query| {
-		url::form_urlencoded::parse(query.as_bytes())
-			.find(|(key, _)| key == "expression")
-			.map(|(_, value)| value.into_owned())
-	});
-	let follow = req.uri().query().is_some_and(|query| {
-		url::form_urlencoded::parse(query.as_bytes())
-			.any(|(key, value)| key == "follow" && value == "true")
-	});
+	let query: HashMap<String, String> = req
+		.uri()
+		.query()
+		.map(|query| {
+			url::form_urlencoded::parse(query.as_bytes())
+				.into_owned()
+				.collect()
+		})
+		.unwrap_or_default();
+	let expression = query.get("expression").cloned();
+	let follow = query.get("follow").is_some_and(|value| value == "true");
+	let max_duration_ms = query.get("maxDurationMs").cloned();
+	let requested_max_duration = match max_duration_ms {
+		Some(value) => match value.parse::<u64>() {
+			Ok(0) | Err(_) => {
+				return plaintext_response(
+					hyper::StatusCode::BAD_REQUEST,
+					"maxDurationMs must be a positive integer\n".into(),
+				);
+			},
+			Ok(value) => Some(Duration::from_millis(value)),
+		},
+		None => None,
+	};
+	if requested_max_duration.is_some() && !follow {
+		return plaintext_response(
+			hyper::StatusCode::BAD_REQUEST,
+			"maxDurationMs requires follow=true\n".into(),
+		);
+	}
+	let max_duration =
+		follow.then(|| requested_max_duration.unwrap_or(TRACE_FOLLOW_DEFAULT_DURATION));
+	if max_duration.is_some_and(|duration| duration > TRACE_FOLLOW_MAX_DURATION) {
+		return plaintext_response(
+			hyper::StatusCode::BAD_REQUEST,
+			"maxDurationMs must not exceed 3600000\n".into(),
+		);
+	}
 	let expression = match expression {
 		Some(expression) => match crate::cel::Expression::new_strict(&expression) {
 			Ok(expression) => Some(expression),
@@ -375,11 +406,17 @@ pub async fn handle_debug_trace(req: Request) -> Response {
 		crate::proxy::dtrace::track_expression(expression)
 	};
 	let sse_stream = trace_sse_stream(rx);
+	let body = match max_duration {
+		Some(max_duration) => {
+			crate::http::Body::from_stream(sse_stream.take_until(time::sleep(max_duration)))
+		},
+		None => crate::http::Body::from_stream(sse_stream),
+	};
 	::http::Response::builder()
 		.status(hyper::StatusCode::OK)
 		.header("Content-Type", "text/event-stream")
 		.header("Cache-Control", "no-cache")
-		.body(crate::http::Body::from_stream(sse_stream))
+		.body(body)
 		.expect("builder with known status code should not fail")
 }
 

--- a/crates/agentgateway/src/management/admin.rs
+++ b/crates/agentgateway/src/management/admin.rs
@@ -360,34 +360,12 @@ pub async fn handle_debug_trace(req: Request) -> Response {
 		})
 		.unwrap_or_default();
 	let expression = query.get("expression").cloned();
-	let follow = query.get("follow").is_some_and(|value| value == "true");
-	let max_duration_ms = query.get("maxDurationMs").cloned();
-	let requested_max_duration = match max_duration_ms {
-		Some(value) => match value.parse::<u64>() {
-			Ok(0) | Err(_) => {
-				return plaintext_response(
-					hyper::StatusCode::BAD_REQUEST,
-					"maxDurationMs must be a positive integer\n".into(),
-				);
-			},
-			Ok(value) => Some(Duration::from_millis(value)),
+	let max_duration = match parse_trace_follow_duration(query.get("follow").map(String::as_str)) {
+		Ok(duration) => duration,
+		Err(message) => {
+			return plaintext_response(hyper::StatusCode::BAD_REQUEST, message.into());
 		},
-		None => None,
 	};
-	if requested_max_duration.is_some() && !follow {
-		return plaintext_response(
-			hyper::StatusCode::BAD_REQUEST,
-			"maxDurationMs requires follow=true\n".into(),
-		);
-	}
-	let max_duration =
-		follow.then(|| requested_max_duration.unwrap_or(TRACE_FOLLOW_DEFAULT_DURATION));
-	if max_duration.is_some_and(|duration| duration > TRACE_FOLLOW_MAX_DURATION) {
-		return plaintext_response(
-			hyper::StatusCode::BAD_REQUEST,
-			"maxDurationMs must not exceed 3600000\n".into(),
-		);
-	}
 	let expression = match expression {
 		Some(expression) => match crate::cel::Expression::new_strict(&expression) {
 			Ok(expression) => Some(expression),
@@ -400,7 +378,7 @@ pub async fn handle_debug_trace(req: Request) -> Response {
 		},
 		None => None,
 	};
-	let rx = if follow {
+	let rx = if max_duration.is_some() {
 		crate::proxy::dtrace::track_expression_follow(expression)
 	} else {
 		crate::proxy::dtrace::track_expression(expression)
@@ -418,6 +396,24 @@ pub async fn handle_debug_trace(req: Request) -> Response {
 		.header("Cache-Control", "no-cache")
 		.body(body)
 		.expect("builder with known status code should not fail")
+}
+
+fn parse_trace_follow_duration(value: Option<&str>) -> Result<Option<Duration>, &'static str> {
+	match value {
+		None | Some("false") => Ok(None),
+		Some("") | Some("true") => Ok(Some(TRACE_FOLLOW_DEFAULT_DURATION)),
+		Some(value) => {
+			let duration = agent_core::durfmt::parse(value)
+				.map_err(|_| "follow must be empty, true, false, or a valid duration\n")?;
+			if duration < Duration::from_millis(1) {
+				return Err("follow duration must be at least 1ms\n");
+			}
+			if duration > TRACE_FOLLOW_MAX_DURATION {
+				return Err("follow duration must not exceed 1h\n");
+			}
+			Ok(Some(duration))
+		},
+	}
 }
 
 fn trace_sse_stream(

--- a/crates/agentgateway/src/proxy/dtrace.rs
+++ b/crates/agentgateway/src/proxy/dtrace.rs
@@ -247,6 +247,8 @@ use crate::http::{Body, DropBody, RecordedBody, RecordedBodyHandle};
 #[allow(non_snake_case)]
 #[serde(rename_all = "camelCase")]
 pub struct Message {
+	#[serde(rename = "requestId")]
+	request_id: u64,
 	// Relative time from start, in us
 	event_start: Option<u64>,
 	event_end: u64,
@@ -471,6 +473,7 @@ fn cel_severity(result: &Value) -> Severity {
 #[derive(Clone, Debug)]
 pub struct DebugTracer {
 	sender: tokio::sync::mpsc::Sender<Message>,
+	request_id: u64,
 	start: Instant,
 	scope_state: Arc<Mutex<ScopeState>>,
 }
@@ -484,10 +487,12 @@ struct Watcher {
 	id: u64,
 	expression: Option<Expression>,
 	sender: Sender<Message>,
+	follow: bool,
 }
 
 static HAS_WATCHERS: AtomicBool = AtomicBool::new(false);
 static NEXT_WATCHER_ID: AtomicU64 = AtomicU64::new(0);
+static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 static WATCHERS: Mutex<Vec<Watcher>> = Mutex::new(Vec::new());
 
 pub struct TraceReceiver {
@@ -524,6 +529,14 @@ impl Drop for TraceReceiver {
 }
 
 pub fn track_expression(expression: Option<Expression>) -> TraceReceiver {
+	track_expression_mode(expression, false)
+}
+
+pub fn track_expression_follow(expression: Option<Expression>) -> TraceReceiver {
+	track_expression_mode(expression, true)
+}
+
+fn track_expression_mode(expression: Option<Expression>, follow: bool) -> TraceReceiver {
 	let (tx, rx) = tokio::sync::mpsc::channel(32);
 	let id = NEXT_WATCHER_ID.fetch_add(1, Ordering::Relaxed);
 	let Ok(mut watchers) = WATCHERS.lock() else {
@@ -533,6 +546,7 @@ pub fn track_expression(expression: Option<Expression>) -> TraceReceiver {
 		id,
 		expression,
 		sender: tx,
+		follow,
 	});
 	HAS_WATCHERS.store(true, Ordering::Release);
 	TraceReceiver { id, receiver: rx }
@@ -549,7 +563,7 @@ fn remove_pending_watcher(id: u64) {
 	}
 }
 
-fn take_sender(req: &Request) -> Option<Sender<Message>> {
+fn take_sender(req: &Request) -> Option<(Sender<Message>, u64)> {
 	if !HAS_WATCHERS.load(Ordering::Acquire) {
 		return None;
 	}
@@ -569,11 +583,15 @@ fn take_sender(req: &Request) -> Option<Sender<Message>> {
 			Some(expression) => executor.eval_bool(expression),
 			None => true,
 		})?;
-	let sender = watchers.remove(index).sender;
+	let sender = if watchers[index].follow {
+		watchers[index].sender.clone()
+	} else {
+		watchers.remove(index).sender
+	};
 	if watchers.is_empty() {
 		HAS_WATCHERS.store(false, Ordering::Release);
 	}
-	Some(sender)
+	Some((sender, NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed)))
 }
 
 impl DebugTracer {
@@ -582,11 +600,12 @@ impl DebugTracer {
 		F: FnOnce(Request) -> Fut,
 		Fut: Future,
 	{
-		let Some(tx) = take_sender(&req) else {
+		let Some((tx, request_id)) = take_sender(&req) else {
 			return f(req).await;
 		};
 		let ins = DebugTracer {
 			sender: tx,
+			request_id,
 			start: Instant::now(),
 			scope_state: Arc::new(Mutex::new(ScopeState { stack: Vec::new() })),
 		};
@@ -599,6 +618,7 @@ impl DebugTracer {
 		let scope_state = self.scope_state.lock().expect("scope mutex poisoned");
 		Self {
 			sender: self.sender.clone(),
+			request_id: self.request_id,
 			start: self.start,
 			scope_state: Arc::new(Mutex::new(ScopeState {
 				stack: scope_state.stack.clone(),
@@ -639,6 +659,7 @@ impl DebugTracer {
 	) {
 		// If the client is disconnected or full then we just drop the events.
 		let _ = self.sender.try_send(Message {
+			request_id: self.request_id,
 			event_start: start.map(|s| u64::try_from((s - self.start).as_micros()).unwrap_or(u64::MAX)),
 			event_end: u64::try_from((end - self.start).as_micros()).unwrap_or(u64::MAX),
 			severity,
@@ -810,6 +831,7 @@ mod tests {
 		let (tx, mut rx) = tokio::sync::mpsc::channel(2);
 		let tracer = DebugTracer {
 			sender: tx,
+			request_id: 1,
 			start: Instant::now(),
 			scope_state: Arc::new(Mutex::new(ScopeState { stack: Vec::new() })),
 		};
@@ -875,10 +897,33 @@ mod tests {
 	}
 
 	#[tokio::test]
+	async fn follow_trace_captures_multiple_requests_with_distinct_ids() {
+		const PATH: &str = "/follow-trace-multiple";
+		let mut trace_rx = track_expression_follow(Some(
+			Expression::new_strict(format!("request.path == '{PATH}'")).unwrap(),
+		));
+		for _ in 0..2 {
+			let req = http::Request::builder()
+				.uri(format!("http://example.com{PATH}"))
+				.body(Body::empty())
+				.unwrap();
+			DebugTracer::maybe_scope(req, |req| async move {
+				let _ = req;
+				trace(|tracer| tracer.request_started());
+			})
+			.await;
+		}
+		let first = trace_rx.recv().await.unwrap();
+		let second = trace_rx.recv().await.unwrap();
+		assert_ne!(first.request_id, second.request_id);
+	}
+
+	#[tokio::test]
 	async fn cel_eval_emits_events_with_captured_debug_tracer() {
 		let (tx, mut rx) = tokio::sync::mpsc::channel(1);
 		let tracer = DebugTracer {
 			sender: tx,
+			request_id: 1,
 			start: Instant::now(),
 			scope_state: Arc::new(Mutex::new(ScopeState { stack: Vec::new() })),
 		};


### PR DESCRIPTION
## Summary

- Add `--follow` support to `agctl proxy trace`
- Keep the server-side trace watcher active for multiple matching requests
- Add `requestId` to trace events to distinguish concurrent requests
- Display request IDs in the TUI and isolate snapshot state per request
- Preserve the existing one-shot behavior when `--follow` is not specified