### PR TITLE
preserve latest cache control when guardrails rewrites messages

### DIFF
--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -2972,6 +2972,226 @@ fn test_apply_regex_response_preserves_tool_structure(
 		]
 	}))
 )]
+// the common caching layout: breakpoint on a big context block, volatile text after it
+#[case::mask_carries_drained_blocks_cache_control(
+	ChatFmt::Anthropic,
+	Action::Mask,
+	email_and_ssn(),
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact admin@example.com", "cache_control": {"type": "ephemeral"}},
+				{"type": "text", "text": "for help"}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact <EMAIL_ADDRESS> for help", "cache_control": {"type": "ephemeral"}}
+			]}
+		]
+	}))
+)]
+// two breakpoints collapse into one; the later one wins
+#[case::mask_keeps_survivors_cache_control_over_drained(
+	ChatFmt::Anthropic,
+	Action::Mask,
+	email_and_ssn(),
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact admin@example.com", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+				{"type": "text", "text": "for help", "cache_control": {"type": "ephemeral"}}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact <EMAIL_ADDRESS> for help", "cache_control": {"type": "ephemeral"}}
+			]}
+		]
+	}))
+)]
+#[case::system_array_mask_carries_cache_control(
+	ChatFmt::Anthropic,
+	Action::Mask,
+	email_and_ssn(),
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"system": [
+			{"type": "text", "text": "Contact admin@example.com", "cache_control": {"type": "ephemeral"}},
+			{"type": "text", "text": "for support"}
+		],
+		"messages": [{"role": "user", "content": "hello"}]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"system": [
+			{"type": "text", "text": "Contact <EMAIL_ADDRESS>\nfor support", "cache_control": {"type": "ephemeral"}}
+		],
+		"messages": [{"role": "user", "content": "hello"}]
+	}))
+)]
+// OpenAI-format providers (Bedrock, OpenRouter) accept cache_control on content parts
+#[case::completions_mask_carries_cache_control(
+	ChatFmt::Completions,
+	Action::Mask,
+	ssn_only(),
+	serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "my ssn is 123-45-6789", "cache_control": {"type": "ephemeral"}},
+				{"type": "text", "text": "thanks"}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "my ssn is <SSN> thanks", "cache_control": {"type": "ephemeral"}}
+			]}
+		]
+	}))
+)]
+// OpenAI explicit breakpoints (prompt_cache_breakpoint) survive a collapse too
+#[case::responses_mask_carries_prompt_cache_breakpoint(
+	ChatFmt::Responses,
+	Action::Mask,
+	ssn_only(),
+	serde_json::json!({
+		"model": "gpt-4o",
+		"input": [
+			{"role": "user", "content": [
+				{"type": "input_text", "text": "my ssn is 123-45-6789", "prompt_cache_breakpoint": {"mode": "explicit"}},
+				{"type": "input_text", "text": "thanks"}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "gpt-4o",
+		"input": [
+			{"role": "user", "content": [
+				{"type": "input_text", "text": "my ssn is <SSN>\nthanks", "prompt_cache_breakpoint": {"mode": "explicit"}}
+			]}
+		]
+	}))
+)]
+#[case::completions_mask_carries_prompt_cache_breakpoint(
+	ChatFmt::Completions,
+	Action::Mask,
+	ssn_only(),
+	serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "my ssn is 123-45-6789", "prompt_cache_breakpoint": {"mode": "explicit"}},
+				{"type": "text", "text": "thanks"}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "gpt-4o",
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "my ssn is <SSN> thanks", "prompt_cache_breakpoint": {"mode": "explicit"}}
+			]}
+		]
+	}))
+)]
+// a masked run must not steal the breakpoint from an untouched run before the image
+#[case::mask_does_not_leak_cache_control_across_runs(
+	ChatFmt::Anthropic,
+	Action::Mask,
+	ssn_only(),
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "project context", "cache_control": {"type": "ephemeral"}},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+				{"type": "text", "text": "my ssn is 123-45-6789"},
+				{"type": "text", "text": "thanks"}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "project context", "cache_control": {"type": "ephemeral"}},
+				{"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "aGk="}},
+				{"type": "text", "text": "my ssn is <SSN> thanks"}
+			]}
+		]
+	}))
+)]
+// two drained parts both marked: the later breakpoint is the one carried
+#[case::mask_carries_latest_drained_cache_control(
+	ChatFmt::Anthropic,
+	Action::Mask,
+	email_and_ssn(),
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact admin@example.com", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+				{"type": "text", "text": "for help", "cache_control": {"type": "ephemeral"}},
+				{"type": "text", "text": "thanks"}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact <EMAIL_ADDRESS> for help thanks", "cache_control": {"type": "ephemeral"}}
+			]}
+		]
+	}))
+)]
+// an explicit null marker is not a breakpoint and must not shadow the real one
+#[case::null_cache_control_does_not_shadow_real_marker(
+	ChatFmt::Anthropic,
+	Action::Mask,
+	email_and_ssn(),
+	serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact admin@example.com", "cache_control": {"type": "ephemeral"}},
+				{"type": "text", "text": "for help", "cache_control": null}
+			]}
+		]
+	}),
+	Expect::Masked(serde_json::json!({
+		"model": "claude-sonnet-5",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "contact <EMAIL_ADDRESS> for help", "cache_control": {"type": "ephemeral"}}
+			]}
+		]
+	}))
+)]
 #[case::mask_preserves_non_text_block_between_runs(
 	ChatFmt::Anthropic,
 	Action::Mask,

