### PR TITLE
chore: update golangci-lint plugins and enable unconvert linter

### DIFF
--- a/controller/.custom-gcl.yml
+++ b/controller/.custom-gcl.yml
@@ -5,4 +5,4 @@ plugins:
 - module: github.com/kgateway-dev/krtequals
   version: 'v0.0.0-20251210234050-024ef4e99e5c'
 - module: 'sigs.k8s.io/kube-api-linter'
-  version: 'v0.0.0-20260518104151-5ebe05f9440b' # Pin to a commit while there's no tag
+  version: 'v0.0.0-20260716143926-092fe0c72997' # Pin to a commit while there's no tag

--- a/controller/.golangci.yaml
+++ b/controller/.golangci.yaml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   concurrency: 4
+  go: '1.27'
   tests: true
 output:
   formats:
@@ -30,6 +31,7 @@ linters:
     - sloglint
     - spancheck
     - staticcheck
+    - unconvert
     - unparam
     - unused
     - usestdlibvars

--- a/controller/Makefile
+++ b/controller/Makefile
@@ -144,7 +144,7 @@ ensure-custom-golangci-lint:
 	if [ ! -x "$(CUSTOM_GOLANGCI_LINT_BIN)" ] || [ "$$current_go_version" != "$$expected_go_version" ]; then \
 		echo "Rebuilding golangci-lint custom with $$expected_go_version..."; \
 		rm -f "$(CUSTOM_GOLANGCI_LINT_BIN)"; \
-		golangci-lint custom; \
+		GOTOOLCHAIN="$$expected_go_version" golangci-lint custom; \
 	fi
 
 .PHONY: lint-actions

