### PR TITLE
xds: reject non-FIPS RSA key parameters when running in FIPS mode

### DIFF
--- a/controller/pkg/setup/xds_tls.go
+++ b/controller/pkg/setup/xds_tls.go
@@ -375,9 +375,9 @@ func generateLeafFromCA(caPEM, caKeyPEM []byte, hosts []string) ([]byte, []byte,
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), keyPEM, nil
 }
 
-// checkFIPSRSAKeyParameters validates RSA parameters on private keys the
-// controller uses to sign or serve xDS TLS material. It does not validate
-// non-RSA keys, certificate chains, or peer certificates. The fips140=on
+// checkFIPSRSAKeyParameters validates the RSA modulus and public exponent of
+// keys the controller uses to sign or serve xDS TLS material. It does not
+// validate non-RSA keys, certificate chains, or peer certificates. The fips140=on
 // setting restricts TLS algorithms but, unlike fips140=only, does not enforce
 // RSA key parameters itself. Keep standard builds backward compatible.
 func checkFIPSRSAKeyParameters(key crypto.PublicKey) error {

--- a/controller/pkg/setup/xds_tls.go
+++ b/controller/pkg/setup/xds_tls.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/fips140"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/subtle"
@@ -134,6 +135,9 @@ func (s *xdsTLSMaterialSyncer) refreshSecret(secret *corev1.Secret, force bool) 
 	cert.Leaf, err = parseCertificate(certPEM)
 	if err != nil {
 		return err
+	}
+	if err := checkFIPSRSAKeyParameters(cert.Leaf.PublicKey); err != nil {
+		return fmt.Errorf("xDS serving key: %w", err)
 	}
 	s.material.setCertificate(cert)
 	s.lastRV = secret.ResourceVersion
@@ -334,6 +338,9 @@ func generateLeafFromCA(caPEM, caKeyPEM []byte, hosts []string) ([]byte, []byte,
 	if !publicKeysEqual(caCert.PublicKey, caKey.Public()) {
 		return nil, nil, fmt.Errorf("CA certificate and key do not match")
 	}
+	if err := checkFIPSRSAKeyParameters(caKey.Public()); err != nil {
+		return nil, nil, fmt.Errorf("xDS CA key: %w", err)
+	}
 	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, err
@@ -366,6 +373,32 @@ func generateLeafFromCA(caPEM, caKeyPEM []byte, hosts []string) ([]byte, []byte,
 		return nil, nil, err
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), keyPEM, nil
+}
+
+// checkFIPSRSAKeyParameters validates RSA parameters on private keys the
+// controller uses to sign or serve xDS TLS material. It does not validate
+// non-RSA keys, certificate chains, or peer certificates. The fips140=on
+// setting restricts TLS algorithms but, unlike fips140=only, does not enforce
+// RSA key parameters itself. Keep standard builds backward compatible.
+func checkFIPSRSAKeyParameters(key crypto.PublicKey) error {
+	if !fips140.Enabled() {
+		return nil
+	}
+	rsaKey, ok := key.(*rsa.PublicKey)
+	if !ok {
+		return nil
+	}
+	bits := rsaKey.N.BitLen()
+	if bits < 2048 {
+		return fmt.Errorf("RSA modulus is %d bits; FIPS mode requires at least 2048 bits", bits)
+	}
+	if bits%2 != 0 {
+		return fmt.Errorf("RSA modulus is %d bits; FIPS mode requires an even modulus size", bits)
+	}
+	if rsaKey.E <= 1<<16 {
+		return fmt.Errorf("RSA public exponent is %d; FIPS mode requires an exponent greater than 2^16", rsaKey.E)
+	}
+	return nil
 }
 
 func parsePrivateKey(keyPEM []byte) (crypto.Signer, error) {

--- a/controller/pkg/setup/xds_tls_test.go
+++ b/controller/pkg/setup/xds_tls_test.go
@@ -426,7 +426,7 @@ func generateWeakRSAServingCert(t *testing.T) ([]byte, []byte) {
 
 func weakRSAKey(t *testing.T) *rsa.PrivateKey {
 	t.Helper()
-	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	key, err := rsa.GenerateKey(rand.Reader, 1024) //nolint:gosec // G403: the weak key is the point; FIPS mode must reject it
 	if err != nil {
 		t.Skipf("1024-bit RSA keys are unavailable: %v", err)
 	}

--- a/controller/pkg/setup/xds_tls_test.go
+++ b/controller/pkg/setup/xds_tls_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/fips140"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -333,4 +334,101 @@ func generateCACert(t *testing.T, commonName string, publicKey, privateKey any) 
 	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, publicKey, privateKey)
 	require.NoError(t, err)
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestGenerateLeafFromCARejectsWeakRSAKeyUnderFIPS(t *testing.T) {
+	caCert, caKey := generateWeakRSACA(t)
+
+	_, _, err := generateLeafFromCA(caCert, caKey, []string{"xds.default.svc"})
+	if fips140.Enabled() {
+		require.ErrorContains(t, err, "requires at least 2048 bits")
+		return
+	}
+	require.NoError(t, err)
+}
+
+func TestRefreshSecretRejectsWeakRSAServingKeyUnderFIPS(t *testing.T) {
+	certPEM, keyPEM := generateWeakRSAServingCert(t)
+	syncer := &xdsTLSMaterialSyncer{material: &xdsTLSMaterial{}, hosts: []string{"xds.default.svc"}}
+
+	err := syncer.refreshSecret(xdsSecret(map[string][]byte{
+		xdsCertKey:   certPEM,
+		xdsKeyKey:    keyPEM,
+		xdsCACertKey: certPEM,
+	}), true)
+	if fips140.Enabled() {
+		require.ErrorContains(t, err, "requires at least 2048 bits")
+		return
+	}
+	require.NoError(t, err)
+}
+
+func TestFIPSRSAKeyParameters(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	valid := key.PublicKey
+	oddModulusSize := valid
+	oddModulusSize.N = new(big.Int).Set(valid.N)
+	oddModulusSize.N.SetBit(oddModulusSize.N, 2048, 1)
+	smallExponent := valid
+	smallExponent.E = 3
+
+	tests := []struct {
+		name string
+		key  *rsa.PublicKey
+		want string
+	}{
+		{name: "approved", key: &valid},
+		{name: "odd modulus size", key: &oddModulusSize, want: "even modulus size"},
+		{name: "small exponent", key: &smallExponent, want: "greater than 2^16"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkFIPSRSAKeyParameters(tt.key)
+			if !fips140.Enabled() || tt.want == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.want)
+		})
+	}
+}
+
+func generateWeakRSACA(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	key := weakRSAKey(t)
+	cert := generateCACert(t, "weak-rsa-ca", &key.PublicKey, key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return cert, keyPEM
+}
+
+func generateWeakRSAServingCert(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	key := weakRSAKey(t)
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	require.NoError(t, err)
+	tpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "weak-rsa-leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"xds.default.svc"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return certPEM, keyPEM
+}
+
+func weakRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Skipf("1024-bit RSA keys are unavailable: %v", err)
+	}
+	return key
 }