--- a/crates/llm/src/types/completions.rs
+++ b/crates/llm/src/types/completions.rs
@@ -318,6 +318,14 @@ fn extract_output_messages(choices: &[Choice]) -> Option<Vec<OutputMessage>> {
 	(!messages.is_empty()).then_some(messages)
 }
 
+/// `rest` keys preserved when a masked text run collapses; see `scan_text_runs`.
+const PRESERVED_REST_KEYS: &[&str] = &[
+	// Anthropic-style cache breakpoint, accepted by OpenAI-compat providers (Bedrock, OpenRouter)
+	"cache_control",
+	// OpenAI explicit prompt-cache breakpoint
+	"prompt_cache_breakpoint",
+];
+
 impl super::RequestType for Request {
 	fn body_is_json(&self) -> bool {
 		true
@@ -418,6 +426,7 @@ impl super::RequestType for Request {
 						" ",
 						|p| p.text.as_mut(),
 						|p| Some(&mut p.rest),
+						PRESERVED_REST_KEYS,
 						&mut |text| f(scope, text),
 					);
 				},

--- a/crates/llm/src/types/completions.rs
+++ b/crates/llm/src/types/completions.rs
@@ -413,7 +413,13 @@ impl super::RequestType for Request {
 			match &mut msg.content {
 				Some(Content::Text(text)) => f(scope, text),
 				Some(Content::Array(parts)) => {
-					super::scan_text_runs(parts, " ", |p| p.text.as_mut(), &mut |text| f(scope, text));
+					super::scan_text_runs(
+						parts,
+						" ",
+						|p| p.text.as_mut(),
+						|p| Some(&mut p.rest),
+						&mut |text| f(scope, text),
+					);
 				},
 				None => {},
 			}

--- a/crates/llm/src/types/gemini.rs
+++ b/crates/llm/src/types/gemini.rs
@@ -127,6 +127,8 @@ fn visit_content_text(content: &mut vg::Content, f: &mut dyn FnMut(&mut String))
 			vg::Part::Text(tp) if tp.thought != Some(true) => Some(&mut tp.text),
 			_ => None,
 		},
+		// Gemini has no per-part cache marker
+		|_| None,
 		f,
 	);
 }

--- a/crates/llm/src/types/gemini.rs
+++ b/crates/llm/src/types/gemini.rs
@@ -127,8 +127,8 @@ fn visit_content_text(content: &mut vg::Content, f: &mut dyn FnMut(&mut String))
 			vg::Part::Text(tp) if tp.thought != Some(true) => Some(&mut tp.text),
 			_ => None,
 		},
