### PR TITLE
inference routing: do not trust client header

### DIFF
--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -39,6 +39,8 @@ pub(crate) const EXTPROC_GRPC_INITIAL_METADATA_NAMESPACE: &str =
 mod tests;
 
 const TRACE_POLICY_KIND: &str = "ext_proc";
+const INFERENCE_DESTINATION_HEADER: HeaderName =
+	HeaderName::from_static("x-gateway-destination-endpoint");
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -212,15 +214,16 @@ impl InferencePoolRouter {
 		let Some(ext_proc) = &mut self.ext_proc else {
 			return Ok(Default::default());
 		};
+		// The destination header is an EPP output, not a client-controlled input.
+		req.headers_mut().remove(&INFERENCE_DESTINATION_HEADER);
 		let r = std::mem::take(req);
 		let (new_req, pr) = ext_proc.mutate_request(r).await?;
 		let failed_open = ext_proc.skipped;
 		*req = new_req;
 		let dest = req
-			.headers()
-			.get(HeaderName::from_static("x-gateway-destination-endpoint"))
-			.and_then(|v| v.to_str().ok())
-			.map(|v| v.parse::<SocketAddr>())
+			.headers_mut()
+			.remove(&INFERENCE_DESTINATION_HEADER)
+			.and_then(|v| v.to_str().ok().map(|v| v.parse::<SocketAddr>()))
 			.transpose()
 			.map_err(|e| ProxyError::Processing(anyhow!("EPP returned invalid address: {e}")))?;
 		Ok(InferenceRequestResult {

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -2791,16 +2791,35 @@ mod standalone_inference_routing {
 
 	#[tokio::test]
 	async fn standalone_inference_routing_requires_epp_selected_destination() {
+		let client_selected_backend = named_backend("client-selected-backend").await;
 		let request_headers_seen = Arc::new(AtomicUsize::new(0));
 		let (_ext_proc, _bind, io) =
 			setup_inference_routing_mock(None, request_headers_seen.clone(), Some("passthrough")).await;
 
-		let res = send_request(io, Method::GET, "http://lo").await;
+		let res = send_request_headers(
+			io,
+			Method::GET,
+			"http://lo",
+			&[(
+				"x-gateway-destination-endpoint",
+				&client_selected_backend.address().to_string(),
+			)],
+		)
+		.await;
 		assert_eq!(res.status(), 503);
 		assert_eq!(
 			request_headers_seen.load(Ordering::SeqCst),
 			1,
 			"gateway should consult EPP before rejecting the request",
+		);
+		assert_eq!(
+			client_selected_backend
+				.received_requests()
+				.await
+				.expect("backend recording should be enabled")
+				.len(),
+			0,
+			"a client-provided destination must not be used when EPP selects none",
 		);
 	}
 }


### PR DESCRIPTION
Just some hardening