### PR TITLE
api keys: reserve agentgateway.dev/ metadata prefix

### DIFF
--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -325,14 +325,37 @@ pub(crate) const MCP_SETTINGS_FIELDS: [&str; 5] = [
 	"failureMode",
 ];
 
+const API_KEY_METADATA_PREFIX: &str = "agentgateway.dev/";
+const API_KEY_ID_METADATA: &str = "agentgateway.dev/id";
+const API_KEY_CREATED_AT_METADATA: &str = "agentgateway.dev/createdAt";
+
 /// Older file keys have no stored ID, so expose their array position to the resource API.
 fn file_api_key_id(value: &Value, index: usize) -> String {
-	value
-		.pointer("/metadata/id")
+	api_key_metadata(value)
+		.and_then(|metadata| metadata.get(API_KEY_ID_METADATA))
 		.and_then(Value::as_str)
 		.filter(|id| !id.is_empty())
 		.map(ToString::to_string)
 		.unwrap_or_else(|| format!("@index:{index}"))
+}
+
+fn api_key_metadata(value: &Value) -> Option<&serde_json::Map<String, Value>> {
+	value.get("metadata").and_then(Value::as_object)
+}
+
+pub(crate) fn file_api_key_created_at(config: &Value, id: &str) -> Option<i64> {
+	crate::json::traverse(config, &["llm", "policies", "apiKey", "keys"])
+		.and_then(Value::as_array)?
+		.iter()
+		.enumerate()
+		.find(|(index, value)| file_api_key_id(value, *index) == id)
+		.and_then(|(_, value)| api_key_created_at(value))
+}
+
+pub(crate) fn api_key_created_at(value: &Value) -> Option<i64> {
+	api_key_metadata(value)?
+		.get(API_KEY_CREATED_AT_METADATA)?
+		.as_i64()
 }
 
 /// Direct mappings from a resource kind to its native YAML collection.