-		// Gemini has no per-part cache marker
 		|_| None,
+		&[],
 		f,
 	);
 }

--- a/crates/llm/src/types/messages.rs
+++ b/crates/llm/src/types/messages.rs
@@ -201,6 +201,12 @@ pub fn get_messages_helper(
 	out
 }
 
+/// `rest` keys preserved when a masked text run collapses; see `scan_text_runs`.
+const PRESERVED_REST_KEYS: &[&str] = &[
+	// Anthropic prompt-cache breakpoint
+	"cache_control",
+];
+
 impl RequestType for Request {
 	fn body_is_json(&self) -> bool {
 		true
@@ -289,6 +295,7 @@ impl RequestType for Request {
 					"\n",
 					TextPart::text_mut,
 					TextPart::rest_mut,
+					PRESERVED_REST_KEYS,
 					&mut |text| f(ContentScope::SystemPrompt, text),
 				);
 			},
@@ -308,6 +315,7 @@ impl RequestType for Request {
 						" ",
 						ContentPart::text_mut,
 						ContentPart::rest_mut,
+						PRESERVED_REST_KEYS,
 						&mut |text| f(ContentScope::Messages, text),
 					);
 				},

--- a/crates/llm/src/types/messages.rs
+++ b/crates/llm/src/types/messages.rs
@@ -90,6 +90,13 @@ impl TextPart {
 			TextPart::Unknown(_) => None,
 		}
 	}
+
+	fn rest_mut(&mut self) -> Option<&mut serde_json::Value> {
+		match self {
+			TextPart::Text { rest, .. } => Some(rest),
+			TextPart::Unknown(_) => None,
+		}
+	}
 }
 
 impl ContentPart {
@@ -103,6 +110,13 @@ impl ContentPart {
 	fn text_mut(&mut self) -> Option<&mut String> {
 		match self {
 			ContentPart::Text { text, .. } => Some(text),
+			ContentPart::Unknown(_) => None,
+		}
+	}
+
+	fn rest_mut(&mut self) -> Option<&mut serde_json::Value> {
+		match self {
+			ContentPart::Text { rest, .. } => Some(rest),
 			ContentPart::Unknown(_) => None,
 		}
 	}
@@ -270,9 +284,13 @@ impl RequestType for Request {
 		match &mut self.system {
 			Some(TextBlock::Text(text)) => f(ContentScope::SystemPrompt, text),
 			Some(TextBlock::Array(parts)) => {
-				crate::types::scan_text_runs(parts, "\n", TextPart::text_mut, &mut |text| {
-					f(ContentScope::SystemPrompt, text)
-				});
+				crate::types::scan_text_runs(
+					parts,
+					"\n",
+					TextPart::text_mut,
+					TextPart::rest_mut,
+					&mut |text| f(ContentScope::SystemPrompt, text),
+				);
 			},
 			None => {},
 		}
@@ -285,9 +303,13 @@ impl RequestType for Request {
 							visit_tool_part_text(value, f);
 						}
 					}
-					crate::types::scan_text_runs(parts, " ", ContentPart::text_mut, &mut |text| {
-						f(ContentScope::Messages, text)
-					});
+					crate::types::scan_text_runs(
+						parts,
+						" ",
+						ContentPart::text_mut,
+						ContentPart::rest_mut,
+						&mut |text| f(ContentScope::Messages, text),
+					);
 				},
 				None => {},
 			}

--- a/crates/llm/src/types/mod.rs
+++ b/crates/llm/src/types/mod.rs
@@ -118,13 +118,21 @@ pub trait RequestType: Send + Sync {
 	fn visit_text_mut(&mut self, f: &mut dyn FnMut(ContentScope, &mut String));
 }
 
+/// Per-part cache breakpoint markers: Anthropic's `cache_control` and OpenAI's explicit
+/// `prompt_cache_breakpoint` (Responses and Chat Completions).
+const CACHE_MARKER_KEYS: [&str; 2] = ["cache_control", "prompt_cache_breakpoint"];
+
 /// Scan runs of consecutive text parts as one `sep`-joined string: `[t1, t2, img, t3]` scans
