### PR TITLE
mcp: populate `mcp.methodName` during RBAC evaluation

### DIFF
--- a/architecture/cel.md
+++ b/architecture/cel.md
@@ -5,13 +5,18 @@ CEL is an expression language that can evaluate user-defined (at runtime) expres
 
 A simple example of an expression that could be used for MCP authorization: `jwt.sub == "test-user" && mcp.tool.name == "add"`.
 
+Request-time CEL also includes `mcp.methodName` alongside the identity fields (`mcp.tool`,
+`mcp.prompt`, `mcp.resource`, `mcp.task`), so a policy can distinguish e.g. listing a tool from
+calling it.
+
 For post-request logging, tracing, and metrics CEL, MCP tool calls also expose payload fields such as
-`mcp.methodName`, `mcp.sessionId`, `mcp.tool.arguments`, `mcp.tool.result`, and `mcp.tool.error`.
-Request-time authorization keeps the `mcp` context identity-only, so those payload fields are absent during RBAC evaluation.
+`mcp.sessionId`, `mcp.tool.arguments`, `mcp.tool.result`, and `mcp.tool.error` - these remain absent
+during RBAC evaluation.
 
 While CEL is not as powerful as alternatives like Lua or WASM, it is pretty fast and good enough for many use cases.
 
 Agentgateway currently uses CEL for:
+
 * Defining attributes to include in logs/traces. For example `user_agent: 'request.headers["user-agent"]'`.
 * Modifying HTTP headers and bodies.
 * Authorization policies

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -2447,7 +2447,7 @@ pub fn full_example_executor() -> ExecutorSerde {
 			cost_status: None,
 		}),
 		mcp: Some(MCPInfo {
-			method_name: Some("tools/call".to_string()),
+			method_name: Some("tools/call".into()),
 			session_id: Some("session-123".to_string()),
 			tool: Some(MCPTool {
 				target: "my-mcp-server".to_string(),

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -2164,8 +2164,9 @@ pub struct ExecutorSerde {
 	pub destination: Option<DestinationContext>,
 
 	/// `mcp` contains attributes about the MCP request.
-	/// Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.
-	/// Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.
+	/// Request-time CEL includes identity fields (`tool`, `prompt`, `resource`,
+	/// `task`) plus `methodName`. Post-request CEL may also include fields like
+	/// `sessionId` and tool payloads.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub mcp: Option<MCPInfo>,
 

--- a/crates/agentgateway/src/mcp/guardrails/methods.rs
+++ b/crates/agentgateway/src/mcp/guardrails/methods.rs
@@ -1,6 +1,8 @@
 use rmcp::model::{
 	CallToolRequestMethod, CompleteRequestMethod, ConstString, GetPromptRequestMethod,
-	ReadResourceRequestMethod, SubscribeRequestMethod, UnsubscribeRequestMethod,
+	ListPromptsRequestMethod, ListResourceTemplatesRequestMethod, ListResourcesRequestMethod,
+	ListToolsRequestMethod, ReadResourceRequestMethod, SubscribeRequestMethod,
+	UnsubscribeRequestMethod,
 };
 
 // Method names for the non-fanout requests that carry a mutable body. The
@@ -8,6 +10,15 @@ use rmcp::model::{
 pub const TOOLS_CALL: &str = CallToolRequestMethod::VALUE;
 pub const PROMPTS_GET: &str = GetPromptRequestMethod::VALUE;
 pub const RESOURCES_READ: &str = ReadResourceRequestMethod::VALUE;
+
+// Method names for the fanout list requests, one per dedicated `Relay::merge_*`
+// function. Used to populate `mcp.methodName` for RBAC authorization (see
+// `rbac::McpAuthorizationSet::validate`), so a policy can distinguish listing a
+// resource from calling/reading it.
+pub const TOOLS_LIST: &str = ListToolsRequestMethod::VALUE;
+pub const PROMPTS_LIST: &str = ListPromptsRequestMethod::VALUE;
+pub const RESOURCES_LIST: &str = ListResourcesRequestMethod::VALUE;
+pub const RESOURCES_TEMPLATES_LIST: &str = ListResourceTemplatesRequestMethod::VALUE;
 
 // Single-target methods that don't run the request-phase hook yet; only the
 // response phase fires for them.

--- a/crates/agentgateway/src/mcp/guardrails/methods.rs
+++ b/crates/agentgateway/src/mcp/guardrails/methods.rs
@@ -1,3 +1,4 @@
+use agent_core::strng::{self, Strng};
 use rmcp::model::{
 	CallToolRequestMethod, CompleteRequestMethod, ConstString, GetPromptRequestMethod,
 	ListPromptsRequestMethod, ListResourceTemplatesRequestMethod, ListResourcesRequestMethod,
@@ -7,18 +8,19 @@ use rmcp::model::{
 
 // Method names for the non-fanout requests that carry a mutable body. The
 // fanout (`*/list`, `initialize`, ...) path resolves method names dynamically.
-pub const TOOLS_CALL: &str = CallToolRequestMethod::VALUE;
-pub const PROMPTS_GET: &str = GetPromptRequestMethod::VALUE;
-pub const RESOURCES_READ: &str = ReadResourceRequestMethod::VALUE;
+pub const TOOLS_CALL: Strng = strng::literal!(CallToolRequestMethod::VALUE);
+pub const PROMPTS_GET: Strng = strng::literal!(GetPromptRequestMethod::VALUE);
+pub const RESOURCES_READ: Strng = strng::literal!(ReadResourceRequestMethod::VALUE);
 
 // Method names for the fanout list requests, one per dedicated `Relay::merge_*`
 // function. Used to populate `mcp.methodName` for RBAC authorization (see
 // `rbac::McpAuthorizationSet::validate`), so a policy can distinguish listing a
 // resource from calling/reading it.
-pub const TOOLS_LIST: &str = ListToolsRequestMethod::VALUE;
-pub const PROMPTS_LIST: &str = ListPromptsRequestMethod::VALUE;
-pub const RESOURCES_LIST: &str = ListResourcesRequestMethod::VALUE;
-pub const RESOURCES_TEMPLATES_LIST: &str = ListResourceTemplatesRequestMethod::VALUE;
+pub const TOOLS_LIST: Strng = strng::literal!(ListToolsRequestMethod::VALUE);
+pub const PROMPTS_LIST: Strng = strng::literal!(ListPromptsRequestMethod::VALUE);
+pub const RESOURCES_LIST: Strng = strng::literal!(ListResourcesRequestMethod::VALUE);
+pub const RESOURCES_TEMPLATES_LIST: Strng =
+	strng::literal!(ListResourceTemplatesRequestMethod::VALUE);
 
 // Single-target methods that don't run the request-phase hook yet; only the
 // response phase fires for them.

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -349,6 +349,10 @@ impl Relay {
 				// these UI resources
 				policies.validate(
 					&rbac::ResourceType::Resource(rbac::ResourceId::new(target.clone(), uri.to_string())),
+					// rewrite_tool_list_ui_meta only ever invokes this closure when the message it's
+					// rewriting is itself a ListToolsResult, so this check only ever fires for a
+					// tools/list response's embedded UI resource URIs.
+					crate::mcp::guardrails::methods::TOOLS_LIST,
 					&cel,
 				)
 			};
@@ -733,6 +737,7 @@ impl Relay {
 									server_name.to_string(),
 									t.name.to_string(),
 								)),
+								crate::mcp::guardrails::methods::TOOLS_LIST,
 								cel,
 							)
 						})
@@ -882,6 +887,7 @@ impl Relay {
 									server_name.to_string(),
 									p.name.to_string(),
 								)),
+								crate::mcp::guardrails::methods::PROMPTS_LIST,
 								cel,
 							)
 						})
