### PR TITLE
mcp: treat schemaless application/json request bodies as unconstrained

### DIFF
--- a/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/mod.rs
@@ -270,12 +270,13 @@ pub(crate) fn parse_openapi_schema(
 								Some(body) => {
 									let body = resolve_request_body(body, open_api)?;
 									if let Some(media_type) = body.content.get("application/json") {
-										let schema_ref = media_type
-											.schema
-											.as_ref()
-											.ok_or(ParseError::MissingReference("application/json".to_string()))?;
-										let body_schema =
-											serde_json::to_value(schema_ref).map_err(ParseError::SerdeError)?;
+										// No schema means an unconstrained payload per OpenAPI.
+										let body_schema = match media_type.schema.as_ref() {
+											Some(schema_ref) => {
+												serde_json::to_value(schema_ref).map_err(ParseError::SerdeError)?
+											},
+											None => json!({}),
+										};
 										Some((BODY_NAME.clone(), body_schema, body.required))
 									} else if body.content.contains_key("application/octet-stream") {
 										request_content_type = Some("application/octet-stream".to_string());

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -852,6 +852,51 @@ fn test_parse_openapi_schema_maps_summary_to_tool_title() {
 }
 
 #[test]
+fn test_parse_openapi_schema_body_without_schema_is_unconstrained() {
+	// GitHub's REST API spec has an operation (repos/get-content) whose
+	// application/json body declares only examples, no schema. That means an
+	// unconstrained payload, not a broken document.
+	let raw = r#"{
+		"openapi": "3.0.0",
+		"info": {"title": "SchemalessBody", "version": "1.0.0"},
+		"paths": {
+			"/echo": {
+				"post": {
+					"operationId": "echo",
+					"requestBody": {
+						"required": true,
+						"content": {
+							"application/json": {
+								"examples": {"anything": {"value": {"hello": "world"}}}
+							}
+						}
+					},
+					"responses": {"200": {"description": "ok"}}
+				}
+			}
+		}
+	}"#;
+	let open_api: OpenAPI = serde_json::from_str(raw).expect("valid OpenAPI schema");
+	let tools = super::parse_openapi_schema(&open_api).expect("schema should parse");
+
+	let (tool, _) = tools
+		.iter()
+		.find(|(tool, _)| tool.name == "echo")
+		.expect("tool should exist");
+	let properties = tool
+		.input_schema
+		.get("properties")
+		.and_then(|v| v.as_object())
+		.expect("input schema should have properties");
+	assert_eq!(properties.get("body"), Some(&json!({})));
+	assert_eq!(
+		tool.input_schema.get("required"),
+		Some(&json!(["body"])),
+		"required flag should be preserved"
+	);
+}
+
+#[test]
 fn test_parse_openapi_schema_includes_path_level_parameters_in_tool_schema() {
 	let raw = r#"{
 		"openapi": "3.0.0",


### PR DESCRIPTION
A media type object without a `schema` means an unconstrained payload per the OpenAPI spec, not a broken document. Previously a single schemaless `application/json` request body failed translation of the entire spec with `MissingReference("application/json")`.

This is not hypothetical: GitHub's REST API description (13MB, 1222 operations) is currently rejected wholesale because exactly one operation (`repos/get-content`) declares an `application/json` body with only `examples` and no `schema`. With this change the full spec translates cleanly (~8ms, 1222 tools).

The fix maps a missing schema to the empty JSON Schema `{}` (accepts any value), preserving the `required` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xfE7XFnZRnZexGYAedbDe
