### PR TITLE
fix(pii): keep phone matches within one line

### DIFF
--- a/crates/agentgateway/src/llm/policy/pii/phone_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/phone_recognizer.rs
@@ -23,7 +23,7 @@ impl PhoneRecognizer {
 impl Recognizer for PhoneRecognizer {
 	fn recognize(&self, text: &str) -> Vec<RecognizerResult> {
 		static CANDIDATE_RE: Lazy<Regex> =
-			Lazy::new(|| Regex::new(r"(?i)(^|[^0-9])([+()]?[0-9][0-9\s().\-]{6,30})").unwrap());
+			Lazy::new(|| Regex::new(r"(?i)(^|[^0-9])([+()]?[0-9][0-9\t\p{Zs}().\-]{6,30})").unwrap());
 
 		// Map region strings once.
 		fn to_country(code: &str) -> Option<country::Id> {

--- a/crates/agentgateway/src/llm/policy/pii/tests.rs
+++ b/crates/agentgateway/src/llm/policy/pii/tests.rs
@@ -68,6 +68,21 @@ fn test_phone_recognizer() {
 }
 
 #[test]
+fn test_phone_recognizer_does_not_cross_line_breaks() {
+	let recognizer = PhoneRecognizer::new();
+	let text = "Call (212) 555-0100\n123 in the next line";
+
+	let results = recognizer.recognize(text);
+
+	assert!(
+		results
+			.iter()
+			.any(|result| result.matched == "(212) 555-0100"),
+		"expected the phone number before the line break to be recognized, got {results:?}"
+	);
+}
+
+#[test]
 fn test_url_recognizer() {
 	let recognizer = UrlRecognizer::new();
 


### PR DESCRIPTION
## Summary

Fixes #3142.

`PhoneRecognizer` used `\s` in its candidate pattern, so a candidate could span a line break when the following line began with digits, spaces, or punctuation. The longer cross-line candidate then failed `phonenumber` validation and the valid phone number before the line break was discarded.

The candidate pattern now accepts horizontal whitespace (`TAB` and Unicode `Zs`) without consuming line breaks. Existing matching, validation, scoring, and deduplication behavior is unchanged.

## Verification

- `cargo test -p agentgateway test_phone_recognizer --lib` passed.
- `cargo fmt --check -- --config imports_granularity=Module,group_imports=StdExternalCrate,normalize_comments=true` passed.
- `cargo clippy -p agentgateway --all-targets -- -D warnings -A clippy::nonminimal_bool` passed. The repository currently has an unrelated baseline `nonminimal_bool` warning in `crates/agentgateway/src/http/budget/status.rs:60`.
- `make test` ran successfully for the other workspace tests, but the existing suite still has five MCP access-log failures at `crates/core/src/telemetry.rs:751` because expected global log records are absent in this environment. The PII tests pass, and the failures are outside this change.
