### PR TITLE
metrics: minimal fix to return prometheus compat

### DIFF
--- a/crates/agentgateway/src/management/metrics_server.rs
+++ b/crates/agentgateway/src/management/metrics_server.rs
@@ -10,7 +10,7 @@ use hyper::Request;
 use hyper::body::Incoming;
 use mediatype::{MediaType, ReadParams, WriteParams};
 use prometheus_client::encoding::prometheus_protobuf::encode_to_vec as encode_protobuf;
-use prometheus_client::encoding::text::encode as encode_text;
+use prometheus_client::encoding::text::encode as encode_openmetrics;
 use prometheus_client::registry::Registry;
 
 use super::hyper_helpers;
@@ -50,9 +50,9 @@ async fn handle_metrics(reg: Arc<Mutex<Registry>>, req: Request<Incoming>) -> Re
 	let reg = reg.lock().expect("mutex");
 	let content_type = content_type(&req);
 	let result = match content_type {
-		ContentType::PlainText => {
+		ContentType::OpenMetrics => {
 			let mut str_buf = String::new();
-			encode_text(&mut str_buf, &reg)
+			encode_openmetrics(&mut str_buf, &reg)
 				.map(|_| str_buf.into_bytes())
 				.map_err(|err| err.to_string())
 		},
@@ -76,16 +76,16 @@ async fn handle_metrics(reg: Arc<Mutex<Registry>>, req: Request<Incoming>) -> Re
 #[derive(Default)]
 enum ContentType {
 	#[default]
-	PlainText,
+	OpenMetrics,
 	Protobuf,
 }
 
 impl From<ContentType> for &str {
 	fn from(c: ContentType) -> Self {
 		match c {
-			ContentType::PlainText => "text/plain;charset=utf-8",
+			ContentType::OpenMetrics => "application/openmetrics-text;version=1.0.0;charset=utf-8",
 			ContentType::Protobuf => {
-				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricSet;encoding=delimited;version=1.0.0"
+				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
 			},
 		}
 	}
@@ -93,19 +93,21 @@ impl From<ContentType> for &str {
 
 fn content_type_from_media_type(m: &MediaType) -> Option<ContentType> {
 	let ty_str: &str = m.ty.as_str();
-	if ty_str == mediatype::names::TEXT.as_str() && m.subty == mediatype::names::PLAIN.as_str() {
-		return Some(ContentType::PlainText);
-	} else if ty_str != mediatype::names::APPLICATION.as_str() {
+	if ty_str != mediatype::names::APPLICATION.as_str() {
 		return None;
 	}
 	match m.subty.as_str() {
+		"openmetrics-text" => Some(ContentType::OpenMetrics),
 		"vnd.google.protobuf" | "protobuf" | "x-protobuf" => Some(ContentType::Protobuf),
 		_ => None,
 	}
 }
 
 const AVAILABLE_MEDIA_TYPES: [MediaType<'static>; 4] = [
-	MediaType::new(mediatype::names::TEXT, mediatype::names::PLAIN),
+	MediaType::new(
+		mediatype::names::APPLICATION,
+		mediatype::Name::new_unchecked("openmetrics-text"),
+	),
 	MediaType::new(
 		mediatype::names::APPLICATION,
 		mediatype::Name::new_unchecked("vnd.google.protobuf"),
@@ -143,13 +145,14 @@ fn content_type<T>(req: &Request<T>) -> ContentType {
 		.unwrap_or_default()
 }
 
+#[cfg(test)]
 mod test {
 	#[test]
 	fn test_content_type() {
 		let plain_text_req = http::Request::new("I want some plain text");
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&plain_text_req)),
-			"text/plain;charset=utf-8"
+			"application/openmetrics-text;version=1.0.0;charset=utf-8"
 		);
 
 		let json_or_text_req = http::Request::builder()
@@ -160,17 +163,26 @@ mod test {
 			.unwrap();
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&json_or_text_req)),
-			"text/plain;charset=utf-8"
+			"application/openmetrics-text;version=1.0.0;charset=utf-8"
+		);
+
+		let openmetrics_req = http::Request::builder()
+			.header("Accept", "application/openmetrics-text;version=0.0.1")
+			.body("I would like OpenMetrics")
+			.unwrap();
+		assert_eq!(
+			Into::<&str>::into(super::content_type(&openmetrics_req)),
+			"application/openmetrics-text;version=1.0.0;charset=utf-8"
 		);
 
 		let mixed_req = http::Request::builder()
           .header("X-Custom-Beep", "boop")
-          .header("Accept", "application/vnd.google.protobuf;proto=io.prometheus.client.MetricSet;encoding=delimited;q=0.6,application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,application/openmetrics-text;version=0.0.1;q=0.4,text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3,text/plain;version=0.0.4;q=0.2,*/*;q=0.1")
+		  .header("Accept", "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.6,application/openmetrics-text;version=1.0.0;escaping=allow-utf-8;q=0.5,application/openmetrics-text;version=0.0.1;q=0.4,text/plain;version=1.0.0;escaping=allow-utf-8;q=0.3,text/plain;version=0.0.4;q=0.2,*/*;q=0.1")
           .body("I would like protobuf")
           .unwrap();
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&mixed_req)),
-			"application/vnd.google.protobuf;proto=io.prometheus.client.MetricSet;encoding=delimited;version=1.0.0"
+			"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
 		);
 
 		let unsupported_req_accept = http::Request::builder()
@@ -180,43 +192,43 @@ mod test {
 		// asking for something we don't support, fall back to plaintext
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&unsupported_req_accept)),
-			"text/plain;charset=utf-8"
+			"application/openmetrics-text;version=1.0.0;charset=utf-8"
 		);
 
 		let q_values_req = http::Request::builder()
 			.header(
 				"Accept",
-				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricSet;encoding=delimited;q=0.1, text/plain;q=0.9",
+				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.1, text/plain;q=0.9",
 			)
 			.body("text is preferred")
 			.unwrap();
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&q_values_req)),
-			"text/plain;charset=utf-8"
+			"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
 		);
 
 		let q_zero_req = http::Request::builder()
 			.header(
 				"Accept",
-				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricSet;encoding=delimited;q=0, text/plain;q=1",
+				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0, text/plain;q=1",
 			)
 			.body("protobuf is forbidden")
 			.unwrap();
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&q_zero_req)),
-			"text/plain;charset=utf-8"
+			"application/openmetrics-text;version=1.0.0;charset=utf-8"
 		);
 
 		let parameterized_protobuf_req = http::Request::builder()
 			.header(
 				"Accept",
-				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricSet;encoding=delimited",
+				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited",
 			)
 			.body("protobuf parameters describe the representation")
 			.unwrap();
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&parameterized_protobuf_req)),
-			"application/vnd.google.protobuf;proto=io.prometheus.client.MetricSet;encoding=delimited;version=1.0.0"
+			"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
 		);
 	}
 }