--- a/controller/pkg/agentgateway/jwks/request_test.go
+++ b/controller/pkg/agentgateway/jwks/request_test.go
@@ -205,7 +205,7 @@ func staticBackend(name, host string, port int32, tlsPolicy *agentgateway.Backen
 }
 
 func remoteProvider(path string, backendRef gwv1.BackendObjectReference) agentgateway.RemoteJWKS {
-	jwksPath := agentgateway.LongString(path)
+	jwksPath := path
 	return agentgateway.RemoteJWKS{
 		JwksPath:   &jwksPath,
 		BackendRef: &backendRef,

--- a/controller/pkg/agentgateway/jwks/resolver_test.go
+++ b/controller/pkg/agentgateway/jwks/resolver_test.go
@@ -119,7 +119,7 @@ func TestResolverBackendRefGrant(t *testing.T) {
 					JwksPath: ptr.Of(agentgateway.LongString("keys")),
 					PolicyBackendEndpoint: agentgateway.PolicyBackendEndpoint{
 						BackendRef: &gwv1.BackendObjectReference{
-							Name:      gwv1.ObjectName(targetName),
+							Name:      targetName,
 							Namespace: tt.refNamespace,
 							Port:      new(gwv1.PortNumber(80)),
 						},

--- a/controller/pkg/agentgateway/jwks/store_test.go
+++ b/controller/pkg/agentgateway/jwks/store_test.go
@@ -497,7 +497,7 @@ func testRemotePolicy(name, uri string, ttl time.Duration) *agentgateway.Agentga
 }
 
 func longStringPtr(s string) *agentgateway.LongString {
-	v := agentgateway.LongString(s)
+	v := s
 	return &v
 }
 
@@ -505,7 +505,7 @@ func jwksPath(s *agentgateway.LongString) string {
 	if s == nil {
 		return ""
 	}
-	return string(*s)
+	return *s
 }
 
 func testBackend(name, uri string, ttl time.Duration) *agentgateway.AgentgatewayBackend {

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -1573,11 +1573,11 @@ func buildAwsAuthPolicy(ctx PolicyCtx, auth *agentgateway.AwsAuth, namespace str
 	var sessionToken *string
 	var serviceName string
 	if auth.ServiceName != nil {
-		serviceName = string(*auth.ServiceName)
+		serviceName = *auth.ServiceName
 	}
 	var region string
 	if auth.Region != nil {
-		region = string(*auth.Region)
+		region = *auth.Region
 	}
 	var assumeRole *api.AwsAssumeRole
 	if auth.AssumeRole != nil {

--- a/controller/pkg/agentgateway/plugins/backend_tls_policy_test.go
+++ b/controller/pkg/agentgateway/plugins/backend_tls_policy_test.go
@@ -165,7 +165,7 @@ func TestTranslateBackendTLSCAErrorUpdatesPolicyStatus(t *testing.T) {
 		t.Fatalf("status ancestors = %#v, want one ancestor with conditions", status.Ancestors)
 	}
 	condition := status.Ancestors[0].Conditions[0]
-	if condition.Type != string(agentgateway.PolicyConditionAccepted) || condition.Status != metav1.ConditionTrue || condition.Reason != string(agentgateway.PolicyReasonPartiallyValid) {
+	if condition.Type != agentgateway.PolicyConditionAccepted || condition.Status != metav1.ConditionTrue || condition.Reason != agentgateway.PolicyReasonPartiallyValid {
 		t.Fatalf("accepted condition = %#v, want partially valid", condition)
 	}
 	if !strings.Contains(condition.Message, "Secret default/missing not found") {

--- a/controller/pkg/agentgateway/plugins/custom_provider.go
+++ b/controller/pkg/agentgateway/plugins/custom_provider.go
@@ -22,7 +22,7 @@ func TranslateCustomProviderFormats(formats []agentgateway.ProviderFormatConfig)
 		}
 		var path *string
 		if format.Path != "" {
-			path = new(string(format.Path))
+			path = new(format.Path)
 		}
 		translated = append(translated, &api.AIBackend_ProviderFormatConfig{Format: formatType, Path: path})
 	}
@@ -84,7 +84,7 @@ func TranslateCustomProviderBackendRef(
 
 	var port *gwv1.PortNumber
 	if ref.Port != nil {
-		port = new(gwv1.PortNumber(*ref.Port))
+		port = new(*ref.Port)
 	}
 	return routeBackend(krtctx, namespace, gk, gwv1.ObjectName(ref.Name), nil, port)
 }

--- a/controller/pkg/agentgateway/plugins/jwks_translation_test.go
+++ b/controller/pkg/agentgateway/plugins/jwks_translation_test.go
@@ -23,7 +23,7 @@ func (s stubJWKSLookup) InlineForOwner(krt.HandlerContext, jwks.RemoteJwksOwner)
 }
 
 func longStringPtr(s string) *agentgateway.LongString {
-	v := agentgateway.LongString(s)
+	v := s
 	return &v
 }
 

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -269,7 +269,7 @@ func TranslateAgentgatewayPolicy(
 		}
 		var portNum int32
 		if port != nil {
-			portNum = int32(*port)
+			portNum = *port
 		}
 		key := targetKey{Group: gk.Group, Kind: gk.Kind, Name: string(name), Namespace: targetNamespace, SectionName: section, Port: portNum}
 		if _, ok := seen[key]; ok {
@@ -323,35 +323,35 @@ func PolicyConditionMap(err error, hasTranslatedPolicies bool) map[string]*Condi
 	if err != nil {
 		// If we produced some policies alongside errors, treat as partial validity
 		if hasTranslatedPolicies {
-			conds[string(agentgateway.PolicyConditionAccepted)] = &Condition{
+			conds[agentgateway.PolicyConditionAccepted] = &Condition{
 				Status:  metav1.ConditionTrue,
-				Reason:  string(agentgateway.PolicyReasonPartiallyValid),
+				Reason:  agentgateway.PolicyReasonPartiallyValid,
 				Message: err.Error(),
 			}
 		} else {
 			// No policies produced and error present -> invalid
-			conds[string(agentgateway.PolicyConditionAccepted)] = &Condition{
+			conds[agentgateway.PolicyConditionAccepted] = &Condition{
 				Status:  metav1.ConditionFalse,
-				Reason:  string(agentgateway.PolicyReasonInvalid),
+				Reason:  agentgateway.PolicyReasonInvalid,
 				Message: err.Error(),
 			}
-			conds[string(agentgateway.PolicyConditionAttached)] = &Condition{
+			conds[agentgateway.PolicyConditionAttached] = &Condition{
 				Status:  metav1.ConditionFalse,
-				Reason:  string(agentgateway.PolicyReasonPending),
+				Reason:  agentgateway.PolicyReasonPending,
 				Message: "Policy is not attached due to invalid status",
 			}
 		}
 	} else {
 		// Check for partial validity
 		// Build success conditions per ancestor
-		conds[string(agentgateway.PolicyConditionAccepted)] = &Condition{
+		conds[agentgateway.PolicyConditionAccepted] = &Condition{
 			Status:  metav1.ConditionTrue,
-			Reason:  string(agentgateway.PolicyReasonValid),
+			Reason:  agentgateway.PolicyReasonValid,
 			Message: reporter.PolicyAcceptedMsg,
 		}
-		conds[string(agentgateway.PolicyConditionAttached)] = &Condition{
+		conds[agentgateway.PolicyConditionAttached] = &Condition{
 			Status:  metav1.ConditionTrue,
-			Reason:  string(agentgateway.PolicyReasonAttached),
+			Reason:  agentgateway.PolicyReasonAttached,
 			Message: reporter.PolicyAttachedMsg,
 		}
 	}
@@ -360,9 +360,9 @@ func PolicyConditionMap(err error, hasTranslatedPolicies bool) map[string]*Condi
 
 func attachmentErrorConditionMap(baseConds map[string]*Condition, attachmentErrors []string) map[string]*Condition {
 	conds := maps.Clone(baseConds)
-	conds[string(agentgateway.PolicyConditionAttached)] = &Condition{
+	conds[agentgateway.PolicyConditionAttached] = &Condition{
 		Status:  metav1.ConditionFalse,
-		Reason:  string(agentgateway.PolicyReasonPending),
+		Reason:  agentgateway.PolicyReasonPending,
 		Message: strings.Join(attachmentErrors, "\n"),
 	}
 	return conds
@@ -1915,7 +1915,7 @@ func buildPolicyBackendEndpoint(ctx PolicyCtx, endpoint agentgateway.PolicyBacke
 	if endpoint.URL == nil {
 		return nil, nil, nil, fmt.Errorf("backendRef or url is required")
 	}
-	parsed, p, err := remotehttp.ParseHTTPURL(string(*endpoint.URL))
+	parsed, p, err := remotehttp.ParseHTTPURL(*endpoint.URL)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/controller/pkg/agentgateway/remotehttp/connection_resolver.go
+++ b/controller/pkg/agentgateway/remotehttp/connection_resolver.go
@@ -195,7 +195,7 @@ func (r *defaultResolver) resolveTunnelProxy(
 		}
 		var port int32
 		if p := ptr.OrEmpty(backendRef.Port); p != 0 {
-			port = int32(p)
+			port = p
 		} else if backend.Static.Port != 0 {
 			port = backend.Static.Port
 		} else {

--- a/controller/pkg/agentgateway/remotehttp/secret_ca_test.go
+++ b/controller/pkg/agentgateway/remotehttp/secret_ca_test.go
@@ -232,6 +232,6 @@ func kindPtr(value string) *gwv1.Kind {
 }
 
 func port(value int32) *gwv1.PortNumber {
-	port := gwv1.PortNumber(value)
+	port := value
 	return &port
 }

--- a/controller/pkg/agentgateway/remotehttp/service_matcher.go
+++ b/controller/pkg/agentgateway/remotehttp/service_matcher.go
@@ -20,7 +20,7 @@ func (r *defaultResolver) serviceTargetSectionMatcher(
 	}
 
 	if port := ptr.OrEmpty(refPort); port != 0 {
-		appendPort(int32(port))
+		appendPort(port)
 	} else if defaultPort != "" {
 		if parsed, err := strconv.ParseInt(defaultPort, 10, 32); err == nil {
 			appendPort(int32(parsed))
@@ -45,7 +45,7 @@ func (r *defaultResolver) backendTLSServiceTargetSectionMatcher(
 	}
 
 	if port := ptr.OrEmpty(refPort); port != 0 {
-		appendPort(int32(port))
+		appendPort(port)
 	} else if defaultPort != "" {
 		if parsed, err := strconv.ParseInt(defaultPort, 10, 32); err == nil {
 			appendPort(int32(parsed))

--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -276,7 +276,7 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 			obj.GetAnnotations()[annotations.InternalPorts],
 			func(p int32) bool {
 				for _, l := range kgw.Listeners {
-					if int32(l.Port) == p {
+					if l.Port == p {
 						return true
 					}
 				}
@@ -528,7 +528,7 @@ func ListenerSetBuilder(
 		obj.GetAnnotations()[annotations.InternalPorts],
 		func(p int32) bool {
 			for _, l := range ls.Listeners {
-				if port, err := kubeutils.DetectListenerPortNumber(l.Protocol, l.Port); err == nil && int32(port) == p {
+				if port, err := kubeutils.DetectListenerPortNumber(l.Protocol, l.Port); err == nil && port == p {
 					return true
 				}
 			}

--- a/controller/pkg/agentgateway/translator/model_collections.go
+++ b/controller/pkg/agentgateway/translator/model_collections.go
@@ -567,7 +567,7 @@ func translateModelLLMProvider(ctx RouteContext, namespace string, model *agentg
 	}
 	provider := &api.AIBackend_Provider{Name: providerName, InlinePolicies: inlinePolicies}
 	if model.BaseURL != nil {
-		provider.BaseUrl = new(string(*model.BaseURL))
+		provider.BaseUrl = new(*model.BaseURL)
 	}
 	if model.Provider != nil {
 		if preset, ok := modelProviderPreset(*model.Provider); ok {
@@ -586,15 +586,15 @@ func translateModelLLMProvider(ctx RouteContext, namespace string, model *agentg
 	}
 	if provider.HostOverride == nil && llm.Host != "" {
 		provider.HostOverride = &api.AIBackend_HostOverride{
-			Host: string(llm.Host),
+			Host: llm.Host,
 			Port: ptr.NonEmptyOrDefault(llm.Port, 443),
 		}
 	}
 	if provider.PathOverride == nil && llm.Path != "" {
-		provider.PathOverride = new(string(llm.Path))
+		provider.PathOverride = new(llm.Path)
 	}
 	if provider.PathPrefix == nil && llm.PathPrefix != "" {
-		provider.PathPrefix = new(string(llm.PathPrefix))
+		provider.PathPrefix = new(llm.PathPrefix)
 	}
 
 	switch {
@@ -606,7 +606,7 @@ func translateModelLLMProvider(ctx RouteContext, namespace string, model *agentg
 			resourceType = api.AIBackend_FOUNDRY
 		}
 		provider.Provider = &api.AIBackend_Provider_Azure{Azure: &api.AIBackend_Azure{
-			ResourceName: string(llm.Azure.ResourceName),
+			ResourceName: llm.Azure.ResourceName,
 			ResourceType: resourceType,
 			Model:        providerModel(selectedModel, llm.Azure.Model),
 			ApiVersion:   stringPtr(llm.Azure.ApiVersion),
@@ -618,15 +618,15 @@ func translateModelLLMProvider(ctx RouteContext, namespace string, model *agentg
 		provider.Provider = &api.AIBackend_Provider_Gemini{Gemini: &api.AIBackend_Gemini{Model: providerModel(selectedModel, llm.Gemini.Model)}}
 	case llm.VertexAI != nil:
 		provider.Provider = &api.AIBackend_Provider_Vertex{Vertex: &api.AIBackend_Vertex{
-			Region:    string(llm.VertexAI.Region),
+			Region:    llm.VertexAI.Region,
 			Model:     providerModel(selectedModel, llm.VertexAI.Model),
-			ProjectId: string(llm.VertexAI.ProjectId),
+			ProjectId: llm.VertexAI.ProjectId,
 		}}
 	case llm.Bedrock != nil:
 		var guardrailIdentifier, guardrailVersion *string
 		if llm.Bedrock.Guardrail != nil {
-			guardrailIdentifier = new(string(llm.Bedrock.Guardrail.GuardrailIdentifier))
-			guardrailVersion = new(string(llm.Bedrock.Guardrail.GuardrailVersion))
+			guardrailIdentifier = new(llm.Bedrock.Guardrail.GuardrailIdentifier)
+			guardrailVersion = new(llm.Bedrock.Guardrail.GuardrailVersion)
 		}
 		provider.Provider = &api.AIBackend_Provider_Bedrock{Bedrock: &api.AIBackend_Bedrock{
 			Model:               providerModel(selectedModel, llm.Bedrock.Model),
@@ -758,7 +758,7 @@ func modelLLMProvider(model *agentgateway.AgentgatewayModelSpec) (*agentgateway.
 func validateModelBaseURL(model *agentgateway.AgentgatewayModelSpec) error {
 	var baseURL string
 	if model.BaseURL != nil {
-		baseURL = string(*model.BaseURL)
+		baseURL = *model.BaseURL
 	}
 	if model.Provider != nil && *model.Provider == agentgateway.ModelProviderOllama && baseURL == "" {
 		return fmt.Errorf("ollama requires baseURL")
@@ -846,7 +846,7 @@ func resolveModelTarget(ctx RouteContext, namespace string, target agentgateway.
 		return nil, "", fmt.Errorf("model target %s/%s not found", namespace, target.ModelRef.Name)
 	}
 	if target.Model != nil {
-		return ref, string(*target.Model), nil
+		return ref, *target.Model, nil
 	}
 	modelName := effectiveModelName(ref)
 	if strings.Contains(modelName, "*") {
@@ -881,7 +881,7 @@ func stringPtr[T ~string](v *T) *string {
 
 func effectiveModelName(model *agentgateway.AgentgatewayModel) string {
 	if model.Spec.Match != nil && model.Spec.Match.Model != nil {
-		return string(*model.Spec.Match.Model)
+		return *model.Spec.Match.Model
 	}
 	return model.Name
 }

--- a/controller/pkg/agentgateway/translator/model_collections_test.go
+++ b/controller/pkg/agentgateway/translator/model_collections_test.go
@@ -247,7 +247,7 @@ func TestModelProviderInlinePolicies(t *testing.T) {
 				Response: &gwv1.HTTPHeaderFilter{Add: []gwv1.HTTPHeader{{Name: "x-model-response-policy", Value: "enabled"}}},
 			},
 			PromptGuard: &agentgateway.AIPromptGuard{Request: []agentgateway.PromptguardRequest{{
-				Regex: &agentgateway.Regex{Action: new(agentgateway.Action(agentgateway.REJECT)), Matches: []agentgateway.LongString{"blocked"}},
+				Regex: &agentgateway.Regex{Action: new(agentgateway.REJECT), Matches: []agentgateway.LongString{"blocked"}},
 			}}},
 		},
 	}
@@ -367,7 +367,7 @@ func TestTranslatePresetProviderBaseURL(t *testing.T) {
 	if provider.GetProviderPreset() != api.AIBackend_PROVIDER_PRESET_OLLAMA {
 		t.Fatalf("provider preset = %v, want Ollama", provider.GetProviderPreset())
 	}
-	if provider.GetBaseUrl() != string(baseURL) {
+	if provider.GetBaseUrl() != baseURL {
 		t.Errorf("base URL = %q, want %q", provider.GetBaseUrl(), baseURL)
 	}
 }

--- a/controller/pkg/pluginsdk/collections/deployer.go
+++ b/controller/pkg/pluginsdk/collections/deployer.go
@@ -97,7 +97,7 @@ func ComputeInternalPorts(gw *gwv1.Gateway, lsets []*gwv1.ListenerSet) smallset.
 		gw.GetAnnotations()[annotations.InternalPorts],
 		func(p int32) bool {
 			for _, l := range gw.Spec.Listeners {
-				if int32(l.Port) == p {
+				if l.Port == p {
 					return true
 				}
 			}
@@ -105,7 +105,7 @@ func ComputeInternalPorts(gw *gwv1.Gateway, lsets []*gwv1.ListenerSet) smallset.
 		},
 	)
 	for _, l := range gw.Spec.Listeners {
-		portModes[int32(l.Port)] = gwInternal.Has(l.Port)
+		portModes[l.Port] = gwInternal.Has(l.Port)
 	}
 
 	slices.SortFunc(lsets, func(a, b *gwv1.ListenerSet) int {

--- a/controller/pkg/syncer/backend/backend_plugin.go
+++ b/controller/pkg/syncer/backend/backend_plugin.go
@@ -128,7 +128,7 @@ func appendLLMProviderBackendReferences(llm *agentgateway.LLMProvider, app func(
 	}
 	var port *gwv1.PortNumber
 	if llm.Custom.BackendRef.Port != nil {
-		port = new(gwv1.PortNumber(*llm.Custom.BackendRef.Port))
+		port = new(*llm.Custom.BackendRef.Port)
 	}
 	app(gwv1.BackendObjectReference{Group: group, Kind: kind, Name: gwv1.ObjectName(llm.Custom.BackendRef.Name), Port: port})
 }
@@ -150,7 +150,7 @@ func BuildAgwBackend(
 		case b.UnixPath != nil:
 			sb.UnixPath = *b.UnixPath
 		default:
-			sb.Host = string(b.Host)
+			sb.Host = b.Host
 			sb.Port = b.Port
 		}
 		return []*api.Backend{{
@@ -164,7 +164,7 @@ func BuildAgwBackend(
 	}
 	if b := backend.Spec.A2A; b != nil {
 		sb := &api.StaticBackend{}
-		sb.Host = string(b.Host)
+		sb.Host = b.Host
 		sb.Port = b.Port
 		a2aPolicy := &api.BackendPolicySpec{
 			Kind: &api.BackendPolicySpec_A2A_{
@@ -492,7 +492,7 @@ func translateLLMProvider(ctx plugins.PolicyCtx, namespace string, llm *agentgat
 			},
 		}
 	} else if llm.AzureOpenAI != nil {
-		resourceName, resourceType := parseAzureEndpoint(string(llm.AzureOpenAI.Endpoint))
+		resourceName, resourceType := parseAzureEndpoint(llm.AzureOpenAI.Endpoint)
 		provider.Provider = &api.AIBackend_Provider_Azure{
 			Azure: &api.AIBackend_Azure{
 				ResourceName: resourceName,
@@ -508,7 +508,7 @@ func translateLLMProvider(ctx plugins.PolicyCtx, namespace string, llm *agentgat
 		}
 		provider.Provider = &api.AIBackend_Provider_Azure{
 			Azure: &api.AIBackend_Azure{
-				ResourceName: string(llm.Azure.ResourceName),
+				ResourceName: llm.Azure.ResourceName,
 				ResourceType: resourceType,
 				Model:        llm.Azure.Model,
 				ApiVersion:   llm.Azure.ApiVersion,
@@ -588,7 +588,7 @@ func translateOpenAIInlineModeration(m *agentgateway.OpenAIInlineModeration) (*a
 	if err != nil {
 		return nil, err
 	}
-	model := string(m.Model)
+	model := m.Model
 	if model == "" {
 		model = defaultOpenAIInlineModerationModel
 	}

--- a/controller/pkg/syncer/backend/backend_plugin_test.go
+++ b/controller/pkg/syncer/backend/backend_plugin_test.go
@@ -804,7 +804,7 @@ func TestBuildAgwBackendReferencesIncludesCustomProviderBackendRefs(t *testing.T
 }
 
 func shortStringPtr(s string) *agentgateway.ShortString {
-	v := agentgateway.ShortString(s)
+	v := s
 	return &v
 }
 

--- a/controller/test/e2e/backendauth_test.go
+++ b/controller/test/e2e/backendauth_test.go
@@ -73,9 +73,9 @@ func testInvalidJwtSign(t base.Test) {
 	assertions.EventuallyAgwPolicyStatus(t, "backendauth-invalid-jwt-sign", base.Namespace, func(status gwv1.PolicyStatus) error {
 		for _, ancestor := range status.Ancestors {
 			for _, condition := range ancestor.Conditions {
-				if condition.Type == string(agentgateway.PolicyConditionAccepted) &&
+				if condition.Type == agentgateway.PolicyConditionAccepted &&
 					condition.Status == metav1.ConditionTrue &&
-					condition.Reason == string(agentgateway.PolicyReasonPartiallyValid) &&
+					condition.Reason == agentgateway.PolicyReasonPartiallyValid &&
 					strings.Contains(condition.Message, missingKeyRef) {
 					return nil
 				}

--- a/controller/test/e2e/backendtls_test.go
+++ b/controller/test/e2e/backendtls_test.go
@@ -38,7 +38,7 @@ func TestBackendTLSPolicyAndStatus(tt *testing.T) {
 	t.Send("foo.com", base.Expect(http.StatusMovedPermanently))
 
 	assertBackendTLSPolicyStatus(t, backendTLSPolicy, metav1.Condition{
-		Type:               string(agentgateway.PolicyConditionAccepted),
+		Type:               agentgateway.PolicyConditionAccepted,
 		Status:             metav1.ConditionTrue,
 		Reason:             string(gwv1.PolicyReasonAccepted),
 		ObservedGeneration: backendTLSPolicy.Generation,

--- a/controller/test/e2e/jwtauth_test.go
+++ b/controller/test/e2e/jwtauth_test.go
@@ -68,9 +68,9 @@ func testJwtAuthInvalidInlineJwks(t base.Test) {
 	assertions.EventuallyAgwPolicyStatus(t, "route-invalid-inline-jwks-policy", base.Namespace, func(status gwv1.PolicyStatus) error {
 		for _, ancestor := range status.Ancestors {
 			for _, condition := range ancestor.Conditions {
-				if condition.Type == string(agentgateway.PolicyConditionAccepted) &&
+				if condition.Type == agentgateway.PolicyConditionAccepted &&
 					condition.Status == metav1.ConditionTrue &&
-					condition.Reason == string(agentgateway.PolicyReasonPartiallyValid) &&
+					condition.Reason == agentgateway.PolicyReasonPartiallyValid &&
 					strings.Contains(condition.Message, "invalid inline") {
 					return nil
 				}

--- a/controller/test/e2e/policystatus_test.go
+++ b/controller/test/e2e/policystatus_test.go
@@ -56,9 +56,9 @@ func addAncestorStatus(t base.Test, policyName, policyNamespace, gwName, control
 			ControllerName: gwv1.GatewayController(controllerName),
 			Conditions: []metav1.Condition{
 				{
-					Type:               string(agentgateway.PolicyConditionAccepted),
+					Type:               agentgateway.PolicyConditionAccepted,
 					Status:             metav1.ConditionTrue,
-					Reason:             string(agentgateway.PolicyReasonValid),
+					Reason:             agentgateway.PolicyReasonValid,
 					Message:            "Accepted by fake controller",
 					LastTransitionTime: metav1.Now(),
 				},

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/agentgateway/agentgateway/tools
 
-go 1.26.0
+go 1.27.0
 
 tool (
 	github.com/agentgateway/agentgateway/tools/cmd/oss_compliance


### PR DESCRIPTION
## Changes

- Bump `kube-api-linter` plugin to latest commit
- Add `go: '1.27'` toolchain pin and enable `unconvert` linter in `.golangci.yaml`
- Set `GOTOOLCHAIN` env var when building custom golangci-lint binary in Makefile
- Bump `tools/go.mod` to Go 1.27
- Remove redundant type conversions flagged by `unconvert` (e.g. unnecessary `string()`, `int32()` casts) across 17 files