### PR TITLE
Improve metrics endpoint handling

### DIFF
--- a/crates/agentgateway/src/management/metrics_server.rs
+++ b/crates/agentgateway/src/management/metrics_server.rs
@@ -62,6 +62,7 @@ async fn handle_metrics(reg: Arc<Registry>, req: Request<Incoming>) -> Result<Re
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum MetricsFormat {
 	#[default]
+	PlainText,
 	OpenMetricsText,
 	PrometheusProtobuf,
 }
@@ -69,6 +70,7 @@ enum MetricsFormat {
 impl MetricsFormat {
 	fn content_type(self) -> &'static str {
 		match self {
+			Self::PlainText => "text/plain;charset=utf-8",
 			Self::OpenMetricsText => {
 				"application/openmetrics-text;version=1.0.0;charset=utf-8;escaping=allow-utf-8"
 			},
@@ -80,7 +82,7 @@ impl MetricsFormat {
 
 	fn encode(self, registry: &Registry) -> Result<Vec<u8>> {
 		match self {
-			Self::OpenMetricsText => {
+			Self::OpenMetricsText | Self::PlainText => {
 				let mut buffer = String::new();
 				encode_openmetrics(&mut buffer, registry)?;
 				Ok(buffer.into_bytes())
@@ -92,7 +94,7 @@ impl MetricsFormat {
 
 fn negotiate_format<T>(req: &Request<T>) -> Option<MetricsFormat> {
 	use mediatype::Name;
-	use mediatype::names::{APPLICATION, Q};
+	use mediatype::names::{APPLICATION, PLAIN, Q, TEXT};
 
 	let mut values = req.headers().get_all(http::header::ACCEPT).iter();
 	Accept::decode(&mut values)
@@ -107,15 +109,16 @@ fn negotiate_format<T>(req: &Request<T>) -> Option<MetricsFormat> {
 		})
 		.collect::<Accept>()
 		.negotiate(&[
+			MediaType::new(TEXT, PLAIN),
 			MediaType::new(APPLICATION, Name::new_unchecked("openmetrics-text")),
 			MediaType::new(APPLICATION, Name::new_unchecked("vnd.google.protobuf")),
 			MediaType::new(APPLICATION, Name::new_unchecked("protobuf")),
 			MediaType::new(APPLICATION, Name::new_unchecked("x-protobuf")),
 		])
-		.and_then(|media_type| match media_type.subty.as_str() {
-			"openmetrics-text" => Some(MetricsFormat::OpenMetricsText),
-			"vnd.google.protobuf" | "protobuf" | "x-protobuf" => Some(MetricsFormat::PrometheusProtobuf),
-			_ => None,
+		.map(|media_type| match media_type.subty.as_str() {
+			"openmetrics-text" => MetricsFormat::OpenMetricsText,
+			"vnd.google.protobuf" | "protobuf" | "x-protobuf" => MetricsFormat::PrometheusProtobuf,
+			_ => MetricsFormat::PlainText,
 		})
 }
 
@@ -133,12 +136,13 @@ mod tests {
 	use crate::Address;
 
 	#[rstest]
-	#[case::no_accept(None, MetricsFormat::OpenMetricsText)]
-	#[case::wildcard(Some("*/*"), MetricsFormat::OpenMetricsText)]
+	#[case::no_accept(None, MetricsFormat::PlainText)]
+	#[case::wildcard(Some("*/*"), MetricsFormat::PlainText)]
 	#[case::openmetrics(
 		Some("application/openmetrics-text;version=1.0.0"),
 		MetricsFormat::OpenMetricsText
 	)]
+	#[case::plain_text(Some("text/plain;version=0.0.4"), MetricsFormat::PlainText)]
 	#[case::canonical_protobuf(
 		Some(
 			"APPLICATION/VND.GOOGLE.PROTOBUF;PROTO=io.prometheus.client.MetricFamily;ENCODING=delimited"
@@ -194,7 +198,7 @@ mod tests {
 		"application/vnd.google.protobuf;q=0.9,text/plain;q=0.8",
 		MetricsFormat::PrometheusProtobuf
 	)]
-	#[case::wildcard_parameter("*/*;unknown=parameter", MetricsFormat::OpenMetricsText)]
+	#[case::wildcard_parameter("*/*;unknown=parameter", MetricsFormat::PlainText)]
 	#[case::quoted_openmetrics_parameters(
 		"application/openmetrics-text;version=\"1.0.0\";escaping=\"allow-utf-8\"",
 		MetricsFormat::OpenMetricsText
@@ -219,7 +223,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn serves_each_wire_format() {
+	async fn serves_each_metrics_format() {
 		let counter: Counter = Counter::default();
 		let mut registry = Registry::default();
 		registry.register("requests", "Requests", counter.clone());
@@ -253,6 +257,19 @@ mod tests {
 			"application/openmetrics-text;version=1.0.0;charset=utf-8;escaping=allow-utf-8"
 		);
 		assert!(openmetrics.bytes().await.unwrap().ends_with(b"# EOF\n"));
+
+		let plain_text = client
+			.get(&url)
+			.header("accept", "text/plain;version=0.0.4")
+			.send()
+			.await
+			.unwrap();
+		assert_eq!(plain_text.status(), reqwest::StatusCode::OK);
+		assert_eq!(
+			plain_text.headers()[reqwest::header::CONTENT_TYPE],
+			"text/plain;charset=utf-8"
+		);
+		assert!(plain_text.text().await.unwrap().contains("requests_total"));
 
 		let protobuf = client
 			.get(url)

--- a/crates/agentgateway/src/management/metrics_server.rs
+++ b/crates/agentgateway/src/management/metrics_server.rs
@@ -1,15 +1,16 @@
 // Originally derived from https://github.com/istio/ztunnel (Apache 2.0 licensed)
 
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use agent_core::drain::DrainWatcher;
+use anyhow::{Context, Result};
 use headers::Header;
 use headers_accept::Accept;
-use hyper::Request;
 use hyper::body::Incoming;
+use hyper::{Request, StatusCode, header};
 use mediatype::{MediaType, ReadParams, WriteParams};
-use prometheus_client::encoding::prometheus_protobuf::encode_to_vec as encode_protobuf;
+use prometheus_client::encoding::prometheus_protobuf;
 use prometheus_client::encoding::text::encode as encode_openmetrics;
 use prometheus_client::registry::Registry;
 
@@ -18,16 +19,12 @@ use crate::Address;
 use crate::http::Response;
 
 pub struct Server {
-	s: hyper_helpers::Server<Mutex<Registry>>,
+	s: hyper_helpers::Server<Registry>,
 }
 
 impl Server {
-	pub async fn new(
-		addr: Address,
-		drain_rx: DrainWatcher,
-		registry: Registry,
-	) -> anyhow::Result<Self> {
-		hyper_helpers::Server::<Mutex<Registry>>::bind("stats", addr, drain_rx, Mutex::new(registry))
+	pub async fn new(addr: Address, drain_rx: DrainWatcher, registry: Registry) -> Result<Self> {
+		hyper_helpers::Server::<Registry>::bind("stats", addr, drain_rx, registry)
 			.await
 			.map(|s| Server { s })
 	}
@@ -39,202 +36,240 @@ impl Server {
 	pub fn spawn(self) {
 		self.s.spawn(|registry, req| async move {
 			match req.uri().path() {
-				"/metrics" | "/stats/prometheus" => Ok(handle_metrics(registry, req).await),
+				"/metrics" | "/stats/prometheus" => handle_metrics(registry, req).await,
 				_ => Ok(hyper_helpers::empty_response(hyper::StatusCode::NOT_FOUND)),
 			}
 		})
 	}
 }
 
-async fn handle_metrics(reg: Arc<Mutex<Registry>>, req: Request<Incoming>) -> Response {
-	let reg = reg.lock().expect("mutex");
-	let content_type = content_type(&req);
-	let result = match content_type {
-		ContentType::PlainText | ContentType::OpenMetrics => {
-			let mut str_buf = String::new();
-			encode_openmetrics(&mut str_buf, &reg)
-				.map(|_| str_buf.into_bytes())
-				.map_err(|err| err.to_string())
-		},
-		ContentType::Protobuf => encode_protobuf(&reg).map_err(|err| err.to_string()),
-	};
-	match result {
-		Ok(buf) => ::http::Response::builder()
-			.status(hyper::StatusCode::OK)
-			.header(
-				hyper::header::CONTENT_TYPE,
-				Into::<&str>::into(content_type),
-			)
-			.body(buf.into()),
-		Err(err) => ::http::Response::builder()
-			.status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
-			.body(err.into()),
-	}
-	.expect("builder with known status code should not fail")
+async fn handle_metrics(reg: Arc<Registry>, req: Request<Incoming>) -> Result<Response> {
+	let format = negotiate_format(&req).unwrap_or_default();
+
+	let body = tokio::task::spawn_blocking(move || format.encode(&reg))
+		.await
+		.context("metrics encoding failed")??;
+
+	Ok(
+		::http::Response::builder()
+			.status(StatusCode::OK)
+			.header(header::CONTENT_TYPE, format.content_type())
+			.header(header::VARY, header::ACCEPT.as_str())
+			.body(body.into())?,
+	)
 }
 
-#[derive(Copy, Clone, Default)]
-enum ContentType {
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum MetricsFormat {
 	#[default]
-	PlainText,
-	OpenMetrics,
-	Protobuf,
+	OpenMetricsText,
+	PrometheusProtobuf,
 }
 
-impl From<ContentType> for &str {
-	fn from(c: ContentType) -> Self {
-		match c {
-			ContentType::PlainText => "text/plain;charset=utf-8",
-			ContentType::OpenMetrics => "application/openmetrics-text;version=1.0.0;charset=utf-8",
-			ContentType::Protobuf => {
+impl MetricsFormat {
+	fn content_type(self) -> &'static str {
+		match self {
+			Self::OpenMetricsText => {
+				"application/openmetrics-text;version=1.0.0;charset=utf-8;escaping=allow-utf-8"
+			},
+			Self::PrometheusProtobuf => {
 				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
 			},
 		}
 	}
-}
 
-fn content_type_from_media_type(m: &MediaType) -> Option<ContentType> {
-	let ty_str: &str = m.ty.as_str();
-	if ty_str == mediatype::names::TEXT.as_str() && m.subty == mediatype::names::PLAIN.as_str() {
-		return Some(ContentType::PlainText);
-	}
-	if ty_str != mediatype::names::APPLICATION.as_str() {
-		return None;
-	}
-	match m.subty.as_str() {
-		"openmetrics-text" => Some(ContentType::OpenMetrics),
-		"vnd.google.protobuf" | "protobuf" | "x-protobuf" => Some(ContentType::Protobuf),
-		_ => None,
+	fn encode(self, registry: &Registry) -> Result<Vec<u8>> {
+		match self {
+			Self::OpenMetricsText => {
+				let mut buffer = String::new();
+				encode_openmetrics(&mut buffer, registry)?;
+				Ok(buffer.into_bytes())
+			},
+			Self::PrometheusProtobuf => Ok(prometheus_protobuf::encode_to_vec(registry)?),
+		}
 	}
 }
 
-const AVAILABLE_MEDIA_TYPES: [MediaType<'static>; 5] = [
-	MediaType::new(mediatype::names::TEXT, mediatype::names::PLAIN),
-	MediaType::new(
-		mediatype::names::APPLICATION,
-		mediatype::Name::new_unchecked("openmetrics-text"),
-	),
-	MediaType::new(
-		mediatype::names::APPLICATION,
-		mediatype::Name::new_unchecked("vnd.google.protobuf"),
-	),
-	MediaType::new(
-		mediatype::names::APPLICATION,
-		mediatype::Name::new_unchecked("protobuf"),
-	),
-	MediaType::new(
-		mediatype::names::APPLICATION,
-		mediatype::Name::new_unchecked("x-protobuf"),
-	),
-];
+fn negotiate_format<T>(req: &Request<T>) -> Option<MetricsFormat> {
+	use mediatype::Name;
+	use mediatype::names::{APPLICATION, Q};
 
-#[inline(always)]
-fn content_type<T>(req: &Request<T>) -> ContentType {
 	let mut values = req.headers().get_all(http::header::ACCEPT).iter();
-	let accept = match Accept::decode(&mut values) {
-		Ok(header) => header,
-		Err(_) => return ContentType::default(),
-	};
-	let normalized_accept = accept
+	Accept::decode(&mut values)
+		.ok()?
 		.media_types()
 		.map(|media_type| {
 			let mut normalized = media_type.essence();
-			if let Some(q) = media_type.get_param(mediatype::names::Q) {
-				normalized.set_param(mediatype::names::Q, q);
+			if let Some(quality) = media_type.get_param(Q) {
+				normalized.set_param(Q, quality);
 			}
 			normalized
 		})
-		.collect::<Accept>();
-	normalized_accept
-		.negotiate(&AVAILABLE_MEDIA_TYPES)
-		.and_then(content_type_from_media_type)
-		.unwrap_or_default()
+		.collect::<Accept>()
+		.negotiate(&[
+			MediaType::new(APPLICATION, Name::new_unchecked("openmetrics-text")),
+			MediaType::new(APPLICATION, Name::new_unchecked("vnd.google.protobuf")),
+			MediaType::new(APPLICATION, Name::new_unchecked("protobuf")),
+			MediaType::new(APPLICATION, Name::new_unchecked("x-protobuf")),
+		])
+		.and_then(|media_type| match media_type.subty.as_str() {
+			"openmetrics-text" => Some(MetricsFormat::OpenMetricsText),
+			"vnd.google.protobuf" | "protobuf" | "x-protobuf" => Some(MetricsFormat::PrometheusProtobuf),
+			_ => None,
+		})
 }
 
 #[cfg(test)]
-mod test {
-	#[test]
-	fn test_content_type() {
-		let plain_text_req = http::Request::new("I want some plain text");
-		assert_eq!(
-			Into::<&str>::into(super::content_type(&plain_text_req)),
-			"text/plain;charset=utf-8"
-		);
+mod tests {
+	use std::net::{Ipv4Addr, SocketAddr};
 
-		let json_or_text_req = http::Request::builder()
-			.header("X-Custom-Beep", "boop")
-			.header("Accept", "application/json")
-			.header("Accept", "application/openmetrics-text; other stuff")
-			.body("Invalid header defaulting to text/plain")
+	use prometheus_client::encoding::prometheus_protobuf::prometheus_data_model::MetricFamily;
+	use prometheus_client::metrics::counter::Counter;
+	use prometheus_client::registry::Registry;
+	use prost::Message;
+	use rstest::rstest;
+
+	use super::{MetricsFormat, Server};
+	use crate::Address;
+
+	#[rstest]
+	#[case::no_accept(None, MetricsFormat::OpenMetricsText)]
+	#[case::wildcard(Some("*/*"), MetricsFormat::OpenMetricsText)]
+	#[case::openmetrics(
+		Some("application/openmetrics-text;version=1.0.0"),
+		MetricsFormat::OpenMetricsText
+	)]
+	#[case::canonical_protobuf(
+		Some(
+			"APPLICATION/VND.GOOGLE.PROTOBUF;PROTO=io.prometheus.client.MetricFamily;ENCODING=delimited"
+		),
+		MetricsFormat::PrometheusProtobuf
+	)]
+	#[case::protobuf_alias(Some("application/protobuf"), MetricsFormat::PrometheusProtobuf)]
+	#[case::x_protobuf_alias(Some("application/x-protobuf"), MetricsFormat::PrometheusProtobuf)]
+	fn negotiates_supported_formats(#[case] accept: Option<&str>, #[case] expected: MetricsFormat) {
+		let mut request = http::Request::new(());
+		if let Some(accept) = accept {
+			request
+				.headers_mut()
+				.insert(http::header::ACCEPT, accept.parse().unwrap());
+		}
+		assert_eq!(
+			super::negotiate_format(&request).unwrap_or_default(),
+			expected
+		);
+	}
+
+	#[rstest]
+	#[case::openmetrics_preferred(
+		"application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,application/openmetrics-text;version=0.0.1;q=0.4,text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3,text/plain;version=0.0.4;q=0.2,*/*;q=0.1",
+		MetricsFormat::OpenMetricsText
+	)]
+	#[case::protobuf_preferred(
+		"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6,application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,application/openmetrics-text;version=0.0.1;q=0.4,text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3,text/plain;version=0.0.4;q=0.2,*/*;q=0.1",
+		MetricsFormat::PrometheusProtobuf
+	)]
+	fn negotiates_prometheus_scrape_headers(#[case] accept: &str, #[case] expected: MetricsFormat) {
+		let request = http::Request::builder()
+			.header(http::header::ACCEPT, accept)
+			.body(())
 			.unwrap();
 		assert_eq!(
-			Into::<&str>::into(super::content_type(&json_or_text_req)),
-			"text/plain;charset=utf-8"
+			super::negotiate_format(&request).unwrap_or_default(),
+			expected,
+			"{accept}"
 		);
+	}
 
-		let openmetrics_req = http::Request::builder()
-			.header("Accept", "application/openmetrics-text;version=0.0.1")
-			.body("I would like OpenMetrics")
+	#[rstest]
+	#[case::quality(
+		"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6,application/openmetrics-text;version=1.0.0;q=0.5,text/plain;version=0.0.4;q=0.4",
+		MetricsFormat::PrometheusProtobuf
+	)]
+	#[case::bare_openmetrics(
+		"application/openmetrics-text;q=0.9,text/plain;q=0.8",
+		MetricsFormat::OpenMetricsText
+	)]
+	#[case::bare_protobuf(
+		"application/vnd.google.protobuf;q=0.9,text/plain;q=0.8",
+		MetricsFormat::PrometheusProtobuf
+	)]
+	#[case::wildcard_parameter("*/*;unknown=parameter", MetricsFormat::OpenMetricsText)]
+	#[case::quoted_openmetrics_parameters(
+		"application/openmetrics-text;version=\"1.0.0\";escaping=\"allow-utf-8\"",
+		MetricsFormat::OpenMetricsText
+	)]
+	#[case::quoted_protobuf_parameters(
+		"application/vnd.google.protobuf;proto=\"io.prometheus.client.MetricFamily\";encoding=\"delimited\"",
+		MetricsFormat::PrometheusProtobuf
+	)]
+	fn honors_quality_and_representation_parameters(
+		#[case] accept: &str,
+		#[case] expected: MetricsFormat,
+	) {
+		let request = http::Request::builder()
+			.header(http::header::ACCEPT, accept)
+			.body(())
 			.unwrap();
 		assert_eq!(
-			Into::<&str>::into(super::content_type(&openmetrics_req)),
-			"application/openmetrics-text;version=1.0.0;charset=utf-8"
+			super::negotiate_format(&request).unwrap_or_default(),
+			expected,
+			"{accept}"
 		);
+	}
 
-		let mixed_req = http::Request::builder()
-          .header("X-Custom-Beep", "boop")
-		  .header("Accept", "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6,application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,application/openmetrics-text;version=0.0.1;q=0.4,text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3,text/plain;version=0.0.4;q=0.2,*/*;q=0.1")
-          .body("I would like protobuf")
-          .unwrap();
-		assert_eq!(
-			Into::<&str>::into(super::content_type(&mixed_req)),
-			"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
-		);
+	#[tokio::test]
+	async fn serves_each_wire_format() {
+		let counter: Counter = Counter::default();
+		let mut registry = Registry::default();
+		registry.register("requests", "Requests", counter.clone());
+		counter.inc();
 
-		let unsupported_req_accept = http::Request::builder()
-			.header("Accept", "application/json")
-			.body("I would like some json")
-			.unwrap();
-		// asking for something we don't support, fall back to plaintext
-		assert_eq!(
-			Into::<&str>::into(super::content_type(&unsupported_req_accept)),
-			"text/plain;charset=utf-8"
-		);
+		let (_drain_tx, drain_rx) = agent_core::drain::new();
+		let server = Server::new(
+			Address::SocketAddr(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))),
+			drain_rx,
+			registry,
+		)
+		.await
+		.unwrap();
+		let address = server.address().unwrap();
+		server.spawn();
 
-		let q_values_req = http::Request::builder()
+		let client = reqwest::Client::new();
+		let url = format!("http://{address}/metrics");
+		let openmetrics = client
+			.get(&url)
 			.header(
-				"Accept",
-				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.1, text/plain;q=0.9",
+				"accept",
+				"application/openmetrics-text;version=1.0.0;escaping=allow-utf-8",
 			)
-			.body("text is preferred")
+			.send()
+			.await
 			.unwrap();
+		assert_eq!(openmetrics.status(), reqwest::StatusCode::OK);
 		assert_eq!(
-			Into::<&str>::into(super::content_type(&q_values_req)),
-			"text/plain;charset=utf-8"
+			openmetrics.headers()[reqwest::header::CONTENT_TYPE],
+			"application/openmetrics-text;version=1.0.0;charset=utf-8;escaping=allow-utf-8"
 		);
+		assert!(openmetrics.bytes().await.unwrap().ends_with(b"# EOF\n"));
 
-		let q_zero_req = http::Request::builder()
+		let protobuf = client
+			.get(url)
 			.header(
-				"Accept",
-				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0, text/plain;q=1",
-			)
-			.body("protobuf is forbidden")
-			.unwrap();
-		assert_eq!(
-			Into::<&str>::into(super::content_type(&q_zero_req)),
-			"text/plain;charset=utf-8"
-		);
-
-		let parameterized_protobuf_req = http::Request::builder()
-			.header(
-				"Accept",
+				"accept",
 				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited",
 			)
-			.body("protobuf parameters describe the representation")
+			.send()
+			.await
 			.unwrap();
+		assert_eq!(protobuf.status(), reqwest::StatusCode::OK);
 		assert_eq!(
-			Into::<&str>::into(super::content_type(&parameterized_protobuf_req)),
+			protobuf.headers()[reqwest::header::CONTENT_TYPE],
 			"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
 		);
+		let protobuf = protobuf.bytes().await.unwrap();
+		let family = MetricFamily::decode_length_delimited(protobuf.as_ref()).unwrap();
+		assert_eq!(family.name, "requests_total");
 	}
 }

--- a/examples/mcp-telemetry/README.md
+++ b/examples/mcp-telemetry/README.md
@@ -52,13 +52,14 @@ agentgateway_requests_total{gateway="bind/3000",method="DELETE",status="202"} 2
 
 ## Metrics Formats
 
-The metrics can be retrived in either text format or protobuf, controlled via the `Accept` header on the request. Specifying multiple formats with a quality parameter will cause the gateway to choose the best match of highest quality (standard accept header behaviour).
+Metrics are available as OpenMetrics text or Prometheus protobuf, selected using the request's `Accept` header. When multiple formats are requested, standard quality parameters determine which supported format is returned.
 
-If you use protobuf, the response contains length-delimited `io.prometheus.client.MetricFamily` messages. These can be deserialized using the official [Prometheus protobuf definition](https://github.com/prometheus/prometheus/blob/main/prompb/io/prometheus/client/metrics.proto).
+For OpenMetrics text, use:
 
-For OpenMetrics text format use `Accept: application/openmetrics-text`.
+* `Accept: application/openmetrics-text;version=1.0.0`
 
-For Protobuf use one of:
-* `Accept: application/vnd.google.protobuf`
-* `Accept: application/protobuf`
-* `Accept: application/x-protobuf`
+For Prometheus protobuf, use:
+
+* `Accept: application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited`
+
+The protobuf response is a length-delimited stream of `io.prometheus.client.MetricFamily` messages defined by the official [Prometheus client model](https://github.com/prometheus/client_model/blob/master/io/prometheus/client/metrics.proto).


### PR DESCRIPTION
This PR follows up on #3186 by simplifying metrics content negotiation. It defaults to `text/plain`, matching ztunnel’s behavior, while supporting explicit OpenMetrics text and Prometheus protobuf requests.

### Additional cleanup

- Removes the unnecessary registry mutex.
- Moves metrics encoding off the async runtime.
- Adds HTTP-level Rust tests for all supported formats.
- Correctly identifies protobuf responses as delimited `MetricFamily` messages.

Validated default, OpenMetrics, and protobuf scraping with Prometheus using:

```yaml
global:
  scrape_interval: 1s

scrape_configs:
- job_name: default
  static_configs:
  - targets: [127.0.0.1:15020]
- job_name: openmetrics
  scrape_protocols: [OpenMetricsText1.0.0]
  static_configs:
  - targets: [127.0.0.1:15020]
- job_name: protobuf
  scrape_protocols: [PrometheusProto]
  static_configs:
  - targets: [127.0.0.1:15020]