### PR TITLE
wip: default routes for AI backends

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -13366,7 +13366,8 @@ type BackendPolicySpec_Ai struct {
 	// Routes defines how to identify the type of LLM request to handle.
 	// The keys are URL suffix matches (e.g., "/v1/chat/completions", "/v1/messages").
 	// The special "*" wildcard matches any path.
-	// If empty or no route matches, the implementation defaults to COMPLETIONS behavior.
+	// Configured entries win; otherwise standard API paths are detected via a built-in
+	// table, and unrecognized paths default to COMPLETIONS behavior.
 	Routes        map[string]BackendPolicySpec_Ai_RouteType `protobuf:"bytes,7,rep,name=routes,proto3" json:"routes,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value,enum=agentgateway.dev.resource.BackendPolicySpec_Ai_RouteType"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -2265,7 +2265,10 @@ type BackendAI struct {
 	// The keys are URL path suffixes matched using ends-with comparison, for
 	// example `"/v1/chat/completions"`.
 	// The special `*` wildcard matches any path.
-	// If not specified, all traffic defaults to `completions` type.
+	// Configured entries win; otherwise standard API paths (`/v1/chat/completions`,
+	// `/v1/messages`, `/v1/embeddings`, Gemini-style suffixes, and so on) are
+	// detected via a built-in table, and unrecognized paths default to
+	// `completions`.
 	// +optional
 	Routes map[string]RouteType `json:"routes,omitempty"`
 }

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -4283,7 +4283,10 @@ spec:
                                           The keys are URL path suffixes matched using ends-with comparison, for
                                           example `"/v1/chat/completions"`.
                                           The special `*` wildcard matches any path.
-                                          If not specified, all traffic defaults to `completions` type.
+                                          Configured entries win; otherwise standard API paths (`/v1/chat/completions`,
+                                          `/v1/messages`, `/v1/embeddings`, Gemini-style suffixes, and so on) are
+                                          detected via a built-in table, and unrecognized paths default to
+                                          `completions`.
                                         type: object
                                       transformations:
                                         description: |-
@@ -13230,7 +13233,10 @@ spec:
                           The keys are URL path suffixes matched using ends-with comparison, for
                           example `"/v1/chat/completions"`.
                           The special `*` wildcard matches any path.
-                          If not specified, all traffic defaults to `completions` type.
+                          Configured entries win; otherwise standard API paths (`/v1/chat/completions`,
+                          `/v1/messages`, `/v1/embeddings`, Gemini-style suffixes, and so on) are
+                          detected via a built-in table, and unrecognized paths default to
+                          `completions`.
                         type: object
                       transformations:
                         description: |-

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -3393,7 +3393,10 @@ spec:
                           The keys are URL path suffixes matched using ends-with comparison, for
                           example `"/v1/chat/completions"`.
                           The special `*` wildcard matches any path.
-                          If not specified, all traffic defaults to `completions` type.
+                          Configured entries win; otherwise standard API paths (`/v1/chat/completions`,
+                          `/v1/messages`, `/v1/embeddings`, Gemini-style suffixes, and so on) are
+                          detected via a built-in table, and unrecognized paths default to
+                          `completions`.
                         type: object
                       transformations:
                         description: |-

--- a/crates/agentgateway/src/llm/model_router.rs
+++ b/crates/agentgateway/src/llm/model_router.rs
@@ -52,46 +52,61 @@ impl ModelVisibility {
 	}
 }
 
+static DEFAULT_ROUTE_TYPES: std::sync::LazyLock<Arc<llm::Policy>> =
+	std::sync::LazyLock::new(|| {
+		Arc::new(llm::Policy {
+			routes: [
+				(
+					strng::new("/v1/chat/completions"),
+					llm::RouteType::Completions,
+				),
+				(strng::new("/v1/messages"), llm::RouteType::Messages),
+				(
+					strng::new("/v1/messages/count_tokens"),
+					llm::RouteType::AnthropicTokenCount,
+				),
+				(strng::new(":rawPredict"), llm::RouteType::Messages),
+				(strng::new(":streamRawPredict"), llm::RouteType::Messages),
+				(
+					strng::new(":generateContent"),
+					llm::RouteType::GenerateContent,
+				),
+				(
+					strng::new(":streamGenerateContent"),
+					llm::RouteType::GenerateContent,
+				),
+				(
+					strng::new(":countTokens"),
+					llm::RouteType::GeminiCountTokens,
+				),
+				(strng::new("/v1/responses"), llm::RouteType::Responses),
+				(strng::new("/v1/images/generations"), llm::RouteType::Detect),
+				(strng::new("/v1/images/edits"), llm::RouteType::Detect),
+				(strng::new("/v1/images/variations"), llm::RouteType::Detect),
+				(strng::new("/v1/responses/compact"), llm::RouteType::Detect),
+				(strng::new("/v1/embeddings"), llm::RouteType::Embeddings),
+				(strng::new("/v1/rerank"), llm::RouteType::Rerank),
+				(strng::new("/v2/rerank"), llm::RouteType::Rerank),
+				(strng::new("*"), llm::RouteType::Passthrough),
+			]
+			.into_iter()
+			.collect(),
+			..Default::default()
+		})
+	});
+
 pub fn default_route_types() -> Arc<llm::Policy> {
-	Arc::new(llm::Policy {
-		routes: [
-			(
-				strng::new("/v1/chat/completions"),
-				llm::RouteType::Completions,
-			),
-			(strng::new("/v1/messages"), llm::RouteType::Messages),
-			(
-				strng::new("/v1/messages/count_tokens"),
-				llm::RouteType::AnthropicTokenCount,
-			),
-			(strng::new(":rawPredict"), llm::RouteType::Messages),
-			(strng::new(":streamRawPredict"), llm::RouteType::Messages),
-			(
-				strng::new(":generateContent"),
-				llm::RouteType::GenerateContent,
-			),
-			(
-				strng::new(":streamGenerateContent"),
-				llm::RouteType::GenerateContent,
-			),
-			(
-				strng::new(":countTokens"),
-				llm::RouteType::GeminiCountTokens,
-			),
-			(strng::new("/v1/responses"), llm::RouteType::Responses),
-			(strng::new("/v1/images/generations"), llm::RouteType::Detect),
-			(strng::new("/v1/images/edits"), llm::RouteType::Detect),
-			(strng::new("/v1/images/variations"), llm::RouteType::Detect),
-			(strng::new("/v1/responses/compact"), llm::RouteType::Detect),
-			(strng::new("/v1/embeddings"), llm::RouteType::Embeddings),
-			(strng::new("/v1/rerank"), llm::RouteType::Rerank),
-			(strng::new("/v2/rerank"), llm::RouteType::Rerank),
-			(strng::new("*"), llm::RouteType::Passthrough),
-		]
-		.into_iter()
-		.collect(),
-		..Default::default()
-	})
+	DEFAULT_ROUTE_TYPES.clone()
+}
+
+/// Route type for a standard API path suffix; the "*" entry is skipped so
+/// unrecognized paths keep the historical Completions default.
+pub fn default_route_for_path(path: &str) -> Option<llm::RouteType> {
+	DEFAULT_ROUTE_TYPES
+		.routes
+		.iter()
+		.find(|(suffix, _)| suffix.as_str() != "*" && path.ends_with(suffix.as_str()))
+		.map(|(_, rt)| *rt)
 }
 
 #[apply(schema_ser_schema!)]

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -702,6 +702,13 @@ impl Policy {
 	}
 
 	pub fn resolve_route(&self, path: &str) -> crate::llm::RouteType {
+		self
+			.resolve_route_opt(path)
+			.unwrap_or(crate::llm::RouteType::Completions)
+	}
+
+	/// Like [`Self::resolve_route`], but None when no entry (including "*") matches.
+	pub fn resolve_route_opt(&self, path: &str) -> Option<crate::llm::RouteType> {
 		let mut wildcard: Option<crate::llm::RouteType> = None;
 
 		// `self.routes` is stored longest->shortest, with "*" last, so the first match wins.
@@ -711,11 +718,11 @@ impl Policy {
 				continue;
 			}
 			if path.ends_with(path_suffix.as_str()) {
-				return *rt;
+				return Some(*rt);
 			}
 		}
 
-		wildcard.unwrap_or(crate::llm::RouteType::Completions)
+		wildcard
 	}
 
 	pub fn has_request_body_mutations(&self) -> bool {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2365,10 +2365,7 @@ async fn make_backend_call(
 				let route_type = route_policies
 					.clone()
 					.merge_backend_policies(effective_policies.llm.clone())
-					.llm
-					.as_ref()
-					.map(|policy| policy.resolve_route(req.uri().path()))
-					.unwrap_or(llm::RouteType::Completions);
+					.resolve_llm_route(req.uri().path());
 				let target = match &provider.host_override {
 					Some(target) => target.clone(),
 					None => provider
@@ -2536,11 +2533,7 @@ async fn make_backend_call(
 		if let Some(llm) = &backend_call.backend_policies.llm_provider {
 			// LLM requires CEL execution after the snapshot so we do not clear extensions
 			let mut req = req.take_and_snapshot_without_clearing_extensions(log.as_mut())?;
-			let route_type = llm_request_policies
-				.llm
-				.as_ref()
-				.map(|policy| policy.resolve_route(req.uri().path()))
-				.unwrap_or(llm::RouteType::Completions);
+			let route_type = llm_request_policies.resolve_llm_route(req.uri().path());
 			trace!("llm: route {} to {route_type:?}", req.uri().path());
 			let llm_provider = llm.provider.provider().to_string();
 			dtrace::trace(|trace| {

--- a/crates/agentgateway/src/store/binds.rs
+++ b/crates/agentgateway/src/store/binds.rs
@@ -497,6 +497,16 @@ impl LLMRequestPolicies {
 		Arc::new(route_policies)
 	}
 
+	/// Resolve the LLM route type for an AI backend request.
+	pub fn resolve_llm_route(&self, path: &str) -> llm::RouteType {
+		self
+			.llm
+			.as_ref()
+			.and_then(|p| p.resolve_route_opt(path))
+			.or_else(|| crate::llm::model_router::default_route_for_path(path))
+			.unwrap_or(llm::RouteType::Completions)
+	}
+
 	fn merge_llm_policies(
 		preferred: &Arc<llm::Policy>,
 		fallback: &Arc<llm::Policy>,
@@ -4194,6 +4204,77 @@ mod tests {
 		);
 		assert_eq!(policy.resolve_route("/v1/messages"), RouteType::Messages);
 		assert_eq!(policy.resolve_route("/v1/models"), RouteType::Passthrough);
+	}
+
+	#[test]
+	fn ai_backend_without_routes_detects_standard_paths() {
+		use crate::llm::RouteType;
+
+		// A binds: ai backend with no ai policy: /v1/messages must parse as Messages,
+		// while unrecognized paths keep the historical Completions default.
+		let policies = LLMRequestPolicies::default();
+		assert_eq!(
+			policies.resolve_llm_route("/v1/messages"),
+			RouteType::Messages
+		);
+		assert_eq!(
+			policies.resolve_llm_route("/v1/chat/completions"),
+			RouteType::Completions
+		);
+		assert_eq!(
+			policies.resolve_llm_route("/mychat"),
+			RouteType::Completions
+		);
+	}
+
+	#[test]
+	fn partial_routes_policy_composes_with_default_table() {
+		use crate::llm::policy::SortedRoutes;
+		use crate::llm::{self, RouteType};
+
+		// A user pinning one path (the old routes workaround) keeps detection for the rest.
+		let mut routes = SortedRoutes::default();
+		routes.insert(strng::new("/v1/messages"), RouteType::Completions);
+		let policies = LLMRequestPolicies {
+			llm: Some(Arc::new(llm::Policy {
+				routes,
+				..Default::default()
+			})),
+			..Default::default()
+		};
+		// The user's key wins over the default for that path.
+		assert_eq!(
+			policies.resolve_llm_route("/v1/messages"),
+			RouteType::Completions
+		);
+		// Defaults still detect unlisted standard paths.
+		assert_eq!(
+			policies.resolve_llm_route("/v1/embeddings"),
+			RouteType::Embeddings
+		);
+	}
+
+	#[test]
+	fn wildcard_routes_policy_opts_out_of_detection() {
+		use crate::llm::policy::SortedRoutes;
+		use crate::llm::{self, RouteType};
+
+		// routes: {"*": passthrough} opts the whole backend out of LLM processing;
+		// the built-in table must not resurrect parsing for standard paths.
+		let mut routes = SortedRoutes::default();
+		routes.insert(strng::new("*"), RouteType::Passthrough);
+		let policies = LLMRequestPolicies {
+			llm: Some(Arc::new(llm::Policy {
+				routes,
+				..Default::default()
+			})),
+			..Default::default()
+		};
+		assert_eq!(
+			policies.resolve_llm_route("/v1/messages"),
+			RouteType::Passthrough
+		);
+		assert_eq!(policies.resolve_llm_route("/other"), RouteType::Passthrough);
 	}
 
 	#[test]

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -1,6 +1,5 @@
 use agentgateway::llm::{AIProvider, custom, gemini, openai};
 use agentgateway::test_helpers::ratelimitmock;
-use agentgateway::types::agent::TrafficPolicy;
 use tokio::sync::mpsc;
 use url::Position;
 
@@ -593,11 +592,7 @@ fn setup_custom_llm_provider_backend_mock_with_formats(
 			SimpleBackendReference::InlineBackend(Target::Address(*mock.address())),
 			formats,
 		));
-	let mut route = basic_named_route(strng::format!("/{backend_name}"));
-	route.inline_policies.push(TrafficPolicy::AI(
-		agentgateway::llm::model_router::default_route_types(),
-	));
-	let t = t.with_route(route);
+	let t = t.with_route(basic_named_route(strng::format!("/{backend_name}")));
 	let io = t.serve_http(BIND_KEY);
 	(mock, t, io)
 }

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1486,7 +1486,8 @@ message BackendPolicySpec {
     // Routes defines how to identify the type of LLM request to handle.
     // The keys are URL suffix matches (e.g., "/v1/chat/completions", "/v1/messages").
     // The special "*" wildcard matches any path.
-    // If empty or no route matches, the implementation defaults to COMPLETIONS behavior.
+    // Configured entries win; otherwise standard API paths are detected via a built-in
+    // table, and unrecognized paths default to COMPLETIONS behavior.
     map<string, RouteType> routes = 7;
   }
   message A2a {}


### PR DESCRIPTION
```yaml
binds:
- port: 3000
  listeners:
  - routes:
    - backends:
      - ai:
          name: anthropic
          provider:
            anthropic: {}
```

it's a bit awkward that this requires manually  mapping routes to the API you want like this:


```yaml
  policies:
        ai:
          routes:               
            /v1/chat/completions: completions
            /v1/messages: messages
            /v1/embeddings: embeddings
```

this PR makes it so the routes are automatically configured based on the provider, like the simple `llm.models` config