@@ -923,6 +929,7 @@ impl Relay {
 										server_name.to_string(),
 										r.uri.to_string(),
 									)),
+									crate::mcp::guardrails::methods::RESOURCES_LIST,
 									cel,
 								)
 							})
@@ -969,6 +976,7 @@ impl Relay {
 										server_name.to_string(),
 										rt.uri_template.to_string(),
 									)),
+									crate::mcp::guardrails::methods::RESOURCES_TEMPLATES_LIST,
 									cel,
 								)
 							})

--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -352,7 +352,7 @@ impl Relay {
 					// rewrite_tool_list_ui_meta only ever invokes this closure when the message it's
 					// rewriting is itself a ListToolsResult, so this check only ever fires for a
 					// tools/list response's embedded UI resource URIs.
-					crate::mcp::guardrails::methods::TOOLS_LIST,
+					&crate::mcp::guardrails::methods::TOOLS_LIST,
 					&cel,
 				)
 			};
@@ -737,7 +737,7 @@ impl Relay {
 									server_name.to_string(),
 									t.name.to_string(),
 								)),
-								crate::mcp::guardrails::methods::TOOLS_LIST,
+								&crate::mcp::guardrails::methods::TOOLS_LIST,
 								cel,
 							)
 						})
@@ -887,7 +887,7 @@ impl Relay {
 									server_name.to_string(),
 									p.name.to_string(),
 								)),
-								crate::mcp::guardrails::methods::PROMPTS_LIST,
+								&crate::mcp::guardrails::methods::PROMPTS_LIST,
 								cel,
 							)
 						})
@@ -929,7 +929,7 @@ impl Relay {
 										server_name.to_string(),
 										r.uri.to_string(),
 									)),
-									crate::mcp::guardrails::methods::RESOURCES_LIST,
+									&crate::mcp::guardrails::methods::RESOURCES_LIST,
 									cel,
 								)
 							})
@@ -976,7 +976,7 @@ impl Relay {
 										server_name.to_string(),
 										rt.uri_template.to_string(),
 									)),
