### PR TITLE
fix(auth): send WWW-Authenticate challenge on JWT 401

### DIFF
--- a/crates/agentgateway/src/http/jwt.rs
+++ b/crates/agentgateway/src/http/jwt.rs
@@ -41,6 +41,25 @@ pub enum TokenError {
 	CredentialRemoval(String),
 }
 
+impl TokenError {
+	/// The `WWW-Authenticate` challenge to send with the `401` this error produces.
+	///
+	/// RFC 6750 §3 requires a bearer-protected resource to challenge rejected requests, and
+	/// RFC 7235 §4.1 requires every `401` to carry the header.
+	pub fn challenge(&self) -> &'static str {
+		match self {
+			// RFC 6750 §3.1: only report `invalid_token` when a presented token was rejected.
+			// A request with no credentials -- or one whose token validated but could not be
+			// stripped -- gets a bare challenge, so clients do not loop refreshing a good token.
+			TokenError::Missing | TokenError::CredentialRemoval(_) => "Bearer",
+			TokenError::Invalid(_)
+			| TokenError::InvalidHeader(_)
+			| TokenError::MissingKeyId
+			| TokenError::UnknownKeyId(_) => r#"Bearer error="invalid_token""#,
+		}
+	}
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum JwkError {
 	#[error("failed to load JWKS: {0}")]

--- a/crates/agentgateway/src/http/jwt_tests.rs
+++ b/crates/agentgateway/src/http/jwt_tests.rs
@@ -503,6 +503,63 @@ pub async fn test_apply_strict_missing_token() {
 	assert!(matches!(res, Err(super::TokenError::Missing)));
 }
 
+// RFC 6750 §3: a request with no credentials is challenged, but without an error code.
+#[tokio::test]
+pub async fn test_missing_token_response_has_bare_bearer_challenge() {
+	let jwt = super::Jwt {
+		mode: super::Mode::Strict,
+		providers: vec![],
+		location: bearer_location(),
+		preserve_token: false,
+	};
+
+	let mut req = crate::http::Request::new(crate::http::Body::empty());
+	let mut req_log = make_min_req_log();
+
+	let err = jwt
+		.apply(Some(&mut req_log), &mut req)
+		.await
+		.expect_err("strict mode should reject a request without a token");
+	let resp = crate::proxy::ProxyError::JwtAuthenticationFailure(err).into_response_with_grpc(false);
+
+	assert_eq!(resp.status(), ::http::StatusCode::UNAUTHORIZED);
+	assert_eq!(
+		resp
+			.headers()
+			.get(::http::header::WWW_AUTHENTICATE)
+			.unwrap(),
+		"Bearer"
+	);
+}
+
+// RFC 6750 §3.1: a rejected token is reported as `invalid_token` so clients know to refresh.
+#[test]
+pub fn test_expired_token_response_reports_invalid_token() {
+	use std::time::{SystemTime, UNIX_EPOCH};
+
+	let (jwt, kid, issuer, allowed_aud) = setup_test_jwt();
+	let now = SystemTime::now()
+		.duration_since(UNIX_EPOCH)
+		.unwrap()
+		.as_secs();
+	let expired = build_unsigned_token(kid, issuer, allowed_aud, now - 100_000);
+
+	let err = jwt
+		.validate_claims(&expired)
+		.expect_err("an expired token should be rejected");
+	assert!(matches!(err, TokenError::Invalid(_)));
+	let resp = crate::proxy::ProxyError::JwtAuthenticationFailure(err).into_response_with_grpc(false);
+
+	assert_eq!(resp.status(), ::http::StatusCode::UNAUTHORIZED);
+	assert_eq!(
+		resp
+			.headers()
+			.get(::http::header::WWW_AUTHENTICATE)
+			.unwrap(),
+		r#"Bearer error="invalid_token""#
+	);
+}
+
 // Permissive mode: allow requests without a token and do not attach claims
 #[tokio::test]
 pub async fn test_apply_permissive_no_token_ok() {

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -492,6 +492,17 @@ impl ProxyError {
 			}
 		}
 
+		// Add an authentication challenge for JWT failures. RFC 6750 §3 requires a `Bearer`
+		// challenge on the `401` returned by a bearer-protected resource; without it a client
+		// cannot tell that it should acquire or refresh a token. The MCP variant below carries
+		// its own challenge, pointing at the protected resource metadata.
+		if let ProxyError::JwtAuthenticationFailure(err) = &self {
+			rb = rb.header(
+				hyper::header::WWW_AUTHENTICATE,
+				HeaderValue::from_static(err.challenge()),
+			);
+		}
+
 		if let Some(grpc_status) = grpc_status {
 			return rb
 				.status(StatusCode::OK)


### PR DESCRIPTION
Fixes #3172

## What this fixes

A `jwtAuth` policy that rejects a request short-circuits into `ProxyError::JwtAuthenticationFailure`, which produced a bare `401 Unauthorized` with no `WWW-Authenticate` header.

* [RFC 7235 §4.1](https://www.rfc-editor.org/rfc/rfc7235#section-4.1) — a server generating a 401 **MUST** send a `WWW-Authenticate` header field containing at least one challenge.
* [RFC 6750 §3](https://www.rfc-editor.org/rfc/rfc6750#section-3) — a resource server responding with a 401 to a bearer-token request **MUST** include a `WWW-Authenticate` header using the `Bearer` scheme.

Because the rejection happens inside the request policy chain, the response never reaches the response filters, so a `transformations.response` policy cannot add the header as a workaround. It has to be attached where the error becomes a response.

The visible symptom is that clients which key off the challenge — MCP clients in particular, which refresh their access token on a 401 with `error="invalid_token"` and retry — cannot recover automatically and force the user to re-authenticate by hand.

## The change

* `TokenError::challenge()` (new, in `crates/agentgateway/src/http/jwt.rs`) returns the challenge for a given failure.
* `ProxyError::into_response_with_grpc` attaches it as `WWW-Authenticate`, next to the existing block that does the same for basic auth.

Challenge selection follows [RFC 6750 §3.1](https://www.rfc-editor.org/rfc/rfc6750#section-3.1), which says the error code is omitted when the request carried no authentication information:

| `TokenError` | Challenge |
| --- | --- |
| `Missing` | `Bearer` |
| `CredentialRemoval` | `Bearer` |
| `Invalid`, `InvalidHeader`, `MissingKeyId`, `UnknownKeyId` | `Bearer error="invalid_token"` |

`CredentialRemoval` is grouped with the bare challenge deliberately: the token validated successfully and only stripping it from the request failed, so reporting `invalid_token` would send the client into a pointless refresh loop for a token that is in fact good.

## What is not changed

`ProxyError::McpJwtAuthenticationFailure` already emits its own challenge pointing at the protected resource metadata (`crates/agentgateway/src/mcp/auth.rs`), and is untouched. The new block matches only the plain `JwtAuthenticationFailure` variant, so the two cannot collide.

No realm is emitted — `jwtAuth` has no realm to configure, and RFC 6750 makes the `realm` parameter optional.

## Tests

Two tests added to `crates/agentgateway/src/http/jwt_tests.rs`, following the pattern of the existing challenge assertions in `basicauth_tests.rs`:

* `test_missing_token_response_has_bare_bearer_challenge` — `Mode::Strict` with no credentials yields 401 + `WWW-Authenticate: Bearer` (no error code).
* `test_expired_token_response_reports_invalid_token` — an expired token yields 401 + `WWW-Authenticate: Bearer error="invalid_token"`.

The existing integration tests in `crates/agentgateway/tests/tests/auth.rs` assert only the status code on these paths, so they are unaffected.