-/// `"t1{sep}t2"` then `"t3"`. An edited run collapses into its last part (keeping its other
-/// fields, e.g. `cache_control`); untouched runs pass through unchanged.
+/// `"t1{sep}t2"` then `"t3"`. An edited run collapses into its last part, which inherits the
+/// run's last cache breakpoint marker (positional metadata; dropping it with the drained parts
+/// would silently disable prompt caching). Other fields of drained parts are dropped. Untouched
+/// runs pass through unchanged. `rest_of` exposes a part's extra-fields JSON object for the
+/// breakpoint carry; return `None` for formats without per-part cache markers.
 pub(crate) fn scan_text_runs<T>(
 	parts: &mut Vec<T>,
 	sep: &str,
 	mut text_of: impl FnMut(&mut T) -> Option<&mut String>,
+	mut rest_of: impl FnMut(&mut T) -> Option<&mut serde_json::Value>,
 	f: &mut dyn FnMut(&mut String),
 ) {
 	if let [part] = parts.as_mut_slice() {
@@ -158,6 +166,36 @@ pub(crate) fn scan_text_runs<T>(
 		if joined == original {
 			i = end;
 			continue;
+		}
+
+		// a breakpoint anywhere in the run must survive the collapse; the survivor's own wins,
+		// else carry the latest one from the parts about to be drained
+		for key in CACHE_MARKER_KEYS {
+			// a JSON-null marker is not a breakpoint; don't let it shadow or carry as one
+			let survivor_marked = rest_of(&mut parts[end - 1])
+				.and_then(|rest| rest.get(key))
+				.is_some_and(|v| !v.is_null());
+			if survivor_marked {
+				continue;
+			}
+			let carried = parts[i..end - 1].iter_mut().rev().find_map(|p| {
+				rest_of(p)
+					.and_then(serde_json::Value::as_object_mut)
+					.and_then(|obj| obj.remove(key))
+					.filter(|v| !v.is_null())
+			});
+			if let Some(marker) = carried
+				&& let Some(rest) = rest_of(&mut parts[end - 1])
+			{
+				// Null only for typed parts whose `rest` defaults to Null; a whole-part
+				// accessor (responses.rs) must never reach here or this would wipe the part
+				if !rest.is_object() {
+					*rest = serde_json::Value::Object(Default::default());
+				}
+				if let Some(obj) = rest.as_object_mut() {
+					obj.insert(key.to_string(), marker);
+				}
+			}
 		}
 
 		// collapse the run's text into the last part, and remove the others

--- a/crates/llm/src/types/mod.rs
+++ b/crates/llm/src/types/mod.rs
@@ -118,21 +118,16 @@ pub trait RequestType: Send + Sync {
 	fn visit_text_mut(&mut self, f: &mut dyn FnMut(ContentScope, &mut String));
 }
 
-/// Per-part cache breakpoint markers: Anthropic's `cache_control` and OpenAI's explicit
-/// `prompt_cache_breakpoint` (Responses and Chat Completions).
-const CACHE_MARKER_KEYS: [&str; 2] = ["cache_control", "prompt_cache_breakpoint"];
-
 /// Scan runs of consecutive text parts as one `sep`-joined string: `[t1, t2, img, t3]` scans
-/// `"t1{sep}t2"` then `"t3"`. An edited run collapses into its last part, which inherits the
-/// run's last cache breakpoint marker (positional metadata; dropping it with the drained parts
-/// would silently disable prompt caching). Other fields of drained parts are dropped. Untouched
-/// runs pass through unchanged. `rest_of` exposes a part's extra-fields JSON object for the
-/// breakpoint carry; return `None` for formats without per-part cache markers.
+/// `"t1{sep}t2"` then `"t3"`. An edited run collapses into its last part; untouched runs pass
+/// through unchanged. `preserved_rest_keys`: when a text run is masked, which keys in `rest`
+/// should be preserved.
 pub(crate) fn scan_text_runs<T>(
 	parts: &mut Vec<T>,
 	sep: &str,
 	mut text_of: impl FnMut(&mut T) -> Option<&mut String>,
 	mut rest_of: impl FnMut(&mut T) -> Option<&mut serde_json::Value>,
+	preserved_rest_keys: &[&str],
 	f: &mut dyn FnMut(&mut String),
 ) {
 	if let [part] = parts.as_mut_slice() {
@@ -168,14 +163,13 @@ pub(crate) fn scan_text_runs<T>(
 			continue;
 		}
 
-		// a breakpoint anywhere in the run must survive the collapse; the survivor's own wins,
-		// else carry the latest one from the parts about to be drained
-		for key in CACHE_MARKER_KEYS {
-			// a JSON-null marker is not a breakpoint; don't let it shadow or carry as one
-			let survivor_marked = rest_of(&mut parts[end - 1])
+		// a preserved key anywhere in the run must survive the collapse: the survivor's own
+		// value wins, else carry the latest drained one; JSON null counts as absent
+		for &key in preserved_rest_keys {
+			let survivor_has = rest_of(&mut parts[end - 1])
 				.and_then(|rest| rest.get(key))
 				.is_some_and(|v| !v.is_null());
-			if survivor_marked {
+			if survivor_has {
 				continue;
 			}
 			let carried = parts[i..end - 1].iter_mut().rev().find_map(|p| {
@@ -184,16 +178,15 @@ pub(crate) fn scan_text_runs<T>(
 					.and_then(|obj| obj.remove(key))
 					.filter(|v| !v.is_null())
 			});
-			if let Some(marker) = carried
+			if let Some(value) = carried
 				&& let Some(rest) = rest_of(&mut parts[end - 1])
 			{
-				// Null only for typed parts whose `rest` defaults to Null; a whole-part
-				// accessor (responses.rs) must never reach here or this would wipe the part
+				// typed parts default `rest` to Null
 				if !rest.is_object() {
 					*rest = serde_json::Value::Object(Default::default());
 				}
 				if let Some(obj) = rest.as_object_mut() {
-					obj.insert(key.to_string(), marker);
+					obj.insert(key.to_string(), value);
 				}
 			}
 		}

--- a/crates/llm/src/types/responses.rs
+++ b/crates/llm/src/types/responses.rs
@@ -196,6 +196,14 @@ fn visit_tool_item_text(value: &mut Value, f: &mut dyn FnMut(ContentScope, &mut 
 	}
 }
 
+/// `rest` keys preserved when a masked text run collapses; see `scan_text_runs`.
+const PRESERVED_REST_KEYS: &[&str] = &[
+	// Anthropic-style cache breakpoint, accepted by some OpenAI-compat providers
+	"cache_control",
+	// OpenAI explicit prompt-cache breakpoint
+	"prompt_cache_breakpoint",
+];
+
 fn scan_value_text_runs(
 	scope: ContentScope,
 	parts: &mut Vec<Value>,
@@ -216,8 +224,9 @@ fn scan_value_text_runs(
 				_ => None,
 			}
 		},
-		// parts are pass-through JSON; some providers accept cache_control here
+		// parts are pass-through JSON, so `rest` is the whole part
 		|part| Some(part),
+		PRESERVED_REST_KEYS,
 		&mut |text| f(scope, text),
 	);
 }

--- a/crates/llm/src/types/responses.rs
+++ b/crates/llm/src/types/responses.rs
@@ -216,6 +216,8 @@ fn scan_value_text_runs(
 				_ => None,
 			}
 		},
+		// parts are pass-through JSON; some providers accept cache_control here
+		|part| Some(part),
 		&mut |text| f(scope, text),
 	);
 }


### PR DESCRIPTION

Previously after #2755 we would preserve stuff like cache_control/prompt_cache_breakpoint if it was on the last block of a multi-block span. Instead, we should accumulate the last marker onto the rewritten message. Avoids a mask firing anywhere in such a run could silently delete the request's cache breakpoints, disabling prompt caching for every request the guard edited