-									crate::mcp::guardrails::methods::RESOURCES_TEMPLATES_LIST,
+									&crate::mcp::guardrails::methods::RESOURCES_TEMPLATES_LIST,
 									cel,
 								)
 							})

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -1465,6 +1465,54 @@ async fn task_methods_respect_mcp_authorization_deny_policy() {
 	assert_eq!(get["error"]["message"], "Unknown task: task-abc");
 }
 
+/// Test that a policy keyed on mcp.methodName sees the right method for each
+/// call site: tasks/get is allowed, tasks/cancel for the exact same task is
+/// denied.
+#[tokio::test]
+async fn authorization_by_method_name_allows_tasks_get_denies_tasks_cancel() {
+	let mock = mock_task_streamable_http_server().await;
+	let get_only_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![],
+		vec![],
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"mcp.methodName == "tasks/get""#).unwrap(),
+		)],
+	)));
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		false,
+		false,
+		vec![BackendTrafficPolicy::McpAuthorization(get_only_policy)],
+	)
+	.await;
+
+	let get = modern_request(
+		io,
+		1,
+		"tasks/get",
+		"task-abc",
+		serde_json::json!({"taskId": "task-abc"}),
+	)
+	.await;
+	assert_eq!(
+		get["result"]["status"], "completed",
+		"expected tasks/get to be allowed, got: {get}"
+	);
+
+	let cancel = modern_request(
+		io,
+		2,
+		"tasks/cancel",
+		"task-abc",
+		serde_json::json!({"taskId": "task-abc"}),
+	)
+	.await;
+	assert_eq!(
+		cancel["error"]["code"], -32602,
+		"expected tasks/cancel to be denied for a tasks/get-only policy, got: {cancel}"
+	);
+}
+
 #[tokio::test]
 async fn legacy_multiplex_invalid_target_keeps_internal_error() {
 	let first = mock_streamable_http_server(true).await;
@@ -2649,6 +2697,59 @@ async fn authorization_denied_returns_unknown_tool_error() {
 	);
 }
 
+/// Test that a policy keyed on mcp.methodName sees the right method for each
+/// call site: tools/list is allowed, tools/call for the exact same tool is
+/// denied.
+#[tokio::test]
+async fn authorization_by_method_name_allows_list_denies_call() {
+	let mock = mock_streamable_http_server(true).await;
+
+	// Mirrors the shape of a real `action: Require` AgentgatewayPolicy: no allow/deny rules,
+	// so with no allow rules present a passing require defaults to allow (denylist semantics).
+	let list_only_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![],
+		vec![],
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"mcp.methodName == "tools/list""#).unwrap(),
+		)],
+	)));
+
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		true,
+		false,
+		vec![BackendTrafficPolicy::McpAuthorization(list_only_policy)],
+	)
+	.await;
+
+	let client = mcp_streamable_client(io).await;
+
+	let tools = client
+		.list_tools(None)
+		.await
+		.expect("tools/list should be allowed");
+	assert!(
+		tools.tools.iter().any(|t| t.name == "echo"),
+		"expected the echo tool to be listed, got: {:?}",
+		tools.tools
+	);
+
+	let result = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("echo").with_arguments(
+				serde_json::json!({"hi": "world"})
+					.as_object()
+					.cloned()
+					.unwrap(),
+			),
+		)
+		.await;
+	assert!(
+		result.is_err(),
+		"expected tools/call to be denied for a tools/list-only policy"
+	);
+}
+
 #[tokio::test]
 async fn stateful_session_cannot_cross_mcp_backends() {
 	let sensitive = mock_streamable_http_server(true).await;
@@ -2784,6 +2885,49 @@ async fn authorization_denied_returns_unknown_prompt_error() {
 	}
 }
 
+/// Test that a policy keyed on mcp.methodName sees the right method for each
+/// call site: prompts/list is allowed, prompts/get is denied.
+#[tokio::test]
+async fn authorization_by_method_name_allows_prompts_list_denies_prompts_get() {
+	let mock = mock_streamable_http_server(true).await;
+
+	let list_only_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![],
+		vec![],
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"mcp.methodName == "prompts/list""#).unwrap(),
+		)],
+	)));
+
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		true,
+		false,
+		vec![BackendTrafficPolicy::McpAuthorization(list_only_policy)],
+	)
+	.await;
+
+	let client = mcp_streamable_client(io).await;
+
+	let prompts = client
+		.list_prompts(None)
+		.await
+		.expect("prompts/list should be allowed");
+	assert!(
+		prompts.prompts.iter().any(|p| p.name == "example_prompt"),
+		"expected example_prompt to be listed, got: {:?}",
+		prompts.prompts
+	);
+
+	let result = client
+		.get_prompt(rmcp::model::GetPromptRequestParams::new("example_prompt"))
+		.await;
+	assert!(
+		result.is_err(),
+		"expected prompts/get to be denied for a prompts/list-only policy"
+	);
+}
+
 /// Test that reading a resource denied by MCP authorization policy returns proper JSON-RPC error
 /// with INVALID_PARAMS error code (-32602) and message "Unknown resource: {resource_uri}"
 #[tokio::test]
