### PR TITLE
controller: allow cross-namespace InferencePool backendRefs

### DIFF
--- a/controller/pkg/agentgateway/plugins/reference_indexes.go
+++ b/controller/pkg/agentgateway/plugins/reference_indexes.go
@@ -91,6 +91,7 @@ func DefaultReferenceTypes(agw *AgwCollections) ReferenceTypes {
 			wellknown.SecretGVK.GroupKind(),
 			wellknown.AgentgatewayBackendGVK.GroupKind(),
 			wellknown.HTTPRouteGVK.GroupKind(),
+			wellknown.InferencePoolGVK.GroupKind(),
 		),
 		// AgentgatewayPolicy targets
 		PolicyTargets: func(krtctx krt.HandlerContext, namespace string, name gwv1.ObjectName, gk schema.GroupKind, sectionName *gwv1.SectionName, port *gwv1.PortNumber) ([]*api.PolicyTarget, error) {

--- a/controller/pkg/agentgateway/translator/route_collections.go
+++ b/controller/pkg/agentgateway/translator/route_collections.go
@@ -331,6 +331,7 @@ func buildDelegatedHTTPRoutes(
 		if !isDelegatedChildHTTPRoute(obj) {
 			return nil
 		}
+		ctx := inputs.WithCtx(krtctx)
 		source := utils.TypedNamespacedName{
 			Namespace: obj.Namespace,
 			Name:      obj.Name,
@@ -351,6 +352,9 @@ func buildDelegatedHTTPRoutes(
 			for _, backend := range rule.BackendRefs {
 				ref, refNs, refName := GetBackendRef(backend)
 				if ref == wellknown.HTTPRouteGVK.GroupKind() {
+					continue
+				}
+				if !ancestorBackendAllowed(ctx, wellknown.HTTPRouteGVK, obj.Namespace, ref, refNs, refName) {
 					continue
 				}
 				backends.Insert(utils.TypedNamespacedName{
@@ -607,26 +611,26 @@ func AgwRouteCollection(
 	ancestorBackends := krt.JoinCollection([]krt.Collection[*utils.AncestorBackend]{
 		krt.NewManyCollection(httpRouteCol, func(krtctx krt.HandlerContext, obj *gwv1.HTTPRoute) []*utils.AncestorBackend {
 			ctx := inputs.WithCtx(krtctx)
-			return extractAncestorBackends(ctx, obj, "HTTPRoute", obj.Spec.Rules, func(r gwv1.HTTPRouteRule) []gwv1.HTTPBackendRef {
+			return extractAncestorBackends(ctx, obj, wellknown.HTTPRouteGVK, obj.Spec.Rules, func(r gwv1.HTTPRouteRule) []gwv1.HTTPBackendRef {
 				return r.BackendRefs
 			})
 		}, krtopts.ToOptions("translator/HTTPAncestors")...),
 		delegatedHTTPAncestors,
 		krt.NewManyCollection(grpcRouteCol, func(krtctx krt.HandlerContext, obj *gwv1.GRPCRoute) []*utils.AncestorBackend {
 			ctx := inputs.WithCtx(krtctx)
-			return extractAncestorBackends(ctx, obj, "GRPCRoute", obj.Spec.Rules, func(r gwv1.GRPCRouteRule) []gwv1.GRPCBackendRef {
+			return extractAncestorBackends(ctx, obj, wellknown.GRPCRouteGVK, obj.Spec.Rules, func(r gwv1.GRPCRouteRule) []gwv1.GRPCBackendRef {
 				return r.BackendRefs
 			})
 		}, krtopts.ToOptions("translator/GRPCAncestors")...),
 		krt.NewManyCollection(tlsRouteCol, func(krtctx krt.HandlerContext, obj *gwv1.TLSRoute) []*utils.AncestorBackend {
 			ctx := inputs.WithCtx(krtctx)
-			return extractAncestorBackends(ctx, obj, "TLSRoute", obj.Spec.Rules, func(r gwv1.TLSRouteRule) []gwv1.BackendRef {
+			return extractAncestorBackends(ctx, obj, wellknown.TLSRouteGVK, obj.Spec.Rules, func(r gwv1.TLSRouteRule) []gwv1.BackendRef {
 				return r.BackendRefs
 			})
 		}, krtopts.ToOptions("translator/TLSAncestors")...),
 		krt.NewManyCollection(tcpRouteCol, func(krtctx krt.HandlerContext, obj *gwv1.TCPRoute) []*utils.AncestorBackend {
 			ctx := inputs.WithCtx(krtctx)
-			return extractAncestorBackends(ctx, obj, "TCPRoute", obj.Spec.Rules, func(r gwv1.TCPRouteRule) []gwv1.BackendRef {
+			return extractAncestorBackends(ctx, obj, wellknown.TCPRouteGVK, obj.Spec.Rules, func(r gwv1.TCPRouteRule) []gwv1.BackendRef {
 				return r.BackendRefs
 			})
 		}, krtopts.ToOptions("translator/TCPAncestors")...),
@@ -1131,11 +1135,11 @@ func delegatedGatewayRouteAttachmentCountCollection(
 	}, opts.ToOptions("translator/DelegatedHTTPRoute/count")...)
 }
 
-func extractAncestorBackends[T controllers.Object, RT, BT any](ctx RouteContext, obj T, kind string, rules []RT, extract func(RT) []BT) []*utils.AncestorBackend {
+func extractAncestorBackends[T controllers.Object, RT, BT any](ctx RouteContext, obj T, sourceGVK schema.GroupVersionKind, rules []RT, extract func(RT) []BT) []*utils.AncestorBackend {
 	source := utils.TypedNamespacedName{
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
-		Kind:      kind,
+		Kind:      sourceGVK.Kind,
 	}
 	gateways := sets.Set[types.NamespacedName]{}
 	for _, parent := range FilteredReferences(extractParentReferenceInfo(ctx, ctx.RouteParents, obj)) {
@@ -1146,6 +1150,9 @@ func extractAncestorBackends[T controllers.Object, RT, BT any](ctx RouteContext,
 		for _, b := range extract(r) {
 			ref, refNs, refName := GetBackendRef(b)
 			if ref == wellknown.HTTPRouteGVK.GroupKind() || ref == wellknown.AgentgatewayModelGVK.GroupKind() {
+				continue
+			}
+			if !ancestorBackendAllowed(ctx, sourceGVK, obj.GetNamespace(), ref, refNs, refName) {
 				continue
 			}
 			be := utils.TypedNamespacedName{
@@ -1169,6 +1176,13 @@ func extractAncestorBackends[T controllers.Object, RT, BT any](ctx RouteContext,
 		}
 	}
 	return res
+}
+
+func ancestorBackendAllowed(ctx RouteContext, sourceGVK schema.GroupVersionKind, sourceNamespace string, ref schema.GroupKind, refNamespace *gwv1.Namespace, refName gwv1.ObjectName) bool {
+	if refNamespace == nil || string(*refNamespace) == sourceNamespace {
+		return true
+	}
+	return ctx.Grants.BackendAllowed(ctx.Krt, sourceGVK, refName, *refNamespace, sourceNamespace, ref, ctx.BackendRefGrantMode)
 }
 
 func GetBackendRef[I any](spec I) (schema.GroupKind, *gwv1.Namespace, gwv1.ObjectName) {

--- a/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-policy-references.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/delegation/route-delegation-policy-references.yaml
@@ -33,6 +33,24 @@ spec:
     backendRefs:
     - name: httpbin
       port: 8000
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1/pool/with-grant
+    backendRefs:
+    - name: pool-with-grant
+      namespace: pool-ns
+      group: inference.networking.k8s.io
+      kind: InferencePool
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1/pool/without-grant
+    backendRefs:
+    - name: pool-without-grant
+      namespace: pool-ns
+      group: inference.networking.k8s.io
+      kind: InferencePool
 ---
 apiVersion: v1
 kind: Service
@@ -42,6 +60,68 @@ metadata:
 spec:
   ports:
   - port: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pool-endpoint-picker
+  namespace: pool-ns
+spec:
+  ports:
+  - port: 9002
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: pool-with-grant
+  namespace: pool-ns
+spec:
+  endpointPickerRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: pool-endpoint-picker
+    port:
+      number: 9002
+  selector:
+    matchLabels:
+      app: with-grant
+  targetPorts:
+  - number: 8080
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: pool-without-grant
+  namespace: pool-ns
+spec:
+  endpointPickerRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: pool-endpoint-picker
+    port:
+      number: 9002
+  selector:
+    matchLabels:
+      app: without-grant
+  targetPorts:
+  - number: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-child-pool
+  namespace: pool-ns
+spec:
+  from:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    namespace: team1
+  to:
+  - group: inference.networking.k8s.io
+    kind: InferencePool
+    name: pool-with-grant
 ---
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayBackend
@@ -107,6 +187,46 @@ output:
     Namespace: default
   resource:
     policy:
+      backend:
+        inferenceRouting:
+          endpointPicker:
+            port: 9002
+            service:
+              hostname: pool-endpoint-picker.pool-ns.svc.cluster.local
+              namespace: pool-ns
+          failureMode: FAIL_CLOSED
+      key: pool-ns/pool-with-grant:inference
+      name:
+        kind: InferencePool
+        name: pool-with-grant
+        namespace: pool-ns
+      target:
+        service:
+          hostname: pool-with-grant.pool-ns.inference.cluster.local
+          namespace: pool-ns
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          verification: INSECURE_ALL
+      key: pool-ns/pool-with-grant:inferencetls
+      name:
+        kind: InferencePool
+        name: pool-with-grant
+        namespace: pool-ns
+      target:
+        service:
+          hostname: pool-endpoint-picker.pool-ns.svc.cluster.local
+          namespace: pool-ns
+          port: 9002
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    policy:
       key: traffic/team1/agw:extauth:team1/child-team1-foo
       name:
         kind: AgentgatewayPolicy
@@ -162,7 +282,60 @@ output:
         name: child-team1-foo
         namespace: team1
       routeGroupKey: default/parent/team1/*
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    route:
+      backends:
+      - backend:
+          port: 8080
+          service:
+            hostname: pool-with-grant.pool-ns.inference.cluster.local
+            namespace: pool-ns
+        weight: 1
+      key: team1/child-team1-foo.01.routegroup.default.parent.team1.wildcard
+      matches:
+      - path:
+          pathPrefix: /anything/team1/pool/with-grant
+      name:
+        kind: HTTPRoute
+        name: child-team1-foo
+        namespace: team1
+      routeGroupKey: default/parent/team1/*
 status:
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: pool-with-grant
+    namespace: pool-ns
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: All InferencePool references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: pool-without-grant
+    namespace: pool-ns
+  spec: null
+  status: {}
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:

--- a/controller/pkg/agentgateway/translator/testdata/references-policy-refgrants/denied-route-backend.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/references-policy-refgrants/denied-route-backend.yaml
@@ -1,0 +1,42 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: denied-backend
+  namespace: default
+spec:
+  parentRefs:
+  - name: test
+  rules:
+  - backendRefs:
+    - group: agentgateway.dev
+      kind: AgentgatewayBackend
+      name: denied
+      namespace: other
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: denied
+  namespace: other
+spec:
+  static:
+    host: denied.example.com
+    port: 80
+
+---
+# Output
+output: []
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayBackend
+  metadata:
+    name: denied
+    namespace: other
+  spec: null
+  status:
+    conditions:
+    - lastTransitionTime: fake
+      message: Backend successfully accepted
+      reason: Accepted
+      status: "True"
+      type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-cross-namespace-backends.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-cross-namespace-backends.yaml
@@ -25,6 +25,10 @@ spec:
           namespace: cross-ns-with-grant
           group: agentgateway.dev
           kind: AgentgatewayBackend
+        - name: cross-ns-pool-with-grant
+          namespace: cross-ns-with-grant
+          group: inference.networking.k8s.io
+          kind: InferencePool
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -43,6 +47,10 @@ spec:
           namespace: cross-ns-without-grant
           group: agentgateway.dev
           kind: AgentgatewayBackend
+        - name: cross-ns-pool-without-grant
+          namespace: cross-ns-without-grant
+          group: inference.networking.k8s.io
+          kind: InferencePool
 ---
 apiVersion: v1
 kind: Service
@@ -63,6 +71,25 @@ spec:
     host: with-grant.example.com
     port: 80
 ---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: cross-ns-pool-with-grant
+  namespace: cross-ns-with-grant
+spec:
+  endpointPickerRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: cross-ns-service-with-grant
+    port:
+      number: 8080
+  selector:
+    matchLabels:
+      app: with-grant
+  targetPorts:
+    - number: 8080
+---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
@@ -80,6 +107,9 @@ spec:
     - group: agentgateway.dev
       kind: AgentgatewayBackend
       name: cross-ns-backend-with-grant
+    - group: inference.networking.k8s.io
+      kind: InferencePool
+      name: cross-ns-pool-with-grant
 ---
 apiVersion: v1
 kind: Service
@@ -99,10 +129,109 @@ spec:
   static:
     host: without-grant.example.com
     port: 80
+---
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: cross-ns-pool-without-grant
+  namespace: cross-ns-without-grant
+spec:
+  endpointPickerRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: cross-ns-service-without-grant
+    port:
+      number: 8080
+  selector:
+    matchLabels:
+      app: without-grant
+  targetPorts:
+    - number: 8080
 
 ---
 # Output
 output:
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker:
+            port: 8080
+            service:
+              hostname: cross-ns-service-with-grant.cross-ns-with-grant.svc.cluster.local
+              namespace: cross-ns-with-grant
+          failureMode: FAIL_CLOSED
+      key: cross-ns-with-grant/cross-ns-pool-with-grant:inference
+      name:
+        kind: InferencePool
+        name: cross-ns-pool-with-grant
+        namespace: cross-ns-with-grant
+      target:
+        service:
+          hostname: cross-ns-pool-with-grant.cross-ns-with-grant.inference.cluster.local
+          namespace: cross-ns-with-grant
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          verification: INSECURE_ALL
+      key: cross-ns-with-grant/cross-ns-pool-with-grant:inferencetls
+      name:
+        kind: InferencePool
+        name: cross-ns-pool-with-grant
+        namespace: cross-ns-with-grant
+      target:
+        service:
+          hostname: cross-ns-service-with-grant.cross-ns-with-grant.svc.cluster.local
+          namespace: cross-ns-with-grant
+          port: 8080
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker:
+            port: 8080
+            service:
+              hostname: cross-ns-service-without-grant.cross-ns-without-grant.svc.cluster.local
+              namespace: cross-ns-without-grant
+          failureMode: FAIL_CLOSED
+      key: cross-ns-without-grant/cross-ns-pool-without-grant:inference
+      name:
+        kind: InferencePool
+        name: cross-ns-pool-without-grant
+        namespace: cross-ns-without-grant
+      target:
+        service:
+          hostname: cross-ns-pool-without-grant.cross-ns-without-grant.inference.cluster.local
+          namespace: cross-ns-without-grant
+- gateway:
+    Name: test-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          verification: INSECURE_ALL
+      key: cross-ns-without-grant/cross-ns-pool-without-grant:inferencetls
+      name:
+        kind: InferencePool
+        name: cross-ns-pool-without-grant
+        namespace: cross-ns-without-grant
+      target:
+        service:
+          hostname: cross-ns-service-without-grant.cross-ns-without-grant.svc.cluster.local
+          namespace: cross-ns-without-grant
+          port: 8080
 - gateway:
     Name: test-gateway
     Namespace: default
@@ -118,6 +247,12 @@ output:
       - backend:
           backend: cross-ns-with-grant/cross-ns-backend-with-grant
         weight: 1
+      - backend:
+          port: 8080
+          service:
+            hostname: cross-ns-pool-with-grant.cross-ns-with-grant.inference.cluster.local
+            namespace: cross-ns-with-grant
+        weight: 1
       key: default/cross-ns-with-refgrant.00.http
       listenerKey: default/test-gateway.http
       name:
@@ -132,6 +267,7 @@ output:
       backends:
       - weight: 1
       - weight: 1
+      - weight: 1
       key: default/cross-ns-without-refgrant.00.http
       listenerKey: default/test-gateway.http
       name:
@@ -139,6 +275,56 @@ output:
         name: cross-ns-without-refgrant
         namespace: default
 status:
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: cross-ns-pool-with-grant
+    namespace: cross-ns-with-grant
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: All InferencePool references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: cross-ns-pool-without-grant
+    namespace: cross-ns-without-grant
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: All InferencePool references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test-gateway
+        namespace: default
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:
@@ -179,8 +365,8 @@ status:
         status: "True"
         type: Accepted
       - lastTransitionTime: fake
-        message: backendRef cross-ns-without-grant/cross-ns-backend-without-grant
-          not accessible to a HTTPRoute in namespace "default" (missing a ReferenceGrant?)
+        message: backendRef cross-ns-without-grant/cross-ns-pool-without-grant not
+          accessible to a HTTPRoute in namespace "default" (missing a ReferenceGrant?)
         reason: RefNotPermitted
         status: "False"
         type: ResolvedRefs

--- a/controller/pkg/agentgateway/translator/testdata/routes/httproute-cross-namespace-backends.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/routes/httproute-cross-namespace-backends.yaml
@@ -196,46 +196,6 @@ output:
     Name: test-gateway
     Namespace: default
   resource:
-    policy:
-      backend:
-        inferenceRouting:
-          endpointPicker:
-            port: 8080
-            service:
-              hostname: cross-ns-service-without-grant.cross-ns-without-grant.svc.cluster.local
-              namespace: cross-ns-without-grant
-          failureMode: FAIL_CLOSED
-      key: cross-ns-without-grant/cross-ns-pool-without-grant:inference
-      name:
-        kind: InferencePool
-        name: cross-ns-pool-without-grant
-        namespace: cross-ns-without-grant
-      target:
-        service:
-          hostname: cross-ns-pool-without-grant.cross-ns-without-grant.inference.cluster.local
-          namespace: cross-ns-without-grant
-- gateway:
-    Name: test-gateway
-    Namespace: default
-  resource:
-    policy:
-      backend:
-        backendTls:
-          verification: INSECURE_ALL
-      key: cross-ns-without-grant/cross-ns-pool-without-grant:inferencetls
-      name:
-        kind: InferencePool
-        name: cross-ns-pool-without-grant
-        namespace: cross-ns-without-grant
-      target:
-        service:
-          hostname: cross-ns-service-without-grant.cross-ns-without-grant.svc.cluster.local
-          namespace: cross-ns-without-grant
-          port: 8080
-- gateway:
-    Name: test-gateway
-    Namespace: default
-  resource:
     route:
       backends:
       - backend:
@@ -306,25 +266,7 @@ status:
     name: cross-ns-pool-without-grant
     namespace: cross-ns-without-grant
   spec: null
-  status:
-    parents:
-    - conditions:
-      - lastTransitionTime: fake
-        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
-        reason: Accepted
-        status: "True"
-        type: Accepted
-      - lastTransitionTime: fake
-        message: All InferencePool references have been resolved
-        reason: ResolvedRefs
-        status: "True"
-        type: ResolvedRefs
-      controllerName: agentgateway.dev/agentgateway
-      parentRef:
-        group: gateway.networking.k8s.io
-        kind: Gateway
-        name: test-gateway
-        namespace: default
+  status: {}
 - apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:


### PR DESCRIPTION
Add InferencePool to KnownToReferences so ReferenceGrants authorize cross-namespace backendRefs. Extend the existing golden test with granted and denied cases.