### PR TITLE
feat(api): allow transformation policies on MCP targets

### DIFF
--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -202,6 +202,10 @@ type BackendSimple struct {
 	// Settings for managing authentication to the backend
 	// +optional
 	Auth *BackendAuth `json:"auth,omitempty"`
+
+	// Mutates and transforms requests and responses sent to and from the backend.
+	// +optional
+	Transformation *Transformation `json:"transformation,omitempty"`
 }
 
 // PolicyBackendEndpoint identifies a backend used by policy features.
@@ -373,10 +377,6 @@ type BackendWithAI struct {
 	// +optional
 	AI *BackendAI `json:"ai,omitempty"`
 
-	// Mutates and transforms requests and responses sent to and from the backend.
-	// +optional
-	Transformation *Transformation `json:"transformation,omitempty"`
-
 	// Settings for passive and active health checking.
 	// +optional
 	Health *Health `json:"health,omitempty"`
@@ -395,10 +395,6 @@ type BackendFull struct {
 	// connecting to a `Backend` of type `mcp`.
 	// +optional
 	MCP *BackendMCP `json:"mcp,omitempty"`
-
-	// Mutates and transforms requests and responses sent to and from the backend.
-	// +optional
-	Transformation *Transformation `json:"transformation,omitempty"`
 
 	// Settings for passive and active health checking.
 	// +optional

--- a/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
+++ b/controller/api/v1alpha1/agentgateway/zz_generated.deepcopy.go
@@ -1602,11 +1602,6 @@ func (in *BackendFull) DeepCopyInto(out *BackendFull) {
 		*out = new(BackendMCP)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Transformation != nil {
-		in, out := &in.Transformation, &out.Transformation
-		*out = new(Transformation)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Health != nil {
 		in, out := &in.Health, &out.Health
 		*out = new(Health)
@@ -1710,6 +1705,11 @@ func (in *BackendSimple) DeepCopyInto(out *BackendSimple) {
 	if in.Auth != nil {
 		in, out := &in.Auth, &out.Auth
 		*out = new(BackendAuth)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Transformation != nil {
+		in, out := &in.Transformation, &out.Transformation
+		*out = new(Transformation)
 		(*in).DeepCopyInto(*out)
 	}
 }
@@ -1831,11 +1831,6 @@ func (in *BackendWithAI) DeepCopyInto(out *BackendWithAI) {
 	if in.AI != nil {
 		in, out := &in.AI, &out.AI
 		*out = new(BackendAI)
-		(*in).DeepCopyInto(*out)
-	}
-	if in.Transformation != nil {
-		in, out := &in.Transformation, &out.Transformation
-		*out = new(Transformation)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Health != nil {

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -9785,6 +9785,262 @@ spec:
                                       insecureSkipVerify] may be set
                                     rule: '[has(self.verifySubjectAltNames),has(self.insecureSkipVerify)].filter(x,x==true).size()
                                       <= 1'
+                                transformation:
+                                  description: Mutates and transforms requests and
+                                    responses sent to and from the backend.
+                                  properties:
+                                    request:
+                                      description: Request transformation settings.
+                                      properties:
+                                        add:
+                                          description: |-
+                                            Headers to add to the request and what each value
+                                            should be set to. If there is already a header with these values then
+                                            append the value as an extra entry.
+                                          items:
+                                            properties:
+                                              name:
+                                                description: The name of the header
+                                                  to add.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^:?[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                                x-kubernetes-validations:
+                                                - message: pseudo-headers must be
+                                                    one of :authority, :method, :path,
+                                                    :scheme, or :status
+                                                  rule: '!self.startsWith('':'') ||
+                                                    self in ['':authority'', '':method'',
+                                                    '':path'', '':scheme'', '':status'']'
+                                              value:
+                                                description: |-
+                                                  CEL expression that generates the output value for
+                                                  the header.
+                                                maxLength: 16384
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        body:
+                                          description: HTTP body transformation.
+                                          maxLength: 16384
+                                          minLength: 1
+                                          type: string
+                                        metadata:
+                                          additionalProperties:
+                                            description: A Common Expression Language
+                                              (CEL) expression.
+                                            maxLength: 16384
+                                            minLength: 1
+                                            type: string
+                                          description: |-
+                                            Stores CEL-evaluated values under the `metadata` CEL variable
+                                            for subsequent policy evaluations. `metadata` is evaluated before header
+                                            or body transformations.
+                                          maxProperties: 16
+                                          minProperties: 1
+                                          type: object
+                                        remove:
+                                          description: |-
+                                            Header names to remove from the request or
+                                            response.
+                                          items:
+                                            description: HTTP header name.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^:?[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: pseudo-headers must be one
+                                                of :authority, :method, :path, :scheme,
+                                                or :status
+                                              rule: '!self.startsWith('':'') || self
+                                                in ['':authority'', '':method'', '':path'',
+                                                '':scheme'', '':status'']'
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        set:
+                                          description: Headers to set and the values
+                                            to use.
+                                          items:
+                                            properties:
+                                              name:
+                                                description: The name of the header
+                                                  to add.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^:?[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                                x-kubernetes-validations:
+                                                - message: pseudo-headers must be
+                                                    one of :authority, :method, :path,
+                                                    :scheme, or :status
+                                                  rule: '!self.startsWith('':'') ||
+                                                    self in ['':authority'', '':method'',
+                                                    '':path'', '':scheme'', '':status'']'
+                                              value:
+                                                description: |-
+                                                  CEL expression that generates the output value for
+                                                  the header.
+                                                maxLength: 16384
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [add
+                                          body metadata remove set] must be set
+                                        rule: '[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size()
+                                          >= 1'
+                                    response:
+                                      description: Response transformation settings.
+                                      properties:
+                                        add:
+                                          description: |-
+                                            Headers to add to the request and what each value
+                                            should be set to. If there is already a header with these values then
+                                            append the value as an extra entry.
+                                          items:
+                                            properties:
+                                              name:
+                                                description: The name of the header
+                                                  to add.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^:?[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                                x-kubernetes-validations:
+                                                - message: pseudo-headers must be
+                                                    one of :authority, :method, :path,
+                                                    :scheme, or :status
+                                                  rule: '!self.startsWith('':'') ||
+                                                    self in ['':authority'', '':method'',
+                                                    '':path'', '':scheme'', '':status'']'
+                                              value:
+                                                description: |-
+                                                  CEL expression that generates the output value for
+                                                  the header.
+                                                maxLength: 16384
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        body:
+                                          description: HTTP body transformation.
+                                          maxLength: 16384
+                                          minLength: 1
+                                          type: string
+                                        metadata:
+                                          additionalProperties:
+                                            description: A Common Expression Language
+                                              (CEL) expression.
+                                            maxLength: 16384
+                                            minLength: 1
+                                            type: string
+                                          description: |-
+                                            Stores CEL-evaluated values under the `metadata` CEL variable
+                                            for subsequent policy evaluations. `metadata` is evaluated before header
+                                            or body transformations.
+                                          maxProperties: 16
+                                          minProperties: 1
+                                          type: object
+                                        remove:
+                                          description: |-
+                                            Header names to remove from the request or
+                                            response.
+                                          items:
+                                            description: HTTP header name.
+                                            maxLength: 256
+                                            minLength: 1
+                                            pattern: ^:?[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: pseudo-headers must be one
+                                                of :authority, :method, :path, :scheme,
+                                                or :status
+                                              rule: '!self.startsWith('':'') || self
+                                                in ['':authority'', '':method'', '':path'',
+                                                '':scheme'', '':status'']'
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-type: set
+                                        set:
+                                          description: Headers to set and the values
+                                            to use.
+                                          items:
+                                            properties:
+                                              name:
+                                                description: The name of the header
+                                                  to add.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^:?[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                                x-kubernetes-validations:
+                                                - message: pseudo-headers must be
+                                                    one of :authority, :method, :path,
+                                                    :scheme, or :status
+                                                  rule: '!self.startsWith('':'') ||
+                                                    self in ['':authority'', '':method'',
+                                                    '':path'', '':scheme'', '':status'']'
+                                              value:
+                                                description: |-
+                                                  CEL expression that generates the output value for
+                                                  the header.
+                                                maxLength: 16384
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          minItems: 1
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                      x-kubernetes-validations:
+                                      - message: at least one of the fields in [add
+                                          body metadata remove set] must be set
+                                        rule: '[has(self.add),has(self.body),has(self.metadata),has(self.remove),has(self.set)].filter(x,x==true).size()
+                                          >= 1'
+                                  type: object
+                                  x-kubernetes-validations:
+                                  - message: at least one of the fields in [request
+                                      response] must be set
+                                    rule: '[has(self.request),has(self.response)].filter(x,x==true).size()
+                                      >= 1'
                                 tunnel:
                                   description: Settings for managing tunnel connections
                                     to the backend, like `HTTPS_PROXY`

--- a/controller/pkg/syncer/backend/backend_plugin.go
+++ b/controller/pkg/syncer/backend/backend_plugin.go
@@ -92,11 +92,10 @@ func BuildAgwBackendReferences(
 				appendLLMProviderBackendReferences(&p.LLMProvider, app)
 				if p.Policies != nil {
 					plugins.BackendReferencesFromBackendPolicy(&agentgateway.BackendFull{
-						BackendSimple:  p.Policies.BackendSimple,
-						AI:             p.Policies.AI,
-						MCP:            nil,
-						Transformation: p.Policies.Transformation,
-						Health:         p.Policies.Health,
+						BackendSimple: p.Policies.BackendSimple,
+						AI:            p.Policies.AI,
+						MCP:           nil,
+						Health:        p.Policies.Health,
 					}, app)
 				}
 			}
@@ -452,10 +451,9 @@ func translateAIBackendPolicies(
 		return nil, nil
 	}
 	return TranslateBackendPolicies(ctx, namespace, &agentgateway.BackendFull{
-		BackendSimple:  policies.BackendSimple,
-		AI:             policies.AI,
-		Transformation: policies.Transformation,
-		Health:         policies.Health,
+		BackendSimple: policies.BackendSimple,
+		AI:            policies.AI,
+		Health:        policies.Health,
 	})
 }
 

--- a/controller/pkg/syncer/backend/backend_plugin_test.go
+++ b/controller/pkg/syncer/backend/backend_plugin_test.go
@@ -54,6 +54,45 @@ func TestBuildMCP(t *testing.T) {
 			},
 		},
 		{
+			name: "Static MCPBackend target with per-target transformation",
+			backend: &agentgateway.AgentgatewayBackend{
+				Name:      "per-target-transformation-mcp-backend",
+				Namespace: "test-ns",
+				Spec: agentgateway.AgentgatewayBackendSpec{
+					MCP: &agentgateway.MCPBackend{
+						Targets: []agentgateway.McpTargetSelector{
+							{
+								Name: "identity-aware-target",
+								Static: &agentgateway.McpTarget{
+									Host: shortStringPtr("mcp-server.example.com"),
+									Port: 8080,
+									Policies: &agentgateway.BackendSimple{
+										Transformation: &agentgateway.Transformation{
+											Request: &agentgateway.Transform{
+												Add: []agentgateway.HeaderTransformation{
+													{
+														Name:  "x-authenticated-user",
+														Value: `has(jwt.sub) ? jwt.sub : ""`,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "plain-target",
+								Static: &agentgateway.McpTarget{
+									Host: shortStringPtr("other-server.example.com"),
+									Port: 8080,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Static MCPBackend backend with prefixMode Never",
 			backend: &agentgateway.AgentgatewayBackend{
 				Name:      "never-prefix-mcp-backend",

--- a/controller/pkg/syncer/backend/testdata/Static_MCPBackend_target_with_per-target_transformation.yaml
+++ b/controller/pkg/syncer/backend/testdata/Static_MCPBackend_target_with_per-target_transformation.yaml
@@ -1,0 +1,32 @@
+- inlinePolicies:
+  - transformation:
+      request:
+        add:
+        - expression: 'has(jwt.sub) ? jwt.sub : ""'
+          name: x-authenticated-user
+  key: test-ns/per-target-transformation-mcp-backend/identity-aware-target
+  name:
+    name: per-target-transformation-mcp-backend
+    namespace: test-ns
+  static:
+    host: mcp-server.example.com
+    port: 8080
+- key: test-ns/per-target-transformation-mcp-backend/plain-target
+  name:
+    name: per-target-transformation-mcp-backend
+    namespace: test-ns
+  static:
+    host: other-server.example.com
+    port: 8080
+- key: test-ns/per-target-transformation-mcp-backend
+  mcp:
+    targets:
+    - backend:
+        backend: test-ns/per-target-transformation-mcp-backend/identity-aware-target
+      name: identity-aware-target
+    - backend:
+        backend: test-ns/per-target-transformation-mcp-backend/plain-target
+      name: plain-target
+  name:
+    name: per-target-transformation-mcp-backend
+    namespace: test-ns


### PR DESCRIPTION
Fixes #3157

### Problem

`AgentgatewayBackend.spec.mcp.targets[].static.policies` is typed as `BackendSimple`, which carries `tcp`/`tls`/`http`/`tunnel`/`auth` but not `transformation`. Transformation is only reachable on `BackendFull`, which applies to the whole backend — so on a multiplexed MCP backend a transformation is all-targets or none.

Concretely: we front several MCP servers with one backend. One needs the caller's identity from the Okta JWT; another is a BigQuery MCP that should not receive it. Backend scope forces a choice between leaking identity to a third party and having no attribution at all.

### Change

Move `Transformation` from `BackendFull` and `BackendWithAI` into the embedded `BackendSimple`.

```go
 type BackendSimple struct {
     TCP, TLS, HTTP, Tunnel, Auth
+    Transformation *Transformation `json:"transformation,omitempty"`
 }

 type BackendFull struct {
     BackendSimple `json:",inline"`
     AI, MCP, Health, ExtAuth
-    Transformation *Transformation `json:"transformation,omitempty"`
 }
```

Both structs embed `BackendSimple` with `json:",inline"`, so the serialized shape of the existing types does not change.

### Why no translator or data plane change is needed

- `backend_plugin.go` already wraps per-target policies into a `BackendFull` and calls the same `TranslateBackendPolicies`, storing the result in `staticBackend.InlinePolicies`.
- `translateBackendPolicyToAgw` already handles `backend.Transformation` regardless of where the `BackendFull` came from.
- The data plane already applies `target.backend_policies` per target and already has a `BackendTrafficPolicy::Transformation` variant.

The only other edits are two composite literals that set `Transformation:` directly on a `BackendFull`; they now inherit it through the embedded struct.

### Compatibility

- `agentgateway.dev_agentgatewaypolicies.yaml` — **byte-identical** after regeneration.
- `agentgateway.dev_agentgatewaybackends.yaml` — **+256/−0**, purely additive: a new optional `transformation` under `spec.mcp.targets[].static.policies`.

No existing field moves, changes type, or is removed in the serialized API.

### Testing

- `go test ./controller/...` — 39 packages pass.
- `./controller/hack/generate.sh` is idempotent: re-running after the commit produces no further diff.
- New golden test `Static MCPBackend target with per-target transformation` covers a two-target backend and asserts the scoping:

```yaml
- inlinePolicies:
  - transformation:
      request:
        add:
        - expression: 'has(jwt.sub) ? jwt.sub : ""'
          name: x-authenticated-user
  key: test-ns/per-target-transformation-mcp-backend/identity-aware-target
  ...
- key: test-ns/per-target-transformation-mcp-backend/plain-target   # no inlinePolicies
```

One note: `go vet` fails on `controller/pkg/syncer/service.go:588` (`assignment copies lock value`). That reproduces on unmodified `main` and is unrelated to this change.

### Usage

```yaml
mcp:
  targets:
  - name: feedback
    static:
      host: feedback-mcp.internal
      port: 8080
      policies:
        transformation:
          request:
            add:
            - name: x-authenticated-user
              value: 'has(jwt.sub) ? jwt.sub : ""'
  - name: bigquery          # receives no such header
    static:
      host: bq-mcp.internal
      port: 8080
```

Happy to adjust the API shape if you'd prefer the field somewhere else — e.g. left on `BackendFull` and added to `BackendSimple` separately rather than moved.