@@ -2839,6 +2983,54 @@ async fn authorization_denied_returns_unknown_resource_error() {
 		},
 		other => panic!("Expected ServiceError::McpError, got: {:?}", other),
 	}
+}
+
+/// Test that a policy keyed on mcp.methodName sees the right method for each
+/// call site: resources/list is allowed, resources/read is denied.
+#[tokio::test]
+async fn authorization_by_method_name_allows_resources_list_denies_resources_read() {
+	let mock = mock_streamable_http_server(true).await;
+
+	let list_only_policy = McpAuthorization::new(RuleSet::new(PolicySet::new(
+		vec![],
+		vec![],
+		vec![Arc::new(
+			cel::Expression::new_strict(r#"mcp.methodName == "resources/list""#).unwrap(),
+		)],
+	)));
+
+	let (_bind, io) = setup_proxy_policies(
+		&mock,
+		true,
+		false,
+		vec![BackendTrafficPolicy::McpAuthorization(list_only_policy)],
+	)
+	.await;
+
+	let client = mcp_streamable_client(io).await;
+
+	let resources = client
+		.list_resources(None)
+		.await
+		.expect("resources/list should be allowed");
+	assert!(
+		resources
+			.resources
+			.iter()
+			.any(|r| r.uri == "memo://insights"),
+		"expected memo://insights to be listed, got: {:?}",
+		resources.resources
+	);
+
+	let result = client
+		.read_resource(rmcp::model::ReadResourceRequestParams::new(
+			"memo://insights",
+		))
+		.await;
+	assert!(
+		result.is_err(),
+		"expected resources/read to be denied for a resources/list-only policy"
+	);
 }
 
 #[tokio::test]

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -17,6 +17,7 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 
+use agent_core::strng::Strng;
 use axum_core::BoxError;
 use prometheus_client::encoding::{EncodeLabelValue, LabelValueEncoder};
 pub use rbac::{McpAuthorization, McpAuthorizationSet, ResourceId, ResourceType};
@@ -339,7 +340,7 @@ impl MCPTask {
 #[dynamic(rename_all = "camelCase")]
 pub struct MCPInfo {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub method_name: Option<String>,
+	pub method_name: Option<Strng>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub session_id: Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -48,12 +48,13 @@ impl McpAuthorizationSet {
 		Self(self.0.merge(other.0))
 	}
 
-	pub fn validate(&self, res: &ResourceType, cel: &CelExecWrapper) -> bool {
+	pub fn validate(&self, res: &ResourceType, method_name: &str, cel: &CelExecWrapper) -> bool {
 		if !self.0.has_rules() {
 			return true;
 		}
 		tracing::debug!("Checking RBAC for resource: {:?}", res);
-		let mcp = crate::mcp::MCPInfo::from(res);
+		let mut mcp = crate::mcp::MCPInfo::from(res);
+		mcp.method_name = Some(method_name.to_string());
 		let exec = crate::cel::Executor::new_mcp_request(cel.0.as_ref(), &mcp);
 		self.0.validate(&exec)
 	}
@@ -177,12 +178,20 @@ mod tests {
 		let res = tool_resource("server", "increment");
 
 		let no_rule_sets = McpAuthorizationSet::new(RuleSets::from(vec![]));
-		assert!(no_rule_sets.validate(&res, &CelExecWrapper::new(req_without_claims())));
+		assert!(no_rule_sets.validate(
+			&res,
+			"tools/call",
+			&CelExecWrapper::new(req_without_claims())
+		));
 
 		let empty_rule_set = McpAuthorizationSet::new(RuleSets::from(vec![RuleSet::new(
 			PolicySet::new(vec![], vec![], vec![]),
 		)]));
-		assert!(empty_rule_set.validate(&res, &CelExecWrapper::new(req_without_claims())));
+		assert!(empty_rule_set.validate(
+			&res,
+			"tools/call",
+			&CelExecWrapper::new(req_without_claims())
+		));
 	}
 
 	#[test]
@@ -206,14 +215,19 @@ mod tests {
 			.merge(with_authz(authorization_set("true")))
 			.mcp_authorization
 			.unwrap();
-		assert!(!merged.validate(&res, &cel));
+		assert!(!merged.validate(&res, "tools/call", &cel));
 
 		// A policy on only one side passes through
 		for merged in [
 			with_authz(deny_all()).merge(Default::default()),
 			crate::store::BackendPolicies::default().merge(with_authz(deny_all())),
 		] {
-			assert!(!merged.mcp_authorization.unwrap().validate(&res, &cel));
+			assert!(
+				!merged
+					.mcp_authorization
+					.unwrap()
+					.validate(&res, "tools/call", &cel)
+			);
 		}
 	}
 
@@ -223,7 +237,7 @@ mod tests {
 		let req = req_with_claims(json!({ "sub": "1234567890" }));
 		let res = tool_resource("server", "increment");
 
-		assert!(authz.validate(&res, &CelExecWrapper::new(req)));
+		assert!(authz.validate(&res, "tools/call", &CelExecWrapper::new(req)));
 	}
 
 	#[test]
@@ -232,7 +246,7 @@ mod tests {
 		let req = req_with_claims(json!({ "user": { "role": "viewer" } }));
 		let res = tool_resource("server", "increment");
 
-		assert!(!authz.validate(&res, &CelExecWrapper::new(req)));
+		assert!(!authz.validate(&res, "tools/call", &CelExecWrapper::new(req)));
 	}
 
 	#[test]
@@ -241,6 +255,17 @@ mod tests {
 		let req = req_without_claims();
 		let res = tool_resource("server", "increment");
 
-		assert!(!authz.validate(&res, &CelExecWrapper::new(req)));
+		assert!(!authz.validate(&res, "tools/call", &CelExecWrapper::new(req)));
+	}
+
+	#[test]
+	fn test_mcp_authorization_method_name_distinguishes_list_from_call() {
+		let authz = authorization_set(r#"mcp.methodName == "tools/list""#);
+		let req = req_without_claims();
+		let res = tool_resource("server", "increment");
+		let cel = CelExecWrapper::new(req);
+
+		assert!(authz.validate(&res, "tools/list", &cel));
+		assert!(!authz.validate(&res, "tools/call", &cel));
 	}
 }

--- a/crates/agentgateway/src/mcp/rbac.rs
+++ b/crates/agentgateway/src/mcp/rbac.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use ::cel::Value;
 use ::cel::objects::{KeyRef, MapValue};
+use agent_core::strng::Strng;
 use serde::Serialize;
 use vector_map::VecMap;
 
@@ -48,13 +49,13 @@ impl McpAuthorizationSet {
 		Self(self.0.merge(other.0))
 	}
 
-	pub fn validate(&self, res: &ResourceType, method_name: &str, cel: &CelExecWrapper) -> bool {
+	pub fn validate(&self, res: &ResourceType, method_name: &Strng, cel: &CelExecWrapper) -> bool {
 		if !self.0.has_rules() {
 			return true;
 		}
 		tracing::debug!("Checking RBAC for resource: {:?}", res);
 		let mut mcp = crate::mcp::MCPInfo::from(res);
-		mcp.method_name = Some(method_name.to_string());
+		mcp.method_name = Some(method_name.clone());
 		let exec = crate::cel::Executor::new_mcp_request(cel.0.as_ref(), &mcp);
 		self.0.validate(&exec)
 	}
@@ -135,6 +136,7 @@ mod tests {
 
 	use super::*;
 	use crate::http::authorization::PolicySet;
+	use crate::mcp::guardrails::methods::{TOOLS_CALL, TOOLS_LIST};
 
 	fn tool_resource(target: &str, name: &str) -> ResourceType {
 		ResourceType::Tool(ResourceId::new(target.to_string(), name.to_string()))
@@ -180,7 +182,7 @@ mod tests {
 		let no_rule_sets = McpAuthorizationSet::new(RuleSets::from(vec![]));
 		assert!(no_rule_sets.validate(
 			&res,
-			"tools/call",
+			&TOOLS_CALL,
 			&CelExecWrapper::new(req_without_claims())
 		));
 
@@ -189,7 +191,7 @@ mod tests {
 		)]));
 		assert!(empty_rule_set.validate(
 			&res,
-			"tools/call",
+			&TOOLS_CALL,
 			&CelExecWrapper::new(req_without_claims())
 		));
 	}
@@ -215,7 +217,7 @@ mod tests {
 			.merge(with_authz(authorization_set("true")))
 			.mcp_authorization
 			.unwrap();
-		assert!(!merged.validate(&res, "tools/call", &cel));
+		assert!(!merged.validate(&res, &TOOLS_CALL, &cel));
 
 		// A policy on only one side passes through
 		for merged in [
@@ -226,7 +228,7 @@ mod tests {
 				!merged
 					.mcp_authorization
 					.unwrap()
-					.validate(&res, "tools/call", &cel)
+					.validate(&res, &TOOLS_CALL, &cel)
 			);
 		}
 	}
@@ -237,7 +239,7 @@ mod tests {
 		let req = req_with_claims(json!({ "sub": "1234567890" }));
 		let res = tool_resource("server", "increment");
 
-		assert!(authz.validate(&res, "tools/call", &CelExecWrapper::new(req)));
+		assert!(authz.validate(&res, &TOOLS_CALL, &CelExecWrapper::new(req)));
 	}
 
 	#[test]
@@ -246,7 +248,7 @@ mod tests {
 		let req = req_with_claims(json!({ "user": { "role": "viewer" } }));
 		let res = tool_resource("server", "increment");
 
-		assert!(!authz.validate(&res, "tools/call", &CelExecWrapper::new(req)));
+		assert!(!authz.validate(&res, &TOOLS_CALL, &CelExecWrapper::new(req)));
 	}
 
 	#[test]
@@ -255,7 +257,7 @@ mod tests {
 		let req = req_without_claims();
 		let res = tool_resource("server", "increment");
 
-		assert!(!authz.validate(&res, "tools/call", &CelExecWrapper::new(req)));
+		assert!(!authz.validate(&res, &TOOLS_CALL, &CelExecWrapper::new(req)));
 	}
 
 	#[test]
@@ -265,7 +267,7 @@ mod tests {
 		let res = tool_resource("server", "increment");
 		let cel = CelExecWrapper::new(req);
 
-		assert!(authz.validate(&res, "tools/list", &cel));
-		assert!(!authz.validate(&res, "tools/call", &cel));
+		assert!(authz.validate(&res, &TOOLS_LIST, &cel));
+		assert!(!authz.validate(&res, &TOOLS_CALL, &cel));
 	}
 }

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -184,6 +184,7 @@ impl Session {
 	async fn authorize_prompt_request<'a, 'b: 'a>(
 		&'a self,
 		name: &'b str,
+		method: &str,
 		log: &AsyncLog<mcp::MCPInfo>,
 		cel: &rbac::CelExecWrapper,
 		ctx: &IncomingRequestContext,
@@ -200,6 +201,7 @@ impl Session {
 				service_name.to_string(),
 				prompt.to_string(),
 			)),
+			method,
 			cel,
 		) {
 			return Err(UpstreamError::Authorization {
@@ -214,6 +216,7 @@ impl Session {
 		&self,
 		service_name: &str,
 		uri: &str,
+		method: &str,
 		log: &AsyncLog<mcp::MCPInfo>,
 		cel: &rbac::CelExecWrapper,
 	) -> Result<(), UpstreamError> {
@@ -225,6 +228,7 @@ impl Session {
 				service_name.to_string(),
 				uri.to_string(),
 			)),
+			method,
 			cel,
 		) {
 			return Err(UpstreamError::Authorization {
@@ -240,6 +244,7 @@ impl Session {
 		&self,
 		service_name: &str,
 		task_id: &str,
+		method: &str,
 		log: &AsyncLog<mcp::MCPInfo>,
 		cel: &rbac::CelExecWrapper,
 	) -> Result<(), UpstreamError> {
@@ -251,6 +256,7 @@ impl Session {
 				service_name.to_string(),
 				task_id.to_string(),
 			)),
+			method,
 			cel,
 		) {
 			return Err(UpstreamError::Authorization {
@@ -281,7 +287,7 @@ impl Session {
 			.maybe_run_guardrails_call_request(backend, method, params, ctx)
 			.await?;
 		let cel = rbac::CelExecWrapper::new(ctx.as_request().map(|_| ()));
-		if self.relay.policies.validate(&res, &cel) {
+		if self.relay.policies.validate(&res, method, &cel) {
 			Ok(())
 		} else {
 			Err(UpstreamError::Authorization {
@@ -528,7 +534,7 @@ impl Session {
 							.unwrap_or_default()
 						{
 							let (service_name, upstream_uri) = self.relay.parse_resource_uri(uri)?;
-							self.authorize_resource_request(service_name, &upstream_uri, &log, &cel)?;
+							self.authorize_resource_request(service_name, &upstream_uri, &method, &log, &cel)?;
 							resource_subs.push(ResourceSubscription {
 								owner: service_name.to_string(),
 								client_uri: uri.clone(),
@@ -643,14 +649,14 @@ impl Session {
 					ClientRequest::SubscribeRequest(sr) => {
 						let uri = sr.params.uri.clone();
 						let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
-						self.authorize_resource_request(service_name, &original_uri, &log, &cel)?;
+						self.authorize_resource_request(service_name, &original_uri, &method, &log, &cel)?;
 						sr.params.uri = original_uri;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::UnsubscribeRequest(ur) => {
 						let uri = ur.params.uri.clone();
 						let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
-						self.authorize_resource_request(service_name, &original_uri, &log, &cel)?;
+						self.authorize_resource_request(service_name, &original_uri, &method, &log, &cel)?;
 						ur.params.uri = original_uri;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
@@ -658,21 +664,21 @@ impl Session {
 					ClientRequest::GetTaskRequest(gtr) => {
 						let (service_name, original_id) =
 							mcp::handler::parse_task_id(&self.relay.upstreams, &gtr.params.task_id)?;
-						self.authorize_task_request(service_name, &original_id, &log, &cel)?;
+						self.authorize_task_request(service_name, &original_id, &method, &log, &cel)?;
 						gtr.params.task_id = original_id;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::UpdateTaskRequest(utr) => {
 						let (service_name, original_id) =
 							mcp::handler::parse_task_id(&self.relay.upstreams, &utr.params.task_id)?;
-						self.authorize_task_request(service_name, &original_id, &log, &cel)?;
+						self.authorize_task_request(service_name, &original_id, &method, &log, &cel)?;
 						utr.params.task_id = original_id;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
 					ClientRequest::CancelTaskRequest(ctr) => {
 						let (service_name, original_id) =
 							mcp::handler::parse_task_id(&self.relay.upstreams, &ctr.params.task_id)?;
-						self.authorize_task_request(service_name, &original_id, &log, &cel)?;
+						self.authorize_task_request(service_name, &original_id, &method, &log, &cel)?;
 						ctr.params.task_id = original_id;
 						Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 					},
@@ -690,14 +696,14 @@ impl Session {
 						Reference::Prompt(prompt) => {
 							let name = prompt.name.clone();
 							let (service_name, prompt_name) =
-								Box::pin(self.authorize_prompt_request(&name, &log, &cel, &ctx)).await?;
+								Box::pin(self.authorize_prompt_request(&name, &method, &log, &cel, &ctx)).await?;
 							cr.params.r#ref = Reference::for_prompt(prompt_name.to_string());
 							Box::pin(self.relay.send_single(r, ctx, &service_name, None)).await
 						},
 						Reference::Resource(resource) => {
 							let uri = resource.uri.clone();
 							let (service_name, original_uri) = self.relay.parse_resource_uri(&uri)?;
-							self.authorize_resource_request(service_name, &original_uri, &log, &cel)?;
+							self.authorize_resource_request(service_name, &original_uri, &method, &log, &cel)?;
 							cr.params.r#ref = Reference::for_resource(original_uri);
 							Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 						},

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -8,6 +8,7 @@ use ::http::StatusCode;
 use ::http::header::CONTENT_TYPE;
 use ::http::request::Parts;
 use agent_core::prelude::AssertSize;
+use agent_core::strng::Strng;
 use agent_core::version::BuildInfo;
 use anyhow::anyhow;
 use futures_util::StreamExt;
@@ -184,7 +185,7 @@ impl Session {
 	async fn authorize_prompt_request<'a, 'b: 'a>(
 		&'a self,
 		name: &'b str,
-		method: &str,
+		method: &Strng,
 		log: &AsyncLog<mcp::MCPInfo>,
 		cel: &rbac::CelExecWrapper,
 		ctx: &IncomingRequestContext,
@@ -216,7 +217,7 @@ impl Session {
 		&self,
 		service_name: &str,
 		uri: &str,
-		method: &str,
+		method: &Strng,
 		log: &AsyncLog<mcp::MCPInfo>,
 		cel: &rbac::CelExecWrapper,
 	) -> Result<(), UpstreamError> {
@@ -244,7 +245,7 @@ impl Session {
 		&self,
 		service_name: &str,
 		task_id: &str,
-		method: &str,
+		method: &Strng,
 		log: &AsyncLog<mcp::MCPInfo>,
 		cel: &rbac::CelExecWrapper,
 	) -> Result<(), UpstreamError> {
@@ -271,7 +272,7 @@ impl Session {
 	async fn authorize_with_ctx<P>(
 		&self,
 		backend: &str,
-		method: &str,
+		method: &Strng,
 		params: &mut P,
 		ctx: &mut IncomingRequestContext,
 		res: rbac::ResourceType,
@@ -412,7 +413,7 @@ impl Session {
 		mut init_request: InitializeRequest,
 		service_name: &str,
 	) -> Result<Response, UpstreamError> {
-		let method = init_request.method.as_str().to_string();
+		let method: Strng = init_request.method.as_str().into();
 		let ctx = IncomingRequestContext::new(&parts);
 		let (log, _) = mcp::handler::setup_request_log(parts);
 		let session_id = (!self.synthetic).then(|| self.id.to_string());
@@ -442,7 +443,7 @@ impl Session {
 			method: Default::default(),
 			extensions: Default::default(),
 		};
-		let method = initialized.method.as_str().to_string();
+		let method: Strng = initialized.method.as_str().into();
 		let ctx = IncomingRequestContext::new(&parts);
 		let (log, _) = mcp::handler::setup_request_log(parts);
 		let session_id = (!self.synthetic).then(|| self.id.to_string());
@@ -471,7 +472,7 @@ impl Session {
 		// It's very common to not have any notifications, though.
 		match message {
 			ClientJsonRpcMessage::Request(mut r) => {
-				let method = r.request.method().to_string();
+				let method: Strng = r.request.method().into();
 				let mut ctx = IncomingRequestContext::new(&parts);
 				let (log, cel) = mcp::handler::setup_request_log(parts);
 				let session_id = (!self.synthetic).then(|| self.id.to_string());
@@ -579,7 +580,7 @@ impl Session {
 						ctr.params.name = tn.into();
 						Box::pin(self.authorize_with_ctx(
 							&service_name,
-							mcp::guardrails::methods::TOOLS_CALL,
+							&mcp::guardrails::methods::TOOLS_CALL,
 							&mut ctr.params,
 							&mut ctx,
 							rbac::ResourceType::Tool(rbac::ResourceId::new(
@@ -611,7 +612,7 @@ impl Session {
 						gpr.params.name = prompt.to_string();
 						Box::pin(self.authorize_with_ctx(
 							&service_name,
-							mcp::guardrails::methods::PROMPTS_GET,
+							&mcp::guardrails::methods::PROMPTS_GET,
 							&mut gpr.params,
 							&mut ctx,
 							rbac::ResourceType::Prompt(rbac::ResourceId::new(
@@ -633,7 +634,7 @@ impl Session {
 						rrr.params.uri = original_uri.clone();
 						Box::pin(self.authorize_with_ctx(
 							service_name,
-							mcp::guardrails::methods::RESOURCES_READ,
+							&mcp::guardrails::methods::RESOURCES_READ,
 							&mut rrr.params,
 							&mut ctx,
 							rbac::ResourceType::Resource(rbac::ResourceId::new(
@@ -707,9 +708,9 @@ impl Session {
 							cr.params.r#ref = Reference::for_resource(original_uri);
 							Box::pin(self.relay.send_single(r, ctx, service_name, None)).await
 						},
-						_ => Err(UpstreamError::InvalidMethod(method)),
+						_ => Err(UpstreamError::InvalidMethod(method.to_string())),
 					},
-					_ => Err(UpstreamError::InvalidMethod(method)),
+					_ => Err(UpstreamError::InvalidMethod(method.to_string())),
 				}
 			},
 			ClientJsonRpcMessage::Notification(r) => {
@@ -725,7 +726,7 @@ impl Session {
 				let (log, _cel) = mcp::handler::setup_request_log(parts);
 				let session_id = (!self.synthetic).then(|| self.id.to_string());
 				log.non_atomic_mutate(|l| {
-					l.method_name = Some(method.to_string());
+					l.method_name = Some(method.into());
 					l.session_id = session_id;
 				});
 				// TODO: the notification needs to be fanned out in some cases and sent to a single one in others

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1383,7 +1383,7 @@ impl Drop for DropOnLog {
 					.metrics
 					.mcp_requests
 					.get_or_create(&MCPCall {
-						method: mcp.method_name.as_ref().map(RichStrng::from).into(),
+						method: mcp.method_name.clone().map(RichStrng::from).into(),
 						resource_type: mcp.resource_type().into(),
 						server: mcp.target_name().map(RichStrng::from).into(),
 						resource: mcp.metric_resource_name().map(RichStrng::from).into(),
@@ -1785,7 +1785,7 @@ impl Drop for DropOnLog {
 				.or_else(|| {
 					let request = log.request_snapshot.as_ref()?;
 					crate::http::is_grpc_content_type(&request.headers)
-						.then(|| request.path.path().trim_start_matches('/').to_owned())
+						.then(|| strng::new(request.path.path().trim_start_matches('/')))
 				});
 
 			if enable_trace && let Some(t) = &log.tracer {

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -948,7 +948,7 @@ mod tests {
 		}
 
 		let mcp = crate::mcp::MCPInfo {
-			method_name: Some("tools/call".to_string()),
+			method_name: Some(strng::literal!("tools/call")),
 			..Default::default()
 		};
 

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -928,7 +928,7 @@
       "additionalProperties": false
     },
     "mcp": {
-      "description": "`mcp` contains attributes about the MCP request.\nRequest-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.\nPost-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.",
+      "description": "`mcp` contains attributes about the MCP request.\nRequest-time CEL includes identity fields (`tool`, `prompt`, `resource`,\n`task`) plus `methodName`. Post-request CEL may also include fields like\n`sessionId` and tool payloads.",
       "type": [
         "object",
         "null"

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -128,7 +128,7 @@
 |`destination.address`|string|The IP address of the downstream request destination at agentgateway.|
 |`destination.port`|integer|The port of the downstream request destination at agentgateway.|
 |`destination.hostname`|string|The requested destination hostname, when known. For TLS connections this is the sniffed SNI.|
-|`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL only includes identity fields such as `tool`, `prompt`, or `resource`.<br>Post-request CEL may also include fields like `methodName`, `sessionId`, and tool payloads.|
+|`mcp`|object|`mcp` contains attributes about the MCP request.<br>Request-time CEL includes identity fields (`tool`, `prompt`, `resource`,<br>`task`) plus `methodName`. Post-request CEL may also include fields like<br>`sessionId` and tool payloads.|
 |`mcp.methodName`|string||
 |`mcp.sessionId`|string||
 |`mcp.tool`|object||


### PR DESCRIPTION
Allows consumers to scope callers access to, for example, only listing a resource (e.g. `tools/list`) without being able to call/read it (e.g. `tools/call`).

Fixes https://github.com/agentgateway/agentgateway/issues/721