### PR DESCRIPTION
The controller can be built with Go's FIPS 140-3 cryptographic module (`GOFIPS140=v1.0.0`, which stamps `DefaultGODEBUG=fips140=on`). In that mode Go restricts TLS algorithms, but it does not reject RSA keys whose parameters fall outside FIPS 186-5: `crypto/internal/fips140/rsa.checkPublicKey` only clears an internal `fipsApproved` flag for a modulus under 2048 bits, an odd modulus bit length, or a public exponent <= 2^16. The signing operation still runs, it is just recorded as non-approved via the service indicator. Only `fips140=only` turns those into hard errors, and that mode is too strict to build the controller with.

The practical consequence is that an operator can hand the controller a 1024-bit RSA CA or serving key in the xDS TLS secret and get a binary that claims FIPS mode while signing and serving xDS with a non-approved key, silently.

This adds `checkFIPSRSAKeyParameters`, which applies the same three FIPS 186-5 conditions Go uses for its approval flag and turns them into a load-time error. It runs on the two keys the controller actually signs or serves with:

- the CA key in `generateLeafFromCA`, before it is used to sign the xDS leaf
- the serving leaf key in `refreshSecret`, before the certificate is installed

Both paths fail closed, so a non-conforming key surfaces at startup or on secret reload with an actionable message rather than degrading the FIPS claim at runtime.

Scope is deliberately narrow: RSA only, and only on keys the controller signs or serves with. Certificate chains, peer certificates, and non-RSA keys are not validated here. The check is a no-op unless `fips140.Enabled()` is true, so standard builds are unaffected and existing keys of any size keep working.

The generated CA and generated leaf keys are ECDSA P-256, so this only ever applies to key material supplied by the operator.

### Testing

Unit tests cover the parameter check directly plus both call sites. Each asserts the rejection when `fips140.Enabled()` is true and the unchanged accept-everything behavior otherwise, so the suite is meaningful whichever way the controller is built:

    go test ./controller/pkg/setup/...
    GOFIPS140=v1.0.0 go test ./controller/pkg/setup/...

Both pass. The default build is not FIPS, so the `fips140.Enabled()` branches are exercised by the second form - that is the point of the fork in the tests rather than a build tag, since the same source has to be correct in both modes.

