### PR TITLE
Substrate Refinements

### DIFF
--- a/crates/agentgateway/src/client/connect_tunnel.rs
+++ b/crates/agentgateway/src/client/connect_tunnel.rs
@@ -13,24 +13,9 @@ const PROXY_AUTHORIZATION_HEADER: &str = "Proxy-Authorization";
 #[error("atunnel rejected a stale worker assignment")]
 struct StaleAssignment;
 
-pub fn is_stale_assignment_error(error: &anyhow::Error) -> bool {
-	if error.downcast_ref::<StaleAssignment>().is_some() {
-		return true;
-	}
-	error
-		.downcast_ref::<agent_hbone::client::UnexpectedConnectResponse>()
-		.is_some_and(|response| {
-			response.status == http::StatusCode::MISDIRECTED_REQUEST
-				&& response
-					.headers
-					.get(STALE_ASSIGNMENT_HEADER)
-					.is_some_and(|value| value == "true")
-		})
-}
-
 /// Establish an HTTP/1.1 CONNECT tunnel.
 ///
-/// This is the HTTP/1.1 fallback selected by [`handshake_proxy`] when its
+/// This is the HTTP/1.1 fallback selected by [`handshake`] when its
 /// connection does not negotiate ALPN.
 pub async fn handshake_h1(
 	conn: Socket,
@@ -107,44 +92,13 @@ fn h1_stale_assignment(response: &[u8]) -> bool {
 	})
 }
 