@@ -691,11 +714,12 @@ fn delete_file_model_catalog(config: &mut Value) -> anyhow::Result<bool> {
 pub(crate) fn prepare_file_api_key_update(
 	id: String,
 	mut value: Value,
+	created_at: Option<i64>,
 ) -> anyhow::Result<PreparedResource> {
 	validate_id(&id)?;
-	ensure_no_api_key_id(&value)?;
+	validate_api_key_metadata(&value)?;
 	if !id.starts_with("@index:") {
-		set_api_key_id(&mut value, id.clone())?;
+		set_api_key_managed_metadata(&mut value, id.clone(), created_at)?;
 	}
 	Ok(PreparedResource {
 		kind: ConfigResourceKind::LlmApiKey,
@@ -717,10 +741,11 @@ pub(crate) fn prepare_resources(
 pub(crate) fn prepare_api_key_update(
 	id: String,
 	mut value: Value,
+	created_at: Option<i64>,
 ) -> anyhow::Result<PreparedResource> {
 	validate_id(&id)?;
-	ensure_no_api_key_id(&value)?;
-	set_api_key_id(&mut value, id.clone())?;
+	validate_api_key_metadata(&value)?;
+	set_api_key_managed_metadata(&mut value, id.clone(), created_at)?;
 	Ok(PreparedResource {
 		kind: ConfigResourceKind::LlmApiKey,
 		id,
@@ -1247,9 +1272,9 @@ pub(crate) fn prepare_resource(
 ) -> anyhow::Result<PreparedResource> {
 	let id = match kind {
 		ConfigResourceKind::LlmApiKey => {
-			ensure_no_api_key_id(&value)?;
+			validate_api_key_metadata(&value)?;
 			let id = uuid::Uuid::new_v4().to_string();
-			set_api_key_id(&mut value, id.clone())?;
+			set_api_key_managed_metadata(&mut value, id.clone(), Some(Utc::now().timestamp()))?;
 			id
 		},
 		ConfigResourceKind::LlmPolicy
@@ -1285,13 +1310,15 @@ fn resource_id(kind: ConfigResourceKind, value: &Value) -> anyhow::Result<String
 			})
 		}),
 		ConfigResourceKind::LlmApiKey => value
-			.pointer("/metadata/id")
+			.get("metadata")
+			.and_then(Value::as_object)
+			.and_then(|metadata| metadata.get(API_KEY_ID_METADATA))
 			.and_then(Value::as_str)
 			.map(ToString::to_string)
 			.ok_or_else(|| {
-				ConfigResourceError::InvalidRequest(
-					"llm.apiKey resources require value.metadata.id".to_string(),
-				)
+				ConfigResourceError::InvalidRequest(format!(
+					"llm.apiKey resources require value.metadata.{API_KEY_ID_METADATA}"
+				))
 				.into()
 			}),
 		ConfigResourceKind::LlmPolicy
@@ -1302,19 +1329,30 @@ fn resource_id(kind: ConfigResourceKind, value: &Value) -> anyhow::Result<String
 	}
 }
 
-fn ensure_no_api_key_id(value: &Value) -> anyhow::Result<()> {
-	if value.pointer("/metadata/id").is_some() {
+fn validate_api_key_metadata(value: &Value) -> anyhow::Result<()> {
+	if let Some(field) = value
+		.get("metadata")
+		.and_then(Value::as_object)
+		.and_then(|metadata| {
+			metadata
+				.keys()
+				.find(|field| field.starts_with(API_KEY_METADATA_PREFIX))
+		}) {
 		return Err(
-			ConfigResourceError::InvalidRequest(
-				"llm.apiKey resources must not include value.metadata.id".to_string(),
-			)
+			ConfigResourceError::InvalidRequest(format!(
+				"llm.apiKey metadata field {field} uses the reserved agentgateway.dev/ prefix"
+			))
 			.into(),
 		);
 	}
 	Ok(())
 }
 
-fn set_api_key_id(value: &mut Value, id: String) -> anyhow::Result<()> {
+fn set_api_key_managed_metadata(
+	value: &mut Value,
+	id: String,
+	created_at: Option<i64>,
+) -> anyhow::Result<()> {
 	let Some(object) = value.as_object_mut() else {
 		return Err(
 			ConfigResourceError::InvalidRequest("llm.apiKey resources must be JSON objects".to_string())
@@ -1332,7 +1370,13 @@ fn set_api_key_id(value: &mut Value, id: String) -> anyhow::Result<()> {
 			.into(),
 		);
 	};
-	metadata.insert("id".to_string(), Value::String(id));
+	metadata.insert(API_KEY_ID_METADATA.to_string(), Value::String(id));
+	if let Some(created_at) = created_at {
+		metadata.insert(
+			API_KEY_CREATED_AT_METADATA.to_string(),
+			Value::Number(created_at.into()),
+		);
+	}
 	Ok(())
 }
 
@@ -1853,13 +1897,41 @@ mod tests {
 		.expect("api key id");
 		uuid::Uuid::parse_str(&created.id).expect("UUID v4");
 		assert_eq!(
-			created.value.pointer("/metadata/id"),
+			created
+				.value
+				.get("metadata")
+				.and_then(Value::as_object)
+				.and_then(|metadata| metadata.get(API_KEY_ID_METADATA)),
+			Some(&Value::String(created.id.clone()))
+		);
+		let created_at = api_key_created_at(&created.value).expect("managed creation timestamp");
+		assert!(created_at > 0);
+		let updated = prepare_api_key_update(
+			created.id.clone(),
+			json!({"metadata": {"name": "updated"}}),
+			Some(created_at),
+		)
+		.expect("API key update");
+		assert_eq!(api_key_created_at(&updated.value), Some(created_at));
+		assert_eq!(
+			api_key_metadata(&updated.value).and_then(|metadata| metadata.get(API_KEY_ID_METADATA)),
 			Some(&Value::String(created.id))
 		);
+		let err = prepare_resource(
+			ConfigResourceKind::LlmApiKey,
+			json!({"metadata": {"agentgateway.dev/owner": "client"}}),
+		)
+		.expect_err("reserved API key metadata should fail");
 		assert!(
-			prepare_resource(
-				ConfigResourceKind::LlmApiKey,
-				json!({"metadata": {"id": "client-id"}}),
+			err
+				.to_string()
+				.contains("reserved agentgateway.dev/ prefix")
+		);
+		assert!(
+			prepare_api_key_update(
+				"key-id".to_string(),
+				json!({"metadata": {"agentgateway.dev/owner": "client"}}),
+				None,
 			)
 			.is_err()
 		);
@@ -2011,7 +2083,7 @@ mcp:
 			test_resource(
 				ConfigResourceKind::LlmApiKey,
 				"key_01",
-				json!({"key": "agw_sk_test", "metadata": {"id": "key_01", "name": "test"}}),
+				json!({"key": "agw_sk_test", "metadata": {"agentgateway.dev/id": "key_01", "name": "test"}}),
 			),
 			test_resource(ConfigResourceKind::UiPolicy, "csrf", json!({})),
 			test_resource(
@@ -2288,7 +2360,7 @@ routes:
 		assert_eq!(config.pointer("/gateways/private/port"), Some(&json!(8081)));
 
 		let missing_key =
-			prepare_file_api_key_update("missing".to_string(), json!({"key": "agw_missing"}))
+			prepare_file_api_key_update("missing".to_string(), json!({"key": "agw_missing"}), None)
 				.expect("prepare API key update");
 		let err = upsert_file_config_resource(&mut config, &missing_key, Some("missing"))
 			.expect_err("missing API key update must fail");

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -451,6 +451,11 @@ async fn update_config_resource(
 	let kind = kind
 		.parse::<ConfigResourceKind>()
 		.map_err(resource_api_error)?;
+	let file_config = if app.state.storage.mode == ConfigStoreMode::File {
+		Some(read_file_config(&app).await?)
+	} else {
+		None
+	};
 	if app.state.storage.mode == ConfigStoreMode::Hybrid && kind == ConfigResourceKind::McpSettings {
 		remove_file_owned_mcp_settings(&read_file_config(&app).await?, &mut resource.value)?;
 	}
@@ -477,11 +482,26 @@ async fn update_config_resource(
 					"config resource not found: {kind}/{id}"
 				))));
 			}
+			let created_at = if let Some(config) = file_config.as_ref() {
+				crate::config_store::file_api_key_created_at(config, &id)
+			} else {
+				stored_resources
+					.as_ref()
+					.and_then(|resources| {
+						resources
+							.iter()
+							.find(|resource| resource.kind == kind && resource.id == id)
+					})
+					.and_then(|resource| {
+						crate::config_store::api_key_created_at(&resource.value)
+							.or_else(|| Some(resource.created_at.timestamp()))
+					})
+			};
 			vec![if app.state.storage.mode == ConfigStoreMode::File {
-				crate::config_store::prepare_file_api_key_update(id.clone(), resource.value)
+				crate::config_store::prepare_file_api_key_update(id.clone(), resource.value, created_at)
 					.map_err(resource_api_error)?
 			} else {
-				crate::config_store::prepare_api_key_update(id.clone(), resource.value)
+				crate::config_store::prepare_api_key_update(id.clone(), resource.value, created_at)
 					.map_err(resource_api_error)?
 			}]
 		},
@@ -496,7 +516,7 @@ async fn update_config_resource(
 		},
 	};
 	if app.state.storage.mode == ConfigStoreMode::File {
-		let mut config = read_file_config(&app).await?;
+		let mut config = file_config.expect("file mode loads the file config");
 		for resource in &prepared {
 			crate::config_store::upsert_file_config_resource(&mut config, resource, Some(id.as_str()))
 				.map_err(resource_api_error)?;

--- a/ui/src/pages/Keys.tsx
+++ b/ui/src/pages/Keys.tsx
@@ -42,12 +42,13 @@ import {
 } from '@/policies/AuthorizationLocation';
 import { KeyValueEditor } from '@/policies/PolicyFormControls';
 import { AdvancedSettingRow } from '@/policies/PolicyLayout';
-import { randomUuid } from '@/randomUuid';
 import { type SchemaHelp, useSchemaHelp } from '@/schemaHelp';
 import type { GatewayConfig, LlmApiKeyPolicy, VirtualApiKey } from '@/types';
 
 const fileOwnedPolicyMessage =
 	'This API key policy is file-owned and cannot be modified in hybrid mode.';
+const managedMetadataPrefix = 'agentgateway.dev/';
+const apiKeyIdMetadata = 'agentgateway.dev/id';
 
 export function KeysPage() {
 	const {
@@ -105,7 +106,7 @@ export function KeysPage() {
 		const previousId = previous ? keyId(previous) || `@index:${previousIndex}` : undefined;
 		const value = structuredClone(key);
 		if (value.metadata && typeof value.metadata === 'object') {
-			delete value.metadata.id;
+			value.metadata = withoutServerMetadata(metadataObject(value.metadata));
 		}
 		upsertResource.mutate({ kind: 'llm.apiKey', value, previousId }, { onSuccess: closeKeyDrawer });
 	}
@@ -569,13 +570,8 @@ function KeyEditor(props: {
 	const duplicateName = isNew ? duplicateKeyName(name, props.existingKeys) : false;
 
 	function virtualKey() {
-		const metadataId =
-			typeof initialMetadata.id === 'string' && initialMetadata.id.trim()
-				? initialMetadata.id.trim()
-				: randomUuid();
 		const metadata = {
 			...metadataValues,
-			id: metadataId,
 			...(name.trim() ? { name: name.trim() } : {})
 		};
 		const nextKey = isNew
@@ -724,7 +720,7 @@ function KeyEditor(props: {
 function newVirtualKey(): VirtualApiKey {
 	return {
 		key: '',
-		metadata: { id: randomUuid(), name: '' }
+		metadata: { name: '' }
 	};
 }
 
@@ -766,13 +762,14 @@ function normalizeKeyName(name: string) {
 
 function keyId(key: VirtualApiKey) {
 	const metadata = metadataObject(key.metadata);
-	return typeof metadata.id === 'string' && metadata.id.trim() ? metadata.id.trim() : '';
+	const id = metadata[apiKeyIdMetadata];
+	return typeof id === 'string' && id.trim() ? id.trim() : '';
 }
 
 function keyResourceForDisplay(key: VirtualApiKey) {
 	const value = structuredClone(key);
 	if (value.metadata && typeof value.metadata === 'object') {
-		delete value.metadata.id;
+		value.metadata = withoutServerMetadata(metadataObject(value.metadata));
 	}
 	return value;
 }
@@ -889,10 +886,15 @@ function metadataObject(value: unknown): Record<string, unknown> {
 }
 
 function withoutManagedMetadata(value: Record<string, unknown>) {
-	const next = { ...value };
+	const next = withoutServerMetadata(value);
 	delete next.name;
-	delete next.id;
 	return next;
+}
+
+function withoutServerMetadata(value: Record<string, unknown>) {
+	return Object.fromEntries(
+		Object.entries(value).filter(([key]) => !key.startsWith(managedMetadataPrefix))
+	);
 }
 
 function stringMetadata(value: Record<string, unknown>) {

--- a/ui/tests/e2e/fixtures.ts
+++ b/ui/tests/e2e/fixtures.ts
@@ -580,13 +580,17 @@ function upsertFileConfigResource(
 		const index = previousId
 			? keys.findIndex((key, keyIndex) => {
 					const keyValue = record(key);
-					return (stringValue(record(keyValue.metadata).id) || `@index:${keyIndex}`) === previousId;
+					return (
+						(stringValue(record(keyValue.metadata)['agentgateway.dev/id']) ||
+							`@index:${keyIndex}`) === previousId
+					);
 				})
 			: -1;
 		if (!previousId || !previousId.startsWith('@index:')) {
 			value.metadata = {
 				...record(value.metadata),
-				id: previousId ?? `test-key-${keys.length + 1}`
+				'agentgateway.dev/id': previousId ?? `test-key-${keys.length + 1}`,
+				'agentgateway.dev/createdAt': 1783641600
 			};
 		}
 		if (index >= 0) keys[index] = value;
@@ -649,7 +653,9 @@ function deleteFileConfigResource(config: TestConfig, kind: string, id: string) 
 		const policy = record(record(record(config.llm).policies).apiKey);
 		policy.keys = array(policy.keys).filter((key, index) => {
 			const value = record(key);
-			return (stringValue(record(value.metadata).id) || `@index:${index}`) !== id;
+			return (
+				(stringValue(record(value.metadata)['agentgateway.dev/id']) || `@index:${index}`) !== id
+			);
 		});
 		return;
 	}

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -249,7 +249,11 @@ test('raw configuration lists hybrid database resources with masked keys', async
 						id: 'key-id',
 						value: {
 							key: 'agw_sk_supersecret123',
-							metadata: { id: 'key-id', name: 'Test key' }
+							metadata: {
+								'agentgateway.dev/id': 'key-id',
+								'agentgateway.dev/createdAt': 1783641600,
+								name: 'Test key'
+							}
 						},
 						revision: 1,
 						createdAt: '2026-07-10T00:00:00Z',


### PR DESCRIPTION
This allows for server-side populated info, such as adding authenticated
user info into the key.

Signed-off-by: John Howard <john.howard@solo.io>
