### PR TITLE
Add API-key scoped budgets for LLM traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,7 @@ dependencies = [
  "cookie",
  "core_affinity",
  "crossbeam",
+ "dashmap",
  "divan",
  "flagset",
  "frozen-collections",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.6", features = ["derive"] }
 clocksource = "1.0"
 crossbeam = "0.8"
+dashmap = "6.2"
 divan = "0.1"
 durationfmt = "0.1"
 go-parse-duration = "0.1"

--- a/crates/agentgateway-app/src/commands/run.rs
+++ b/crates/agentgateway-app/src/commands/run.rs
@@ -51,24 +51,38 @@ pub(crate) fn execute(args: RunArgs) -> anyhow::Result<()> {
 				"running with config: {}",
 				serdes::yamlviajson::to_string(&config)?
 			);
+			let database_pool = match config.database.as_ref() {
+				Some(database) => Some(
+					agentgateway::database::DatabasePool::connect_with_max_connections(
+						&database.url,
+						database.max_connections,
+					)
+					.await?,
+				),
+				None => None,
+			};
+			if let Some(pool) = database_pool.clone() {
+				config.budget_policy.initialize(pool).await?;
+			}
 			let config_resource_store = if config.storage.mode == ConfigStoreMode::Hybrid {
-				let database = config
-					.database
-					.as_ref()
-					.expect("hybrid config store requires config.database");
-				Some(agentgateway::config_store::setup(database).await?)
+				Some(
+					agentgateway::config_store::ConfigResourceStore::from_pool(
+						database_pool
+							.clone()
+							.expect("hybrid config store requires config.database"),
+					)
+					.await?,
+				)
 			} else {
 				None
 			};
 			let request_log_store = match config.logging.database.as_ref() {
 				Some(cfg) => {
-					let pool = config_resource_store.as_ref().and_then(|store| {
-						config
-							.database
-							.as_ref()
-							.filter(|database| cfg == *database)
-							.map(|_| store.pool())
-					});
+					let pool = config
+						.database
+						.as_ref()
+						.filter(|database| cfg == *database)
+						.and(database_pool.clone());
 					match agentgateway::telemetry::log_store::setup_with_pool(cfg, pool).await {
 						Ok(store) => Some(store),
 						Err(err) => {
@@ -79,7 +93,11 @@ pub(crate) fn execute(args: RunArgs) -> anyhow::Result<()> {
 				},
 				None => None,
 			};
-			let result = proxy(Arc::new(config), config_resource_store).await;
+			let config = Arc::new(config);
+			let result = proxy(config.clone(), config_resource_store).await;
+			if let Err(err) = config.budget_policy.flush().await {
+				error!(?err, "failed to flush budget usage during shutdown");
+			}
 			if let Some(request_log_store) = request_log_store {
 				request_log_store.shutdown_and_wait().await;
 			}

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -58,6 +58,7 @@ chrono.workspace = true
 clocksource.workspace = true
 core_affinity.workspace = true
 crossbeam.workspace = true
+dashmap.workspace = true
 divan = { workspace = true, optional = true }
 frozen-collections.workspace = true
 fs-err = { workspace = true }

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -422,6 +422,7 @@ pub fn parse_config(
 		threading_mode,
 		backend: raw.backend,
 		admin_runtime_handle: None,
+		budget_policy: Arc::new(crate::http::budget::BudgetPolicy::default()),
 		termination_max_deadline: match termination_max_deadline {
 				Some(period) => period,
 				None => match parse::<u64>("TERMINATION_GRACE_PERIOD_SECONDS")? {

--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -150,7 +150,7 @@ impl ConfigResourceStore {
 		Self::from_pool(DatabasePool::connect_with_max_connections(url, max_connections).await?).await
 	}
 
-	async fn from_pool(pool: DatabasePool) -> anyhow::Result<Self> {
+	pub async fn from_pool(pool: DatabasePool) -> anyhow::Result<Self> {
 		let (change_tx, _) = watch::channel(());
 		match &pool {
 			DatabasePool::Sqlite(pool) => {

--- a/crates/agentgateway/src/http/apikey.rs
+++ b/crates/agentgateway/src/http/apikey.rs
@@ -1,12 +1,15 @@
+use std::collections::HashSet;
 use std::hash::Hash;
 
 use ::cel::Value;
+use rust_decimal::Decimal;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Deserializer, Serializer};
 use subtle::ConstantTimeEq;
 
 use crate::http::Request;
 use crate::http::auth::AuthorizationLocation;
+use crate::http::budget::{Budget, BudgetLimitUnit, MatchedBudgets, NANODOLLARS_PER_USD};
 use crate::proxy::dtrace::{self, pol_result};
 use crate::proxy::{ProxyError, ProxyResponse};
 use crate::{apply, *};
@@ -109,6 +112,10 @@ pub struct APIKeyHash(
 );
 
 impl APIKeyHash {
+	pub(crate) fn as_str(&self) -> &str {
+		&self.0
+	}
+
 	pub fn from_raw_key(key: &str) -> Self {
 		let digest = crate::crypto::digest::sha256(key.as_bytes());
 		APIKeyHash(hex::encode(digest))
@@ -160,6 +167,7 @@ pub struct APIKeyAuthentication {
 pub struct APIKeyPolicy {
 	pub metadata: UserMetadata,
 	pub allowed_models: AllowedModels,
+	pub budgets: Option<MatchedBudgets>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -317,6 +325,7 @@ pub fn discoverable_models<'a>(
 struct AuthenticatedAPIKey {
 	claims: Claims,
 	model_access: ModelAccessPolicy,
+	budgets: Option<MatchedBudgets>,
 }
 
 impl APIKeyAuthentication {
@@ -335,6 +344,7 @@ impl APIKeyAuthentication {
 							APIKeyPolicy {
 								metadata,
 								allowed_models: AllowedModels::default(),
+								budgets: None,
 							},
 						)
 					})
@@ -380,6 +390,7 @@ impl APIKeyAuthentication {
 				model_access: ModelAccessPolicy {
 					allowed_models: policy.allowed_models.clone(),
 				},
+				budgets: policy.budgets.clone(),
 			}))
 		} else if self.mode == Mode::Permissive {
 			pol_result!(
@@ -414,6 +425,9 @@ impl crate::store::RequestPolicyTrait for APIKeyAuthentication {
 			// Insert the claims into extensions so we can reference it later
 			req.extensions_mut().insert(authenticated.claims);
 			req.extensions_mut().insert(authenticated.model_access);
+			if let Some(budgets) = authenticated.budgets {
+				req.extensions_mut().insert(budgets);
+			}
 		}
 		Ok(crate::http::PolicyResponse::default())
 	}
@@ -449,6 +463,10 @@ pub enum LocalAPIKey {
 		/// Omitted means no additional constraint; an empty list denies all models.
 		#[serde(rename = "allowedModels", default)]
 		allowed_models: Option<Vec<String>>,
+		/// Independent budgets charged after LLM responses. A request is not charged when its provider
+		/// does not report the usage or cost required by the budget unit.
+		#[serde(default)]
+		budgets: Vec<Budget>,
 	},
 	Sha256 {
 		/// SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.
@@ -460,28 +478,89 @@ pub enum LocalAPIKey {
 		/// Omitted means no additional constraint; an empty list denies all models.
 		#[serde(rename = "allowedModels", default)]
 		allowed_models: Option<Vec<String>>,
+		/// Independent budgets charged after LLM responses. A request is not charged when its provider
+		/// does not report the usage or cost required by the budget unit.
+		#[serde(default)]
+		budgets: Vec<Budget>,
 	},
 }
 
 impl LocalAPIKey {
 	fn into_parts(self) -> anyhow::Result<(APIKeyHash, APIKeyPolicy)> {
-		let (key_hash, metadata, allowed_models) = match self {
+		let (key_hash, metadata, allowed_models, budgets) = match self {
 			LocalAPIKey::Key {
 				key,
 				metadata,
 				allowed_models,
-			} => (key.sha256(), metadata, allowed_models),
+				budgets,
+			} => (key.sha256(), metadata, allowed_models, budgets),
 			LocalAPIKey::Sha256 {
 				key_hash,
 				metadata,
 				allowed_models,
-			} => (key_hash, metadata, allowed_models),
+				budgets,
+			} => (key_hash, metadata, allowed_models, budgets),
 		};
+		let metadata = metadata.unwrap_or_default();
+		let api_key = metadata
+			.get("name")
+			.and_then(serde_json::Value::as_str)
+			.filter(|name| !name.is_empty())
+			.map(str::to_owned);
+		if !budgets.is_empty() && api_key.is_none() {
+			anyhow::bail!("API keys with budgets must have a metadata.name");
+		}
+		let mut budget_names = HashSet::new();
+		for budget in &budgets {
+			anyhow::ensure!(!budget.name.is_empty(), "budget names must not be empty");
+			anyhow::ensure!(
+				budget_names.insert(&budget.name),
+				"duplicate budget name {:?} on API key {:?}",
+				budget.name,
+				api_key.as_deref().unwrap_or_default(),
+			);
+			let window_ms = budget.window.rolling.as_millis();
+			anyhow::ensure!(
+				window_ms > 0,
+				"budget rolling windows must be greater than zero"
+			);
+			anyhow::ensure!(
+				window_ms <= i64::MAX as u128,
+				"budget rolling window is too large"
+			);
+			let amount = budget.limit.amount.decimal().normalize();
+			let multiplier = match budget.limit.unit {
+				BudgetLimitUnit::Usd => {
+					anyhow::ensure!(
+						amount.scale() <= 9,
+						"USD budget limits support at most 9 fractional digits"
+					);
+					NANODOLLARS_PER_USD
+				},
+				BudgetLimitUnit::Tokens => {
+					anyhow::ensure!(
+						amount.fract().is_zero(),
+						"token budget limits must be whole numbers"
+					);
+					1
+				},
+			};
+			anyhow::ensure!(
+				amount * Decimal::from(multiplier) <= Decimal::from(i64::MAX),
+				"budget limit exceeds database integer range"
+			);
+		}
+		let budgets = (!budgets.is_empty()).then(|| MatchedBudgets {
+			api_key: api_key.expect("budget API keys have a name"),
+			api_key_id: key_hash.as_str().to_owned(),
+			budgets,
+		});
 		Ok((
 			key_hash,
 			APIKeyPolicy {
-				metadata: metadata.unwrap_or_default(),
+				metadata,
 				allowed_models: AllowedModels::compile(allowed_models)?,
+				budgets,
 			},
 		))
 	}

--- a/crates/agentgateway/src/http/budget/database.rs
+++ b/crates/agentgateway/src/http/budget/database.rs
@@ -1,0 +1,313 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use chrono::Utc;
+use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
+
+use super::{
+	BudgetCounter, BudgetLimitUnit, BudgetPolicy, NANODOLLARS_PER_USD, PendingBudgetUsage,
+	PersistedBudgetUsage, UnixDate,
+};
+
+const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+const SQLITE_SCHEMA: &str = include_str!("sqlite_schema.sql");
+const POSTGRES_SCHEMA: &str = include_str!("postgres_schema.sql");
+const SQLITE_UPSERT: &str = include_str!("sqlite_upsert.sql");
+const POSTGRES_UPSERT: &str = include_str!("postgres_upsert.sql");
+
+impl BudgetPolicy {
+	/// Initializes and migrates the budget tables, prunes expired rows, preloads every persisted
+	/// counter into memory, and starts the periodic flush task.
+	pub async fn initialize(
+		self: &Arc<Self>,
+		pool: crate::database::DatabasePool,
+	) -> anyhow::Result<()> {
+		let now = Utc::now();
+		match &pool {
+			crate::database::DatabasePool::Sqlite(pool) => {
+				sqlx::raw_sql(SQLITE_SCHEMA)
+					.execute(pool)
+					.await
+					.context("failed to initialize budget database")?;
+				let has_unit = sqlx::query_scalar::<_, i64>(
+					"SELECT COUNT(*) FROM pragma_table_info('budget_usage') WHERE name = 'unit'",
+				)
+				.fetch_one(pool)
+				.await
+				.context("failed to inspect budget database schema")?;
+				if has_unit == 0 {
+					sqlx::query("ALTER TABLE budget_usage ADD COLUMN unit TEXT")
+						.execute(pool)
+						.await
+						.context("failed to migrate budget database schema")?;
+				}
+				sqlx::query("DELETE FROM budget_usage WHERE window_end <= ?")
+					.bind(now.timestamp_millis())
+					.execute(pool)
+					.await
+					.context("failed to prune expired budget usage")?;
+			},
+			crate::database::DatabasePool::Postgres(pool) => {
+				sqlx::raw_sql(POSTGRES_SCHEMA)
+					.execute(pool)
+					.await
+					.context("failed to initialize budget database")?;
+				sqlx::query("ALTER TABLE budget_usage ADD COLUMN IF NOT EXISTS unit TEXT")
+					.execute(pool)
+					.await
+					.context("failed to migrate budget database schema")?;
+				sqlx::query("DELETE FROM budget_usage WHERE window_end <= $1")
+					.bind(now.timestamp_millis())
+					.execute(pool)
+					.await
+					.context("failed to prune expired budget usage")?;
+			},
+		};
+		let persisted = Self::read_persisted(&pool)
+			.await
+			.context("failed to preload budget usage")?;
+		if self.database.set(pool).is_err() {
+			return Ok(());
+		}
+		self.reconcile(persisted, now);
+
+		let policy = Arc::downgrade(self);
+		tokio::spawn(async move {
+			let mut interval = tokio::time::interval(FLUSH_INTERVAL);
+			interval.tick().await;
+			loop {
+				interval.tick().await;
+				let Some(policy) = policy.upgrade() else {
+					return;
+				};
+				if let Err(err) = policy.flush().await {
+					tracing::warn!(target: "budget", ?err, "failed to flush budget usage");
+				}
+			}
+		});
+		Ok(())
+	}
+
+	async fn read_persisted(
+		pool: &crate::database::DatabasePool,
+	) -> anyhow::Result<HashMap<String, PersistedBudgetUsage>> {
+		let rows = match pool {
+			crate::database::DatabasePool::Sqlite(pool) => {
+				sqlx::query_as::<_, (String, i64, i64, Option<String>, i64, i64)>(
+					"SELECT budget_id, window_start, window_end, unit, used_amount, updated_at FROM budget_usage",
+				)
+				.fetch_all(pool)
+				.await?
+			},
+			crate::database::DatabasePool::Postgres(pool) => {
+				sqlx::query_as::<_, (String, i64, i64, Option<String>, i64, i64)>(
+					"SELECT budget_id, window_start, window_end, unit, used_amount, updated_at FROM budget_usage",
+				)
+				.fetch_all(pool)
+				.await?
+			},
+		};
+		rows
+			.into_iter()
+			.map(
+				|(budget_id, window_start, window_end, unit, used_amount, updated_at)| {
+					Ok((
+						budget_id,
+						PersistedBudgetUsage {
+							window_start: UnixDate::from_timestamp_millis(window_start)
+								.context("budget window start is out of range")?,
+							window_end: UnixDate::from_timestamp_millis(window_end)
+								.context("budget window end is out of range")?,
+							unit: unit.as_deref().and_then(BudgetLimitUnit::from_database),
+							used_amount,
+							updated_at: UnixDate::from_timestamp_millis(updated_at)
+								.context("budget update timestamp is out of range")?,
+						},
+					))
+				},
+			)
+			.collect()
+	}
+
+	fn reconcile(&self, persisted: HashMap<String, PersistedBudgetUsage>, now: UnixDate) {
+		for (budget_id, row) in &persisted {
+			match self.counters.entry(budget_id.clone()) {
+				dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+					entry.get_mut().reconcile(Some(row), now);
+				},
+				dashmap::mapref::entry::Entry::Vacant(entry) => {
+					entry.insert(BudgetCounter::from_persisted(row));
+				},
+			}
+		}
+		for mut counter in self.counters.iter_mut() {
+			if !persisted.contains_key(counter.key()) {
+				counter.reconcile(None, now);
+			}
+		}
+	}
+
+	/// Snapshots nonzero per-counter deltas, atomically increments them in the database, subtracts
+	/// only the successful snapshot, then reconciles totals written by concurrent workers.
+	pub async fn flush(&self) -> anyhow::Result<()> {
+		let Some(pool) = self.database.get() else {
+			return Ok(());
+		};
+		let _flush = self.flush_lock.lock().await;
+		if !self
+			.counters
+			.iter()
+			.any(|counter| counter.definition.is_some() || !counter.pending.is_zero())
+		{
+			return Ok(());
+		}
+		let updated_at = Utc::now();
+		let mut pending = Vec::new();
+		for mut counter in self.counters.iter_mut() {
+			if counter.definition.is_some() {
+				counter.refresh(updated_at);
+			}
+			if counter.pending.is_zero() {
+				continue;
+			}
+			let unit = counter
+				.unit
+				.context("configured budget counter has no unit")?;
+			let scaled = match unit {
+				BudgetLimitUnit::Usd => counter.pending * Decimal::from(NANODOLLARS_PER_USD),
+				BudgetLimitUnit::Tokens => counter.pending,
+			};
+			let used_amount = scaled
+				.trunc()
+				.to_i64()
+				.context("budget usage exceeds database integer range")?;
+			if used_amount == 0 {
+				continue;
+			}
+			pending.push(PendingBudgetUsage {
+				budget_id: counter.key().clone(),
+				window_start: counter.window_start,
+				window_end: counter.window_end,
+				unit,
+				used_amount,
+				flushed: match unit {
+					BudgetLimitUnit::Usd => Decimal::new(used_amount, 9),
+					BudgetLimitUnit::Tokens => Decimal::from(used_amount),
+				},
+			});
+		}
+		pending.sort_by(|a, b| {
+			(&a.budget_id, a.window_start, a.window_end).cmp(&(
+				&b.budget_id,
+				b.window_start,
+				b.window_end,
+			))
+		});
+
+		if !pending.is_empty() {
+			match pool {
+				crate::database::DatabasePool::Sqlite(pool) => {
+					let mut transaction = pool.begin().await?;
+					for counter in &pending {
+						sqlx::query(SQLITE_UPSERT)
+							.bind(&counter.budget_id)
+							.bind(counter.window_start.timestamp_millis())
+							.bind(counter.window_end.timestamp_millis())
+							.bind(counter.unit.as_str())
+							.bind(counter.used_amount)
+							.bind(updated_at.timestamp_millis())
+							.execute(&mut *transaction)
+							.await?;
+					}
+					transaction.commit().await?;
+				},
+				crate::database::DatabasePool::Postgres(pool) => {
+					let mut transaction = pool.begin().await?;
+					for counter in &pending {
+						sqlx::query(POSTGRES_UPSERT)
+							.bind(&counter.budget_id)
+							.bind(counter.window_start.timestamp_millis())
+							.bind(counter.window_end.timestamp_millis())
+							.bind(counter.unit.as_str())
+							.bind(counter.used_amount)
+							.bind(updated_at.timestamp_millis())
+							.execute(&mut *transaction)
+							.await?;
+					}
+					transaction.commit().await?;
+				},
+			}
+		}
+		for flushed in pending {
+			let Some(mut counter) = self.counters.get_mut(&flushed.budget_id) else {
+				continue;
+			};
+			if counter.window_start == flushed.window_start
+				&& counter.window_end == flushed.window_end
+				&& counter.unit == Some(flushed.unit)
+			{
+				counter.pending -= flushed.flushed;
+			}
+		}
+		let persisted = Self::read_persisted(pool).await?;
+		self.reconcile(persisted, updated_at);
+		Ok(())
+	}
+}
+
+impl BudgetCounter {
+	fn from_persisted(row: &PersistedBudgetUsage) -> Self {
+		Self {
+			definition: None,
+			amount: match row.unit {
+				Some(BudgetLimitUnit::Usd) => Decimal::new(row.used_amount, 9),
+				Some(BudgetLimitUnit::Tokens) => Decimal::from(row.used_amount),
+				None => Decimal::ZERO,
+			},
+			pending: Decimal::ZERO,
+			unit: row.unit,
+			rolling: (row.window_end - row.window_start)
+				.to_std()
+				.unwrap_or(Duration::ZERO),
+			window_start: row.window_start,
+			window_end: row.window_end,
+			updated_at: row.updated_at,
+		}
+	}
+
+	fn reconcile(&mut self, row: Option<&PersistedBudgetUsage>, now: UnixDate) {
+		if self.definition.is_none() {
+			if let Some(row) = row {
+				*self = Self::from_persisted(row);
+			}
+			return;
+		}
+
+		self.refresh(now);
+		let row = row.filter(|row| {
+			row.window_end > now
+				&& (row.window_end - row.window_start)
+					.to_std()
+					.is_ok_and(|rolling| rolling == self.rolling)
+				&& row.unit == self.unit
+		});
+		let Some(row) = row else {
+			self.amount = self.pending;
+			return;
+		};
+		if self.window_start != row.window_start || self.window_end != row.window_end {
+			self.pending = Decimal::ZERO;
+		}
+		self.amount = match row.unit {
+			Some(BudgetLimitUnit::Usd) => Decimal::new(row.used_amount, 9),
+			Some(BudgetLimitUnit::Tokens) => Decimal::from(row.used_amount),
+			None => Decimal::ZERO,
+		} + self.pending;
+		self.window_start = row.window_start;
+		self.window_end = row.window_end;
+		self.updated_at = self.updated_at.max(row.updated_at);
+	}
+}

--- a/crates/agentgateway/src/http/budget/mod.rs
+++ b/crates/agentgateway/src/http/budget/mod.rs
@@ -1,0 +1,769 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use anyhow::Context;
+use chrono::{DurationRound, TimeDelta, Utc};
+use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::cel::LLMContext;
+use crate::{apply, schema_de, serde_dur};
+
+mod database;
+mod status;
+
+pub use status::{
+	BudgetStatus, BudgetStatusLimit, BudgetStatusResponse, BudgetStatusUsage, BudgetStatusWindow,
+};
+
+pub(crate) const NANODOLLARS_PER_USD: i64 = 1_000_000_000;
+type UnixDate = chrono::DateTime<Utc>;
+
+/// In-memory state for one budget. Database rows are preloaded at startup and configuration is
+/// attached during policy registration, regardless of which happens first.
+#[derive(Debug, Clone)]
+struct BudgetCounter {
+	definition: Option<BudgetDefinition>,
+	amount: Decimal,
+	pending: Decimal,
+	unit: Option<BudgetLimitUnit>,
+	rolling: Duration,
+	window_start: UnixDate,
+	window_end: UnixDate,
+	updated_at: UnixDate,
+}
+
+impl BudgetCounter {
+	fn configured(api_key: &str, budget: &Budget, now: UnixDate) -> anyhow::Result<Self> {
+		let rolling = budget.window.rolling;
+		anyhow::ensure!(
+			!rolling.is_zero(),
+			"budget rolling window must be greater than zero"
+		);
+		let (window_start, window_end) = budget_window(now, rolling)?;
+		Ok(Self {
+			definition: Some(BudgetDefinition {
+				api_key: api_key.to_owned(),
+				budget: budget.clone(),
+			}),
+			amount: Decimal::ZERO,
+			pending: Decimal::ZERO,
+			unit: Some(budget.limit.unit),
+			rolling,
+			window_start,
+			window_end,
+			updated_at: now,
+		})
+	}
+
+	/// Attaches the latest definition and resets runtime state if its window or unit changed.
+	fn configure(&mut self, api_key: &str, budget: &Budget, now: UnixDate) -> anyhow::Result<()> {
+		let rolling = budget.window.rolling;
+		anyhow::ensure!(
+			!rolling.is_zero(),
+			"budget rolling window must be greater than zero"
+		);
+		if now >= self.window_end || self.rolling != rolling || self.unit != Some(budget.limit.unit) {
+			(self.window_start, self.window_end) = budget_window(now, rolling)?;
+			self.amount = Decimal::ZERO;
+			self.pending = Decimal::ZERO;
+			self.unit = Some(budget.limit.unit);
+			self.updated_at = now;
+		}
+		self.rolling = rolling;
+		self.definition = Some(BudgetDefinition {
+			api_key: api_key.to_owned(),
+			budget: budget.clone(),
+		});
+		Ok(())
+	}
+
+	/// Advances an expired counter to the epoch-aligned fixed window containing `now`.
+	fn refresh(&mut self, now: UnixDate) {
+		if now < self.window_end {
+			return;
+		}
+		(self.window_start, self.window_end) =
+			budget_window(now, self.rolling).expect("budget duration was validated");
+		self.amount = Decimal::ZERO;
+		self.pending = Decimal::ZERO;
+		self.updated_at = now;
+	}
+}
+
+#[derive(Debug, Clone)]
+struct PersistedBudgetUsage {
+	window_start: UnixDate,
+	window_end: UnixDate,
+	unit: Option<BudgetLimitUnit>,
+	used_amount: i64,
+	updated_at: UnixDate,
+}
+
+#[derive(Debug, Clone)]
+struct PendingBudgetUsage {
+	budget_id: String,
+	window_start: UnixDate,
+	window_end: UnixDate,
+	unit: BudgetLimitUnit,
+	used_amount: i64,
+	flushed: Decimal,
+}
+
+#[derive(Debug, Clone)]
+struct BudgetDefinition {
+	api_key: String,
+	budget: Budget,
+}
+
+/// A named budget attached to a standalone API key.
+///
+/// Usage is charged after an LLM response when the provider reports the tokens or cost required by
+/// the configured unit. Requests with unavailable usage are logged but cannot be charged or blocked
+/// retroactively.
+#[apply(schema_de!)]
+pub struct Budget {
+	/// Stable name for this budget within its owning API key.
+	pub name: String,
+	/// Maximum usage allowed during the window.
+	pub limit: BudgetLimit,
+	/// Rolling window over which usage will be accumulated.
+	pub window: BudgetWindow,
+	/// Action taken when the budget is exceeded.
+	pub on_budget_exceeded: BudgetExceededAction,
+}
+
+#[apply(schema_de!)]
+pub struct BudgetLimit {
+	pub unit: BudgetLimitUnit,
+	pub amount: BudgetAmount,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BudgetAmount(Decimal);
+
+impl BudgetAmount {
+	pub fn decimal(self) -> Decimal {
+		self.0
+	}
+}
+
+impl std::fmt::Display for BudgetAmount {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		self.0.fmt(f)
+	}
+}
+
+impl<'de> Deserialize<'de> for BudgetAmount {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		let number = serde_json::Number::deserialize(deserializer)?;
+		let amount = Decimal::from_str(&number.to_string()).map_err(serde::de::Error::custom)?;
+		if amount < Decimal::ZERO {
+			return Err(serde::de::Error::custom(
+				"budget amount must not be negative",
+			));
+		}
+		Ok(Self(amount))
+	}
+}
+
+impl Serialize for BudgetAmount {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serde_json::Number::from_str(&self.0.normalize().to_string())
+			.map_err(serde::ser::Error::custom)?
+			.serialize(serializer)
+	}
+}
+
+#[cfg(feature = "schema")]
+impl schemars::JsonSchema for BudgetAmount {
+	fn schema_name() -> std::borrow::Cow<'static, str> {
+		"BudgetAmount".into()
+	}
+
+	fn json_schema(schema_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+		<f64 as schemars::JsonSchema>::json_schema(schema_gen)
+	}
+}
+
+#[apply(schema_de!)]
+#[derive(Copy, Eq, PartialEq, Hash)]
+pub enum BudgetLimitUnit {
+	#[serde(rename = "USD")]
+	Usd,
+	#[serde(rename = "Tokens")]
+	Tokens,
+}
+
+impl BudgetLimitUnit {
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			Self::Usd => "USD",
+			Self::Tokens => "Tokens",
+		}
+	}
+
+	fn from_database(value: &str) -> Option<Self> {
+		match value {
+			"USD" => Some(Self::Usd),
+			"Tokens" => Some(Self::Tokens),
+			_ => None,
+		}
+	}
+}
+
+#[apply(schema_de!)]
+pub struct BudgetWindow {
+	/// Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.
+	/// Windows are aligned to the Unix epoch rather than starting with the first request: `1h`
+	/// follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day
+	/// periods rather than calendar months.
+	#[serde(with = "serde_dur")]
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	pub rolling: Duration,
+}
+
+#[apply(schema_de!)]
+#[derive(Copy)]
+pub enum BudgetExceededAction {
+	#[serde(rename = "Audit")]
+	Audit,
+	#[serde(rename = "Block")]
+	Block,
+}
+
+impl BudgetExceededAction {
+	pub fn as_str(&self) -> &'static str {
+		match self {
+			Self::Audit => "Audit",
+			Self::Block => "Block",
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchedBudgets {
+	pub(crate) api_key: String,
+	pub(crate) api_key_id: String,
+	pub(crate) budgets: Vec<Budget>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct BudgetPolicy {
+	/// All known counters, including preloaded rows whose configuration has not been registered.
+	#[serde(skip)]
+	counters: Arc<DashMap<String, BudgetCounter>>,
+	/// Shared database pool installed once during policy initialization.
+	#[serde(skip)]
+	database: Arc<OnceLock<crate::database::DatabasePool>>,
+	/// Serializes periodic, shutdown, and manually requested flushes across policy clones.
+	#[serde(skip)]
+	flush_lock: Arc<tokio::sync::Mutex<()>>,
+	/// Definitions collected while a local configuration is being normalized. Registration policies
+	/// share runtime counters with the process-wide policy but do not mutate them until reload succeeds.
+	#[serde(skip)]
+	registration: Option<Arc<DashMap<String, BudgetDefinition>>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct BudgetRegistration(HashMap<String, BudgetDefinition>);
+
+/// Deferred charge captured while applying the budget policy and settled once LLM response usage
+/// and cost are available.
+#[derive(Debug)]
+pub struct BudgetSettlement {
+	policy: BudgetPolicy,
+	budgets: MatchedBudgets,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Budget exceeded")]
+pub struct BudgetExceeded {
+	pub retry_after: u64,
+}
+
+fn budget_id(api_key_id: &str, budget: &Budget) -> String {
+	format!(
+		"api-key:{}:{}:{}:{}",
+		api_key_id.len(),
+		api_key_id,
+		budget.name.len(),
+		budget.name
+	)
+}
+
+/// Returns the half-open fixed window `[start, end)` containing `now`.
+///
+/// Windows are anchored at the Unix epoch and repeat at exact `rolling` intervals.
+/// For example, a one-hour duration produces UTC clock-hour windows, while a 30-day duration
+/// produces consecutive 30-day periods measured from 1970-01-01 rather than calendar months.
+/// UTC and fixed durations deliberately avoid daylight-saving and other local-calendar behavior.
+fn budget_window(now: UnixDate, rolling: Duration) -> anyhow::Result<(UnixDate, UnixDate)> {
+	let rolling = TimeDelta::from_std(rolling).context("budget rolling window is too large")?;
+	let start = now
+		.duration_trunc(rolling)
+		.context("failed to align budget rolling window")?;
+	let end = start
+		.checked_add_signed(rolling)
+		.context("budget rolling window is too large")?;
+	Ok((start, end))
+}
+
+impl BudgetPolicy {
+	/// Creates a policy used while normalizing a candidate local configuration. It shares the live
+	/// counters and database handles, but records definitions separately until the candidate wins.
+	pub(crate) fn registration_policy(&self) -> Self {
+		Self {
+			counters: self.counters.clone(),
+			database: self.database.clone(),
+			flush_lock: self.flush_lock.clone(),
+			registration: Some(Arc::new(DashMap::new())),
+		}
+	}
+
+	pub(crate) fn registration(&self) -> BudgetRegistration {
+		BudgetRegistration(
+			self
+				.registration
+				.as_ref()
+				.expect("registration policy")
+				.iter()
+				.map(|definition| (definition.key().clone(), definition.value().clone()))
+				.collect(),
+		)
+	}
+
+	/// Replaces the complete configured definition set after a local configuration reload succeeds.
+	/// Counters without a definition are retained so persisted usage can be reattached later.
+	pub(crate) fn apply_registration(&self, registration: BudgetRegistration) -> anyhow::Result<()> {
+		let now = Utc::now();
+		for (budget_id, definition) in &registration.0 {
+			match self.counters.entry(budget_id.clone()) {
+				Entry::Occupied(mut entry) => {
+					entry
+						.get_mut()
+						.configure(&definition.api_key, &definition.budget, now)?
+				},
+				Entry::Vacant(entry) => {
+					entry.insert(BudgetCounter::configured(
+						&definition.api_key,
+						&definition.budget,
+						now,
+					)?);
+				},
+			}
+		}
+		for mut counter in self.counters.iter_mut() {
+			if !registration.0.contains_key(counter.key()) {
+				counter.definition = None;
+			}
+		}
+		Ok(())
+	}
+
+	/// Registers every configured API key budget in memory. A compatible preloaded database row is
+	/// retained; otherwise the counter starts in the current epoch-aligned window.
+	pub fn register(
+		&self,
+		authentication: &crate::http::apikey::APIKeyAuthentication,
+		database_configured: bool,
+	) -> anyhow::Result<()> {
+		let now = Utc::now();
+		let has_budgets = authentication
+			.users
+			.values()
+			.any(|policy| policy.budgets.is_some());
+		anyhow::ensure!(
+			!has_budgets || self.database.get().is_some() || database_configured,
+			"API key budgets require config.database to be configured"
+		);
+		for policy in authentication.users.values() {
+			let Some(budgets) = policy.budgets.as_ref() else {
+				continue;
+			};
+			for budget in &budgets.budgets {
+				let budget_id = budget_id(&budgets.api_key_id, budget);
+				if let Some(registration) = &self.registration {
+					BudgetCounter::configured(&budgets.api_key, budget, now)?;
+					registration.insert(
+						budget_id,
+						BudgetDefinition {
+							api_key: budgets.api_key.clone(),
+							budget: budget.clone(),
+						},
+					);
+					continue;
+				}
+				match self.counters.entry(budget_id) {
+					Entry::Occupied(mut entry) => {
+						entry.get_mut().configure(&budgets.api_key, budget, now)?;
+					},
+					Entry::Vacant(entry) => {
+						entry.insert(BudgetCounter::configured(&budgets.api_key, budget, now)?);
+					},
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// Refreshes each matched counter before a request, logs exceeded budgets, and returns the first
+	/// exceeded budget configured to block. Audit-only budgets never block the request.
+	fn check(&self, budgets: &MatchedBudgets) -> anyhow::Result<Option<BudgetExceeded>> {
+		let now = Utc::now();
+		let mut blocked = None;
+		for budget in &budgets.budgets {
+			let budget_id = budget_id(&budgets.api_key_id, budget);
+			let (used, window_end) = {
+				let mut counter = self
+					.counters
+					.get_mut(&budget_id)
+					.context("budget counter was not registered")?;
+				counter.refresh(now);
+				(counter.amount, counter.window_end)
+			};
+			let exceeded = used >= budget.limit.amount.decimal();
+			if exceeded {
+				tracing::warn!(
+					target: "budget",
+					api_key = budgets.api_key,
+					budget = budget.name,
+					used = %used,
+					limit_unit = budget.limit.unit.as_str(),
+					limit_amount = %budget.limit.amount,
+					exceeded,
+					"API key budget exceeded"
+				);
+			} else {
+				tracing::debug!(
+					target: "budget",
+					api_key = budgets.api_key,
+					budget = budget.name,
+					used = %used,
+					limit_unit = budget.limit.unit.as_str(),
+					limit_amount = %budget.limit.amount,
+					exceeded,
+					"API key budget checked"
+				);
+			}
+
+			if exceeded
+				&& matches!(budget.on_budget_exceeded, BudgetExceededAction::Block)
+				&& blocked.is_none()
+			{
+				let retry_after = (window_end - now).to_std().unwrap_or_default();
+				blocked = Some(BudgetExceeded {
+					// Retry-After is whole seconds, rounded up from the remaining window duration.
+					retry_after: retry_after
+						.as_secs()
+						.saturating_add(u64::from(retry_after.subsec_nanos() != 0)),
+				});
+			}
+		}
+		Ok(blocked)
+	}
+
+	/// Charges completed response cost or tokens to each in-memory counter and its pending database
+	/// delta. A counter is advanced first if the request crossed a window boundary.
+	fn settle(&self, budgets: &MatchedBudgets, response: &LLMContext) {
+		let now = Utc::now();
+		for budget in &budgets.budgets {
+			let charged = match budget.limit.unit {
+				BudgetLimitUnit::Usd => response.cost.as_ref().map(|cost| cost.total()),
+				BudgetLimitUnit::Tokens => response.total_tokens.map(Decimal::from),
+			};
+			let Some(charged) = charged else {
+				tracing::debug!(
+					target: "budget",
+					api_key = budgets.api_key,
+					budget = budget.name,
+					limit_unit = budget.limit.unit.as_str(),
+					"API key budget could not be charged because usage was unavailable"
+				);
+				continue;
+			};
+
+			let budget_id = budget_id(&budgets.api_key_id, budget);
+			let Some(mut counter) = self.counters.get_mut(&budget_id) else {
+				tracing::warn!(target: "budget", budget_id, "budget counter was not registered before settlement");
+				continue;
+			};
+			counter.refresh(now);
+			counter.amount += charged;
+			counter.pending += charged;
+			counter.updated_at = now;
+			let used = counter.amount;
+			drop(counter);
+
+			tracing::debug!(
+				target: "budget",
+				api_key = budgets.api_key,
+				budget = budget.name,
+				charged = %charged,
+				used = %used,
+				limit_unit = budget.limit.unit.as_str(),
+				limit_amount = %budget.limit.amount,
+				"API key budget charged"
+			);
+		}
+	}
+}
+
+impl BudgetSettlement {
+	pub fn settle(self, response: &LLMContext) {
+		self.policy.settle(&self.budgets, response);
+	}
+}
+
+impl crate::store::RequestPolicyTrait for BudgetPolicy {
+	async fn apply(
+		&self,
+		_client: &crate::proxy::httpproxy::PolicyClient,
+		log: &mut crate::telemetry::log::RequestLog,
+		req: &mut crate::http::Request,
+	) -> Result<crate::http::PolicyResponse, crate::proxy::ProxyResponse> {
+		let Some(budgets) = req.extensions_mut().remove::<MatchedBudgets>() else {
+			return Ok(crate::http::PolicyResponse::default());
+		};
+
+		if let Some(exceeded) = self
+			.check(&budgets)
+			.map_err(|err| crate::proxy::ProxyResponse::from(crate::proxy::ProxyError::Processing(err)))?
+		{
+			return Err(crate::proxy::ProxyError::BudgetExceeded(exceeded).into());
+		}
+
+		log.budgets = Some(BudgetSettlement {
+			policy: self.clone(),
+			budgets,
+		});
+		Ok(crate::http::PolicyResponse::default())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn budgets_require_a_database() {
+		let keys: crate::http::apikey::LocalAPIKeys = serde_json::from_value(serde_json::json!({
+			"keys": [{
+				"key": "sk-budget",
+				"metadata": {"name": "budgeted-key"},
+				"budgets": [{
+					"name": "tokens",
+					"limit": {"unit": "Tokens", "amount": 40},
+					"window": {"rolling": "1h"},
+					"onBudgetExceeded": "Block"
+				}]
+			}]
+		}))
+		.unwrap();
+		let authentication = keys.compile().unwrap();
+		let err = BudgetPolicy::default()
+			.register(&authentication, false)
+			.unwrap_err();
+		assert_eq!(
+			err.to_string(),
+			"API key budgets require config.database to be configured"
+		);
+	}
+
+	#[test]
+	fn registration_replaces_definitions_only_when_applied() {
+		let current: crate::http::apikey::LocalAPIKeys = serde_json::from_value(serde_json::json!({
+			"keys": [{
+				"key": "sk-budget",
+				"metadata": {"name": "budgeted-key"},
+				"budgets": [{
+					"name": "old",
+					"limit": {"unit": "Tokens", "amount": 40},
+					"window": {"rolling": "1h"},
+					"onBudgetExceeded": "Block"
+				}]
+			}]
+		}))
+		.unwrap();
+		let replacement: crate::http::apikey::LocalAPIKeys =
+			serde_json::from_value(serde_json::json!({
+				"keys": [{
+					"key": "sk-budget",
+					"metadata": {"name": "budgeted-key"},
+					"budgets": [{
+						"name": "new",
+						"limit": {"unit": "Tokens", "amount": 80},
+						"window": {"rolling": "1h"},
+						"onBudgetExceeded": "Audit"
+					}]
+				}]
+			}))
+			.unwrap();
+		let policy = BudgetPolicy::default();
+		policy.register(&current.compile().unwrap(), true).unwrap();
+
+		let candidate = policy.registration_policy();
+		candidate
+			.register(&replacement.compile().unwrap(), true)
+			.unwrap();
+		assert_eq!(policy.status(None).unwrap().budgets[0].name, "old");
+
+		policy.apply_registration(candidate.registration()).unwrap();
+		let status = policy.status(None).unwrap();
+		assert_eq!(status.budgets.len(), 1);
+		assert_eq!(status.budgets[0].name, "new");
+		assert_eq!(policy.counters.len(), 2);
+	}
+
+	#[tokio::test]
+	async fn flushes_only_new_usage_with_atomic_increments() {
+		let pool = sqlx::sqlite::SqlitePoolOptions::new()
+			.max_connections(1)
+			.connect("sqlite::memory:")
+			.await
+			.unwrap();
+		sqlx::raw_sql(
+			r#"
+CREATE TABLE budget_usage (
+    budget_id TEXT PRIMARY KEY,
+    window_start INTEGER NOT NULL,
+    window_end INTEGER NOT NULL,
+    used_amount INTEGER NOT NULL DEFAULT 0 CHECK (used_amount >= 0),
+    updated_at INTEGER NOT NULL
+);
+"#,
+		)
+		.execute(&pool)
+		.await
+		.unwrap();
+		let first = Arc::new(BudgetPolicy::default());
+		let second = Arc::new(BudgetPolicy::default());
+		first
+			.initialize(crate::database::DatabasePool::Sqlite(pool.clone()))
+			.await
+			.unwrap();
+		second
+			.initialize(crate::database::DatabasePool::Sqlite(pool.clone()))
+			.await
+			.unwrap();
+		let budget = Budget {
+			name: "window".to_string(),
+			limit: BudgetLimit {
+				unit: BudgetLimitUnit::Tokens,
+				amount: BudgetAmount(Decimal::from(100)),
+			},
+			window: BudgetWindow {
+				rolling: Duration::from_secs(60 * 60),
+			},
+			on_budget_exceeded: BudgetExceededAction::Block,
+		};
+		let now = Utc::now();
+		let (window_start, window_end) = budget_window(now, Duration::from_secs(60 * 60)).unwrap();
+		sqlx::query(
+			"INSERT INTO budget_usage (budget_id, window_start, window_end, unit, used_amount, updated_at) VALUES ('preloaded', ?, ?, 'Tokens', 9, ?), ('expired', 0, 1, 'Tokens', 8, 0)",
+		)
+		.bind(window_start.timestamp_millis())
+		.bind(window_end.timestamp_millis())
+		.bind(now.timestamp_millis())
+		.execute(&pool)
+		.await
+		.unwrap();
+		let preloaded = Arc::new(BudgetPolicy::default());
+		preloaded.counters.insert(
+			"preloaded".to_string(),
+			BudgetCounter::configured("key", &budget, now).unwrap(),
+		);
+		preloaded
+			.initialize(crate::database::DatabasePool::Sqlite(pool.clone()))
+			.await
+			.unwrap();
+		assert_eq!(
+			preloaded.counters.get("preloaded").unwrap().amount,
+			Decimal::from(9),
+		);
+		let expired =
+			sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM budget_usage WHERE budget_id = 'expired'")
+				.fetch_one(&pool)
+				.await
+				.unwrap();
+		assert_eq!(expired, 0);
+		first.counters.insert(
+			"window".to_string(),
+			BudgetCounter::configured("key", &budget, now).unwrap(),
+		);
+		second.counters.insert(
+			"window".to_string(),
+			BudgetCounter::configured("key", &budget, now).unwrap(),
+		);
+		assert_eq!(
+			first.counters.get("window").unwrap().window_start,
+			second.counters.get("window").unwrap().window_start,
+		);
+
+		{
+			let mut counter = first.counters.get_mut("window").unwrap();
+			counter.amount = Decimal::from(3);
+			counter.pending = Decimal::from(3);
+		}
+		{
+			let mut counter = second.counters.get_mut("window").unwrap();
+			counter.amount = Decimal::from(4);
+			counter.pending = Decimal::from(4);
+		}
+
+		first.flush().await.unwrap();
+		second.flush().await.unwrap();
+		first.flush().await.unwrap();
+		assert_eq!(
+			first.counters.get("window").unwrap().amount,
+			Decimal::from(7),
+		);
+
+		let used = sqlx::query_scalar::<_, i64>(
+			"SELECT used_amount FROM budget_usage WHERE budget_id = 'window'",
+		)
+		.fetch_one(&pool)
+		.await
+		.unwrap();
+		assert_eq!(used, 7);
+
+		let usd_budget = Budget {
+			name: "expired-residue".to_string(),
+			limit: BudgetLimit {
+				unit: BudgetLimitUnit::Usd,
+				amount: BudgetAmount(Decimal::ONE),
+			},
+			window: BudgetWindow {
+				rolling: Duration::from_secs(60 * 60),
+			},
+			on_budget_exceeded: BudgetExceededAction::Block,
+		};
+		let mut expired_residue = BudgetCounter::configured("key", &usd_budget, now).unwrap();
+		expired_residue.amount = Decimal::new(1, 10);
+		expired_residue.pending = Decimal::new(1, 10);
+		expired_residue.window_start = UnixDate::from_timestamp_millis(0).unwrap();
+		expired_residue.window_end = now - chrono::TimeDelta::milliseconds(1);
+		first
+			.counters
+			.insert("expired-residue".to_string(), expired_residue);
+		first.flush().await.unwrap();
+		assert!(
+			first
+				.counters
+				.get("expired-residue")
+				.unwrap()
+				.pending
+				.is_zero()
+		);
+	}
+}

--- a/crates/agentgateway/src/http/budget/postgres_schema.sql
+++ b/crates/agentgateway/src/http/budget/postgres_schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS budget_usage (
+    budget_id TEXT PRIMARY KEY,
+    window_start BIGINT NOT NULL,
+    window_end BIGINT NOT NULL,
+    unit TEXT NOT NULL,
+    used_amount BIGINT NOT NULL DEFAULT 0 CHECK (used_amount >= 0),
+    updated_at BIGINT NOT NULL
+);

--- a/crates/agentgateway/src/http/budget/postgres_upsert.sql
+++ b/crates/agentgateway/src/http/budget/postgres_upsert.sql
@@ -1,0 +1,15 @@
+INSERT INTO budget_usage (budget_id, window_start, window_end, unit, used_amount, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT(budget_id) DO UPDATE SET
+    window_start = excluded.window_start,
+    window_end = excluded.window_end,
+    unit = excluded.unit,
+    used_amount = CASE
+        WHEN excluded.window_start = budget_usage.window_start
+          AND excluded.window_end = budget_usage.window_end
+          AND excluded.unit = budget_usage.unit
+        THEN budget_usage.used_amount + excluded.used_amount
+        ELSE excluded.used_amount
+    END,
+    updated_at = GREATEST(budget_usage.updated_at, excluded.updated_at)
+WHERE excluded.window_end >= budget_usage.window_end;

--- a/crates/agentgateway/src/http/budget/sqlite_schema.sql
+++ b/crates/agentgateway/src/http/budget/sqlite_schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS budget_usage (
+    budget_id TEXT PRIMARY KEY,
+    window_start INTEGER NOT NULL,
+    window_end INTEGER NOT NULL,
+    unit TEXT NOT NULL,
+    used_amount INTEGER NOT NULL DEFAULT 0 CHECK (used_amount >= 0),
+    updated_at INTEGER NOT NULL
+);

--- a/crates/agentgateway/src/http/budget/sqlite_upsert.sql
+++ b/crates/agentgateway/src/http/budget/sqlite_upsert.sql
@@ -1,0 +1,15 @@
+INSERT INTO budget_usage (budget_id, window_start, window_end, unit, used_amount, updated_at)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(budget_id) DO UPDATE SET
+    window_start = excluded.window_start,
+    window_end = excluded.window_end,
+    unit = excluded.unit,
+    used_amount = CASE
+        WHEN excluded.window_start = budget_usage.window_start
+          AND excluded.window_end = budget_usage.window_end
+          AND excluded.unit = budget_usage.unit
+        THEN budget_usage.used_amount + excluded.used_amount
+        ELSE excluded.used_amount
+    END,
+    updated_at = MAX(budget_usage.updated_at, excluded.updated_at)
+WHERE excluded.window_end >= budget_usage.window_end;

--- a/crates/agentgateway/src/http/budget/status.rs
+++ b/crates/agentgateway/src/http/budget/status.rs
@@ -1,0 +1,101 @@
+use chrono::Utc;
+use rust_decimal::Decimal;
+
+use super::BudgetPolicy;
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetStatusResponse {
+	pub observed_at: i64,
+	pub budgets: Vec<BudgetStatus>,
+}
+
+/// User-facing snapshot of one budget's definition, current usage, and fixed window.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetStatus {
+	pub api_key_name: String,
+	pub name: String,
+	pub limit: BudgetStatusLimit,
+	pub usage: BudgetStatusUsage,
+	pub window: BudgetStatusWindow,
+	pub on_budget_exceeded: String,
+	pub updated_at: i64,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetStatusLimit {
+	pub unit: String,
+	pub amount: String,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetStatusUsage {
+	pub used: String,
+	pub remaining: String,
+	pub exceeded: bool,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BudgetStatusWindow {
+	pub start: i64,
+	pub end: i64,
+	pub duration_ms: i64,
+	pub expired: bool,
+}
+
+impl BudgetPolicy {
+	/// Returns a point-in-time status snapshot, optionally filtered by API key display name.
+	/// Expired counters are reported with zero usage even if no request has advanced their window.
+	pub fn status(&self, api_key_name: Option<&str>) -> anyhow::Result<BudgetStatusResponse> {
+		let observed_at = Utc::now();
+		let mut budgets = self
+			.counters
+			.iter()
+			.filter_map(|counter| {
+				let definition = counter.definition.as_ref()?;
+				if !api_key_name.is_none_or(|name| definition.api_key == name) {
+					return None;
+				}
+				let limit = definition.budget.limit.amount.decimal();
+				let expired = observed_at >= counter.window_end;
+				let used = if expired {
+					Decimal::ZERO
+				} else {
+					counter.amount
+				};
+				let remaining = (limit - used).max(Decimal::ZERO);
+				Some(BudgetStatus {
+					api_key_name: definition.api_key.clone(),
+					name: definition.budget.name.clone(),
+					limit: BudgetStatusLimit {
+						unit: definition.budget.limit.unit.as_str().to_owned(),
+						amount: limit.normalize().to_string(),
+					},
+					usage: BudgetStatusUsage {
+						used: used.normalize().to_string(),
+						remaining: remaining.normalize().to_string(),
+						exceeded: !expired && used >= limit,
+					},
+					window: BudgetStatusWindow {
+						start: counter.window_start.timestamp_millis(),
+						end: counter.window_end.timestamp_millis(),
+						duration_ms: i64::try_from(counter.rolling.as_millis())
+							.expect("budget duration was validated"),
+						expired,
+					},
+					on_budget_exceeded: definition.budget.on_budget_exceeded.as_str().to_owned(),
+					updated_at: counter.updated_at.timestamp_millis(),
+				})
+			})
+			.collect::<Vec<_>>();
+		budgets.sort_by(|a, b| (&a.api_key_name, &a.name).cmp(&(&b.api_key_name, &b.name)));
+		Ok(BudgetStatusResponse {
+			observed_at: observed_at.timestamp_millis(),
+			budgets,
+		})
+	}
+}

--- a/crates/agentgateway/src/http/mod.rs
+++ b/crates/agentgateway/src/http/mod.rs
@@ -2,6 +2,7 @@ pub mod filters;
 pub mod health;
 pub mod timeout;
 
+pub mod budget;
 pub mod buffer;
 pub mod bufferbody;
 mod buflist;

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -674,6 +674,9 @@ pub struct Config {
 	/// Handle for tasks/spans emitted on the admin runtime.
 	#[serde(skip)]
 	pub admin_runtime_handle: Option<tokio::runtime::Handle>,
+	/// Process-wide budget policy used by standalone configuration.
+	#[serde(skip)]
+	pub budget_policy: Arc<http::budget::BudgetPolicy>,
 
 	pub backend: BackendConfig,
 	pub mcp: McpConfig,
@@ -751,6 +754,8 @@ impl Config {
 		Some(local::AttachedPolicyContext {
 			oidc_policy_id: crate::http::oidc::PolicyId::policy(&policy_key),
 			oidc_cookie_encoder: self.oidc_cookie_encoder.as_ref(),
+			budget_policy: &self.budget_policy,
+			database_configured: self.database.is_some(),
 		})
 	}
 }

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -200,6 +200,10 @@ async fn apply_request_policies(
 		.api_key
 		.apply_without_response("api key", c, l, req, rp.headers())
 		.await?;
+	pol
+		.budget
+		.apply_without_response("budget", c, l, req, rp.headers())
+		.await?;
 
 	pol
 		.ext_authz
@@ -451,6 +455,10 @@ async fn apply_gateway_policies(
 	policies
 		.api_key
 		.apply_without_response("gateway api key", c, l, req, response_policies.headers())
+		.await?;
+	policies
+		.budget
+		.apply_without_response("gateway budget", c, l, req, response_policies.headers())
 		.await?;
 
 	policies

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -94,9 +94,9 @@ impl ProxyError {
 			| ProxyError::UpstreamTCPProxy(_) => ProxyResponseReason::UpstreamFailure,
 			ProxyError::RequestTimeout | ProxyError::UpstreamCallTimeout => ProxyResponseReason::Timeout,
 			ProxyError::ExtProc(_) => ProxyResponseReason::ExtProc,
-			ProxyError::RateLimitFailed | ProxyError::RateLimitExceeded { .. } => {
-				ProxyResponseReason::RateLimit
-			},
+			ProxyError::RateLimitFailed
+			| ProxyError::RateLimitExceeded { .. }
+			| ProxyError::BudgetExceeded(_) => ProxyResponseReason::RateLimit,
 			ProxyError::GuardrailRejected { .. } => ProxyResponseReason::Guardrail,
 		}
 	}
@@ -242,6 +242,8 @@ pub enum ProxyError {
 		remaining: u64,
 		reset_seconds: u64,
 	},
+	#[error(transparent)]
+	BudgetExceeded(#[from] http::budget::BudgetExceeded),
 	#[error("rate limit failed")]
 	RateLimitFailed,
 	#[error("request rejected by {guardrail} guardrail")]
@@ -420,6 +422,7 @@ impl ProxyError {
 			ProxyError::ProcessingString(_) => StatusCode::SERVICE_UNAVAILABLE,
 			ProxyError::SubstrateIngressFailed(status, _) => status,
 			ProxyError::RateLimitExceeded { .. } => StatusCode::TOO_MANY_REQUESTS,
+			ProxyError::BudgetExceeded(_) => StatusCode::TOO_MANY_REQUESTS,
 			// Rate limit service communication failure is a server error (500), not a rate limit (429).
 			// This matches Envoy's behavior (status_on_error defaults to 500).
 			ProxyError::RateLimitFailed => StatusCode::INTERNAL_SERVER_ERROR,
@@ -500,6 +503,23 @@ impl ProxyError {
 				)
 				.body(http::Body::empty())
 				.unwrap();
+		}
+
+		if let ProxyError::BudgetExceeded(exceeded) = &self {
+			return rb
+				.header(hyper::header::CONTENT_TYPE, "application/json")
+				.header(hyper::header::RETRY_AFTER, exceeded.retry_after.to_string())
+				.body(http::Body::from(
+					serde_json::json!({
+						"error": {
+							"message": exceeded.to_string(),
+							"type": "rate_limit_error",
+							"code": "budget_exceeded",
+						}
+					})
+					.to_string(),
+				))
+				.expect("budget exceeded response is valid");
 		}
 
 		// Add WWW-Authenticate header for MCP failures

--- a/crates/agentgateway/src/state_manager.rs
+++ b/crates/agentgateway/src/state_manager.rs
@@ -278,6 +278,10 @@ impl LocalClient {
 				.discovery
 				.sync_local(config.services, config.workloads, prev.discovery)?;
 		let next_binds = bind_result?;
+		self
+			.config
+			.budget_policy
+			.apply_registration(config.budget_registration)?;
 
 		Ok(PreviousState {
 			binds: next_binds,

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -376,6 +376,7 @@ pub struct RoutePolicies {
 	pub oidc: RequestPolicy<oidc::OidcPolicy>,
 	pub basic_auth: RequestPolicy<http::basicauth::BasicAuthentication>,
 	pub api_key: RequestPolicy<http::apikey::APIKeyAuthentication>,
+	pub budget: RequestPolicy<http::budget::BudgetPolicy>,
 	pub ext_authz: RequestPolicy<ext_authz::ExtAuthz>,
 	pub substrate_egress: RequestPolicy<substrate::SubstrateEgress>,
 	pub substrate_ingress: RequestPolicy<substrate::SubstrateIngress>,
@@ -411,6 +412,7 @@ pub struct GatewayPolicies {
 	pub transformation: RequestPolicy<http::transformation_cel::Transformation>,
 	pub basic_auth: RequestPolicy<http::basicauth::BasicAuthentication>,
 	pub api_key: RequestPolicy<http::apikey::APIKeyAuthentication>,
+	pub budget: RequestPolicy<http::budget::BudgetPolicy>,
 	pub buffer: RequestPolicy<http::buffer::Buffer>,
 }
 
@@ -426,6 +428,7 @@ impl GatewayPolicies {
 			&self.transformation as &dyn PolicyExpressions,
 			&self.basic_auth as &dyn PolicyExpressions,
 			&self.api_key as &dyn PolicyExpressions,
+			&self.budget as &dyn PolicyExpressions,
 		]
 		.into_iter()
 	}
@@ -447,6 +450,7 @@ impl RoutePolicies {
 			&self.oidc as &dyn PolicyExpressions,
 			&self.basic_auth as &dyn PolicyExpressions,
 			&self.api_key as &dyn PolicyExpressions,
+			&self.budget as &dyn PolicyExpressions,
 			&self.ext_authz as &dyn PolicyExpressions,
 			&self.substrate_egress as &dyn PolicyExpressions,
 			&self.substrate_ingress as &dyn PolicyExpressions,
@@ -1069,6 +1073,9 @@ impl Store {
 				TrafficPolicy::APIKey(p) => {
 					pol.api_key.merge_with_inheritance(p, lock_inheritance);
 				},
+				TrafficPolicy::Budget(p) => {
+					pol.budget.merge_with_inheritance(p, lock_inheritance);
+				},
 				TrafficPolicy::Transformation(p) => {
 					pol
 						.transformation
@@ -1205,6 +1212,9 @@ impl Store {
 				},
 				TrafficPolicy::APIKey(p) => {
 					pol.api_key.set_if_unset(p);
+				},
+				TrafficPolicy::Budget(p) => {
+					pol.budget.set_if_unset(p);
 				},
 				TrafficPolicy::Authorization(p) => {
 					authz.push(p.clone().0);

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -959,6 +959,7 @@ impl RequestLog {
 			outgoing_span: None,
 			llm_request: None,
 			llm_response: Default::default(),
+			budgets: None,
 			a2a_method: None,
 			a2a_response: None,
 			inference_pool: None,
@@ -1125,6 +1126,7 @@ pub struct RequestLog {
 
 	pub llm_request: Option<llm::LLMRequest>,
 	pub llm_response: AsyncLog<llm::LLMInfo>,
+	pub budgets: Option<crate::http::budget::BudgetSettlement>,
 
 	pub a2a_method: Option<Strng>,
 	pub a2a_response: Option<a2a::ResponseInfo>,
@@ -1208,6 +1210,9 @@ impl Drop for DropOnLog {
 				.map(|llm_info| LLMContext::from_llm_info(llm_info, Some(log.model_catalog.as_ref())));
 			if let Some(llm_response) = llm_response.as_mut() {
 				llm_response.set_token_timing(log.start.as_instant(), end_time.as_instant());
+			}
+			if let (Some(budgets), Some(llm_response)) = (log.budgets.take(), llm_response.as_ref()) {
+				budgets.settle(llm_response);
 			}
 
 			let mcp = log.mcp_status.take();

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -161,7 +161,16 @@ pub fn setup_llm_named_provider_mock(
 	provider: LocalNamedAIProvider,
 	config: &str,
 ) -> (MockServer, TestBind, Client<MemoryConnector, Body>) {
-	let t = setup_proxy_test(config).unwrap();
+	let config = crate::config::parse_config(config.to_string(), None).unwrap();
+	setup_llm_named_provider_mock_with_config(mock, provider, config)
+}
+
+pub fn setup_llm_named_provider_mock_with_config(
+	mock: MockServer,
+	provider: LocalNamedAIProvider,
+	config: crate::Config,
+) -> (MockServer, TestBind, Client<MemoryConnector, Body>) {
+	let t = setup_proxy_test_with_config(config);
 	let resources = crate::resource_manager::ResourceFetcher::direct(t.pi.upstream.clone());
 	let be = futures::executor::block_on(
 		crate::types::local::LocalAIBackend::Provider(provider).translate(&resources),
@@ -1039,6 +1048,12 @@ impl TestBind {
 		)
 		.await
 		.unwrap();
+		self
+			.pi
+			.cfg
+			.budget_policy
+			.apply_registration(normalized.budget_registration.clone())
+			.unwrap();
 		for v in normalized.policies.into_iter() {
 			self.policies += 1;
 			self.with_policy(TargetedPolicy {

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2785,6 +2785,7 @@ pub enum TrafficPolicy {
 	Oidc(RequestPolicy<crate::http::oidc::OidcPolicy>),
 	BasicAuth(RequestPolicy<crate::http::basicauth::BasicAuthentication>),
 	APIKey(RequestPolicy<crate::http::apikey::APIKeyAuthentication>),
+	Budget(RequestPolicy<crate::http::budget::BudgetPolicy>),
 	Transformation(RequestPolicy<crate::http::transformation_cel::Transformation>),
 	Csrf(RequestPolicy<crate::http::csrf::Csrf>),
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2998,6 +2998,7 @@ fn traffic_policy_from_proto(
 						http::apikey::APIKeyPolicy {
 							metadata: meta,
 							allowed_models: Default::default(),
+							budgets: None,
 						},
 					))
 				})
@@ -3875,6 +3876,7 @@ fn traffic_policy_kind_name(policy: &TrafficPolicy) -> &'static str {
 		TrafficPolicy::Oidc(_) => "oidc",
 		TrafficPolicy::BasicAuth(_) => "basicAuth",
 		TrafficPolicy::APIKey(_) => "apiKey",
+		TrafficPolicy::Budget(_) => "budget",
 		TrafficPolicy::Transformation(_) => "transformation",
 		TrafficPolicy::Csrf(_) => "csrf",
 		TrafficPolicy::RequestHeaderModifier(_) => "requestHeaderModifier",

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -85,10 +85,20 @@ impl NormalizedLocalConfig {
 		let s = s.replace("# yaml-language-server: $schema", "#");
 		let s = shellexpand::full(&s)?;
 		let local_config: LocalConfig = serdes::yamlviajson::from_str(&s)?;
+		let mut registration_config = config.clone();
+		let registration_policy = Arc::new(config.budget_policy.registration_policy());
+		registration_config.budget_policy = registration_policy.clone();
 		let scope = resources.scope_full_computation();
-		let result = Box::pin(convert(resources, gateway_name, config, local_config)).await;
+		let result = Box::pin(convert(
+			resources,
+			gateway_name,
+			&registration_config,
+			local_config,
+		))
+		.await;
 		scope.finish(result.is_ok());
-		let t = result?;
+		let mut t = result?;
+		t.budget_registration = registration_policy.registration();
 		Ok(t)
 	}
 }
@@ -301,6 +311,8 @@ fn parse_deprecated_tracing_endpoint(endpoint: &str) -> anyhow::Result<(Target, 
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct NormalizedLocalConfig {
+	#[serde(skip)]
+	pub(crate) budget_registration: crate::http::budget::BudgetRegistration,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub model_catalog: Option<Vec<crate::ModelCatalogSource>>,
 	pub binds: Vec<BindSnapshot>,
@@ -2026,6 +2038,7 @@ fn ui_matches(oidc_redirect_path: Option<Strng>) -> Vec<RouteMatch> {
 		PathMatch::PathPrefix("/api/cel".into()),
 		PathMatch::PathPrefix("/api/logs".into()),
 		PathMatch::PathPrefix("/api/costs".into()),
+		PathMatch::PathPrefix("/api/budgets".into()),
 	];
 	if let Some(path) = oidc_redirect_path
 		&& !paths.iter().any(|existing| match existing {
@@ -3290,6 +3303,7 @@ async fn convert(
 	all_policies.extend_from_slice(&split_frontend_policies(gateway, frontend_policies).await?);
 
 	let normalized = NormalizedLocalConfig {
+		budget_registration: Default::default(),
 		model_catalog,
 		binds: all_binds,
 		listener_routes: all_listener_routes,
@@ -5037,6 +5051,8 @@ pub async fn convert_route(
 			Some(AttachedPolicyContext {
 				oidc_policy_id: crate::http::oidc::PolicyId::route(&key),
 				oidc_cookie_encoder: config.oidc_cookie_encoder.as_ref(),
+				budget_policy: &config.budget_policy,
+				database_configured: config.database.is_some(),
 			}),
 		)
 		.await?
@@ -5076,6 +5092,8 @@ pub(crate) struct ResolvedPolicies {
 pub struct AttachedPolicyContext<'a> {
 	pub oidc_policy_id: crate::http::oidc::PolicyId,
 	pub oidc_cookie_encoder: Option<&'a crate::http::sessionpersistence::Encoder>,
+	pub budget_policy: &'a Arc<crate::http::budget::BudgetPolicy>,
+	pub database_configured: bool,
 }
 
 async fn split_frontend_policies(
@@ -5174,6 +5192,12 @@ pub(crate) async fn split_policies_for_target(
 	attached: Option<AttachedPolicyContext<'_>>,
 	backend_target: bool,
 ) -> Result<ResolvedPolicies, Error> {
+	let budget_policy = attached.as_ref().map(|context| {
+		(
+			Arc::clone(context.budget_policy),
+			context.database_configured,
+		)
+	});
 	let mut resolved = ResolvedPolicies::default();
 	let ResolvedPolicies {
 		backend_policies,
@@ -5314,6 +5338,7 @@ pub(crate) async fn split_policies_for_target(
 		let Some(AttachedPolicyContext {
 			oidc_policy_id,
 			oidc_cookie_encoder,
+			..
 		}) = attached
 		else {
 			return Err(Error::msg("oidc policies must be attached"));
@@ -5337,7 +5362,14 @@ pub(crate) async fn split_policies_for_target(
 		)));
 	}
 	if let Some(p) = api_key {
-		route_policies.push(TrafficPolicy::APIKey(RequestPolicy::single(p.compile()?)));
+		let (budget_policy, database_configured) =
+			budget_policy.ok_or_else(|| Error::msg("API key policies must be attached"))?;
+		let api_key = p.compile()?;
+		budget_policy.register(&api_key, database_configured)?;
+		route_policies.push(TrafficPolicy::APIKey(RequestPolicy::single(api_key)));
+		route_policies.push(TrafficPolicy::Budget(RequestPolicy::single_arc(
+			budget_policy,
+		)));
 	}
 	if let Some(p) = transformations {
 		if backend_target {

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -1272,6 +1272,9 @@ ui:
 		|route_match| matches!(&route_match.path, PathMatch::PathPrefix(path) if path.as_str() == "/ui")
 	));
 	assert!(ui_route.matches.iter().any(
+		|route_match| matches!(&route_match.path, PathMatch::PathPrefix(path) if path.as_str() == "/api/budgets")
+	));
+	assert!(ui_route.matches.iter().any(
 		|route_match| matches!(&route_match.path, PathMatch::Exact(path) if path.as_str() == "/oauth/callback")
 	));
 	assert!(

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use agent_core::version::BuildInfo;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::{StatusCode, Uri};
 use axum::response::sse::Event;
 use axum::response::{IntoResponse, Redirect, Response, Sse};
@@ -109,6 +109,7 @@ pub fn router(
 		.route("/api/logs/analytics/summary", post(analytics_summary))
 		.route("/api/costs/models", get(cost_models))
 		.route("/api/costs/refresh-base", post(refresh_base_costs))
+		.route("/api/budgets/status", get(budget_status))
 		.nest_service("/ui", ui_service)
 		.route("/", get(|| async { Redirect::permanent("/ui") }))
 		.with_state(App {
@@ -752,6 +753,24 @@ async fn cost_models(
 	State(app): State<App>,
 ) -> Result<Json<crate::llm::catalog::ModelCatalogModels>, ErrorResponse> {
 	Ok(Json(app.model_catalog.list_models()))
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BudgetStatusQuery {
+	api_key_name: Option<String>,
+}
+
+async fn budget_status(
+	State(app): State<App>,
+	Query(query): Query<BudgetStatusQuery>,
+) -> Result<Json<crate::http::budget::BudgetStatusResponse>, ErrorResponse> {
+	Ok(Json(
+		app
+			.state
+			.budget_policy
+			.status(query.api_key_name.as_deref())?,
+	))
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -61,6 +61,120 @@ async fn llm_openai_tokenize() {
 }
 
 #[tokio::test]
+async fn llm_token_budget_persists_and_blocks_requests() {
+	let pool =
+		agentgateway::database::DatabasePool::connect_with_max_connections("sqlite::memory:", Some(1))
+			.await
+			.unwrap();
+	let policy = json!({
+		"apiKey": {
+			"keys": [
+				{
+					"key": "sk-budget",
+					"metadata": {"name": "budgeted-key"},
+					"budgets": [{
+						"name": "tokens",
+						"limit": {"unit": "Tokens", "amount": 40},
+						"window": {"rolling": "1h"},
+						"onBudgetExceeded": "Block"
+					}]
+				},
+				{
+					"key": "sk-other-budget",
+					"metadata": {"name": "budgeted-key"},
+					"budgets": [{
+						"name": "tokens",
+						"limit": {"unit": "Tokens", "amount": 40},
+						"window": {"rolling": "1h"},
+						"onBudgetExceeded": "Block"
+					}]
+				}
+			],
+			"mode": "strict"
+		}
+	});
+
+	let mock = body_mock(include_bytes!(
+		"../../../llm/src/tests/response/completions/basic.json"
+	))
+	.await;
+	let provider = llm_named_provider(
+		&mock,
+		AIProvider::OpenAI(openai::Provider {
+			model: None,
+			moderation: None,
+		}),
+		false,
+	);
+	let config = agentgateway::config::parse_config("{}".to_string(), None).unwrap();
+	config.budget_policy.initialize(pool.clone()).await.unwrap();
+	let budget_policy = config.budget_policy.clone();
+	let (_mock, mut bind, io) = setup_llm_named_provider_mock_with_config(mock, provider, config);
+	bind.attach_route_policy(policy.clone()).await;
+
+	let response = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions")
+		.header("authorization", "Bearer sk-budget")
+		.body(Body::from(
+			include_bytes!("../../../llm/src/tests/requests/completions/basic.json").to_vec(),
+		))
+		.send(io.clone())
+		.await
+		.unwrap();
+	assert_eq!(response.status(), StatusCode::OK);
+	response.into_body().collect().await.unwrap();
+
+	// Display names are not identities: another key with the same metadata name and budget name
+	// has an independent counter.
+	let response = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions")
+		.header("authorization", "Bearer sk-other-budget")
+		.body(Body::from(
+			include_bytes!("../../../llm/src/tests/requests/completions/basic.json").to_vec(),
+		))
+		.send(io)
+		.await
+		.unwrap();
+	assert_eq!(response.status(), StatusCode::OK);
+	response.into_body().collect().await.unwrap();
+	budget_policy.flush().await.unwrap();
+
+	let mock = body_mock(include_bytes!(
+		"../../../llm/src/tests/response/completions/basic.json"
+	))
+	.await;
+	let provider = llm_named_provider(
+		&mock,
+		AIProvider::OpenAI(openai::Provider {
+			model: None,
+			moderation: None,
+		}),
+		false,
+	);
+	let config = agentgateway::config::parse_config("{}".to_string(), None).unwrap();
+	config.budget_policy.initialize(pool).await.unwrap();
+	let (mock, mut bind, io) = setup_llm_named_provider_mock_with_config(mock, provider, config);
+	bind.attach_route_policy(policy).await;
+
+	let response = RequestBuilder::new(Method::POST, "http://lo/v1/chat/completions")
+		.header("authorization", "Bearer sk-budget")
+		.body(Body::from(
+			include_bytes!("../../../llm/src/tests/requests/completions/basic.json").to_vec(),
+		))
+		.send(io)
+		.await
+		.unwrap();
+	assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+	assert!(
+		response
+			.headers()
+			.get(::http::header::RETRY_AFTER)
+			.and_then(|value| value.to_str().ok())
+			.and_then(|value| value.parse::<u64>().ok())
+			.is_some_and(|seconds| seconds > 0)
+	);
+	assert_eq!(mock.received_requests().await.unwrap().len(), 0);
+}
+
+#[tokio::test]
 async fn llm_detect_mode_passthrough_without_rewrite() {
 	let mock = body_mock(llm_body!("response/completions/basic.json")).await;
 	let provider = agentgateway::types::local::LocalNamedAIProvider {

--- a/crates/core/src/durfmt.rs
+++ b/crates/core/src/durfmt.rs
@@ -13,13 +13,47 @@ fn err_str(e: &go_parse_duration::Error) -> &str {
 }
 
 pub fn parse(string: &str) -> Result<Duration, Error> {
-	let d = go_parse_duration::parse_duration(string).map_err(Error::ParseError)?;
+	if string.is_empty() {
+		return Err(Error::ParseError(go_parse_duration::Error::ParseError(
+			"duration cannot be empty".to_string(),
+		)));
+	}
+	let day_digits = string.bytes().take_while(u8::is_ascii_digit).count();
+	let (days, remainder) = if day_digits > 0 && string.as_bytes().get(day_digits) == Some(&b'd') {
+		let days = string[..day_digits].parse::<u64>().map_err(|_| {
+			Error::ParseError(go_parse_duration::Error::ParseError(
+				"invalid day count".to_string(),
+			))
+		})?;
+		(days, &string[day_digits + 1..])
+	} else {
+		(0, string)
+	};
+	let day_duration = days
+		.checked_mul(24 * 60 * 60)
+		.map(Duration::from_secs)
+		.ok_or_else(|| {
+			Error::ParseError(go_parse_duration::Error::ParseError(
+				"duration overflow".to_string(),
+			))
+		})?;
+	if remainder.is_empty() {
+		return Ok(day_duration);
+	}
+
+	let d = go_parse_duration::parse_duration(remainder).map_err(Error::ParseError)?;
 	if d < 0 {
 		return Err(Error::ParseError(go_parse_duration::Error::ParseError(
 			"negative string not allowed".to_string(),
 		)));
 	}
-	Ok(Duration::from_nanos(d as u64))
+	day_duration
+		.checked_add(Duration::from_nanos(d as u64))
+		.ok_or_else(|| {
+			Error::ParseError(go_parse_duration::Error::ParseError(
+				"duration overflow".to_string(),
+			))
+		})
 }
 
 pub fn format(d: Duration) -> String {
@@ -49,6 +83,19 @@ fn round_to_3_figs(d: Duration) -> Duration {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn test_parse_days() {
+		assert!(parse("").is_err());
+		assert_eq!(parse("30d"), Ok(Duration::from_secs(30 * 24 * 60 * 60)));
+		assert_eq!(
+			parse("1d12h30m"),
+			Ok(Duration::from_secs((24 + 12) * 60 * 60 + 30 * 60))
+		);
+		assert_eq!(parse("1d"), parse("24h"));
+		assert!(parse("1.5d").is_err());
+		assert!(parse("1h1d").is_err());
+	}
 
 	#[test]
 	fn test_to_string() {

--- a/schema/config.json
+++ b/schema/config.json
@@ -6433,6 +6433,13 @@
                 "type": "string"
               },
               "default": null
+            },
+            "budgets": {
+              "description": "Independent budgets charged after LLM responses. A request is not charged when its provider\ndoes not report the usage or cost required by the budget unit.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Budget"
+              }
             }
           },
           "additionalProperties": false,
@@ -6460,6 +6467,13 @@
                 "type": "string"
               },
               "default": null
+            },
+            "budgets": {
+              "description": "Independent budgets charged after LLM responses. A request is not charged when its provider\ndoes not report the usage or cost required by the budget unit.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Budget"
+              }
             }
           },
           "additionalProperties": false,
@@ -6471,6 +6485,82 @@
     },
     "APIKey": {
       "type": "string"
+    },
+    "Budget": {
+      "description": "A named budget attached to a standalone API key.\n\nUsage is charged after an LLM response when the provider reports the tokens or cost required by\nthe configured unit. Requests with unavailable usage are logged but cannot be charged or blocked\nretroactively.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Stable name for this budget within its owning API key.",
+          "type": "string"
+        },
+        "limit": {
+          "description": "Maximum usage allowed during the window.",
+          "$ref": "#/$defs/BudgetLimit"
+        },
+        "window": {
+          "description": "Rolling window over which usage will be accumulated.",
+          "$ref": "#/$defs/BudgetWindow"
+        },
+        "onBudgetExceeded": {
+          "description": "Action taken when the budget is exceeded.",
+          "$ref": "#/$defs/BudgetExceededAction"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "limit",
+        "window",
+        "onBudgetExceeded"
+      ]
+    },
+    "BudgetLimit": {
+      "type": "object",
+      "properties": {
+        "unit": {
+          "$ref": "#/$defs/BudgetLimitUnit"
+        },
+        "amount": {
+          "$ref": "#/$defs/BudgetAmount"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "unit",
+        "amount"
+      ]
+    },
+    "BudgetLimitUnit": {
+      "type": "string",
+      "enum": [
+        "USD",
+        "Tokens"
+      ]
+    },
+    "BudgetAmount": {
+      "type": "number",
+      "format": "double"
+    },
+    "BudgetWindow": {
+      "type": "object",
+      "properties": {
+        "rolling": {
+          "description": "Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.\nWindows are aligned to the Unix epoch rather than starting with the first request: `1h`\nfollows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day\nperiods rather than calendar months.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "rolling"
+      ]
+    },
+    "BudgetExceededAction": {
+      "type": "string",
+      "enum": [
+        "Audit",
+        "Block"
+      ]
     },
     "APIKeyHash": {
       "type": "string"

--- a/schema/config.md
+++ b/schema/config.md
@@ -3819,6 +3819,14 @@
 |`binds[].listeners[].routes[].policies.apiKey.keys[].key`|string|API key value to accept.|
 |`binds[].listeners[].routes[].policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`binds[].listeners[].routes[].policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`binds[].listeners[].routes[].policies.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`binds[].listeners[].routes[].policies.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`binds[].listeners[].routes[].policies.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`binds[].listeners[].routes[].policies.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`binds[].listeners[].routes[].policies.apiKey.keys[].budgets[].limit.amount`|number||
+|`binds[].listeners[].routes[].policies.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`binds[].listeners[].routes[].policies.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`binds[].listeners[].routes[].policies.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`binds[].listeners[].routes[].policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`binds[].listeners[].routes[].policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`binds[].listeners[].routes[].policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -17534,6 +17542,14 @@
 |`binds[].listeners[].policies.apiKey.keys[].key`|string|API key value to accept.|
 |`binds[].listeners[].policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`binds[].listeners[].policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`binds[].listeners[].policies.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`binds[].listeners[].policies.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`binds[].listeners[].policies.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`binds[].listeners[].policies.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`binds[].listeners[].policies.apiKey.keys[].budgets[].limit.amount`|number||
+|`binds[].listeners[].policies.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`binds[].listeners[].policies.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`binds[].listeners[].policies.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`binds[].listeners[].policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`binds[].listeners[].policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`binds[].listeners[].policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -22447,6 +22463,14 @@
 |`policies[].policy.apiKey.keys[].key`|string|API key value to accept.|
 |`policies[].policy.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`policies[].policy.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`policies[].policy.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`policies[].policy.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`policies[].policy.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`policies[].policy.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`policies[].policy.apiKey.keys[].budgets[].limit.amount`|number||
+|`policies[].policy.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`policies[].policy.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`policies[].policy.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`policies[].policy.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`policies[].policy.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`policies[].policy.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -38267,6 +38291,14 @@
 |`routeGroups[].routes[].policies.apiKey.keys[].key`|string|API key value to accept.|
 |`routeGroups[].routes[].policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`routeGroups[].routes[].policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`routeGroups[].routes[].policies.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`routeGroups[].routes[].policies.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`routeGroups[].routes[].policies.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`routeGroups[].routes[].policies.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`routeGroups[].routes[].policies.apiKey.keys[].budgets[].limit.amount`|number||
+|`routeGroups[].routes[].policies.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`routeGroups[].routes[].policies.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`routeGroups[].routes[].policies.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`routeGroups[].routes[].policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`routeGroups[].routes[].policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`routeGroups[].routes[].policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -51692,6 +51724,14 @@
 |`gateways.*.listeners[].apiKey.keys[].key`|string|API key value to accept.|
 |`gateways.*.listeners[].apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`gateways.*.listeners[].apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`gateways.*.listeners[].apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`gateways.*.listeners[].apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`gateways.*.listeners[].apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`gateways.*.listeners[].apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`gateways.*.listeners[].apiKey.keys[].budgets[].limit.amount`|number||
+|`gateways.*.listeners[].apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`gateways.*.listeners[].apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`gateways.*.listeners[].apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`gateways.*.listeners[].apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`gateways.*.listeners[].apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`gateways.*.listeners[].apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -52992,6 +53032,14 @@
 |`gateways.*.apiKey.keys[].key`|string|API key value to accept.|
 |`gateways.*.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`gateways.*.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`gateways.*.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`gateways.*.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`gateways.*.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`gateways.*.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`gateways.*.apiKey.keys[].budgets[].limit.amount`|number||
+|`gateways.*.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`gateways.*.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`gateways.*.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`gateways.*.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`gateways.*.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`gateways.*.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -56697,6 +56745,14 @@
 |`routes[].policies.apiKey.keys[].key`|string|API key value to accept.|
 |`routes[].policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`routes[].policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`routes[].policies.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`routes[].policies.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`routes[].policies.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`routes[].policies.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`routes[].policies.apiKey.keys[].budgets[].limit.amount`|number||
+|`routes[].policies.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`routes[].policies.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`routes[].policies.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`routes[].policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`routes[].policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`routes[].policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -73866,6 +73922,14 @@
 |`llm.policies.apiKey.keys[].key`|string|API key value to accept.|
 |`llm.policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`llm.policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`llm.policies.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`llm.policies.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`llm.policies.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`llm.policies.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`llm.policies.apiKey.keys[].budgets[].limit.amount`|number||
+|`llm.policies.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`llm.policies.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`llm.policies.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`llm.policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`llm.policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`llm.policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -80130,6 +80194,14 @@
 |`mcp.policies.apiKey.keys[].key`|string|API key value to accept.|
 |`mcp.policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`mcp.policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`mcp.policies.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`mcp.policies.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`mcp.policies.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`mcp.policies.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`mcp.policies.apiKey.keys[].budgets[].limit.amount`|number||
+|`mcp.policies.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`mcp.policies.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`mcp.policies.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`mcp.policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`mcp.policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`mcp.policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|
@@ -82598,6 +82670,14 @@
 |`ui.policies.apiKey.keys[].key`|string|API key value to accept.|
 |`ui.policies.apiKey.keys[].metadata`|any|Optional metadata attached to requests authenticated with this key.|
 |`ui.policies.apiKey.keys[].allowedModels`|[]string|Model patterns this key is allowed to access.<br>Omitted means no additional constraint; an empty list denies all models.|
+|`ui.policies.apiKey.keys[].budgets`|[]object|Independent budgets charged after LLM responses. A request is not charged when its provider<br>does not report the usage or cost required by the budget unit.|
+|`ui.policies.apiKey.keys[].budgets[].name`|string|Stable name for this budget within its owning API key.|
+|`ui.policies.apiKey.keys[].budgets[].limit`|object|Maximum usage allowed during the window.|
+|`ui.policies.apiKey.keys[].budgets[].limit.unit`|enum|Possible values: `USD`, `Tokens`.|
+|`ui.policies.apiKey.keys[].budgets[].limit.amount`|number||
+|`ui.policies.apiKey.keys[].budgets[].window`|object|Rolling window over which usage will be accumulated.|
+|`ui.policies.apiKey.keys[].budgets[].window.rolling`|string|Duration of the fixed usage window, for example `1h`, `24h`, or `30d`.<br>Windows are aligned to the Unix epoch rather than starting with the first request: `1h`<br>follows UTC clock hours, `24h` starts at midnight UTC, and `30d` uses consecutive 30-day<br>periods rather than calendar months.|
+|`ui.policies.apiKey.keys[].budgets[].onBudgetExceeded`|enum|Action taken when the budget is exceeded.<br>Possible values: `Audit`, `Block`.|
 |`ui.policies.apiKey.keys[].keyHash`|string|SHA-256 hash of an API key value to accept, in `sha256:<hex>` format.|
 |`ui.policies.apiKey.mode`|enum|Controls whether requests must include a valid API key.<br>Possible values: `strict`, `optional`, `permissive`.|
 |`ui.policies.apiKey.location`|object|Where to read the API key from in incoming requests.<br>Exactly one of header, queryParameter, cookie, or expression may be set.|

--- a/ui/src/api/budgetsApi.ts
+++ b/ui/src/api/budgetsApi.ts
@@ -1,0 +1,32 @@
+import { requestJson } from '@/api/base';
+
+export interface BudgetStatus {
+	apiKeyName: string;
+	name: string;
+	limit: {
+		unit: 'USD' | 'Tokens';
+		amount: string;
+	};
+	usage: {
+		used: string;
+		remaining: string;
+		exceeded: boolean;
+	};
+	window: {
+		start: number;
+		end: number;
+		durationMs: number;
+		expired: boolean;
+	};
+	onBudgetExceeded: 'Audit' | 'Block';
+	updatedAt: number;
+}
+
+export interface BudgetStatusResponse {
+	observedAt: number;
+	budgets: BudgetStatus[];
+}
+
+export function getBudgetStatus() {
+	return requestJson<BudgetStatusResponse>('/api/budgets/status');
+}

--- a/ui/src/credentialDisplay.ts
+++ b/ui/src/credentialDisplay.ts
@@ -6,11 +6,11 @@ export function maskKey(key: string) {
 }
 
 export function hasKeyValue<T extends { metadata?: unknown }>(key: T): key is T & { key: string } {
-	return 'key' in key;
+	return typeof (key as { key?: unknown }).key === 'string';
 }
 
 export function keyValue(key: VirtualApiKey) {
-	return hasKeyValue(key) ? key.key : key.keyHash;
+	return hasKeyValue(key) ? key.key : (key.keyHash ?? '');
 }
 
 export function keyLabel(key: VirtualApiKey) {

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 
+import { getBudgetStatus } from '@/api/budgetsApi';
 import { getConfig, getEffectiveConfig, writeConfig } from '@/api/configApi';
 import { getConfigDump } from '@/api/configDumpApi';
 import {
@@ -167,6 +168,16 @@ export function useTrafficConfigData(options?: { enabled?: boolean }) {
 		isLoading: config.isLoading || runtime.isLoading || configResources.isLoading,
 		error: config.error ?? runtime.error ?? configResources.error
 	};
+}
+
+export function useBudgetStatus(options?: { enabled?: boolean }) {
+	return useQuery({
+		queryKey: ['budgetStatus'],
+		queryFn: getBudgetStatus,
+		enabled: options?.enabled ?? true,
+		refetchInterval: 15_000,
+		retry: false
+	});
 }
 
 export function useConfigDumpMode() {

--- a/ui/src/pages/Keys.tsx
+++ b/ui/src/pages/Keys.tsx
@@ -1,5 +1,7 @@
 import {
+	Bot,
 	Check,
+	CircleDollarSign,
 	Copy,
 	Eye,
 	EyeOff,
@@ -7,11 +9,13 @@ import {
 	Pencil,
 	Plus,
 	SlidersHorizontal,
+	Tags,
 	Trash2,
 	X
 } from 'lucide-react';
 import { useRef, useState } from 'react';
 
+import type { BudgetStatus, BudgetStatusResponse } from '@/api/budgetsApi';
 import { ConfigDiffSaveActions } from '@/components/ConfigDiffDrawer';
 import { EnumSelector } from '@/components/EnumSelector';
 import {
@@ -21,8 +25,11 @@ import {
 	EmptyState,
 	Field,
 	FieldGroup,
+	formatNumber,
+	formatRelativeTime,
 	PageHeader,
 	Panel,
+	SegmentedControl,
 	StatusBanner,
 	Tooltip
 } from '@/components/Primitives';
@@ -30,6 +37,7 @@ import { getApiKeyPolicy, isDatabaseConfigResource, upsertVirtualKey } from '@/c
 import { hasKeyValue, keyValue, maskKey } from '@/credentialDisplay';
 import { useStickyQueryParam } from '@/drawerRouteState';
 import {
+	useBudgetStatus,
 	useDeleteConfigResource,
 	useLlmConfigData,
 	useUpsertConfigResource,
@@ -40,10 +48,11 @@ import {
 	authorizationLocationToValue,
 	CredentialLocationSetting
 } from '@/policies/AuthorizationLocation';
+import { ListEditor } from '@/policies/ListEditor';
 import { KeyValueEditor } from '@/policies/PolicyFormControls';
-import { AdvancedSettingRow } from '@/policies/PolicyLayout';
+import { AdvancedSettingRow, CollapsiblePolicySection } from '@/policies/PolicyLayout';
 import { type SchemaHelp, useSchemaHelp } from '@/schemaHelp';
-import type { GatewayConfig, LlmApiKeyPolicy, VirtualApiKey } from '@/types';
+import type { GatewayConfig, LlmApiKeyPolicy, VirtualApiKey, VirtualApiKeyBudget } from '@/types';
 
 const fileOwnedPolicyMessage =
 	'This API key policy is file-owned and cannot be modified in hybrid mode.';
@@ -64,6 +73,9 @@ export function KeysPage() {
 	const upsertResource = useUpsertConfigResource();
 	const upsertPolicy = useUpsertPolicyResource();
 	const deleteResource = useDeleteConfigResource();
+	const budgetStatus = useBudgetStatus({
+		enabled: keys.some(key => key.budgets?.length)
+	});
 	const help = useSchemaHelp();
 	const policy = (policies.apiKey ?? null) as LlmApiKeyPolicy | null;
 	const filePolicyOwned = Boolean(
@@ -262,19 +274,33 @@ export function KeysPage() {
 								<tr>
 									<th>Name</th>
 									<th>Key</th>
+									<th>Models</th>
 									<th>Metadata</th>
+									<th>Budgets</th>
 									<th />
 								</tr>
 							</thead>
 							<tbody>
 								{keys.map((item, index) => (
 									<tr key={keyValue(item)}>
-										<td className="strong key-name-cell">{keyName(item) || 'Unnamed key'}</td>
+										<td className="strong key-name-cell">
+											{keyName(item) || <span className="muted">Unnamed key</span>}
+										</td>
 										<td className="key-cell">
 											<VirtualKeyValue value={keyValue(item)} />
 										</td>
 										<td>
+											<AllowedModelsSummary value={item.allowedModels} />
+										</td>
+										<td>
 											<MetadataSummary value={item.metadata} />
+										</td>
+										<td>
+											<BudgetSummary
+												apiKeyName={keyName(item)}
+												value={item.budgets}
+												status={budgetStatus.data}
+											/>
 										</td>
 										<td className="key-action-cell">
 											<div className="key-actions">
@@ -556,6 +582,18 @@ function KeyEditor(props: {
 	const [metadataValues, setMetadataValues] = useState(() =>
 		stringMetadata(withoutManagedMetadata(initialMetadata))
 	);
+	const initialAllowedModels = props.initial.allowedModels ?? undefined;
+	const [modelAccess, setModelAccess] = useState<'unrestricted' | 'deny' | 'restricted'>(() =>
+		initialAllowedModels === undefined
+			? 'unrestricted'
+			: initialAllowedModels.length === 0
+				? 'deny'
+				: 'restricted'
+	);
+	const [allowedModels, setAllowedModels] = useState(initialAllowedModels ?? []);
+	const [budgets, setBudgets] = useState<VirtualApiKeyBudget[]>(() =>
+		structuredClone(props.initial.budgets ?? [])
+	);
 	const [submitted, setSubmitted] = useState(false);
 	const generatedKey = useRef<string | null>(null);
 	const draft = JSON.stringify({
@@ -563,11 +601,48 @@ function KeyEditor(props: {
 		keyMode,
 		key,
 		replaceKey,
-		metadataValues
+		metadataValues,
+		modelAccess,
+		allowedModels,
+		budgets
 	});
 	const [initialDraft] = useState(() => draft);
-	const nameRequired = isNew && !name.trim();
+	const nameRequired = (isNew || budgets.length > 0) && !name.trim();
 	const duplicateName = isNew ? duplicateKeyName(name, props.existingKeys) : false;
+	const modelError =
+		modelAccess !== 'restricted'
+			? null
+			: allowedModels.length === 0
+				? 'Add at least one model pattern or select Deny all.'
+				: allowedModels.includes('*') && allowedModels.length > 1
+					? "'*' cannot be combined with other model patterns."
+					: allowedModels.find(pattern => {
+								const firstWildcard = pattern.indexOf('*');
+								return (
+									pattern !== '*' &&
+									firstWildcard >= 0 &&
+									firstWildcard !== 0 &&
+									firstWildcard !== pattern.length - 1
+								);
+							})
+						? 'Wildcards are only supported at the beginning or end of a pattern.'
+						: allowedModels.some(pattern => pattern !== '*' && pattern.split('*').length > 2)
+							? 'A model pattern can contain at most one wildcard.'
+							: null;
+	const budgetNames = budgets.map(budget => budget.name.trim()).filter(Boolean);
+	const invalidBudgets =
+		budgets.some(
+			budget =>
+				!budget.name.trim() ||
+				!budget.window.rolling?.trim() ||
+				!Number.isFinite(budget.limit.amount) ||
+				budget.limit.amount < 0 ||
+				(budget.limit.unit === 'Tokens' && !Number.isInteger(budget.limit.amount))
+		) || new Set(budgetNames).size !== budgetNames.length;
+	const modelSuggestions = [
+		...(props.config?.llm?.models ?? []).map(model => model.name),
+		...(props.config?.llm?.virtualModels ?? []).map(model => model.name)
+	].filter((name): name is string => typeof name === 'string');
 
 	function virtualKey() {
 		const metadata = {
@@ -581,12 +656,18 @@ function KeyEditor(props: {
 			: replaceKey
 				? key
 				: '';
-		return isNew || replaceKey ? { key: nextKey, metadata } : { ...props.initial, metadata };
+		const value: VirtualApiKey =
+			isNew || replaceKey ? { key: nextKey, metadata } : { ...props.initial, metadata };
+		if (modelAccess === 'unrestricted') delete value.allowedModels;
+		else value.allowedModels = modelAccess === 'deny' ? [] : allowedModels;
+		if (budgets.length) value.budgets = budgets;
+		else delete value.budgets;
+		return value;
 	}
 
 	function nextVirtualKey() {
 		setSubmitted(true);
-		return nameRequired ? null : virtualKey();
+		return nameRequired || modelError || invalidBudgets ? null : virtualKey();
 	}
 
 	function save() {
@@ -639,7 +720,7 @@ function KeyEditor(props: {
 			</Field>
 			{submitted && nameRequired ? (
 				<StatusBanner state="bad" title="Name is required">
-					Add a name before creating this virtual API key.
+					Add a metadata name before saving this virtual API key.
 				</StatusBanner>
 			) : null}
 			{duplicateName ? (
@@ -699,15 +780,104 @@ function KeyEditor(props: {
 					/>
 				</Field>
 			) : null}
-			<KeyValueEditor
-				label="Metadata"
-				tooltip={props.help.field<VirtualApiKey>('LocalAPIKey', 'metadata')}
-				values={metadataValues}
-				quickKeys={['user', 'group']}
-				keyPlaceholder="owner"
-				valuePlaceholder="platform"
-				onChange={setMetadataValues}
-			/>
+			<CollapsiblePolicySection
+				icon={<CircleDollarSign size={17} />}
+				title="Budgets"
+				description="Cap how much this key can spend or consume during each rolling window."
+				summary={
+					submitted && invalidBudgets ? (
+						<span className="badge bad">Invalid</span>
+					) : budgets.length ? (
+						`${budgets.length} ${budgets.length === 1 ? 'budget' : 'budgets'}`
+					) : (
+						'None'
+					)
+				}
+			>
+				<BudgetEditor budgets={budgets} apiKeyName={keyName(props.initial)} onChange={setBudgets} />
+				{submitted && invalidBudgets ? (
+					<StatusBanner state="bad" title="Invalid budgets">
+						Budget names must be present and unique, rolling windows are required, and amounts must
+						be non-negative whole numbers.
+					</StatusBanner>
+				) : null}
+			</CollapsiblePolicySection>
+			<CollapsiblePolicySection
+				icon={<Bot size={17} />}
+				title="Model access"
+				description="Limit which requested model names this key can use."
+				summary={
+					submitted && modelError ? (
+						<span className="badge bad">Invalid</span>
+					) : modelAccess === 'unrestricted' ? (
+						'Unrestricted'
+					) : modelAccess === 'deny' ? (
+						<span className="badge bad">Deny all</span>
+					) : (
+						`${allowedModels.length} ${allowedModels.length === 1 ? 'pattern' : 'patterns'}`
+					)
+				}
+			>
+				<FieldGroup
+					label="Access mode"
+					tooltip={props.help.field<VirtualApiKey>('LocalAPIKey', 'allowedModels')}
+					hint={
+						modelAccess === 'unrestricted'
+							? 'This key can request any model.'
+							: modelAccess === 'restricted'
+								? 'Requests may only use models matching the patterns below.'
+								: 'This key cannot request any model.'
+					}
+				>
+					<SegmentedControl
+						ariaLabel="Model access"
+						value={modelAccess}
+						options={[
+							{ value: 'unrestricted', label: 'Unrestricted' },
+							{ value: 'restricted', label: 'Selected models' },
+							{ value: 'deny', label: 'Deny all' }
+						]}
+						onChange={setModelAccess}
+					/>
+				</FieldGroup>
+				{modelAccess === 'restricted' ? (
+					<ListEditor
+						label="Allowed model patterns"
+						tooltip={props.help.field<VirtualApiKey>('LocalAPIKey', 'allowedModels')}
+						values={allowedModels}
+						onChange={setAllowedModels}
+						placeholder="gpt-5.5 or openai/*"
+						emptyText="No model patterns configured."
+						suggestions={modelSuggestions}
+					/>
+				) : null}
+				{submitted && modelError ? (
+					<StatusBanner state="bad" title="Invalid model access">
+						{modelError}
+					</StatusBanner>
+				) : null}
+			</CollapsiblePolicySection>
+			<CollapsiblePolicySection
+				icon={<Tags size={17} />}
+				title="Metadata"
+				description="Attach custom metadata to requests authenticated with this key."
+				summary={
+					Object.keys(metadataValues).length
+						? `${Object.keys(metadataValues).length} ${
+								Object.keys(metadataValues).length === 1 ? 'entry' : 'entries'
+							}`
+						: 'None'
+				}
+			>
+				<KeyValueEditor
+					tooltip={props.help.field<VirtualApiKey>('LocalAPIKey', 'metadata')}
+					values={metadataValues}
+					quickKeys={['user', 'group']}
+					keyPlaceholder="owner"
+					valuePlaceholder="platform"
+					onChange={setMetadataValues}
+				/>
+			</CollapsiblePolicySection>
 			{props.saveError ? (
 				<StatusBanner state="bad" title="Save failed">
 					{props.saveError}
@@ -715,6 +885,221 @@ function KeyEditor(props: {
 			) : null}
 		</Drawer>
 	);
+}
+
+function BudgetEditor(props: {
+	budgets: VirtualApiKeyBudget[];
+	apiKeyName: string;
+	onChange: (budgets: VirtualApiKeyBudget[]) => void;
+}) {
+	const [editingIndex, setEditingIndex] = useState<number | null>(null);
+	const status = useBudgetStatus({ enabled: props.budgets.length > 0 });
+
+	function addBudget() {
+		props.onChange([
+			...props.budgets,
+			{
+				name: '',
+				limit: { unit: 'USD', amount: 0 },
+				window: { rolling: '30d' },
+				onBudgetExceeded: 'Audit'
+			}
+		]);
+		setEditingIndex(props.budgets.length);
+	}
+
+	function updateBudget(index: number, value: VirtualApiKeyBudget) {
+		props.onChange(
+			props.budgets.map((budget, budgetIndex) => (budgetIndex === index ? value : budget))
+		);
+	}
+
+	function removeBudget(index: number) {
+		props.onChange(props.budgets.filter((_, budgetIndex) => budgetIndex !== index));
+		setEditingIndex(current =>
+			current === null || current === index ? null : current > index ? current - 1 : current
+		);
+	}
+
+	return (
+		<div className="api-key-budget-editor">
+			{props.budgets.length === 0 ? (
+				<div className="empty-inline">No budgets configured. Usage is unlimited.</div>
+			) : (
+				<div className="api-key-budget-list">
+					{props.budgets.map((budget, index) => {
+						const editing = editingIndex === index;
+						const live = status.data?.budgets.find(
+							item => item.apiKeyName === props.apiKeyName && item.name === budget.name.trim()
+						);
+						return (
+							<article className="api-key-budget-card" key={index}>
+								<header className="api-key-budget-card-header">
+									<div className="api-key-budget-card-title">
+										<strong>{budget.name.trim() || 'Untitled budget'}</strong>
+										{live?.usage.exceeded ? <span className="badge bad">Exceeded</span> : null}
+									</div>
+									<div className="button-row compact">
+										<button
+											className="table-action"
+											type="button"
+											onClick={() => setEditingIndex(editing ? null : index)}
+										>
+											{editing ? <Check size={14} /> : <Pencil size={14} />}
+											{editing ? 'Done' : 'Edit'}
+										</button>
+										<button
+											className="table-action danger"
+											type="button"
+											aria-label={`Remove budget ${index + 1}`}
+											onClick={() => removeBudget(index)}
+										>
+											<Trash2 size={14} />
+											Remove
+										</button>
+									</div>
+								</header>
+								{editing ? (
+									<div className="api-key-budget-form">
+										<Field label="Name" hint="Stable identifier used for accounting.">
+											<input
+												value={budget.name}
+												onChange={event =>
+													updateBudget(index, { ...budget, name: event.target.value })
+												}
+												placeholder="monthly-spend"
+											/>
+										</Field>
+										<Field label="Rolling window" hint="Examples: 24h, 7d, or 30d.">
+											<input
+												value={budget.window.rolling ?? ''}
+												onChange={event =>
+													updateBudget(index, {
+														...budget,
+														window: { rolling: event.target.value }
+													})
+												}
+												placeholder="30d"
+											/>
+										</Field>
+										<Field label="Limit amount">
+											<input
+												type="number"
+												min="0"
+												step={budget.limit.unit === 'USD' ? 'any' : '1'}
+												aria-label={`Budget ${index + 1} amount`}
+												value={Number.isFinite(budget.limit.amount) ? budget.limit.amount : ''}
+												onChange={event =>
+													updateBudget(index, {
+														...budget,
+														limit: { ...budget.limit, amount: event.target.valueAsNumber }
+													})
+												}
+											/>
+										</Field>
+										<FieldGroup label="Limit unit">
+											<SegmentedControl
+												ariaLabel={`Budget ${index + 1} unit`}
+												value={budget.limit.unit}
+												options={[
+													{ value: 'USD', label: 'USD' },
+													{ value: 'Tokens', label: 'Tokens' }
+												]}
+												onChange={unit =>
+													updateBudget(index, {
+														...budget,
+														limit: { ...budget.limit, unit }
+													})
+												}
+											/>
+										</FieldGroup>
+										<FieldGroup label="When limit is reached" className="api-key-budget-form-wide">
+											<SegmentedControl
+												ariaLabel={`Budget ${index + 1} enforcement`}
+												value={budget.onBudgetExceeded}
+												options={[
+													{ value: 'Block', label: 'Block requests', description: 'Return 429' },
+													{ value: 'Audit', label: 'Audit only', description: 'Continue serving' }
+												]}
+												onChange={onBudgetExceeded =>
+													updateBudget(index, { ...budget, onBudgetExceeded })
+												}
+											/>
+										</FieldGroup>
+									</div>
+								) : (
+									<BudgetUsage
+										budget={budget}
+										live={live}
+										loading={status.isLoading}
+										unavailable={Boolean(status.error)}
+									/>
+								)}
+							</article>
+						);
+					})}
+				</div>
+			)}
+			<div className="button-row">
+				<button className="button small" type="button" onClick={addBudget}>
+					<Plus size={15} />
+					Add budget
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function BudgetUsage(props: {
+	budget: VirtualApiKeyBudget;
+	live?: BudgetStatus;
+	loading: boolean;
+	unavailable: boolean;
+}) {
+	const { budget, live } = props;
+	if (props.loading) {
+		return <div className="api-key-budget-usage muted">Loading usage…</div>;
+	}
+	if (props.unavailable) {
+		return <div className="api-key-budget-usage muted">Live usage is unavailable.</div>;
+	}
+	const { used, fraction, level } = budgetProgress(budget, live);
+	return (
+		<div className="api-key-budget-usage">
+			<div className="api-key-budget-usage-row">
+				<span>
+					<strong>{budgetAmountLabel(used, budget.limit.unit)}</strong> of{' '}
+					{budgetAmountLabel(budget.limit.amount, budget.limit.unit)} used
+				</span>
+				<span>
+					{live
+						? `${Math.round(fraction * 100)}% · resets ${formatRelativeTime(
+								new Date(live.window.end).toISOString()
+							)}`
+						: `No usage recorded yet · ${budget.window.rolling || 'unset'} rolling window`}
+				</span>
+			</div>
+			<div className="api-key-budget-meter">
+				<div className={level} style={{ width: `${fraction * 100}%` }} />
+			</div>
+		</div>
+	);
+}
+
+function budgetProgress(budget: VirtualApiKeyBudget, live?: BudgetStatus) {
+	const used = live ? Number(live.usage.used) : 0;
+	const limit =
+		Number.isFinite(budget.limit.amount) && budget.limit.amount > 0 ? budget.limit.amount : 0;
+	const fraction = limit > 0 ? Math.min(used / limit, 1) : 0;
+	const exceeded = Boolean(live?.usage.exceeded) || (limit > 0 && used >= limit);
+	return { used, fraction, level: exceeded ? 'bad' : fraction >= 0.8 ? 'warn' : '' };
+}
+
+function budgetAmountLabel(amount: number, unit: VirtualApiKeyBudget['limit']['unit']) {
+	if (!Number.isFinite(amount)) return unit === 'USD' ? '$0' : '0 tokens';
+	return unit === 'USD'
+		? `$${amount.toLocaleString(undefined, { maximumFractionDigits: 9 })}`
+		: `${formatNumber(amount)} tokens`;
 }
 
 function newVirtualKey(): VirtualApiKey {
@@ -863,10 +1248,55 @@ function VirtualKeyValue(props: { value: string }) {
 	);
 }
 
+function AllowedModelsSummary(props: { value?: string[] | null }) {
+	if (props.value == null) return <span className="muted">unrestricted</span>;
+	if (props.value.length === 0) return <span className="badge bad">deny all</span>;
+	if (props.value.length === 1) {
+		return <span className="badge">{props.value[0] === '*' ? 'all models' : props.value[0]}</span>;
+	}
+	return <span className="badge">{props.value.length} patterns</span>;
+}
+
+function BudgetSummary(props: {
+	apiKeyName: string;
+	value?: VirtualApiKeyBudget[];
+	status?: BudgetStatusResponse;
+}) {
+	const budgets = props.value ?? [];
+	if (!budgets.length) return <span className="muted">—</span>;
+	return (
+		<div className="key-budget-summary">
+			{budgets.map((budget, index) => {
+				const live = props.status?.budgets.find(
+					item => item.apiKeyName === props.apiKeyName && item.name === budget.name
+				);
+				const { used, fraction, level } = budgetProgress(budget, live);
+				return (
+					<Tooltip
+						key={`${budget.name}:${index}`}
+						content={`${budgetAmountLabel(used, budget.limit.unit)} of ${budgetAmountLabel(
+							budget.limit.amount,
+							budget.limit.unit
+						)} per ${budget.window.rolling}`}
+					>
+						<div className="key-budget-summary-row">
+							<span className="key-budget-summary-name">{budget.name}</span>
+							<div className="api-key-budget-meter">
+								<div className={level} style={{ width: `${fraction * 100}%` }} />
+							</div>
+							<span className="key-budget-summary-pct">{Math.round(fraction * 100)}%</span>
+						</div>
+					</Tooltip>
+				);
+			})}
+		</div>
+	);
+}
+
 function MetadataSummary(props: { value: unknown }) {
 	const metadata = withoutManagedMetadata(metadataObject(props.value));
 	const entries = Object.entries(metadata);
-	if (!entries.length) return <span className="muted">none</span>;
+	if (!entries.length) return <span className="muted">—</span>;
 	return (
 		<div className="metadata-summary">
 			{entries.slice(0, 3).map(([key, value]) => (

--- a/ui/src/policies/PolicyFormControls.tsx
+++ b/ui/src/policies/PolicyFormControls.tsx
@@ -57,7 +57,7 @@ export function TargetEditor(props: {
 }
 
 export function KeyValueEditor(props: {
-	label: string;
+	label?: string;
 	tooltip?: string;
 	values: Record<string, string>;
 	keyPlaceholder?: string;
@@ -79,77 +79,82 @@ export function KeyValueEditor(props: {
 		setValueDraft('');
 	}
 
-	return (
-		<FieldGroup label={props.label} tooltip={props.tooltip}>
-			<div className="kv-editor">
-				{entries.length ? (
-					<div className="kv-list">
-						{entries.map(([key, value]) => (
-							<div className="kv-row" key={key}>
-								<code>{key}</code>
-								<span>{value}</span>
-								<button
-									className="table-action danger"
-									type="button"
-									onClick={() => {
-										const next = { ...props.values };
-										delete next[key];
-										props.onChange(next);
-									}}
-								>
-									Remove
-								</button>
-							</div>
-						))}
-					</div>
-				) : (
-					<div className="empty-inline">No values configured.</div>
-				)}
-				{props.quickKeys?.length ? (
-					<div className="kv-quick-row" aria-label={`${props.label} quick keys`}>
-						{props.quickKeys.map(key => (
+	const editor = (
+		<div className="kv-editor">
+			{entries.length ? (
+				<div className="kv-list">
+					{entries.map(([key, value]) => (
+						<div className="kv-row" key={key}>
+							<code>{key}</code>
+							<span>{value}</span>
 							<button
-								className="choice-pill compact"
+								className="table-action danger"
 								type="button"
-								key={key}
-								disabled={key in props.values}
 								onClick={() => {
-									setKeyDraft(key);
-									window.requestAnimationFrame(() => valueRef.current?.focus());
+									const next = { ...props.values };
+									delete next[key];
+									props.onChange(next);
 								}}
 							>
-								{key}
+								Remove
 							</button>
-						))}
-					</div>
-				) : null}
-				<div className="kv-add-row">
-					<input
-						value={keyDraft}
-						onChange={event => setKeyDraft(event.target.value)}
-						placeholder={props.keyPlaceholder ?? 'name'}
-					/>
-					<input
-						ref={valueRef}
-						className={props.valueKind === 'cel' ? 'mono-input' : undefined}
-						value={valueDraft}
-						onChange={event => setValueDraft(event.target.value)}
-						onKeyDown={event => {
-							if (event.key === 'Enter') {
-								event.preventDefault();
-								add();
-							}
-						}}
-						placeholder={
-							props.valuePlaceholder ?? (props.valueKind === 'cel' ? 'request.path' : 'value')
-						}
-					/>
-					<button className="button" type="button" onClick={add}>
-						Add
-					</button>
+						</div>
+					))}
 				</div>
+			) : (
+				<div className="empty-inline">No values configured.</div>
+			)}
+			{props.quickKeys?.length ? (
+				<div className="kv-quick-row" aria-label={`${props.label ?? 'Metadata'} quick keys`}>
+					{props.quickKeys.map(key => (
+						<button
+							className="choice-pill compact"
+							type="button"
+							key={key}
+							disabled={key in props.values}
+							onClick={() => {
+								setKeyDraft(key);
+								window.requestAnimationFrame(() => valueRef.current?.focus());
+							}}
+						>
+							{key}
+						</button>
+					))}
+				</div>
+			) : null}
+			<div className="kv-add-row">
+				<input
+					value={keyDraft}
+					onChange={event => setKeyDraft(event.target.value)}
+					placeholder={props.keyPlaceholder ?? 'name'}
+				/>
+				<input
+					ref={valueRef}
+					className={props.valueKind === 'cel' ? 'mono-input' : undefined}
+					value={valueDraft}
+					onChange={event => setValueDraft(event.target.value)}
+					onKeyDown={event => {
+						if (event.key === 'Enter') {
+							event.preventDefault();
+							add();
+						}
+					}}
+					placeholder={
+						props.valuePlaceholder ?? (props.valueKind === 'cel' ? 'request.path' : 'value')
+					}
+				/>
+				<button className="button" type="button" onClick={add}>
+					Add
+				</button>
 			</div>
+		</div>
+	);
+	return props.label ? (
+		<FieldGroup label={props.label} tooltip={props.tooltip}>
+			{editor}
 		</FieldGroup>
+	) : (
+		editor
 	);
 }
 

--- a/ui/src/policies/PolicyLayout.tsx
+++ b/ui/src/policies/PolicyLayout.tsx
@@ -28,6 +28,7 @@ export function CollapsiblePolicySection(props: {
 	description: string;
 	children: ReactNode;
 	defaultOpen?: boolean;
+	summary?: ReactNode;
 	bodyClassName?: string;
 }) {
 	const [open, setOpen] = useState(Boolean(props.defaultOpen));
@@ -50,6 +51,9 @@ export function CollapsiblePolicySection(props: {
 					<h4>{props.title}</h4>
 					<p>{props.description}</p>
 				</div>
+				{props.summary != null ? (
+					<span className="policy-form-section-summary">{props.summary}</span>
+				) : null}
 				{open ? <ChevronDown size={17} /> : <ChevronRight size={17} />}
 			</button>
 			{open ? (

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1622,12 +1622,22 @@ a {
 
 .transform-section-toggle {
 	width: 100%;
-	grid-template-columns: auto minmax(0, 1fr) auto;
+	grid-template-columns: auto minmax(0, 1fr) auto auto;
 	border: 0;
 	background: transparent;
 	color: var(--text);
 	padding: 0;
 	text-align: left;
+}
+
+.policy-form-section-summary {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	color: var(--muted);
+	font-size: 12px;
+	font-weight: 650;
+	white-space: nowrap;
 }
 
 .transform-section-toggle > svg {
@@ -1974,12 +1984,6 @@ a {
 	display: grid;
 	grid-template-columns: minmax(0, 1fr) minmax(150px, 190px) auto;
 	gap: 8px;
-}
-
-.badge.warn {
-	border-color: color-mix(in srgb, var(--warn) 40%, var(--line));
-	background: var(--warn-bg);
-	color: var(--warn);
 }
 
 .badge.mcp-phase {
@@ -3845,14 +3849,17 @@ tbody tr:hover {
 .badge {
 	display: inline-flex;
 	align-items: center;
-	gap: 7px;
-	min-height: 24px;
-	border: 1px solid var(--line);
-	border-radius: 999px;
-	padding: 0 8px;
-	background: var(--surface-2);
-	font-size: 12px;
-	font-weight: 700;
+	gap: 5px;
+	min-height: 20px;
+	border: 0;
+	border-radius: 5px;
+	padding: 2px 7px;
+	background: color-mix(in srgb, var(--text) 7%, transparent);
+	color: color-mix(in srgb, var(--text) 85%, transparent);
+	font-size: 11px;
+	font-weight: 650;
+	line-height: 1.2;
+	letter-spacing: 0.01em;
 	white-space: nowrap;
 }
 
@@ -3867,20 +3874,17 @@ tbody tr:hover {
 }
 
 .badge.ok {
-	border-color: color-mix(in srgb, var(--ok) 35%, var(--line));
-	background: var(--ok-bg);
+	background: color-mix(in srgb, var(--ok) 12%, transparent);
 	color: var(--ok);
 }
 
 .badge.warn {
-	border-color: color-mix(in srgb, var(--warn) 35%, var(--line));
-	background: var(--warn-bg);
+	background: color-mix(in srgb, var(--warn) 14%, transparent);
 	color: var(--warn);
 }
 
 .badge.bad {
-	border-color: color-mix(in srgb, var(--bad) 35%, var(--line));
-	background: var(--bad-bg);
+	background: color-mix(in srgb, var(--bad) 11%, transparent);
 	color: var(--bad);
 }
 
@@ -5379,35 +5383,209 @@ textarea {
 
 .keys-table {
 	table-layout: fixed;
-	min-width: 980px;
+	min-width: 1180px;
 }
 
 .keys-table th:nth-child(1),
 .keys-table td:nth-child(1) {
-	width: 20%;
+	width: 14%;
 }
 
 .keys-table th:nth-child(2),
 .keys-table td:nth-child(2) {
-	width: 34%;
+	width: 22%;
 }
 
 .keys-table th:nth-child(3),
 .keys-table td:nth-child(3) {
-	width: 18%;
+	width: 12%;
 }
 
 .keys-table th:nth-child(4),
 .keys-table td:nth-child(4) {
-	width: 28%;
+	width: 13%;
+}
+
+.keys-table th:nth-child(5),
+.keys-table td:nth-child(5) {
+	width: 21%;
+}
+
+.keys-table th:nth-child(6),
+.keys-table td:nth-child(6) {
+	width: 18%;
+}
+
+.keys-table td {
+	vertical-align: middle;
+}
+
+.keys-table .key-cell code {
+	min-height: 28px;
+	border-color: transparent;
+	background: var(--surface-3);
+}
+
+.keys-table .virtual-key-value .table-action {
+	border-color: transparent;
+	background: transparent;
+	color: var(--muted);
+	padding: 0 6px;
+}
+
+.keys-table .virtual-key-value .table-action:hover {
+	background: var(--surface-3);
+	color: var(--text);
+}
+
+.keys-table .virtual-key-value .table-action.copied {
+	color: var(--ok);
 }
 
 .key-name-cell {
 	overflow-wrap: anywhere;
 }
 
+.key-name-cell .muted {
+	font-weight: 500;
+}
+
 .key-cell {
 	overflow: hidden;
+}
+
+.api-key-budget-list {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.api-key-budget-card {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	background: var(--surface-2);
+	padding: 12px;
+}
+
+.api-key-budget-card-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+}
+
+.api-key-budget-card-title {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	min-width: 0;
+}
+
+.api-key-budget-card-title strong {
+	overflow: hidden;
+	font-size: 13px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.api-key-budget-form {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+	gap: 12px;
+}
+
+.api-key-budget-form .field {
+	margin-bottom: 0;
+}
+
+.api-key-budget-form-wide {
+	grid-column: 1 / -1;
+}
+
+.api-key-budget-usage {
+	display: grid;
+	gap: 7px;
+}
+
+.api-key-budget-usage-row {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+	color: var(--muted);
+	font-size: 12px;
+}
+
+.api-key-budget-usage-row strong {
+	color: var(--text);
+	font-size: 13px;
+	font-variant-numeric: tabular-nums;
+}
+
+.api-key-budget-meter {
+	height: 8px;
+	border-radius: 999px;
+	background: var(--line);
+	overflow: hidden;
+}
+
+.api-key-budget-meter > div {
+	height: 100%;
+	border-radius: 999px;
+	background: var(--primary);
+	transition: width 0.2s ease;
+}
+
+.api-key-budget-meter > div.warn {
+	background: var(--warn);
+}
+
+.api-key-budget-meter > div.bad {
+	background: var(--bad);
+}
+
+.key-budget-summary {
+	display: grid;
+	gap: 6px;
+}
+
+.key-budget-summary .tooltip-wrap,
+.key-budget-summary .tooltip-anchor {
+	display: block;
+}
+
+.key-budget-summary-row {
+	display: grid;
+	grid-template-columns: minmax(56px, 0.55fr) minmax(72px, 1fr) 34px;
+	align-items: center;
+	gap: 8px;
+	font-size: 12px;
+}
+
+.key-budget-summary-name {
+	overflow: hidden;
+	font-weight: 650;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.key-budget-summary-row .api-key-budget-meter {
+	height: 6px;
+}
+
+.key-budget-summary-pct {
+	color: var(--muted);
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
+.api-key-budget-editor {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
 .key-cell code,
@@ -6096,6 +6274,10 @@ details summary {
 	}
 
 	.log-detail-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.api-key-budget-form {
 		grid-template-columns: 1fr;
 	}
 	.monitoring-kpi-grid {

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -2,6 +2,7 @@ import type { StoresDump } from '@/gateway-admin';
 import type {
 	BackendAuth,
 	BackendAuthCompat,
+	Budget,
 	CorsSerde,
 	ExtAuthz,
 	ExtProc,
@@ -53,6 +54,7 @@ export type LlmModel = LocalLLMModels;
 export type LlmVirtualModel = LocalLLMVirtualModel;
 export type LlmProvider = LocalLLMProvider;
 export type LlmGuardrail = PromptGuard;
+export type VirtualApiKeyBudget = Budget;
 export type VirtualApiKey = LocalAPIKey;
 export type LlmApiKeyPolicy = LocalAPIKeys;
 export type LlmPolicy = LocalLLMPolicy;


### PR DESCRIPTION
This adds budgets for an API key that can limit the spend ($ or token) for a given key with LLM traffic. This is exposed in standalone mode only right now as it has a database dependency.

Budgets are stored in memory and flushed to the database every 5s. This implies with multi-replicas we may exceed the budget with a burst of traffic, but in exchange we have no database dependency on the request path.

<img width="3320" height="640" alt="2026-08-24_12-16-46" src="https://github.com/user-attachments/assets/c0369b6b-d614-4b7d-8d40-c5d5469178da" />
<img width="1444" height="1135" alt="2026-08-24_12-27-04" src="https://github.com/user-attachments/assets/684f9f14-3047-4954-965f-5906a76bbabd" />