-/// Establish a configured backend proxy tunnel.
-///
-/// HTTP/1.1 is the established protocol for a plaintext proxy connection,
-/// which cannot negotiate ALPN. TLS proxy connections use their negotiated
-/// protocol when available.
-pub async fn handshake_proxy(
+/// Establish a configured backend proxy tunnel. TLS connections use
+/// ALPN to negotiate the protool and plaintext conections use HTTP 1
+pub(crate) async fn handshake(
 	conn: Socket,
 	dest: &str,
 	auth: Option<HeaderValue>,
 	h2_config: Arc<agent_hbone::H2Config>,
-) -> Result<Socket, anyhow::Error> {
-	handshake(conn, dest, auth, h2_config, AlpnRequirement::Optional).await
-}
-
-/// Establish a native atunnel CONNECT tunnel.
-///
-/// atunnel advertises both HTTP/2 and HTTP/1.1 over TLS. Require ALPN here so
-/// a misconfigured atunnel is rejected before sending an HTTP request.
-pub async fn handshake_atunnel(
-	conn: Socket,
-	dest: &str,
-	h2_config: Arc<agent_hbone::H2Config>,
-) -> Result<Socket, anyhow::Error> {
-	handshake(conn, dest, None, h2_config, AlpnRequirement::Required).await
-}
-
-#[derive(Clone, Copy)]
-enum AlpnRequirement {
-	Optional,
-	Required,
-}
-
-async fn handshake(
-	conn: Socket,
-	dest: &str,
-	auth: Option<HeaderValue>,
-	h2_config: Arc<agent_hbone::H2Config>,
-	alpn_requirement: AlpnRequirement,
 ) -> Result<Socket, anyhow::Error> {
 	// `TunnelConfig::token` has always authenticated configured HTTP proxies
 	// through Proxy-Authorization. Preserve that contract for either protocol
@@ -155,12 +109,7 @@ async fn handshake(
 	{
 		Some(stream::Alpn::H2) => handshake_h2(conn, dest, auth, h2_config).await,
 		Some(stream::Alpn::Http11) => handshake_h1(conn, dest, auth).await,
-		None if matches!(alpn_requirement, AlpnRequirement::Optional) => {
-			handshake_h1(conn, dest, auth).await
-		},
-		None => Err(anyhow::anyhow!(
-			"atunnel CONNECT requires a negotiated ALPN protocol"
-		)),
+		None => handshake_h1(conn, dest, auth).await,
 		Some(alpn) => Err(anyhow::anyhow!(
 			"CONNECT negotiated unsupported ALPN: {alpn:?}"
 		)),
@@ -284,22 +233,7 @@ mod tests {
 			Ok(_) => panic!("stale assignment must fail the tunnel handshake"),
 			Err(error) => error,
 		};
-		assert!(is_stale_assignment_error(&error));
+		assert!(error.downcast_ref::<StaleAssignment>().is_some());
 		server_task.await.expect("server task");
-	}
-
-	#[test]
-	fn handshake_h2_marks_stale_assignment() {
-		let mut headers = http::HeaderMap::new();
-		headers.insert(
-			"x-ate-assignment-stale",
-			http::HeaderValue::from_static("true"),
-		);
-		let error = anyhow::Error::from(agent_hbone::client::UnexpectedConnectResponse {
-			status: http::StatusCode::MISDIRECTED_REQUEST,
-			headers,
-		});
-
-		assert!(is_stale_assignment_error(&error));
 	}
 }

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -351,7 +351,7 @@ impl Connector {
 				// This is recursive but bounded: we cannot even tunnel to a tunnel
 				let con = Box::pin(self.connect(tcfg.target, proxy_dst, *tcfg.connection, false)).await?;
 
-				let con = connect_tunnel::handshake_proxy(con, &dest, tcfg.token, self.h2_config.clone())
+				let con = connect_tunnel::handshake(con, &dest, tcfg.token, self.h2_config.clone())
 					.await
 					.map_err(crate::http::Error::new)?;
 				debug!(%dest, "connected to tunnel proxy (CONNECT)");

--- a/crates/agentgateway/src/http/substrate/egress.rs
+++ b/crates/agentgateway/src/http/substrate/egress.rs
@@ -4,12 +4,11 @@ use crate::proxy::ProxyError;
 use crate::proxy::httpproxy::PolicyClient;
 use crate::store::RequestPolicyTrait;
 use crate::telemetry::log::RequestLog;
+use crate::transport::stream::TLSConnectionInfo;
 use crate::types::agent::SimpleBackendReferenceWithPolicies;
 use crate::*;
 
-const ATESPACE_HEADER: &str = "x-ate-atespace";
-const ACTOR_HEADER: &str = "x-ate-actor";
-const ACTOR_VERSION_HEADER: &str = "x-ate-actor-version";
+const ACTOR_SPIFFE_PREFIX: &str = "spiffe://substrate-actor.local/atespace/";
 
 /// Authorizes an actor's egress to the hostname recovered from an internal CONNECT listener.
 #[apply(schema!)]
@@ -20,54 +19,28 @@ pub struct SubstrateEgress {
 }
 
 impl SubstrateEgress {
-	fn metadata(req: &Request) -> Result<(ActorRef, i64), ProxyError> {
-		let headers = &req
+	fn actor(req: &Request) -> Result<ActorRef, ProxyError> {
+		let spiffe_id = req
 			.extensions()
-			.get::<crate::cel::SourceContext>()
+			.get::<TLSConnectionInfo>()
+			.and_then(|tls| tls.src_identity.as_ref())
+			.and_then(|identity| identity.spiffe_id.as_deref())
 			.ok_or_else(|| {
-				ProxyError::SubstrateEgressDenied(
-					"request did not originate from a CONNECT tunnel".to_owned(),
-				)
-			})?
-			.connect_headers;
-		let required = |name: &'static str| -> Result<&str, ProxyError> {
-			let mut values = headers.get_all(name).iter();
-			let value = values.next().ok_or_else(|| {
-				ProxyError::SubstrateEgressDenied(format!("missing {name} CONNECT header"))
+				ProxyError::SubstrateEgressDenied("missing authenticated actor SPIFFE identity".to_owned())
 			})?;
-			if values.next().is_some() {
-				return Err(ProxyError::SubstrateEgressDenied(format!(
-					"multiple {name} CONNECT headers"
-				)));
-			}
-			value
-				.to_str()
-				.map_err(|_| ProxyError::SubstrateEgressDenied(format!("invalid {name} CONNECT header")))
+		let Some((atespace, name)) = spiffe_id
+			.strip_prefix(ACTOR_SPIFFE_PREFIX)
+			.and_then(|path| path.split_once("/actor/"))
+			.filter(|(atespace, name)| valid_resource_name(atespace) && valid_resource_name(name))
+		else {
+			return Err(ProxyError::SubstrateEgressDenied(
+				"invalid authenticated actor SPIFFE identity".to_owned(),
+			));
 		};
-		let atespace = required(ATESPACE_HEADER)?;
-		let name = required(ACTOR_HEADER)?;
-		if !valid_resource_name(atespace) || !valid_resource_name(name) {
-			return Err(ProxyError::SubstrateEgressDenied(
-				"invalid actor identity CONNECT headers".to_owned(),
-			));
-		}
-		let version = required(ACTOR_VERSION_HEADER)?
-			.parse::<i64>()
-			.map_err(|_| {
-				ProxyError::SubstrateEgressDenied("X-Ate-Actor-Version must be a positive int64".to_owned())
-			})?;
-		if version <= 0 {
-			return Err(ProxyError::SubstrateEgressDenied(
-				"X-Ate-Actor-Version must be a positive int64".to_owned(),
-			));
-		}
-		Ok((
-			ActorRef {
-				atespace: atespace.to_owned(),
-				name: name.to_owned(),
-			},
-			version,
-		))
+		Ok(ActorRef {
+			atespace: atespace.to_owned(),
+			name: name.to_owned(),
+		})
 	}
 }
 
@@ -78,11 +51,54 @@ impl RequestPolicyTrait for SubstrateEgress {
 		log: &mut RequestLog,
 		req: &mut Request,
 	) -> Result<PolicyResponse, crate::proxy::ProxyResponse> {
-		let (actor, _minimum_version) = Self::metadata(req)?;
+		let actor = Self::actor(req)?;
 		log.ate_actor_id = Some(actor.name.clone());
 		log.ate_atespace = Some(actor.atespace.clone());
 		// TODO: implement egress policy in Substrate. Then, we can look it up, cache it, and enforce it.
 		// For now, we just add ate metadata
 		Ok(PolicyResponse::default())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::http::Body;
+	use crate::transport::tls::TlsInfo;
+
+	#[test]
+	fn actor_is_derived_from_the_authenticated_substrate_svid() {
+		let mut req = Request::new(Body::empty());
+		req.extensions_mut().insert(TLSConnectionInfo {
+			src_identity: Some(TlsInfo {
+				spiffe_id: Some(strng::literal!(
+					"spiffe://substrate-actor.local/atespace/demo/actor/my-actor"
+				)),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+
+		assert_eq!(
+			SubstrateEgress::actor(&req).unwrap(),
+			ActorRef {
+				atespace: "demo".into(),
+				name: "my-actor".into(),
+			}
+		);
+	}
+
+	#[test]
+	fn actor_rejects_non_substrate_svids() {
+		let mut req = Request::new(Body::empty());
+		req.extensions_mut().insert(TLSConnectionInfo {
+			src_identity: Some(TlsInfo {
+				spiffe_id: Some(strng::literal!("spiffe://cluster.local/ns/demo/sa/default")),
+				..Default::default()
+			}),
+			..Default::default()
+		});
+
+		assert!(SubstrateEgress::actor(&req).is_err());
 	}
 }

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -27,7 +27,7 @@ const DEFAULT_PARKING_MAX: usize = 1024;
 const DEFAULT_PARKING_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 const DEFAULT_PARKING_RETRY_FACTOR: f64 = 1.1;
 const DEFAULT_ACTOR_PORT: u16 = 80;
-const DEFAULT_CONNECT_TARGET_PORT: NonZeroU16 = NonZeroU16::new(444).unwrap();
+const DEFAULT_CONNECT_TARGET_PORT: NonZeroU16 = NonZeroU16::new(8443).unwrap();
 const TARGET_PORT_HEADER: &str = "x-ate-target-port";
 pub(crate) const STALE_ASSIGNMENT_HEADER: &str = "x-ate-assignment-stale";
 
@@ -145,10 +145,6 @@ pub(crate) struct SubstrateRequestState {
 	current: Arc<Mutex<Option<CachedAssignment>>>,
 }
 
-fn default_target_port() -> NonZeroU16 {
-	NonZeroU16::new(443).unwrap()
-}
-
 fn default_cache_ttl() -> Duration {
 	Duration::from_secs(5)
 }
@@ -244,12 +240,7 @@ pub struct SubstrateIngress {
 	/// Backend that receives ResumeActor calls and policies used when connecting to it.
 	#[serde(flatten)]
 	pub target: SimpleBackendReferenceWithPolicies,
-	/// Port on the resumed worker pod's ordinary atunnel ingress. Defaults to 443.
-	/// This is independent from `connect_target_port`, which is used for raw CONNECT tunnels.
-	#[serde(default = "default_target_port")]
-	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]
-	pub target_port: NonZeroU16,
-	/// Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 444.
+	/// Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 8443.
 	#[serde(default = "default_connect_target_port")]
 	#[cfg_attr(feature = "schema", schemars(with = "std::num::NonZeroU16"))]
 	pub connect_target_port: NonZeroU16,
@@ -326,7 +317,7 @@ impl SubstrateIngress {
 									assignment.worker_pod_ip
 								))
 							})?;
-						return Ok(SocketAddr::new(ip, self.target_port.get()));
+						return Ok(SocketAddr::new(ip, self.connect_target_port.get()));
 					},
 					Ok(Err(status)) if self.retryable_while_parked(status.code()) => {
 						let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -441,18 +432,6 @@ impl SubstrateRequestState {
 			"{}.{}{}:{}",
 			self.actor.name, self.actor.atespace, ACTOR_DNS_SUFFIX, self.actor_port
 		)
-	}
-
-	/// Resolves the actor assignment at the worker's raw CONNECT listener.
-	pub(crate) async fn resolve_connect_target(&self) -> Result<Target, crate::proxy::ProxyResponse> {
-		let target = self.resolve_target().await?;
-		match target {
-			Target::Address(address) => Ok(Target::Address(SocketAddr::new(
-				address.ip(),
-				self.ingress.connect_target_port.get(),
-			))),
-			_ => unreachable!("Substrate assignments are always socket addresses"),
-		}
 	}
 
 	pub(crate) async fn resolve_target(&self) -> Result<Target, crate::proxy::ProxyResponse> {
@@ -657,8 +636,8 @@ mod tests {
 	use crate::types::agent::{Backend, ResourceName};
 
 	#[test]
-	fn default_target_port_matches_atunnel_ingress() {
-		assert_eq!(super::default_target_port().get(), 443);
+	fn default_connect_target_port_matches_atunnel_connect_ingress() {
+		assert_eq!(super::default_connect_target_port().get(), 8443);
 	}
 
 	#[derive(Clone)]
@@ -734,7 +713,7 @@ mod tests {
 			.attach_route_policy(serde_json::json!({
 				"substrateIngress": {
 					"host": control.address.to_string(),
-					"targetPort": actor.address().port(),
+					"connectTargetPort": actor.address().port(),
 					"cacheTtl": "5s"
 				}
 			}))
@@ -781,7 +760,7 @@ mod tests {
 			.attach_route_policy(serde_json::json!({
 				"substrateIngress": {
 					"host": control.address.to_string(),
-					"targetPort": actor.address().port(),
+					"connectTargetPort": actor.address().port(),
 				}
 			}))
 			.await;

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -1050,10 +1050,28 @@ impl Gateway {
 					error!("no bind found for {bind_name}");
 					return;
 				};
-				let Ok(selected_listener) = bind.listeners.get_exactly_one() else {
-					return;
-				};
-				selected_listener
+				let fallback_listeners = bind.listeners.iter().filter(|listener| {
+					inputs
+						.stores
+						.read_binds()
+						.get_listener_tcp_routes(&listener.key)
+						.is_some()
+				});
+				let mut fallback_listeners = fallback_listeners.peekable();
+				match (fallback_listeners.next(), fallback_listeners.next()) {
+					(Some(selected_listener), None) => Arc::new(selected_listener.clone()),
+					(Some(_), Some(_)) => {
+						error!(bind = %bind_name, "multiple TCP fallback listeners configured for bind");
+						return;
+					},
+					(None, _) => {
+						let Ok(selected_listener) = bind.listeners.get_exactly_one() else {
+							error!(bind = %bind_name, "no TCP fallback listener configured for bind");
+							return;
+						};
+						selected_listener
+					},
+				}
 			},
 		};
 		let tcp = stream.tcp();

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -1050,23 +1050,24 @@ impl Gateway {
 					error!("no bind found for {bind_name}");
 					return;
 				};
-				let fallback_listeners = bind.listeners.iter().filter(|listener| {
-					inputs
-						.stores
-						.read_binds()
-						.get_listener_tcp_routes(&listener.key)
-						.is_some()
-				});
-				let mut fallback_listeners = fallback_listeners.peekable();
-				match (fallback_listeners.next(), fallback_listeners.next()) {
+				let tcp_listeners = bind
+					.listeners
+					.iter()
+					.filter(|listener| matches!(listener.protocol, ListenerProtocol::TCP));
+				let mut tcp_listeners = tcp_listeners.peekable();
+				match (tcp_listeners.next(), tcp_listeners.next()) {
 					(Some(selected_listener), None) => Arc::new(selected_listener.clone()),
 					(Some(_), Some(_)) => {
-						error!(bind = %bind_name, "multiple TCP fallback listeners configured for bind");
+						error!(bind = %bind_name, "multiple TCP listeners configured for bind");
+						return;
+					},
+					(None, _) if bind.protocol == BindProtocol::auto => {
+						error!(bind = %bind_name, "no TCP listener configured for raw stream on AUTO bind");
 						return;
 					},
 					(None, _) => {
 						let Ok(selected_listener) = bind.listeners.get_exactly_one() else {
-							error!(bind = %bind_name, "no TCP fallback listener configured for bind");
+							error!(bind = %bind_name, "no TCP listener configured for bind");
 							return;
 						};
 						selected_listener

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -505,25 +505,31 @@ impl Gateway {
 				}
 			},
 			BindProtocol::auto => {
-				// Auto-detect: peek at first byte to distinguish TLS from plaintext HTTP.
+				// Auto-detect: peek at the first bytes to distinguish TLS, plaintext
+				// HTTP, or raw TCP. A TLS ClientHello is identified by its record type
+				// (the first byte, 0x16) alone; telling HTTP apart from an arbitrary
+				// TCP protocol needs a few more bytes -- enough to see a full method
+				// token -- but it's still a bounded, cheap peek, and the socket is
+				// rewound before dispatch either way, so nothing is consumed from
+				// whichever path ends up handling the connection.
+				const AUTO_PROTOCOL_PEEK_LEN: usize = 8;
 				let def = frontend::TLS::default();
 				let to = policies.tls.as_ref().unwrap_or(&def).handshake_timeout;
 				let (ext, metrics, inner) = raw_stream.into_parts();
 				let mut rewind = Socket::new_rewind(inner);
-				let mut buf = [0u8; 1];
-				match tokio::time::timeout(
-					to,
-					tokio::io::AsyncReadExt::read_exact(&mut rewind, &mut buf),
-				)
-				.await
-				{
+				let mut buf = [0u8; AUTO_PROTOCOL_PEEK_LEN];
+				match tokio::time::timeout(to, peek_auto_protocol(&mut rewind, &mut buf)).await {
 					Err(_) => {
 						debug!(bind=%bind_name, "auto protocol detection timed out");
 					},
-					Ok(Ok(_)) => {
+					Ok(Ok(0)) => {
+						debug!(bind=%bind_name, "auto protocol detection: connection closed before any bytes");
+					},
+					Ok(Ok(n)) => {
 						rewind.rewind();
 						let stream = Socket::from_rewind(ext, metrics, rewind);
-						if buf[0] == 0x16 {
+						let peeked = &buf[..n];
+						if peeked[0] == 0x16 {
 							// TLS ClientHello — dispatch as TLS
 							match Self::maybe_terminate_tls(
 								inputs.clone(),
@@ -569,7 +575,7 @@ impl Gateway {
 									log_tls_termination_error(peer_addr, &bind_protocol, &e);
 								},
 							}
-						} else {
+						} else if looks_like_http(peeked) {
 							// Plaintext HTTP
 							let err = Self::proxy(
 								bind_name,
@@ -584,6 +590,11 @@ impl Gateway {
 							if let Err(e) = err {
 								warn!(src.addr = %peer_addr, "proxy error: {e}");
 							}
+						} else {
+							// Neither a TLS ClientHello nor a recognizable HTTP request
+							// line -- treat as opaque TCP rather than force-feeding it to
+							// the HTTP server, where it would just fail to parse.
+							Self::proxy_tcp(bind_name, inputs, None, stream, drain).await
 						}
 					},
 					Ok(Err(e)) => {
@@ -1137,7 +1148,7 @@ impl Gateway {
 					if is_https
 						&& let Some(io) = acceptor.take_io()
 						&& let Some(data) = io.buffered()
-						&& tls_looks_like_http(data)
+						&& looks_like_http(&data)
 					{
 						anyhow::bail!("client sent an HTTP request to an HTTPS listener: {e}");
 						// TODO(https://github.com/rustls/tokio-rustls/pull/147): write
@@ -1584,13 +1595,67 @@ impl Gateway {
 	}
 }
 
-fn tls_looks_like_http(d: Bytes) -> bool {
-	d.starts_with(b"GET /")
-		|| d.starts_with(b"POST /")
-		|| d.starts_with(b"HEAD /")
-		|| d.starts_with(b"PUT /")
-		|| d.starts_with(b"OPTIONS /")
-		|| d.starts_with(b"DELETE /")
+/// Recognizes the start of a plaintext HTTP/1.x request line (an uppercase
+/// method token followed by a space -- RFC 7230's `method SP request-target`)
+/// or the HTTP/2 prior-knowledge preface ("PRI * HTTP/2.0"). CONNECT and
+/// OPTIONS's request-target isn't origin-form ("/"), so this checks the
+/// trailing space rather than assuming a path follows.
+///
+/// Used both to give a clearer error when a client sends plaintext HTTP to an
+/// HTTPS-only listener, and by `BindProtocol::auto` to decide whether non-TLS
+/// bytes should be treated as HTTP or fall through to opaque TCP.
+fn looks_like_http(d: &[u8]) -> bool {
+	const METHODS: &[&[u8]] = &[
+		b"GET ",
+		b"HEAD ",
+		b"POST ",
+		b"PUT ",
+		b"DELETE ",
+		b"CONNECT ",
+		b"OPTIONS ",
+		b"TRACE ",
+		b"PATCH ",
+	];
+	METHODS.iter().any(|m| d.starts_with(m)) || d.starts_with(b"PRI *")
+}
+
+/// Returns whether `d` can still become a recognizable plaintext HTTP request
+/// line after reading more bytes.
+fn could_be_http_prefix(d: &[u8]) -> bool {
+	const METHODS: &[&[u8]] = &[
+		b"GET ",
+		b"HEAD ",
+		b"POST ",
+		b"PUT ",
+		b"DELETE ",
+		b"CONNECT ",
+		b"OPTIONS ",
+		b"TRACE ",
+		b"PATCH ",
+	];
+	METHODS.iter().any(|m| m.starts_with(d)) || b"PRI *".starts_with(d)
+}
+
+/// Reads just enough bytes for `BindProtocol::auto` detection. TLS is decided
+/// by its first byte; non-TLS traffic is read only while it could still be an
+/// HTTP request-line prefix, so opaque TCP does not wait for the peek window.
+async fn peek_auto_protocol<R: tokio::io::AsyncRead + Unpin>(
+	r: &mut R,
+	buf: &mut [u8],
+) -> std::io::Result<usize> {
+	let mut total = 0;
+	while total < buf.len() {
+		let n = tokio::io::AsyncReadExt::read(r, &mut buf[total..total + 1]).await?;
+		if n == 0 {
+			break;
+		}
+		total += n;
+		let peeked = &buf[..total];
+		if peeked[0] == 0x16 || looks_like_http(peeked) || !could_be_http_prefix(peeked) {
+			break;
+		}
+	}
+	Ok(total)
 }
 
 pub fn auto_server(c: Option<&frontend::HTTP>) -> auto::Builder<::hyper_util::rt::TokioExecutor> {

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -46,7 +46,6 @@ mod tests;
 mod locality_tests;
 
 #[derive(Debug, Clone, PartialEq)]
-
 pub enum HboneAddress {
 	SocketAddr(SocketAddr),
 	SvcHostname(Arc<str>, u16),
@@ -1614,6 +1613,18 @@ impl Gateway {
 	}
 }
 
+const METHODS: &[&[u8]] = &[
+	b"GET ",
+	b"HEAD ",
+	b"POST ",
+	b"PUT ",
+	b"DELETE ",
+	b"CONNECT ",
+	b"OPTIONS ",
+	b"TRACE ",
+	b"PATCH ",
+];
+
 /// Recognizes the start of a plaintext HTTP/1.x request line (an uppercase
 /// method token followed by a space -- RFC 7230's `method SP request-target`)
 /// or the HTTP/2 prior-knowledge preface ("PRI * HTTP/2.0"). CONNECT and
@@ -1624,34 +1635,12 @@ impl Gateway {
 /// HTTPS-only listener, and by `BindProtocol::auto` to decide whether non-TLS
 /// bytes should be treated as HTTP or fall through to opaque TCP.
 fn looks_like_http(d: &[u8]) -> bool {
-	const METHODS: &[&[u8]] = &[
-		b"GET ",
-		b"HEAD ",
-		b"POST ",
-		b"PUT ",
-		b"DELETE ",
-		b"CONNECT ",
-		b"OPTIONS ",
-		b"TRACE ",
-		b"PATCH ",
-	];
 	METHODS.iter().any(|m| d.starts_with(m)) || d.starts_with(b"PRI *")
 }
 
 /// Returns whether `d` can still become a recognizable plaintext HTTP request
 /// line after reading more bytes.
 fn could_be_http_prefix(d: &[u8]) -> bool {
-	const METHODS: &[&[u8]] = &[
-		b"GET ",
-		b"HEAD ",
-		b"POST ",
-		b"PUT ",
-		b"DELETE ",
-		b"CONNECT ",
-		b"OPTIONS ",
-		b"TRACE ",
-		b"PATCH ",
-	];
 	METHODS.iter().any(|m| m.starts_with(d)) || b"PRI *".starts_with(d)
 }
 

--- a/crates/agentgateway/src/proxy/gateway_test.rs
+++ b/crates/agentgateway/src/proxy/gateway_test.rs
@@ -34,6 +34,26 @@ fn hbone_address_parsing() {
 	assert!(HboneAddress::try_from(&uri_no_port).is_err());
 }
 
+#[tokio::test]
+async fn auto_protocol_peek_dispatches_non_http_tcp_without_waiting_for_more_bytes() {
+	use std::time::Duration;
+
+	use tokio::io::AsyncWriteExt;
+
+	let (mut client, mut server) = tokio::io::duplex(8);
+	client.write_all(b"\x01").await.unwrap();
+
+	let n = tokio::time::timeout(
+		Duration::from_millis(100),
+		super::peek_auto_protocol(&mut server, &mut [0; 8]),
+	)
+	.await
+	.expect("non-HTTP TCP should be classified without waiting for more bytes")
+	.unwrap();
+
+	assert_eq!(n, 1);
+}
+
 #[test]
 fn hostname_resolution_logic() {
 	// Create a mock service store with a service that has a hostname

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1194,16 +1194,6 @@ impl HTTPProxy {
 		response_policies: &mut ResponsePolicies,
 		req: &mut Request,
 	) -> Result<Response, ProxyResponse> {
-		// A Substrate CONNECT first resolves its actor to the worker's atunnel
-		// CONNECT listener. The raw downstream stream is then CONNECTed through
-		// atunnel to the actor port, rather than directly to the worker address.
-		let substrate_connect_authority = Box::pin(handle_substrate_backend_selection(
-			req,
-			&selected_backend.backend.backend,
-			SubstrateBackendTarget::Connect,
-		))
-		.await?
-		.map(|state| state.connect_authority());
 		let backend_call = build_connect_backend_call(
 			self.inputs.as_ref(),
 			&selected_backend.backend.backend,
@@ -1255,23 +1245,6 @@ impl HTTPProxy {
 				},
 			)
 			.await?;
-		let upstream = if let Some(authority) = substrate_connect_authority {
-			match crate::client::connect_tunnel::handshake_atunnel(
-				upstream,
-				&authority,
-				Arc::new(self.inputs.cfg.hbone.h2.clone()),
-			)
-			.await
-			{
-				Ok(upstream) => upstream,
-				Err(error) if crate::client::connect_tunnel::is_stale_assignment_error(&error) => {
-					return Err(ProxyError::StaleAssignment.into());
-				},
-				Err(error) => return Err(ProxyError::Processing(error).into()),
-			}
-		} else {
-			upstream
-		};
 		let mut resp = ::http::Response::builder()
 			.status(StatusCode::OK)
 			.body(http::Body::empty())
@@ -2065,11 +2038,37 @@ fn resolve_tunnel_backend_call(
 		crate::proxy::tcpproxy::get_backend_policies(inputs, &backend, &tunnel.policies, None);
 	if let Backend::Dynamic(_, expr) = &backend.backend {
 		let executor = crate::cel::Executor::new_request(req);
-		let target =
-			resolve_dynamic_backend_target(None, &executor, expr, || target_from_request(req))?;
+		let target = resolve_dynamic_backend_target(
+			req.extensions().get::<DynamicBackendOverride>(),
+			&executor,
+			expr,
+			|| target_from_request(req),
+		)?;
 		return Ok(BackendCall::new(target, policies));
 	}
 	TCPProxy::build_backend_call(&mut None, None, inputs, &backend.backend, policies, None)
+}
+
+fn configure_tunnel_backend_call(
+	inputs: &ProxyInputs,
+	req: &mut Request,
+	backend_call: &mut BackendCall,
+) -> Result<(), ProxyError> {
+	let Some(tunnel) = backend_call.backend_policies.tunnel.clone() else {
+		return Ok(());
+	};
+	if let Some(state) = req
+		.extensions()
+		.get::<http::substrate::SubstrateRequestState>()
+		&& req.extensions().get::<DynamicBackendOverride>().is_some()
+	{
+		backend_call.target =
+			Target::try_from(state.connect_authority().as_str()).map_err(|error| {
+				ProxyError::ProcessingString(format!("invalid Substrate CONNECT authority: {error}"))
+			})?;
+	}
+	backend_call.set_tunnel_proxy(resolve_tunnel_backend_call(inputs, &tunnel, req)?);
+	Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2282,12 +2281,7 @@ async fn make_backend_call(
 		},
 		_ => (backend, base_policies),
 	};
-	Box::pin(handle_substrate_backend_selection(
-		&mut req,
-		backend,
-		SubstrateBackendTarget::Ingress,
-	))
-	.await?;
+	Box::pin(handle_substrate_backend_selection(&mut req, backend)).await?;
 
 	log.add(|l| {
 		l.backend_info = Some(backend.backend_info());
@@ -2529,9 +2523,7 @@ async fn make_backend_call(
 			|| target_from_request(&req),
 		)?;
 	}
-	if let Some(tunnel) = backend_call.backend_policies.tunnel.clone() {
-		backend_call.set_tunnel_proxy(resolve_tunnel_backend_call(&inputs, &tunnel, &req)?);
-	}
+	configure_tunnel_backend_call(&inputs, &mut req, &mut backend_call)?;
 
 	log.add(|l| {
 		l.endpoint = Some(backend_call.target.clone());
@@ -2994,17 +2986,10 @@ async fn make_backend_call(
 	Ok(resp)
 }
 
-#[derive(Clone, Copy)]
-enum SubstrateBackendTarget {
-	Ingress,
-	Connect,
-}
-
 /// Resolves a Substrate actor assignment into an in-process dynamic backend result.
 async fn handle_substrate_backend_selection(
 	req: &mut Request,
 	backend: &Backend,
-	target: SubstrateBackendTarget,
 ) -> Result<Option<http::substrate::SubstrateRequestState>, ProxyResponse> {
 	if let Some(state) = req
 		.extensions()
@@ -3019,11 +3004,10 @@ async fn handle_substrate_backend_selection(
 				.into(),
 			);
 		}
-		let target = match target {
-			SubstrateBackendTarget::Ingress => Box::pin(state.resolve_target()).await?,
-			SubstrateBackendTarget::Connect => state.resolve_connect_target().await?,
-		};
-		req.extensions_mut().insert(DynamicBackendOverride(target));
+		let resolved_target = Box::pin(state.resolve_target()).await?;
+		req
+			.extensions_mut()
+			.insert(DynamicBackendOverride(resolved_target));
 		Ok(Some(state))
 	} else if req.extensions().get::<DynamicBackendOverride>().is_some()
 		&& !matches!(backend, Backend::Dynamic(_, _))

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1380,13 +1380,15 @@ impl HTTPProxy {
 	}
 
 	fn detect_misdirected(
-		log: &RequestLog,
+		_log: &RequestLog,
 		bind: &BindSnapshot,
 		req: &Request,
 		selected_listener: &Listener,
 	) -> Result<(), ProxyError> {
-		if log.tls_info.is_none() {
-			// Only applicable for HTTPS
+		if !matches!(
+			selected_listener.protocol,
+			ListenerProtocol::HTTPS(_) | ListenerProtocol::TLS(_)
+		) {
 			return Ok(());
 		}
 		// From the spec:

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -866,8 +866,7 @@ impl HTTPProxy {
 		.snapshot_on_err(log, &mut req)?;
 		dtrace::snapshot!(Request, "gateway policies", &req);
 
-		Self::detect_misdirected(log, &bind, &req, &selected_listener)
-			.snapshot_on_err(log, &mut req)?;
+		Self::detect_misdirected(&bind, &req, &selected_listener).snapshot_on_err(log, &mut req)?;
 
 		let selected_route_chain =
 			select_route_chain(&inputs, self.target_address, &selected_listener, &req)
@@ -1353,7 +1352,6 @@ impl HTTPProxy {
 	}
 
 	fn detect_misdirected(
-		_log: &RequestLog,
 		bind: &BindSnapshot,
 		req: &Request,
 		selected_listener: &Listener,

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -1288,8 +1288,16 @@ impl TestBind {
 	}
 
 	pub fn serve_tunnel(&self, bind_name: BindKey) -> DuplexStream {
+		self.serve_tunnel_with_tls_info(bind_name, None)
+	}
+
+	pub fn serve_tunnel_with_tls_info(
+		&self,
+		bind_name: BindKey,
+		tls_info: Option<crate::transport::stream::TLSConnectionInfo>,
+	) -> DuplexStream {
 		let (client, server) = tokio::io::duplex(8192);
-		let server = Socket::from_memory(
+		let mut server = Socket::from_memory(
 			server,
 			TCPConnectionInfo {
 				peer_addr: "127.0.0.1:12345".parse().unwrap(),
@@ -1298,6 +1306,9 @@ impl TestBind {
 				raw_peer_addr: None,
 			},
 		);
+		if let Some(tls_info) = tls_info {
+			server.ext_mut().insert(tls_info);
+		}
 		let bind = self.pi.stores.read_binds().bind(&bind_name).unwrap();
 		let bind_protocol = bind.protocol;
 		let tunnel_protocol = bind.tunnel_protocol;

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1186,6 +1186,9 @@ struct LocalBind {
 	/// via in-process routing). A numeric port is required unless `mode` is `internal`.
 	#[serde(default)]
 	port: Option<u16>,
+	/// Protocol handling for the entire bind. When omitted, it is inferred from the listeners.
+	#[serde(default)]
+	protocol: Option<LocalBindProtocol>,
 	/// Named listeners bound on this port, which may use different protocols and TLS.
 	listeners: Vec<LocalListener>,
 	/// Protocol used to tunnel backend connections, such as Direct or HBONE.
@@ -1195,6 +1198,31 @@ struct LocalBind {
 	/// Set to `internal` to create a routing-only bind that does not bind a socket.
 	#[serde(default)]
 	mode: BindMode,
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "UPPERCASE", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[allow(clippy::upper_case_acronyms)]
+enum LocalBindProtocol {
+	HTTP,
+	TLS,
+	TCP,
+	/// EXPERIMENTAL: Detects TLS, plaintext HTTP, or opaque TCP from the first bytes of each
+	/// connection and chooses the appropriate listener. Use an explicit protocol whenever
+	/// possible. AUTO requires client-first opaque protocols that look like a TLS or HTTP request.
+	AUTO,
+}
+
+impl From<LocalBindProtocol> for BindProtocol {
+	fn from(protocol: LocalBindProtocol) -> Self {
+		match protocol {
+			LocalBindProtocol::HTTP => BindProtocol::http,
+			LocalBindProtocol::TLS => BindProtocol::tls,
+			LocalBindProtocol::TCP => BindProtocol::tcp,
+			LocalBindProtocol::AUTO => BindProtocol::auto,
+		}
+	}
 }
 
 #[apply(schema_de!)]
@@ -1214,7 +1242,7 @@ struct LocalListener {
 	name: LocalListenerName,
 	/// Can be a wildcard
 	hostname: Option<Strng>,
-	/// Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, HBONE, or AUTO.
+	/// Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, or HBONE.
 	#[serde(default)]
 	protocol: LocalListenerProtocol,
 	/// TLS configuration, used with the HTTPS and TLS protocols.
@@ -1239,16 +1267,6 @@ enum LocalListenerProtocol {
 	TLS,
 	TCP,
 	HBONE,
-	// Detect TLS, HTTP, or raw TCP per connection (see `BindProtocol::auto`)
-	// instead of committing to one protocol ahead of time. Requires `routes`,
-	// `tcpRoutes`, or both -- whichever set applies is picked at runtime.
-	//
-	// Not a `///` doc comment: schemars gives a documented variant its own
-	// described oneOf branch instead of folding it into the flat enum list,
-	// which would turn this into a breaking JSON-schema shape change for
-	// anything that expects `LocalListenerProtocol` to stay a plain
-	// `{type: string, enum: [...]}`.
-	Auto,
 }
 
 #[derive(Default)]
@@ -3069,13 +3087,7 @@ async fn convert(
 			strng::format!("bind/{bind_port}")
 		};
 		let mut ls = ListenerSet::default();
-		// convert_listener collapses LocalListenerProtocol::Auto into the
-		// runtime ListenerProtocol::HTTP (see its own comment on why), so that
-		// distinction is gone by the time detect_bind_protocol inspects `ls`.
-		// Capture it here, off the pre-conversion protocol, instead.
-		let mut any_auto = false;
 		for (idx, l) in b.listeners.into_iter().enumerate() {
-			any_auto |= matches!(l.protocol, LocalListenerProtocol::Auto);
 			let (l, routes, tcp_routes, pol, backends) = Box::pin(convert_listener(
 				resources,
 				config,
@@ -3101,11 +3113,10 @@ async fn convert(
 			bind: Arc::new(Bind {
 				key: bind_name,
 				address: sockaddr,
-				protocol: if any_auto {
-					BindProtocol::auto
-				} else {
-					detect_bind_protocol(&ls)
-				},
+				protocol: b
+					.protocol
+					.map(BindProtocol::from)
+					.unwrap_or_else(|| detect_bind_protocol(&ls)),
 				tunnel_protocol: b.tunnel_protocol,
 				mode: b.mode,
 			}),
@@ -4891,7 +4902,6 @@ async fn convert_listener(
 		tcp_routes,
 	} = l;
 
-	let is_auto = matches!(protocol, LocalListenerProtocol::Auto);
 	let protocol = match protocol {
 		LocalListenerProtocol::HTTP => {
 			if routes.is_none() {
@@ -4930,25 +4940,9 @@ async fn convert_listener(
 			ListenerProtocol::TCP
 		},
 		LocalListenerProtocol::HBONE => ListenerProtocol::HBONE,
-		LocalListenerProtocol::Auto => {
-			if routes.is_none() {
-				bail!("protocol AUTO requires 'routes'")
-			}
-			if tcp_routes.is_some() {
-				bail!("protocol AUTO does not support 'tcpRoutes'; configure an explicit TCP listener")
-			}
-			// Auto-detection happens per connection (BindProtocol::auto), before
-			// either route set is consulted, so this listener must still be
-			// discoverable by the HTTP path's Host-based listener match
-			// (ListenerSet::best_match_http filters on exactly this variant). The
-			// TCP path doesn't filter by listener protocol at all -- it resolves
-			// the bind's one listener directly -- so mapping to HTTP costs it
-			// nothing.
-			ListenerProtocol::HTTP
-		},
 	};
 
-	if tcp_routes.is_some() && routes.is_some() && !is_auto {
+	if tcp_routes.is_some() && routes.is_some() {
 		bail!("only 'routes' or 'tcpRoutes' may be set");
 	}
 

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1214,7 +1214,7 @@ struct LocalListener {
 	name: LocalListenerName,
 	/// Can be a wildcard
 	hostname: Option<Strng>,
-	/// Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, or HBONE.
+	/// Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, HBONE, or AUTO.
 	#[serde(default)]
 	protocol: LocalListenerProtocol,
 	/// TLS configuration, used with the HTTPS and TLS protocols.
@@ -1239,6 +1239,16 @@ enum LocalListenerProtocol {
 	TLS,
 	TCP,
 	HBONE,
+	// Detect TLS, HTTP, or raw TCP per connection (see `BindProtocol::auto`)
+	// instead of committing to one protocol ahead of time. Requires `routes`,
+	// `tcpRoutes`, or both -- whichever set applies is picked at runtime.
+	//
+	// Not a `///` doc comment: schemars gives a documented variant its own
+	// described oneOf branch instead of folding it into the flat enum list,
+	// which would turn this into a breaking JSON-schema shape change for
+	// anything that expects `LocalListenerProtocol` to stay a plain
+	// `{type: string, enum: [...]}`.
+	Auto,
 }
 
 #[derive(Default)]
@@ -3059,7 +3069,13 @@ async fn convert(
 			strng::format!("bind/{bind_port}")
 		};
 		let mut ls = ListenerSet::default();
+		// convert_listener collapses LocalListenerProtocol::Auto into the
+		// runtime ListenerProtocol::HTTP (see its own comment on why), so that
+		// distinction is gone by the time detect_bind_protocol inspects `ls`.
+		// Capture it here, off the pre-conversion protocol, instead.
+		let mut any_auto = false;
 		for (idx, l) in b.listeners.into_iter().enumerate() {
+			any_auto |= matches!(l.protocol, LocalListenerProtocol::Auto);
 			let (l, routes, tcp_routes, pol, backends) = Box::pin(convert_listener(
 				resources,
 				config,
@@ -3085,7 +3101,11 @@ async fn convert(
 			bind: Arc::new(Bind {
 				key: bind_name,
 				address: sockaddr,
-				protocol: detect_bind_protocol(&ls),
+				protocol: if any_auto {
+					BindProtocol::auto
+				} else {
+					detect_bind_protocol(&ls)
+				},
 				tunnel_protocol: b.tunnel_protocol,
 				mode: b.mode,
 			}),
@@ -4872,6 +4892,7 @@ async fn convert_listener(
 		tcp_routes,
 	} = l;
 
+	let is_auto = matches!(protocol, LocalListenerProtocol::Auto);
 	let protocol = match protocol {
 		LocalListenerProtocol::HTTP => {
 			if routes.is_none() {
@@ -4910,9 +4931,22 @@ async fn convert_listener(
 			ListenerProtocol::TCP
 		},
 		LocalListenerProtocol::HBONE => ListenerProtocol::HBONE,
+		LocalListenerProtocol::Auto => {
+			if routes.is_none() && tcp_routes.is_none() {
+				bail!("protocol AUTO requires 'routes', 'tcpRoutes', or both")
+			}
+			// Auto-detection happens per connection (BindProtocol::auto), before
+			// either route set is consulted, so this listener must still be
+			// discoverable by the HTTP path's Host-based listener match
+			// (ListenerSet::best_match_http filters on exactly this variant). The
+			// TCP path doesn't filter by listener protocol at all -- it resolves
+			// the bind's one listener directly -- so mapping to HTTP costs it
+			// nothing.
+			ListenerProtocol::HTTP
+		},
 	};
 
-	if tcp_routes.is_some() && routes.is_some() {
+	if tcp_routes.is_some() && routes.is_some() && !is_auto {
 		bail!("only 'routes' or 'tcpRoutes' may be set");
 	}
 

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -3321,8 +3321,6 @@ async fn convert(
 
 	// Add frontend policies targeted to this listener
 	all_policies.extend_from_slice(&split_frontend_policies(gateway, frontend_policies).await?);
-	validate_auto_bind_tcp_fallbacks(&all_binds, &all_listener_tcp_routes)?;
-
 	let normalized = NormalizedLocalConfig {
 		budget_registration: Default::default(),
 		model_catalog,
@@ -4869,33 +4867,6 @@ fn detect_bind_protocol(listeners: &ListenerSet) -> BindProtocol {
 	BindProtocol::http
 }
 
-fn validate_auto_bind_tcp_fallbacks(
-	binds: &[BindSnapshot],
-	listener_tcp_routes: &[(ListenerKey, Vec<TCPRoute>)],
-) -> anyhow::Result<()> {
-	for bind in binds
-		.iter()
-		.filter(|bind| bind.protocol == BindProtocol::auto)
-	{
-		let fallback_count = bind
-			.listeners
-			.iter()
-			.filter(|listener| {
-				listener_tcp_routes
-					.iter()
-					.any(|(key, routes)| key == &listener.key && !routes.is_empty())
-			})
-			.count();
-		if fallback_count > 1 {
-			bail!(
-				"AUTO bind {} has multiple TCP fallback listeners; configure tcpRoutes on at most one listener",
-				bind.key
-			);
-		}
-	}
-	Ok(())
-}
-
 async fn convert_listener(
 	resources: &crate::resource_manager::ResourceFetcher,
 	config: &crate::Config,
@@ -4960,8 +4931,11 @@ async fn convert_listener(
 		},
 		LocalListenerProtocol::HBONE => ListenerProtocol::HBONE,
 		LocalListenerProtocol::Auto => {
-			if routes.is_none() && tcp_routes.is_none() {
-				bail!("protocol AUTO requires 'routes', 'tcpRoutes', or both")
+			if routes.is_none() {
+				bail!("protocol AUTO requires 'routes'")
+			}
+			if tcp_routes.is_some() {
+				bail!("protocol AUTO does not support 'tcpRoutes'; configure an explicit TCP listener")
 			}
 			// Auto-detection happens per connection (BindProtocol::auto), before
 			// either route set is consulted, so this listener must still be

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -3321,6 +3321,7 @@ async fn convert(
 
 	// Add frontend policies targeted to this listener
 	all_policies.extend_from_slice(&split_frontend_policies(gateway, frontend_policies).await?);
+	validate_auto_bind_tcp_fallbacks(&all_binds, &all_listener_tcp_routes)?;
 
 	let normalized = NormalizedLocalConfig {
 		budget_registration: Default::default(),
@@ -4866,6 +4867,33 @@ fn detect_bind_protocol(listeners: &ListenerSet) -> BindProtocol {
 		return BindProtocol::tcp;
 	}
 	BindProtocol::http
+}
+
+fn validate_auto_bind_tcp_fallbacks(
+	binds: &[BindSnapshot],
+	listener_tcp_routes: &[(ListenerKey, Vec<TCPRoute>)],
+) -> anyhow::Result<()> {
+	for bind in binds
+		.iter()
+		.filter(|bind| bind.protocol == BindProtocol::auto)
+	{
+		let fallback_count = bind
+			.listeners
+			.iter()
+			.filter(|listener| {
+				listener_tcp_routes
+					.iter()
+					.any(|(key, routes)| key == &listener.key && !routes.is_empty())
+			})
+			.count();
+		if fallback_count > 1 {
+			bail!(
+				"AUTO bind {} has multiple TCP fallback listeners; configure tcpRoutes on at most one listener",
+				bind.key
+			);
+		}
+	}
+	Ok(())
 }
 
 async fn convert_listener(

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -404,6 +404,28 @@ binds:
 }
 
 #[tokio::test]
+async fn test_auto_bind_rejects_multiple_tcp_fallback_listeners() {
+	let err = normalize_test_yaml(
+		r#"
+binds:
+- port: 1080
+  listeners:
+  - protocol: AUTO
+    tcpRoutes:
+    - backends:
+      - host: "127.0.0.1:1"
+  - protocol: AUTO
+    tcpRoutes:
+    - backends:
+      - host: "127.0.0.1:2"
+"#,
+	)
+	.await
+	.expect_err("an AUTO bind with two TCP fallbacks should be rejected");
+	assert!(err.to_string().contains("multiple TCP fallback"), "{err}");
+}
+
+#[tokio::test]
 async fn test_explicit_port_zero_counts_as_wildcard() {
 	// `port: 0` on an internal bind is the same wildcard sentinel as omitting the port. A portless
 	// wildcard plus an explicit `port: 0` wildcard must still be rejected as two wildcards.

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -361,49 +361,14 @@ binds:
 }
 
 #[tokio::test]
-async fn test_local_listener_protocol_auto_rejects_tcp_routes() {
-	let err = normalize_test_yaml(
-		r#"
-binds:
-- port: 1080
-  listeners:
-  - protocol: AUTO
-    routes:
-    - backends:
-      - dynamic: {}
-    tcpRoutes:
-    - backends:
-      - host: "127.0.0.1:1"
-"#,
-	)
-	.await
-	.expect_err("AUTO must use an explicit TCP listener for opaque TCP");
-	assert!(err.to_string().contains("explicit TCP listener"), "{err}");
-}
-
-#[tokio::test]
-async fn test_local_listener_protocol_auto_requires_a_route_set() {
-	let err = normalize_test_yaml(
-		r#"
-binds:
-- port: 1080
-  listeners:
-  - protocol: AUTO
-"#,
-	)
-	.await
-	.expect_err("an Auto listener without routes should be rejected");
-	assert!(err.to_string().contains("protocol AUTO"), "{err}");
-}
-
-#[tokio::test]
 async fn test_auto_bind_allows_tls_routes_and_one_explicit_tcp_listener() {
 	let normalized = normalize_test_yaml(
 		r#"
 binds:
 - port: 1080
+  protocol: AUTO
   listeners:
-  - protocol: AUTO
+  - protocol: HTTP
     routes:
     - backends:
       - dynamic: {}

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -8,8 +8,8 @@ use secrecy::SecretString;
 use crate::llm::{AIProvider, NamedAIProvider};
 use crate::serdes::FileInlineOrRemote;
 use crate::types::agent::{
-	Backend, BackendTrafficPolicy, ListenerTarget, PathMatch, PolicyPhase, PolicyTarget, PolicyType,
-	ResourceName, RouteBackendTarget, Target, TrafficPolicy,
+	Backend, BackendTrafficPolicy, BindProtocol, ListenerTarget, PathMatch, PolicyPhase,
+	PolicyTarget, PolicyType, ResourceName, RouteBackendTarget, Target, TrafficPolicy,
 };
 use crate::types::local::NormalizedLocalConfig;
 use crate::*;
@@ -358,6 +358,49 @@ binds:
 		err.to_string().contains("at most one wildcard bind"),
 		"{err:?}"
 	);
+}
+
+#[tokio::test]
+async fn test_local_listener_protocol_auto_allows_both_route_sets() {
+	// protocol: AUTO is the one case where a single listener may declare both
+	// `routes` and `tcpRoutes` -- BindProtocol::auto picks whichever applies
+	// per connection, based on peeking the first bytes (see gateway.rs).
+	let normalized = normalize_test_yaml(
+		r#"
+binds:
+- port: 1080
+  listeners:
+  - protocol: AUTO
+    routes:
+    - backends:
+      - dynamic: {}
+    tcpRoutes:
+    - backends:
+      - host: "127.0.0.1:1"
+"#,
+	)
+	.await
+	.expect("an Auto listener with both routes and tcpRoutes should normalize");
+
+	assert_eq!(normalized.binds.len(), 1);
+	assert_eq!(normalized.binds[0].protocol, BindProtocol::auto);
+	assert_eq!(normalized.listener_routes[0].1.len(), 1);
+	assert_eq!(normalized.listener_tcp_routes[0].1.len(), 1);
+}
+
+#[tokio::test]
+async fn test_local_listener_protocol_auto_requires_a_route_set() {
+	let err = normalize_test_yaml(
+		r#"
+binds:
+- port: 1080
+  listeners:
+  - protocol: AUTO
+"#,
+	)
+	.await
+	.expect_err("an Auto listener with neither routes nor tcpRoutes should be rejected");
+	assert!(err.to_string().contains("protocol AUTO"), "{err}");
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -361,11 +361,8 @@ binds:
 }
 
 #[tokio::test]
-async fn test_local_listener_protocol_auto_allows_both_route_sets() {
-	// protocol: AUTO is the one case where a single listener may declare both
-	// `routes` and `tcpRoutes` -- BindProtocol::auto picks whichever applies
-	// per connection, based on peeking the first bytes (see gateway.rs).
-	let normalized = normalize_test_yaml(
+async fn test_local_listener_protocol_auto_rejects_tcp_routes() {
+	let err = normalize_test_yaml(
 		r#"
 binds:
 - port: 1080
@@ -380,12 +377,8 @@ binds:
 "#,
 	)
 	.await
-	.expect("an Auto listener with both routes and tcpRoutes should normalize");
-
-	assert_eq!(normalized.binds.len(), 1);
-	assert_eq!(normalized.binds[0].protocol, BindProtocol::auto);
-	assert_eq!(normalized.listener_routes[0].1.len(), 1);
-	assert_eq!(normalized.listener_tcp_routes[0].1.len(), 1);
+	.expect_err("AUTO must use an explicit TCP listener for opaque TCP");
+	assert!(err.to_string().contains("explicit TCP listener"), "{err}");
 }
 
 #[tokio::test]
@@ -399,30 +392,35 @@ binds:
 "#,
 	)
 	.await
-	.expect_err("an Auto listener with neither routes nor tcpRoutes should be rejected");
+	.expect_err("an Auto listener without routes should be rejected");
 	assert!(err.to_string().contains("protocol AUTO"), "{err}");
 }
 
 #[tokio::test]
-async fn test_auto_bind_rejects_multiple_tcp_fallback_listeners() {
-	let err = normalize_test_yaml(
+async fn test_auto_bind_allows_tls_routes_and_one_explicit_tcp_listener() {
+	let normalized = normalize_test_yaml(
 		r#"
 binds:
 - port: 1080
   listeners:
   - protocol: AUTO
+    routes:
+    - backends:
+      - dynamic: {}
+  - protocol: TLS
+    hostname: "*"
     tcpRoutes:
     - backends:
       - host: "127.0.0.1:1"
-  - protocol: AUTO
+  - protocol: TCP
     tcpRoutes:
     - backends:
       - host: "127.0.0.1:2"
 "#,
 	)
 	.await
-	.expect_err("an AUTO bind with two TCP fallbacks should be rejected");
-	assert!(err.to_string().contains("multiple TCP fallback"), "{err}");
+	.expect("TLS passthrough and explicit TCP listener should normalize");
+	assert_eq!(normalized.binds[0].protocol, BindProtocol::auto);
 }
 
 #[tokio::test]

--- a/crates/agentgateway/tests/tests/auto_protocol.rs
+++ b/crates/agentgateway/tests/tests/auto_protocol.rs
@@ -221,3 +221,90 @@ async fn auto_protocol_peek_timeout() {
 	tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 	// If we reach here, the timeout worked (auto-advance means no real wait).
 }
+
+/// Bytes that are neither a TLS ClientHello nor a recognizable HTTP request
+/// line should fall through to opaque TCP passthrough, rather than being
+/// force-fed to the HTTP server (where they'd fail to parse).
+#[tokio::test]
+async fn auto_protocol_raw_tcp_fallback() {
+	let echo_addr = spawn_tcp_echo().await;
+	let route = basic_named_tcp_route(strng::format!("/{echo_addr}"));
+	let bind = auto_bind(ListenerSet::from_list([Listener {
+		key: LISTENER_KEY,
+		name: Default::default(),
+		hostname: Default::default(),
+		protocol: ListenerProtocol::TCP,
+	}]));
+
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(echo_addr)
+		.with_bind(bind)
+		.with_tcp_route(route);
+
+	let mut io = t.serve(strng::new("bind"));
+	// Not a TLS ClientHello (first byte != 0x16) and not a recognizable HTTP
+	// method token.
+	io.write_all(b"HELLO-RAW-TCP-PAYLOAD").await.unwrap();
+	let mut buf = [0u8; 32];
+	let n = tokio::time::timeout(Duration::from_secs(5), io.read(&mut buf))
+		.await
+		.expect("timed out waiting for echoed bytes")
+		.unwrap();
+	assert_eq!(&buf[..n], b"HELLO-RAW-TCP-PAYLOAD");
+}
+
+/// A partial, non-HTTP, non-TLS prefix followed by the peer closing before the
+/// full peek window fills should still classify as TCP rather than stalling
+/// for the full peek window.
+#[tokio::test]
+async fn auto_protocol_raw_tcp_short_prefix() {
+	let echo_addr = spawn_tcp_echo().await;
+	let route = basic_named_tcp_route(strng::format!("/{echo_addr}"));
+	let bind = auto_bind(ListenerSet::from_list([Listener {
+		key: LISTENER_KEY,
+		name: Default::default(),
+		hostname: Default::default(),
+		protocol: ListenerProtocol::TCP,
+	}]));
+
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(echo_addr)
+		.with_bind(bind)
+		.with_tcp_route(route);
+
+	let mut io = t.serve(strng::new("bind"));
+	// Fewer bytes than the peek window (8), and not a prefix of any known
+	// HTTP method token. Shut down the write half so the peek's read sees EOF
+	// instead of waiting for the rest of the window to fill -- the read half
+	// stays open to receive the echoed bytes below.
+	io.write_all(b"AB").await.unwrap();
+	io.shutdown().await.unwrap();
+	let mut buf = [0u8; 32];
+	let n = tokio::time::timeout(Duration::from_secs(5), io.read(&mut buf))
+		.await
+		.expect("timed out waiting for echoed bytes")
+		.unwrap();
+	assert_eq!(&buf[..n], b"AB");
+}
+
+async fn spawn_tcp_echo() -> std::net::SocketAddr {
+	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let addr = listener.local_addr().unwrap();
+	tokio::spawn(async move {
+		let (mut sock, _) = listener.accept().await.unwrap();
+		let mut buf = [0u8; 1024];
+		loop {
+			match sock.read(&mut buf).await {
+				Ok(0) | Err(_) => break,
+				Ok(n) => {
+					if sock.write_all(&buf[..n]).await.is_err() {
+						break;
+					}
+				},
+			}
+		}
+	});
+	addr
+}

--- a/crates/agentgateway/tests/tests/auto_protocol.rs
+++ b/crates/agentgateway/tests/tests/auto_protocol.rs
@@ -229,12 +229,20 @@ async fn auto_protocol_peek_timeout() {
 async fn auto_protocol_raw_tcp_fallback() {
 	let echo_addr = spawn_tcp_echo().await;
 	let route = basic_named_tcp_route(strng::format!("/{echo_addr}"));
-	let bind = auto_bind(ListenerSet::from_list([Listener {
-		key: LISTENER_KEY,
-		name: Default::default(),
-		hostname: Default::default(),
-		protocol: ListenerProtocol::TCP,
-	}]));
+	let bind = auto_bind(ListenerSet::from_list([
+		Listener {
+			key: LISTENER_KEY,
+			name: Default::default(),
+			hostname: Default::default(),
+			protocol: ListenerProtocol::TCP,
+		},
+		Listener {
+			key: strng::literal!("http-listener"),
+			name: Default::default(),
+			hostname: strng::literal!("http.example.com"),
+			protocol: ListenerProtocol::HTTP,
+		},
+	]));
 
 	let t = setup_proxy_test("{}")
 		.unwrap()

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -1,7 +1,7 @@
 use agentgateway::test_helpers::ateapimock;
 use agentgateway::transport::stream::TLSConnectionInfo;
 use agentgateway::transport::tls::TlsInfo;
-use agentgateway::types::agent::{Backend, BindMode, TunnelProtocol};
+use agentgateway::types::agent::{Backend, BackendWithPolicies, BindMode, TunnelProtocol};
 use protos::ateapi::{Actor, ActorStatus, ResumeActorResponse};
 use tokio::sync::Notify;
 
@@ -136,7 +136,7 @@ async fn actor_ingress_resolves_the_dynamic_backend() {
 		.attach_route_policy(json!({
 			"substrateIngress": {
 				"host": api.address.to_string(),
-				"targetPort": actor.address().port(),
+				"connectTargetPort": actor.address().port(),
 			}
 		}))
 		.await;
@@ -184,7 +184,7 @@ async fn actor_ingress_parks_while_worker_capacity_recovers() {
 		.attach_route_policy(json!({
 			"substrateIngress": {
 				"host": api.address.to_string(),
-				"targetPort": actor.address().port(),
+				"connectTargetPort": actor.address().port(),
 				"requestParking": {
 					"budget": "1s",
 					"max": 1,
@@ -235,7 +235,7 @@ async fn actor_ingress_sheds_when_request_parking_is_full() {
 		.attach_route_policy(json!({
 			"substrateIngress": {
 				"host": api.address.to_string(),
-				"targetPort": actor.address().port(),
+				"connectTargetPort": actor.address().port(),
 				"requestParking": {
 					"budget": "1s",
 					"max": 1,
@@ -294,7 +294,7 @@ async fn actor_ingress_keeps_cached_actor_available_when_parking_is_full() {
 		.attach_route_policy(json!({
 			"substrateIngress": {
 				"host": api.address.to_string(),
-				"targetPort": actor.address().port(),
+				"connectTargetPort": actor.address().port(),
 				"requestParking": {
 					"budget": "1s",
 					"max": 1,
@@ -363,7 +363,7 @@ async fn actor_ingress_uses_the_original_connect_authority() {
 		.attach_route_policy(json!({
 			"substrateIngress": {
 				"host": api.address.to_string(),
-				"targetPort": actor.address().port(),
+				"connectTargetPort": actor.address().port(),
 			}
 		}))
 		.await;
@@ -415,13 +415,35 @@ async fn actor_ingress_uses_the_original_connect_authority() {
 }
 
 #[tokio::test]
-async fn actor_ingress_rejects_atunnel_without_alpn() {
+async fn actor_ingress_uses_backend_tunnel_for_connect() {
+	let actor = simple_mock().await;
+	let actor_address = *actor.address();
 	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
 	let atunnel_address = listener.local_addr().unwrap();
 	let atunnel = tokio::spawn(async move {
-		let (mut stream, _) = listener.accept().await.unwrap();
-		let mut buf = [0; 1];
-		assert_eq!(stream.read(&mut buf).await.unwrap(), 0);
+		let (mut downstream, _) = listener.accept().await.unwrap();
+		let mut request = Vec::new();
+		loop {
+			let mut chunk = [0; 1024];
+			let n = downstream.read(&mut chunk).await.unwrap();
+			assert!(n > 0, "CONNECT request unexpectedly closed");
+			request.extend_from_slice(&chunk[..n]);
+			if request.windows(4).any(|window| window == b"\r\n\r\n") {
+				break;
+			}
+		}
+		let request = String::from_utf8(request).unwrap();
+		assert!(
+			request
+				.starts_with("CONNECT my-actor.demo.actors.resources.substrate.ate.dev:9090 HTTP/1.1\r\n"),
+			"unexpected tunnel request: {request:?}"
+		);
+		downstream
+			.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+			.await
+			.unwrap();
+		let mut upstream = TcpStream::connect(actor_address).await.unwrap();
+		let _ = tokio::io::copy_bidirectional(&mut downstream, &mut upstream).await;
 	});
 
 	let calls = Arc::new(AtomicUsize::new(0));
@@ -436,46 +458,58 @@ async fn actor_ingress_rejects_atunnel_without_alpn() {
 	.spawn()
 	.await;
 
-	let dynamic = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), None);
-	let bind = simple_bind();
+	let dynamic_backend = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), None);
+	let dynamic_name = dynamic_backend.name();
+	let dynamic = BackendWithPolicies {
+		backend: dynamic_backend,
+		inline_policies: vec![BackendTrafficPolicy::Tunnel(backend::Tunnel {
+			proxy: Arc::new(SimpleBackendReference::Backend(dynamic_name.clone())),
+			mode: backend::TunnelMode::Connect,
+			policies: vec![],
+		})],
+	};
+	let mut outer = simple_bind();
+	outer.key = strng::literal!("outer");
+	outer.tunnel_protocol = TunnelProtocol::Connect;
+	let mut inner = simple_bind();
+	inner.key = strng::literal!("bind/wildcard");
+	inner.mode = BindMode::Internal;
 	let mut gateway = setup_proxy_test("{}")
 		.unwrap()
-		.with_raw_backend(dynamic.into())
-		.with_bind(bind)
-		.with_route(basic_named_route(strng::literal!("/dynamic")))
-		.with_connect_enabled();
+		.with_raw_backend(dynamic)
+		.with_bind(outer)
+		.with_bind(inner)
+		.with_route(basic_named_route(strng::literal!("/dynamic")));
 	gateway
 		.attach_route_policy(json!({
 			"substrateIngress": {
 				"host": api.address.to_string(),
-				"targetPort": atunnel_address.port(),
 				"connectTargetPort": atunnel_address.port(),
 			}
 		}))
 		.await;
-
-	let mut io = gateway.serve_tunnel(BIND_KEY);
+	let mut io = gateway.serve_tunnel(strng::literal!("outer"));
 	let authority = "my-actor.demo.actors.resources.substrate.ate.dev:9090";
 	io.write_all(format!("CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\n\r\n").as_bytes())
 		.await
 		.unwrap();
+	let mut response = [0; 128];
+	let response_len = io.read(&mut response).await.unwrap();
+	assert!(String::from_utf8_lossy(&response[..response_len]).starts_with("HTTP/1.1 200 OK\r\n"));
+
+	io.write_all(b"GET / HTTP/1.1\r\nHost: irrelevant.example\r\nConnection: close\r\n\r\n")
+		.await
+		.unwrap();
 	let mut response = Vec::new();
-	loop {
-		let mut chunk = [0; 1024];
-		let n = io.read(&mut chunk).await.unwrap();
-		assert!(n > 0, "CONNECT response unexpectedly closed");
-		response.extend_from_slice(&chunk[..n]);
-		if response.windows(4).any(|window| window == b"\r\n\r\n") {
-			break;
-		}
-	}
-	assert!(
-		String::from_utf8_lossy(&response).contains("HTTP/1.1 503 Service Unavailable"),
-		"unexpected CONNECT response: {}",
-		String::from_utf8_lossy(&response),
-	);
+	tokio::time::timeout(Duration::from_secs(5), io.read_to_end(&mut response))
+		.await
+		.expect("timed out waiting for tunneled response")
+		.unwrap();
+	assert!(String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK\r\n"));
 	assert_eq!(calls.load(Ordering::Relaxed), 1);
-	atunnel.await.unwrap();
+	assert_eq!(actor.received_requests().await.unwrap().len(), 1);
+	drop(io);
+	atunnel.abort();
 }
 
 #[tokio::test]

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -1,4 +1,5 @@
 use agentgateway::test_helpers::ateapimock;
+use agentgateway::transport::{stream::TLSConnectionInfo, tls::TlsInfo};
 use agentgateway::types::agent::{Backend, BindMode, TunnelProtocol};
 use protos::ateapi::{Actor, ActorStatus, ResumeActorResponse};
 use tokio::sync::Notify;
@@ -502,12 +503,21 @@ async fn substrate_egress_authorizes_a_reentered_connect_request() {
 		}))
 		.await;
 
-	let mut io = gateway.serve_tunnel(strng::literal!("outer"));
-	io.write_all(
-		b"CONNECT allowed.example:18080 HTTP/1.1\r\nHost: allowed.example:18080\r\nX-Ate-Atespace: demo\r\nX-Ate-Actor: my-actor\r\nX-Ate-Actor-Version: 1\r\n\r\n",
-	)
-	.await
-	.unwrap();
+	let mut io = gateway.serve_tunnel_with_tls_info(
+		strng::literal!("outer"),
+		Some(TLSConnectionInfo {
+			src_identity: Some(TlsInfo {
+				spiffe_id: Some(strng::literal!(
+					"spiffe://substrate-actor.local/atespace/demo/actor/my-actor"
+				)),
+				..Default::default()
+			}),
+			..Default::default()
+		}),
+	);
+	io.write_all(b"CONNECT allowed.example:18080 HTTP/1.1\r\nHost: allowed.example:18080\r\n\r\n")
+		.await
+		.unwrap();
 	let mut response = Vec::new();
 	loop {
 		let mut chunk = [0; 1024];

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -1,5 +1,6 @@
 use agentgateway::test_helpers::ateapimock;
-use agentgateway::transport::{stream::TLSConnectionInfo, tls::TlsInfo};
+use agentgateway::transport::stream::TLSConnectionInfo;
+use agentgateway::transport::tls::TlsInfo;
 use agentgateway::types::agent::{Backend, BindMode, TunnelProtocol};
 use protos::ateapi::{Actor, ActorStatus, ResumeActorResponse};
 use tokio::sync::Notify;

--- a/schema/config.json
+++ b/schema/config.json
@@ -1225,7 +1225,7 @@
           ]
         },
         "protocol": {
-          "description": "Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, or HBONE.",
+          "description": "Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, HBONE, or AUTO.",
           "$ref": "#/$defs/LocalListenerProtocol"
         },
         "tls": {
@@ -1280,7 +1280,8 @@
         "HTTPS",
         "TLS",
         "TCP",
-        "HBONE"
+        "HBONE",
+        "AUTO"
       ]
     },
     "LocalTLSServerConfig": {

--- a/schema/config.json
+++ b/schema/config.json
@@ -1175,6 +1175,17 @@
           "maximum": 65535,
           "default": null
         },
+        "protocol": {
+          "description": "Protocol handling for the entire bind. When omitted, it is inferred from the listeners.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LocalBindProtocol"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "listeners": {
           "description": "Named listeners bound on this port, which may use different protocols and TLS.",
           "type": "array",
@@ -1196,6 +1207,23 @@
       "additionalProperties": false,
       "required": [
         "listeners"
+      ]
+    },
+    "LocalBindProtocol": {
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "HTTP",
+            "TLS",
+            "TCP"
+          ]
+        },
+        {
+          "description": "EXPERIMENTAL: Detects TLS, plaintext HTTP, or opaque TCP from the first bytes of each\nconnection and chooses the appropriate listener. Use an explicit protocol whenever\npossible. AUTO requires client-first opaque protocols that look like a TLS or HTTP request.",
+          "type": "string",
+          "const": "AUTO"
+        }
       ]
     },
     "LocalListener": {
@@ -1225,7 +1253,7 @@
           ]
         },
         "protocol": {
-          "description": "Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, HBONE, or AUTO.",
+          "description": "Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, or HBONE.",
           "$ref": "#/$defs/LocalListenerProtocol"
         },
         "tls": {
@@ -1280,8 +1308,7 @@
         "HTTPS",
         "TLS",
         "TCP",
-        "HBONE",
-        "AUTO"
+        "HBONE"
       ]
     },
     "LocalTLSServerConfig": {
@@ -7463,21 +7490,13 @@
             }
           ]
         },
-        "targetPort": {
-          "description": "Port on the resumed worker pod's ordinary atunnel ingress. Defaults to 443.\nThis is independent from `connect_target_port`, which is used for raw CONNECT tunnels.",
-          "type": "integer",
-          "format": "uint16",
-          "minimum": 1,
-          "maximum": 65535,
-          "default": 443
-        },
         "connectTargetPort": {
-          "description": "Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 444.",
+          "description": "Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 8443.",
           "type": "integer",
           "format": "uint16",
           "minimum": 1,
           "maximum": 65535,
-          "default": 444
+          "default": 8443
         },
         "cacheTtl": {
           "description": "How long successful actor assignments are reused. Defaults to 5s; 0s disables reuse.",

--- a/schema/config.md
+++ b/schema/config.md
@@ -109,11 +109,12 @@
 |`config.hbone.poolUnusedReleaseTimeout`|string|Duration after which unused pooled connections are released.|
 |`binds`|[]object|binds defines the low-level API for configuring the proxy.<br>Each bind represents a single port the proxy listens on, as well as the full set of configuration<br>(listeners, routes, backends) for that port.<br>Deprecated; usage of `gateways` and `routes` is recommended instead.|
 |`binds[].port`|integer|Port to bind on. Omit it for an internal wildcard bind (which serves any destination port<br>via in-process routing). A numeric port is required unless `mode` is `internal`.|
+|`binds[].protocol`|enum|Protocol handling for the entire bind. When omitted, it is inferred from the listeners.<br>Possible values: `HTTP`, `TLS`, `TCP`, `AUTO`.|
 |`binds[].listeners`|[]object|Named listeners bound on this port, which may use different protocols and TLS.|
 |`binds[].listeners[].name`|string|Name identifying this listener, referenced by `gateways: gateway-name/listener-name`.|
 |`binds[].listeners[].namespace`|string|Namespace scoping this listener.|
 |`binds[].listeners[].hostname`|string|Can be a wildcard|
-|`binds[].listeners[].protocol`|enum|Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, HBONE, or AUTO.<br>Possible values: `HTTP`, `HTTPS`, `TLS`, `TCP`, `HBONE`, `AUTO`.|
+|`binds[].listeners[].protocol`|enum|Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, or HBONE.<br>Possible values: `HTTP`, `HTTPS`, `TLS`, `TCP`, `HBONE`.|
 |`binds[].listeners[].tls`|object|TLS configuration, used with the HTTPS and TLS protocols.|
 |`binds[].listeners[].tls.mode`|enum|Certificate source mode. Static mode uses cert/key as the leaf certificate; dynamic CA<br>mode uses cert/key as a CA for on-demand SNI leaf certificate issuance.<br>Unused when `spiffe` is set.<br>Possible values: `static`, `dynamicCa`.|
 |`binds[].listeners[].tls.cert`|string|Path to the TLS certificate file (leaf certificate, or CA certificate in dynamic CA mode).<br>Required unless `spiffe` is set.|
@@ -5289,8 +5290,7 @@
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
-|`binds[].listeners[].routes[].policies.substrateIngress.targetPort`|integer|Port on the resumed worker pod's ordinary atunnel ingress. Defaults to 443.<br>This is independent from `connect_target_port`, which is used for raw CONNECT tunnels.|
-|`binds[].listeners[].routes[].policies.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 444.|
+|`binds[].listeners[].routes[].policies.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 8443.|
 |`binds[].listeners[].routes[].policies.substrateIngress.cacheTtl`|string|How long successful actor assignments are reused. Defaults to 5s; 0s disables reuse.|
 |`binds[].listeners[].routes[].policies.substrateIngress.requestParking`|object|Bounded request parking while a suspended actor is waiting for worker capacity.|
 |`binds[].listeners[].routes[].policies.substrateIngress.requestParking.budget`|string|Maximum time to wait for the actor to become routable.|
@@ -23935,8 +23935,7 @@
 |`policies[].policy.substrateIngress.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`policies[].policy.substrateIngress.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`policies[].policy.substrateIngress.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
-|`policies[].policy.substrateIngress.targetPort`|integer|Port on the resumed worker pod's ordinary atunnel ingress. Defaults to 443.<br>This is independent from `connect_target_port`, which is used for raw CONNECT tunnels.|
-|`policies[].policy.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 444.|
+|`policies[].policy.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 8443.|
 |`policies[].policy.substrateIngress.cacheTtl`|string|How long successful actor assignments are reused. Defaults to 5s; 0s disables reuse.|
 |`policies[].policy.substrateIngress.requestParking`|object|Bounded request parking while a suspended actor is waiting for worker capacity.|
 |`policies[].policy.substrateIngress.requestParking.budget`|string|Maximum time to wait for the actor to become routable.|
@@ -39764,8 +39763,7 @@
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
-|`routeGroups[].routes[].policies.substrateIngress.targetPort`|integer|Port on the resumed worker pod's ordinary atunnel ingress. Defaults to 443.<br>This is independent from `connect_target_port`, which is used for raw CONNECT tunnels.|
-|`routeGroups[].routes[].policies.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 444.|
+|`routeGroups[].routes[].policies.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 8443.|
 |`routeGroups[].routes[].policies.substrateIngress.cacheTtl`|string|How long successful actor assignments are reused. Defaults to 5s; 0s disables reuse.|
 |`routeGroups[].routes[].policies.substrateIngress.requestParking`|object|Bounded request parking while a suspended actor is waiting for worker capacity.|
 |`routeGroups[].routes[].policies.substrateIngress.requestParking.budget`|string|Maximum time to wait for the actor to become routable.|
@@ -58221,8 +58219,7 @@
 |`routes[].policies.substrateIngress.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`routes[].policies.substrateIngress.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`routes[].policies.substrateIngress.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
-|`routes[].policies.substrateIngress.targetPort`|integer|Port on the resumed worker pod's ordinary atunnel ingress. Defaults to 443.<br>This is independent from `connect_target_port`, which is used for raw CONNECT tunnels.|
-|`routes[].policies.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 444.|
+|`routes[].policies.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 8443.|
 |`routes[].policies.substrateIngress.cacheTtl`|string|How long successful actor assignments are reused. Defaults to 5s; 0s disables reuse.|
 |`routes[].policies.substrateIngress.requestParking`|object|Bounded request parking while a suspended actor is waiting for worker capacity.|
 |`routes[].policies.substrateIngress.requestParking.budget`|string|Maximum time to wait for the actor to become routable.|
@@ -81672,8 +81669,7 @@
 |`mcp.policies.substrateIngress.policies.backendTunnel.proxy.backend`|string|Explicit backend reference. Backend must be defined in the top level backends list|
 |`mcp.policies.substrateIngress.policies.backendTunnel.mode`|enum|How requests are sent through the proxy.<br>Possible values: `auto`, `connect`.|
 |`mcp.policies.substrateIngress.policies.backendTunnel.policies`|any|Policies to connect to the proxy backend|
-|`mcp.policies.substrateIngress.targetPort`|integer|Port on the resumed worker pod's ordinary atunnel ingress. Defaults to 443.<br>This is independent from `connect_target_port`, which is used for raw CONNECT tunnels.|
-|`mcp.policies.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 444.|
+|`mcp.policies.substrateIngress.connectTargetPort`|integer|Port on the resumed worker pod's atunnel CONNECT listener. Defaults to 8443.|
 |`mcp.policies.substrateIngress.cacheTtl`|string|How long successful actor assignments are reused. Defaults to 5s; 0s disables reuse.|
 |`mcp.policies.substrateIngress.requestParking`|object|Bounded request parking while a suspended actor is waiting for worker capacity.|
 |`mcp.policies.substrateIngress.requestParking.budget`|string|Maximum time to wait for the actor to become routable.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -113,7 +113,7 @@
 |`binds[].listeners[].name`|string|Name identifying this listener, referenced by `gateways: gateway-name/listener-name`.|
 |`binds[].listeners[].namespace`|string|Namespace scoping this listener.|
 |`binds[].listeners[].hostname`|string|Can be a wildcard|
-|`binds[].listeners[].protocol`|enum|Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, or HBONE.<br>Possible values: `HTTP`, `HTTPS`, `TLS`, `TCP`, `HBONE`.|
+|`binds[].listeners[].protocol`|enum|Protocol this listener accepts: HTTP, HTTPS, TCP, TLS, HBONE, or AUTO.<br>Possible values: `HTTP`, `HTTPS`, `TLS`, `TCP`, `HBONE`, `AUTO`.|
 |`binds[].listeners[].tls`|object|TLS configuration, used with the HTTPS and TLS protocols.|
 |`binds[].listeners[].tls.mode`|enum|Certificate source mode. Static mode uses cert/key as the leaf certificate; dynamic CA<br>mode uses cert/key as a CA for on-demand SNI leaf certificate issuance.<br>Unused when `spiffe` is set.<br>Possible values: `static`, `dynamicCa`.|
 |`binds[].listeners[].tls.cert`|string|Path to the TLS certificate file (leaf certificate, or CA certificate in dynamic CA mode).<br>Required unless `spiffe` is set.|


### PR DESCRIPTION
Supersedes #2906 for auto bind listeners. Also, identify the actor via mTLS cert instead of headers (which, as far as I can tell, never existed). This PR also augments the substrateIngress policy to allow tunneling to atunnel's CONNECT port, allowing the following configurations

<details>
<summary>Atenet Router/Ingress</summary>

```yaml
    config:
      # Actor sandboxes behind a worker IP are replaced between requests. Do
      # not retain an idle connection that may belong to the previous actor.
      backend:
        poolMaxSize: 0

    frontendPolicies:
      tracing:
        host: $AGENTGATEWAY_OTLP_ADDRESS
        protocol: grpc
        # Matches the router's dataPlaneTraceRatio; static config, so a router
        # OTEL_TRACES_SAMPLER override must adjust it in step.
        randomSampling: 0.01

    # HTTP and HTTPS accept ordinary actor requests. CONNECT is exposed on
    # separate binds below so those requests can be terminated and re-entered.
    gateways:
      http:
        port: 8080
        protocol: HTTP
      https:
        port: 8443
        protocol: HTTPS
        tls:
          cert: /run/servicedns.podcert.ate.dev/credential-bundle.pem
          key: /run/servicedns.podcert.ate.dev/credential-bundle.pem

    backends:
    - name: dynamic
      dynamic: {}
      policies:
        # atunnel is the dynamic worker-side proxy. The inner target is the
        # actor, while this mTLS leg reaches atunnel's CONNECT listener.
        backendTunnel:
          proxy:
            backend: /dynamic
          mode: connect
          policies:
            backendTLS:
              cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
              key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
              root: /run/podidentity.podcert.ate.dev/trust-bundle.pem
              insecureHost: true

    routes:
    - name: substrate-actors
      gateways:
      - http
      - https
      matches:
      - path:
          pathPrefix: /
      policies:
        # AgentGateway calls ate-api directly to resume and resolve the actor.
        substrateIngress:
          host: api.ate-system.svc:443
          # Raw client CONNECT streams must be relayed through atunnel's
          # dedicated CONNECT listener, rather than its HTTP ingress listener.
          connectTargetPort: 8443
          policies:
            # ate-api presents a servicedns certificate and requires the
            # gateway's podidentity client credential.
            backendTLS:
              cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
              key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
              root: /run/servicedns-ca/trust-bundle.pem
      backends:
      - backend: /dynamic

    # Client CONNECT is terminated on dedicated plaintext and TLS ports. The
    # upgraded byte stream retains the CONNECT authority and headers, then
    # re-enters the wildcard internal bind below.
    binds:
    - port: 8081
      tunnelProtocol: connect
      listeners:
      - protocol: HTTP
        routes: []
    - port: 8444
      tunnelProtocol: connect
      listeners:
      - protocol: HTTPS
        tls:
          cert: /run/servicedns.podcert.ate.dev/credential-bundle.pem
          key: /run/servicedns.podcert.ate.dev/credential-bundle.pem
        routes: []
    - mode: internal
      listeners:
      - protocol: HTTP
        routes:
        - name: substrate-actors-tunneled
          matches:
          - path:
              pathPrefix: /
          policies:
            substrateIngress:
              host: api.ate-system.svc:443
              connectTargetPort: 8443
              policies:
                backendTLS:
                  cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
                  key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
                  root: /run/servicedns-ca/trust-bundle.pem
          backends:
          - backend: /dynamic
```
</details>

<details>
<summary>Egress PEP</summary>

```yaml
# yaml-language-server: $schema=https://agentgateway.dev/schema/config
binds:
# The actor tunnel is mutually authenticated with the actor identity SVID.
# CONNECT then re-enters the internal bind selected by :authority.
- port: 8443
  tunnelProtocol: connect
  listeners:
  - protocol: HTTPS
    tls:
      cert: /run/servicedns.podcert.ate.dev/credential-bundle.pem
      key: /run/servicedns.podcert.ate.dev/credential-bundle.pem
      root: /run/actor-id-ca-certs/ca.crt
    # CONNECT is handled by the tunnel frontend and re-enters the
    # internal listeners below; an empty route list satisfies HTTPS
    # listener validation without admitting direct traffic here.
    routes: []

# A portless re-entry bind handles cleartext HTTP/1 and h2c after CONNECT.
# TLS is raw TCP passthrough in this default configuration; the optional
# MITM overlay adds a dynamic-CA HTTPS listener for the encrypted case.
- mode: internal
  protocol: AUTO
  listeners:
  - protocol: TLS
    hostname: "*"
    # TLS without a tls block inspects SNI when present but does not
    # terminate it.
    tcpRoutes:
    - backends:
      - dynamic:
          target: source.connectHeaders["host"]
  - protocol: HTTP
    routes:
    - policies:
        substrateEgress:
          host: api.ate-system.svc:443
          policies:
            backendTLS:
              cert: /run/podidentity.podcert.ate.dev/credential-bundle.pem
              key: /run/podidentity.podcert.ate.dev/credential-bundle.pem
              root: /run/servicedns-ca/trust-bundle.pem
      backends:
      - dynamic:
          target: source.connectHeaders["host"]
  # Raw streams have no HTTP host or TLS SNI. AUTO dispatches them to this
  # bind's one opaque-TCP listener.
  - protocol: TCP
    tcpRoutes:
    - backends:
      - dynamic:
          target: source.connectHeaders["host"]
```
</details>