--- a/crates/agentgateway/src/management/metrics_server.rs
+++ b/crates/agentgateway/src/management/metrics_server.rs
@@ -50,7 +50,7 @@ async fn handle_metrics(reg: Arc<Mutex<Registry>>, req: Request<Incoming>) -> Re
 	let reg = reg.lock().expect("mutex");
 	let content_type = content_type(&req);
 	let result = match content_type {
-		ContentType::OpenMetrics => {
+		ContentType::PlainText | ContentType::OpenMetrics => {
 			let mut str_buf = String::new();
 			encode_openmetrics(&mut str_buf, &reg)
 				.map(|_| str_buf.into_bytes())
@@ -73,9 +73,10 @@ async fn handle_metrics(reg: Arc<Mutex<Registry>>, req: Request<Incoming>) -> Re
 	.expect("builder with known status code should not fail")
 }
 
-#[derive(Default)]
+#[derive(Copy, Clone, Default)]
 enum ContentType {
 	#[default]
+	PlainText,
 	OpenMetrics,
 	Protobuf,
 }
@@ -83,6 +84,7 @@ enum ContentType {
 impl From<ContentType> for &str {
 	fn from(c: ContentType) -> Self {
 		match c {
+			ContentType::PlainText => "text/plain;charset=utf-8",
 			ContentType::OpenMetrics => "application/openmetrics-text;version=1.0.0;charset=utf-8",
 			ContentType::Protobuf => {
 				"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
@@ -93,6 +95,9 @@ impl From<ContentType> for &str {
 
 fn content_type_from_media_type(m: &MediaType) -> Option<ContentType> {
 	let ty_str: &str = m.ty.as_str();
+	if ty_str == mediatype::names::TEXT.as_str() && m.subty == mediatype::names::PLAIN.as_str() {
+		return Some(ContentType::PlainText);
+	}
 	if ty_str != mediatype::names::APPLICATION.as_str() {
 		return None;
 	}
@@ -103,7 +108,8 @@ fn content_type_from_media_type(m: &MediaType) -> Option<ContentType> {
 	}
 }
 
-const AVAILABLE_MEDIA_TYPES: [MediaType<'static>; 4] = [
+const AVAILABLE_MEDIA_TYPES: [MediaType<'static>; 5] = [
+	MediaType::new(mediatype::names::TEXT, mediatype::names::PLAIN),
 	MediaType::new(
 		mediatype::names::APPLICATION,
 		mediatype::Name::new_unchecked("openmetrics-text"),
@@ -152,7 +158,7 @@ mod test {
 		let plain_text_req = http::Request::new("I want some plain text");
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&plain_text_req)),
-			"application/openmetrics-text;version=1.0.0;charset=utf-8"
+			"text/plain;charset=utf-8"
 		);
 
 		let json_or_text_req = http::Request::builder()
@@ -163,7 +169,7 @@ mod test {
 			.unwrap();
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&json_or_text_req)),
-			"application/openmetrics-text;version=1.0.0;charset=utf-8"
+			"text/plain;charset=utf-8"
 		);
 
 		let openmetrics_req = http::Request::builder()
@@ -192,7 +198,7 @@ mod test {
 		// asking for something we don't support, fall back to plaintext
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&unsupported_req_accept)),
-			"application/openmetrics-text;version=1.0.0;charset=utf-8"
+			"text/plain;charset=utf-8"
 		);
 
 		let q_values_req = http::Request::builder()
@@ -204,7 +210,7 @@ mod test {
 			.unwrap();
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&q_values_req)),
-			"application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited"
+			"text/plain;charset=utf-8"
 		);
 
 		let q_zero_req = http::Request::builder()
@@ -216,7 +222,7 @@ mod test {
 			.unwrap();
 		assert_eq!(
 			Into::<&str>::into(super::content_type(&q_zero_req)),
-			"application/openmetrics-text;version=1.0.0;charset=utf-8"
+			"text/plain;charset=utf-8"
 		);
 
 		let parameterized_protobuf_req = http::Request::builder()

--- a/examples/mcp-telemetry/README.md
+++ b/examples/mcp-telemetry/README.md
@@ -54,12 +54,11 @@ agentgateway_requests_total{gateway="bind/3000",method="DELETE",status="202"} 2
 
 The metrics can be retrived in either text format or protobuf, controlled via the `Accept` header on the request. Specifying multiple formats with a quality parameter will cause the gateway to choose the best match of highest quality (standard accept header behaviour).
 
-If you use protobuf, the returned data is of `io.prometheus.client.MetricsSet`, not customisable via the `proto=<type>` accept header parameter. Ideally, this should be deserialised using the offical [Prometheus protobuf definition](https://github.com/prometheus/client_rust/blob/master/src/encoding/proto/metrics.proto)
+If you use protobuf, the response contains length-delimited `io.prometheus.client.MetricFamily` messages. These can be deserialized using the official [Prometheus protobuf definition](https://github.com/prometheus/prometheus/blob/main/prompb/io/prometheus/client/metrics.proto).
 
-For text format use `Accept: text/plain`.
+For OpenMetrics text format use `Accept: application/openmetrics-text`.
 
 For Protobuf use one of:
 * `Accept: application/vnd.google.protobuf`
 * `Accept: application/protobuf`
 * `Accept: application/x-protobuf`
-


### PR DESCRIPTION
Tested with

```yaml
global:
  scrape_interval: 1s

scrape_configs:
- job_name: default
  static_configs:
  - targets: [127.0.0.1:15020]
- job_name: openmetrics
  scrape_protocols: [OpenMetricsText1.0.0]
  static_configs:
  - targets: [127.0.0.1:15020]
- job_name: protobuf
  scrape_protocols: [PrometheusProto]
  static_configs:
  - targets: [127.0.0.1:15020]
```