### PR TITLE
fix(tls/tcp over hbone): preserve hbone identity

### DIFF
--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -1197,8 +1197,16 @@ impl Gateway {
 					let sni = sni.to_string();
 					// Passthrough
 					start.io.rewind();
+					// Preserve an identity authenticated by an outer layer, such as the Istio
+					// mTLS connection carrying HBONE. Inserting a fresh TLSConnectionInfo here
+					// would otherwise shadow it in the wrapped extension, leaving
+					// `source.identity` empty for authorization policies.
+					let src_identity = ext
+						.get::<TLSConnectionInfo>()
+						.and_then(|tls| tls.src_identity.clone());
 					ext.insert(TLSConnectionInfo {
 						server_name: Some(sni),
+						src_identity,
 						..Default::default()
 					});
 					Ok((best, Socket::from_rewind(ext, counter, start.io)))

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -320,11 +320,7 @@ impl TCPProxy {
 			let ch = start.client_hello();
 			let sni = ch.server_name().unwrap_or_default().to_string();
 			start.io.rewind();
-			let existing = ext.remove().unwrap_or_default();
-			ext.insert(TLSConnectionInfo {
-				server_name: Some(sni),
-				..existing
-			});
+			set_sniffed_tls_server_name(&mut ext, sni);
 			Ok(Socket::from_rewind(ext, counter, start.io))
 		};
 		tokio::time::timeout(to, handshake).await?
@@ -340,6 +336,55 @@ fn resolve_tunnel_backend_call(
 	let backend = super::resolve_tunnel_backend(&tunnel.proxy, inputs)?;
 	let policies = get_backend_policies(inputs, &backend, &tunnel.policies, None);
 	TCPProxy::build_backend_call(log, destination, inputs, &backend.backend, policies, None)
+}
+
+// Preserve TLS metadata authenticated by an outer transport layer while recording
+// information observed from the inner TLS ClientHello.
+fn set_sniffed_tls_server_name(ext: &mut crate::transport::stream::Extension, server_name: String) {
+	let existing = ext.get::<TLSConnectionInfo>().cloned().unwrap_or_default();
+	ext.insert(TLSConnectionInfo {
+		server_name: Some(server_name),
+		..existing
+	});
+}
+
+#[cfg(test)]
+mod sniff_tls_sni_tests {
+	use std::sync::Arc;
+
+	use agent_core::strng;
+
+	use crate::transport::stream::{Extension, TLSConnectionInfo};
+	use crate::transport::tls::{IstioIdentity, TlsInfo};
+
+	#[test]
+	fn preserves_identity_from_wrapped_hbone_extension() {
+		let src_identity = TlsInfo {
+			identity: Some(IstioIdentity::new(
+				strng::literal!("cluster.local"),
+				strng::literal!("default"),
+				strng::literal!("client"),
+			)),
+			spiffe_id: Some(strng::literal!(
+				"spiffe://cluster.local/ns/default/sa/client"
+			)),
+			..Default::default()
+		};
+		let mut hbone = Extension::new();
+		hbone.insert(TLSConnectionInfo {
+			src_identity: Some(src_identity.clone()),
+			..Default::default()
+		});
+		let mut stream = Extension::wrap(Arc::new(hbone));
+
+		super::set_sniffed_tls_server_name(&mut stream, "backend.example.com".to_string());
+
+		let info = stream
+			.get::<TLSConnectionInfo>()
+			.expect("sniffed TLS info must be present");
+		assert_eq!(info.src_identity.as_ref(), Some(&src_identity));
+		assert_eq!(info.server_name.as_deref(), Some("backend.example.com"));
+	}
 }
 
 fn select_best_route(

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -1272,6 +1272,42 @@ impl TestBind {
 		client
 	}
 
+	/// Like [`Self::serve`], but the server-side socket already carries a downstream mTLS
+	/// identity, simulating a connection tunneled over HBONE where the outer Istio mTLS
+	/// layer authenticated the peer (see `Gateway::terminate_gateway_hbone`).
+	pub fn serve_with_src_identity(
+		&self,
+		bind_name: BindKey,
+		src_identity: crate::transport::tls::TlsInfo,
+	) -> DuplexStream {
+		let (client, server) = tokio::io::duplex(8192);
+		let mut server = Socket::from_memory(
+			server,
+			TCPConnectionInfo {
+				peer_addr: "127.0.0.1:12345".parse().unwrap(),
+				local_addr: "127.0.0.1:80".parse().unwrap(),
+				start: Instant::now(),
+				raw_peer_addr: None,
+			},
+		);
+		server
+			.ext_mut()
+			.insert(crate::transport::stream::TLSConnectionInfo {
+				src_identity: Some(src_identity),
+				..Default::default()
+			});
+		let bind = self.pi.stores.read_binds().bind(&bind_name).unwrap();
+		let bind = Gateway::proxy_bind(
+			bind_name,
+			bind.protocol,
+			server,
+			self.pi.clone(),
+			self.drain_rx.clone(),
+		);
+		tokio::spawn(bind);
+		client
+	}
+
 	pub fn serve_tunnel(&self, bind_name: BindKey) -> DuplexStream {
 		let (client, server) = tokio::io::duplex(8192);
 		let server = Socket::from_memory(

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -580,7 +580,7 @@ impl Extension {
 	pub fn new() -> Self {
 		Extension::Single(http::Extensions::new())
 	}
-	fn wrap(ext: Arc<Extension>) -> Self {
+	pub(crate) fn wrap(ext: Arc<Extension>) -> Self {
 		Extension::Wrapped(http::Extensions::new(), ext)
 	}
 

--- a/crates/agentgateway/tests/tests/tls.rs
+++ b/crates/agentgateway/tests/tests/tls.rs
@@ -437,3 +437,146 @@ pub fn route_with_prefix(target: std::net::SocketAddr, prefix: &str) -> Route {
 	}];
 	route
 }
+
+fn tls_passthrough_bind() -> BindSnapshot {
+	BindSnapshot::new(
+		Bind {
+			key: BIND_KEY,
+			address: "127.0.0.1:0".parse().unwrap(),
+			protocol: BindProtocol::tls,
+			tunnel_protocol: Default::default(),
+			mode: Default::default(),
+		},
+		ListenerSet::from_list([Listener {
+			key: LISTENER_KEY,
+			// Use the default gateway name so frontend policies attach to this listener.
+			name: agentgateway::types::agent::ListenerName {
+				gateway_name: strng::literal!("default"),
+				gateway_namespace: strng::literal!("default"),
+				listener_name: strng::EMPTY,
+				listener_set: None,
+			},
+			hostname: strng::new("*.example.com"),
+			// No TLS config: passthrough
+			protocol: ListenerProtocol::TLS(None),
+		}]),
+	)
+}
+
+fn hbone_identity(service_account: &str) -> agentgateway::transport::tls::TlsInfo {
+	agentgateway::transport::tls::TlsInfo {
+		identity: Some(agentgateway::transport::tls::IstioIdentity::new(
+			strng::literal!("cluster.local"),
+			strng::literal!("default"),
+			strng::new(service_account),
+		)),
+		..Default::default()
+	}
+}
+
+/// Start a plain TCP backend that captures the first bytes it receives. For TLS passthrough
+/// the gateway forwards the raw TLS bytes, so on success the backend sees the ClientHello.
+async fn passthrough_capture_backend() -> (std::net::SocketAddr, oneshot::Receiver<Vec<u8>>) {
+	let backend = TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let addr = backend.local_addr().unwrap();
+	let (tx, rx) = oneshot::channel();
+	tokio::spawn(async move {
+		if let Ok((mut conn, _)) = backend.accept().await {
+			let mut buf = vec![0u8; 5];
+			if conn.read_exact(&mut buf).await.is_ok() {
+				let _ = tx.send(buf);
+			}
+		}
+	});
+	(addr, rx)
+}
+
+/// Drive a TLS ClientHello from the client side of the duplex. The handshake never completes
+/// (the backend is only a byte sink), we just need the gateway to sniff the SNI, run
+/// authorization, and (on allow) forward the raw bytes.
+fn spawn_client_hello(io: tokio::io::DuplexStream) -> tokio::task::JoinHandle<bool> {
+	let tls: agentgateway::http::backendtls::BackendTLS =
+		agentgateway::http::backendtls::ResolvedBackendTLS {
+			cert: None,
+			key: None,
+			root: Some(include_bytes!("../../../../examples/mcp-tls/certs/ca-cert.pem").to_vec()),
+			hostname: Some("a.example.com".to_string()),
+			insecure: false,
+			insecure_host: true,
+			alpn: None,
+			subject_alt_names: None,
+			key_exchange_groups: None,
+			spiffe: false,
+		}
+		.try_into()
+		.unwrap();
+	tokio::spawn(async move {
+		TlsConnector::from(tls.base_config().config)
+			.connect(ServerName::try_from("a.example.com").unwrap(), io)
+			.await
+			.is_ok()
+	})
+}
+
+/// A TLS passthrough listener must preserve the mTLS identity authenticated by an outer HBONE
+/// layer, so authorization policies asserting on `source.identity` still apply
+/// (https://github.com/agentgateway/agentgateway regression: passthrough dropped the identity).
+#[tokio::test]
+async fn tls_passthrough_preserves_hbone_identity_for_authz() {
+	let (backend_addr, rx) = passthrough_capture_backend().await;
+
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(backend_addr)
+		.with_bind(tls_passthrough_bind())
+		.with_tcp_route(basic_named_tcp_route(strng::format!("/{}", backend_addr)));
+	t.attach_frontend_policy(json!({
+		"networkAuthorization": {
+			"rules": [r#"source.identity.serviceAccount == "test-sa""#],
+		},
+	}))
+	.await;
+
+	let io = t.serve_with_src_identity(BIND_KEY, hbone_identity("test-sa"));
+	let _client = spawn_client_hello(io);
+
+	// The identity matches the policy, so the raw TLS bytes must reach the backend.
+	let first = tokio::time::timeout(Duration::from_secs(5), rx)
+		.await
+		.expect("timed out: passthrough bytes never reached the backend (identity dropped?)")
+		.expect("backend closed without receiving data");
+	assert_eq!(first[0], 0x16, "expected a TLS handshake record");
+}
+
+/// Inverse of the allow test: a non-matching HBONE identity must be denied by the
+/// authorization policy on a TLS passthrough listener.
+#[tokio::test]
+async fn tls_passthrough_hbone_identity_authz_deny() {
+	let (backend_addr, rx) = passthrough_capture_backend().await;
+
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(backend_addr)
+		.with_bind(tls_passthrough_bind())
+		.with_tcp_route(basic_named_tcp_route(strng::format!("/{}", backend_addr)));
+	t.attach_frontend_policy(json!({
+		"networkAuthorization": {
+			"rules": [r#"source.identity.serviceAccount == "test-sa""#],
+		},
+	}))
+	.await;
+
+	let io = t.serve_with_src_identity(BIND_KEY, hbone_identity("other-sa"));
+	let client = spawn_client_hello(io);
+
+	// The gateway denies the connection, so the client's handshake fails...
+	let connected = client.await.unwrap();
+	assert!(!connected, "handshake must fail when authorization denies");
+	// ...and the backend never receives any bytes.
+	assert!(
+		tokio::time::timeout(Duration::from_millis(500), rx)
+			.await
+			.is_err(),
+		"backend must not receive bytes for a denied connection"
+	);
+}


### PR DESCRIPTION
Preserve mTLS identity for TLS / TCP listeners. Validated in my local cluster

fixes https://github.com/agentgateway/agentgateway/issues/3155