### PR TITLE
pool: max connection duration

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -13898,11 +13898,12 @@ func (x *BackendPolicySpec_BackendTLS) GetCertificateSource() BackendPolicySpec_
 }
 
 type BackendPolicySpec_BackendHTTP struct {
-	state          protoimpl.MessageState                    `protogen:"open.v1"`
-	Version        BackendPolicySpec_BackendHTTP_HttpVersion `protobuf:"varint,1,opt,name=version,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_BackendHTTP_HttpVersion" json:"version,omitempty"`
-	RequestTimeout *durationpb.Duration                      `protobuf:"bytes,2,opt,name=request_timeout,json=requestTimeout,proto3" json:"request_timeout,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state                 protoimpl.MessageState                    `protogen:"open.v1"`
+	Version               BackendPolicySpec_BackendHTTP_HttpVersion `protobuf:"varint,1,opt,name=version,proto3,enum=agentgateway.dev.resource.BackendPolicySpec_BackendHTTP_HttpVersion" json:"version,omitempty"`
+	RequestTimeout        *durationpb.Duration                      `protobuf:"bytes,2,opt,name=request_timeout,json=requestTimeout,proto3" json:"request_timeout,omitempty"`
+	MaxConnectionDuration *durationpb.Duration                      `protobuf:"bytes,3,opt,name=max_connection_duration,json=maxConnectionDuration,proto3" json:"max_connection_duration,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *BackendPolicySpec_BackendHTTP) Reset() {
@@ -13945,6 +13946,13 @@ func (x *BackendPolicySpec_BackendHTTP) GetVersion() BackendPolicySpec_BackendHT
 func (x *BackendPolicySpec_BackendHTTP) GetRequestTimeout() *durationpb.Duration {
 	if x != nil {
 		return x.RequestTimeout
+	}
+	return nil
+}
+
+func (x *BackendPolicySpec_BackendHTTP) GetMaxConnectionDuration() *durationpb.Duration {
+	if x != nil {
+		return x.MaxConnectionDuration
 	}
 	return nil
 }
@@ -18642,7 +18650,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xbbg\n" +
+	"\x04kind\"\x8eh\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -18888,10 +18896,11 @@ const file_resource_proto_rawDesc = "" +
 	"\x05_certB\x06\n" +
 	"\x04_keyB\a\n" +
 	"\x05_rootB\v\n" +
-	"\t_hostname\x1a\xe7\x01\n" +
+	"\t_hostname\x1a\xba\x02\n" +
 	"\vBackendHTTP\x12^\n" +
 	"\aversion\x18\x01 \x01(\x0e2D.agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersionR\aversion\x12B\n" +
-	"\x0frequest_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0erequestTimeout\"4\n" +
+	"\x0frequest_timeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0erequestTimeout\x12Q\n" +
+	"\x17max_connection_duration\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\x15maxConnectionDuration\"4\n" +
 	"\vHttpVersion\x12\x0f\n" +
 	"\vUNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05HTTP1\x10\x01\x12\t\n" +
@@ -19910,111 +19919,112 @@ var file_resource_proto_depIdxs = []int32{
 	39,  // 295: agentgateway.dev.resource.BackendPolicySpec.BackendTLS.certificate_source:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTLS.CertificateSource
 	40,  // 296: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.version:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.HttpVersion
 	275, // 297: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.request_timeout:type_name -> google.protobuf.Duration
-	124, // 298: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
-	116, // 299: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	41,  // 300: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.Mode
-	112, // 301: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
-	275, // 302: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
-	42,  // 303: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
-	232, // 304: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
-	43,  // 305: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
-	114, // 306: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
-	80,  // 307: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	235, // 308: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
-	211, // 309: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	211, // 310: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
-	30,  // 311: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
-	31,  // 312: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
-	213, // 313: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
-	124, // 314: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
-	231, // 315: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.headers:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
-	101, // 316: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
-	35,  // 317: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
-	32,  // 318: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
-	116, // 319: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	124, // 320: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	32,  // 321: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
-	116, // 322: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	124, // 323: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	32,  // 324: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
-	116, // 325: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	124, // 326: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	32,  // 327: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
-	116, // 328: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	124, // 329: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
-	32,  // 330: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
-	220, // 331: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	214, // 332: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	215, // 333: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	218, // 334: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	217, // 335: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	219, // 336: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	220, // 337: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
-	214, // 338: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
-	215, // 339: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
-	216, // 340: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
-	218, // 341: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
-	217, // 342: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
-	219, // 343: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
-	33,  // 344: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.scope:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ContentScope
-	222, // 345: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
-	221, // 346: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
-	36,  // 347: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.streaming:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
-	34,  // 348: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
-	233, // 349: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
-	276, // 350: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
-	124, // 351: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
-	45,  // 352: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
-	236, // 353: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
-	116, // 354: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	234, // 355: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
-	237, // 356: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
-	44,  // 357: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
-	250, // 358: agentgateway.dev.resource.AIBackend.OpenAI.moderation:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.Moderation
-	46,  // 359: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
-	47,  // 360: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
-	246, // 361: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
-	238, // 362: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
-	124, // 363: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
-	239, // 364: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
-	240, // 365: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
-	241, // 366: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
-	242, // 367: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
-	243, // 368: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
-	244, // 369: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
-	245, // 370: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
-	247, // 371: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
-	48,  // 372: agentgateway.dev.resource.AIBackend.Provider.provider_preset:type_name -> agentgateway.dev.resource.AIBackend.ProviderPreset
-	116, // 373: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	248, // 374: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
-	251, // 375: agentgateway.dev.resource.AIBackend.OpenAI.Moderation.policy:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy
-	252, // 376: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy.input:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
-	252, // 377: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy.output:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
-	49,  // 378: agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig.mode:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationMode
-	1,   // 379: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.alg:type_name -> agentgateway.dev.resource.JwtSigningAlg
-	55,  // 380: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.certificate_header:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
-	80,  // 381: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	80,  // 382: agentgateway.dev.resource.OAuthTokenExchange.ActorToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	260, // 383: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.in_memory:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
-	275, // 384: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory.default_ttl:type_name -> google.protobuf.Duration
-	124, // 385: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
-	126, // 386: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
-	116, // 387: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	80,  // 388: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
-	267, // 389: agentgateway.dev.resource.ModelRoute.VirtualModel.weighted:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
-	268, // 390: agentgateway.dev.resource.ModelRoute.VirtualModel.conditional:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
-	269, // 391: agentgateway.dev.resource.ModelRoute.VirtualModel.failover:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
-	57,  // 392: agentgateway.dev.resource.ModelRoute.ConcreteModel.model_visibility:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
-	124, // 393: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend:type_name -> agentgateway.dev.resource.BackendReference
-	116, // 394: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
-	270, // 395: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
-	271, // 396: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
-	124, // 397: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover.backend:type_name -> agentgateway.dev.resource.BackendReference
-	398, // [398:398] is the sub-list for method output_type
-	398, // [398:398] is the sub-list for method input_type
-	398, // [398:398] is the sub-list for extension type_name
-	398, // [398:398] is the sub-list for extension extendee
-	0,   // [0:398] is the sub-list for field type_name
+	275, // 298: agentgateway.dev.resource.BackendPolicySpec.BackendHTTP.max_connection_duration:type_name -> google.protobuf.Duration
+	124, // 299: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.proxy:type_name -> agentgateway.dev.resource.BackendReference
+	116, // 300: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	41,  // 301: agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.BackendTunnel.Mode
+	112, // 302: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.keepalive:type_name -> agentgateway.dev.resource.KeepaliveConfig
+	275, // 303: agentgateway.dev.resource.BackendPolicySpec.BackendTCP.connect_timeout:type_name -> google.protobuf.Duration
+	42,  // 304: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.provider:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.McpIDP
+	232, // 305: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.resource_metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata
+	43,  // 306: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.Mode
+	114, // 307: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.jwt_validation_options:type_name -> agentgateway.dev.resource.JWTValidationOptions
+	80,  // 308: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.authorization_location:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	235, // 309: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.processors:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor
+	211, // 310: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.append:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	211, // 311: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptEnrichment.prepend:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Message
+	30,  // 312: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule.builtin:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BuiltinRegexRule
+	31,  // 313: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ActionKind
+	213, // 314: agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules.rules:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRule
+	124, // 315: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.backend:type_name -> agentgateway.dev.resource.BackendReference
+	231, // 316: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.headers:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.HeadersEntry
+	101, // 317: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.forward_header_matches:type_name -> agentgateway.dev.resource.HeaderMatch
+	35,  // 318: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.FailureMode
+	32,  // 319: agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
+	116, // 320: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	124, // 321: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	32,  // 322: agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
+	116, // 323: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	124, // 324: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	32,  // 325: agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
+	116, // 326: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	124, // 327: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	32,  // 328: agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
+	116, // 329: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	124, // 330: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.backend_ref:type_name -> agentgateway.dev.resource.BackendReference
+	32,  // 331: agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety.action:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RejectAuditAction
+	220, // 332: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	214, // 333: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	215, // 334: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	218, // 335: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	217, // 336: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	219, // 337: agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	220, // 338: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.rejection:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestRejection
+	214, // 339: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.regex:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RegexRules
+	215, // 340: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.webhook:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Webhook
+	216, // 341: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.openai_moderation:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.Moderation
+	218, // 342: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.google_model_armor:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.GoogleModelArmor
+	217, // 343: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.bedrock_guardrails:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.BedrockGuardrails
+	219, // 344: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.azure_content_safety:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.AzureContentSafety
+	33,  // 345: agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard.scope:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ContentScope
+	222, // 346: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.request:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RequestGuard
+	221, // 347: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.response:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.ResponseGuard
+	36,  // 348: agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.streaming:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.PromptGuard.Streaming
+	34,  // 349: agentgateway.dev.resource.BackendPolicySpec.Ai.RoutesEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.Ai.RouteType
+	233, // 350: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.extra:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry
+	276, // 351: agentgateway.dev.resource.BackendPolicySpec.McpAuthentication.ResourceMetadata.ExtraEntry.value:type_name -> google.protobuf.Value
+	124, // 352: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.target:type_name -> agentgateway.dev.resource.BackendReference
+	45,  // 353: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.failure_mode:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.FailureMode
+	236, // 354: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.metadata:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.MetadataEntry
+	116, // 355: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	234, // 356: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.remote:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Remote
+	237, // 357: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.methods:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry
+	44,  // 358: agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Processor.MethodsEntry.value:type_name -> agentgateway.dev.resource.BackendPolicySpec.McpGuardrails.Phase
+	250, // 359: agentgateway.dev.resource.AIBackend.OpenAI.moderation:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.Moderation
+	46,  // 360: agentgateway.dev.resource.AIBackend.Azure.resource_type:type_name -> agentgateway.dev.resource.AIBackend.AzureResourceType
+	47,  // 361: agentgateway.dev.resource.AIBackend.ProviderFormatConfig.format:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormat
+	246, // 362: agentgateway.dev.resource.AIBackend.Custom.formats:type_name -> agentgateway.dev.resource.AIBackend.ProviderFormatConfig
+	238, // 363: agentgateway.dev.resource.AIBackend.Provider.host_override:type_name -> agentgateway.dev.resource.AIBackend.HostOverride
+	124, // 364: agentgateway.dev.resource.AIBackend.Provider.provider_backend:type_name -> agentgateway.dev.resource.BackendReference
+	239, // 365: agentgateway.dev.resource.AIBackend.Provider.openai:type_name -> agentgateway.dev.resource.AIBackend.OpenAI
+	240, // 366: agentgateway.dev.resource.AIBackend.Provider.gemini:type_name -> agentgateway.dev.resource.AIBackend.Gemini
+	241, // 367: agentgateway.dev.resource.AIBackend.Provider.vertex:type_name -> agentgateway.dev.resource.AIBackend.Vertex
+	242, // 368: agentgateway.dev.resource.AIBackend.Provider.anthropic:type_name -> agentgateway.dev.resource.AIBackend.Anthropic
+	243, // 369: agentgateway.dev.resource.AIBackend.Provider.bedrock:type_name -> agentgateway.dev.resource.AIBackend.Bedrock
+	244, // 370: agentgateway.dev.resource.AIBackend.Provider.azureopenai:type_name -> agentgateway.dev.resource.AIBackend.AzureOpenAI
+	245, // 371: agentgateway.dev.resource.AIBackend.Provider.azure:type_name -> agentgateway.dev.resource.AIBackend.Azure
+	247, // 372: agentgateway.dev.resource.AIBackend.Provider.custom:type_name -> agentgateway.dev.resource.AIBackend.Custom
+	48,  // 373: agentgateway.dev.resource.AIBackend.Provider.provider_preset:type_name -> agentgateway.dev.resource.AIBackend.ProviderPreset
+	116, // 374: agentgateway.dev.resource.AIBackend.Provider.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	248, // 375: agentgateway.dev.resource.AIBackend.ProviderGroup.providers:type_name -> agentgateway.dev.resource.AIBackend.Provider
+	251, // 376: agentgateway.dev.resource.AIBackend.OpenAI.Moderation.policy:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy
+	252, // 377: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy.input:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
+	252, // 378: agentgateway.dev.resource.AIBackend.OpenAI.ModerationPolicy.output:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig
+	49,  // 379: agentgateway.dev.resource.AIBackend.OpenAI.ModerationConfig.mode:type_name -> agentgateway.dev.resource.AIBackend.OpenAI.ModerationMode
+	1,   // 380: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.alg:type_name -> agentgateway.dev.resource.JwtSigningAlg
+	55,  // 381: agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.certificate_header:type_name -> agentgateway.dev.resource.OAuthClientAuth.PrivateKeyJwt.CertificateHeader
+	80,  // 382: agentgateway.dev.resource.OAuthTokenExchange.TokenSpec.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	80,  // 383: agentgateway.dev.resource.OAuthTokenExchange.ActorToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	260, // 384: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.in_memory:type_name -> agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory
+	275, // 385: agentgateway.dev.resource.OAuthTokenExchange.TokenCache.InMemory.default_ttl:type_name -> google.protobuf.Duration
+	124, // 386: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.token_endpoint:type_name -> agentgateway.dev.resource.BackendReference
+	126, // 387: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.client_auth:type_name -> agentgateway.dev.resource.OAuthClientAuth
+	116, // 388: agentgateway.dev.resource.CrossAppAccessAuth.Endpoint.inline_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	80,  // 389: agentgateway.dev.resource.CrossAppAccessAuth.SubjectToken.source:type_name -> agentgateway.dev.resource.AuthorizationLocation
+	267, // 390: agentgateway.dev.resource.ModelRoute.VirtualModel.weighted:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted
+	268, // 391: agentgateway.dev.resource.ModelRoute.VirtualModel.conditional:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional
+	269, // 392: agentgateway.dev.resource.ModelRoute.VirtualModel.failover:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Failover
+	57,  // 393: agentgateway.dev.resource.ModelRoute.ConcreteModel.model_visibility:type_name -> agentgateway.dev.resource.ModelRoute.ConcreteModel.ModelVisibility
+	124, // 394: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend:type_name -> agentgateway.dev.resource.BackendReference
+	116, // 395: agentgateway.dev.resource.ModelRoute.ConcreteModel.backend_policies:type_name -> agentgateway.dev.resource.BackendPolicySpec
+	270, // 396: agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Weighted.Target
+	271, // 397: agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.targets:type_name -> agentgateway.dev.resource.ModelRoute.VirtualModel.Conditional.Target
+	124, // 398: agentgateway.dev.resource.ModelRoute.VirtualModel.Failover.backend:type_name -> agentgateway.dev.resource.BackendReference
+	399, // [399:399] is the sub-list for method output_type
+	399, // [399:399] is the sub-list for method input_type
+	399, // [399:399] is the sub-list for extension type_name
+	399, // [399:399] is the sub-list for extension extendee
+	0,   // [0:399] is the sub-list for field type_name
 }
 
 func init() { file_resource_proto_init() }

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -216,6 +216,7 @@ impl From<Option<VersionedBackendTLS>> for Transport {
 pub struct ConnectionConfig {
 	pub transport: Transport,
 	pub tcp: Option<types::backend::TCP>,
+	pub max_connection_duration: Option<Duration>,
 }
 
 impl From<Transport> for ConnectionConfig {
@@ -223,6 +224,7 @@ impl From<Transport> for ConnectionConfig {
 		Self {
 			transport,
 			tcp: None,
+			max_connection_duration: None,
 		}
 	}
 }
@@ -319,7 +321,11 @@ impl Connector {
 		connection: ConnectionConfig,
 		http: bool,
 	) -> Result<Socket, http::Error> {
-		let ConnectionConfig { transport, tcp } = connection;
+		let ConnectionConfig {
+			transport,
+			tcp,
+			max_connection_duration,
+		} = connection;
 		let connect_start = std::time::Instant::now();
 		let transport_name = transport.name();
 		let tls = match transport.application() {
@@ -444,6 +450,12 @@ impl Connector {
 
 			"connected"
 		);
+
+		if let Some(max_age) = max_connection_duration {
+			socket
+				.ext_mut()
+				.insert(stream::ConnectionDeadline(connect_start + max_age));
+		}
 
 		socket.with_logging(LoggingMode::Upstream);
 		Ok(socket)
@@ -808,6 +820,42 @@ mod tests {
 				"tunnel protocol {tp:?} should map to no source role",
 			);
 		}
+	}
+
+	#[tokio::test]
+	async fn max_connection_duration_sets_pool_deadline_on_connect() {
+		let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let addr = listener.local_addr().unwrap();
+		tokio::spawn(async move { while listener.accept().await.is_ok() {} });
+
+		let client = Client::new(
+			&Config {
+				resolver_cfg: hickory_resolver::config::ResolverConfig::default(),
+				resolver_opts: hickory_resolver::config::ResolverOpts::default(),
+			},
+			None,
+			crate::BackendConfig::default(),
+			None,
+		);
+
+		let max_age = Duration::from_secs(60);
+		let before = std::time::Instant::now();
+		let socket = client
+			.connect_raw(
+				Target::Address(addr),
+				ConnectionConfig {
+					transport: Transport::Plain(ApplicationTransport::Plaintext),
+					tcp: None,
+					max_connection_duration: Some(max_age),
+				},
+			)
+			.await
+			.expect("connect to loopback listener");
+		let deadline = agent_pool::connect::Connection::connected(&socket)
+			.get_valid_until()
+			.expect("deadline should be set");
+		assert!(deadline >= before + max_age);
+		assert!(deadline <= std::time::Instant::now() + max_age);
 	}
 
 	/// Millisecond truncation put every observation on an exact multiple of 1ms, and a loopback

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1248,6 +1248,7 @@ impl HTTPProxy {
 				client::ConnectionConfig {
 					transport,
 					tcp: backend_call.backend_policies.tcp.clone(),
+					max_connection_duration: None,
 				},
 			)
 			.await?;
@@ -1788,6 +1789,7 @@ pub async fn build_transport(
 			connection: Box::new(client::ConnectionConfig {
 				transport,
 				tcp: call.backend_policies.tcp.clone(),
+				max_connection_duration: None,
 			}),
 			target: call.target.clone(),
 			token,
@@ -2845,6 +2847,11 @@ async fn make_backend_call(
 		connection: client::ConnectionConfig {
 			transport,
 			tcp: backend_call.backend_policies.tcp.clone(),
+			max_connection_duration: backend_call
+				.backend_policies
+				.http
+				.as_ref()
+				.and_then(|h| h.max_connection_duration),
 		},
 	};
 	let span_target = backend_call.span_target;

--- a/crates/agentgateway/src/proxy/tcpproxy.rs
+++ b/crates/agentgateway/src/proxy/tcpproxy.rs
@@ -234,6 +234,7 @@ impl TCPProxy {
 				connection: client::ConnectionConfig {
 					transport,
 					tcp: backend_call.backend_policies.tcp.clone(),
+					max_connection_duration: None,
 				},
 			})
 			.await?;

--- a/crates/agentgateway/src/transport/stream.rs
+++ b/crates/agentgateway/src/transport/stream.rs
@@ -129,6 +129,10 @@ impl Connection for Socket {
 #[derive(Debug, Clone, Default)]
 pub struct HttpProxy;
 
+/// Deadline after which the connection pool will not reuse this connection for new requests.
+#[derive(Debug, Clone, Copy)]
+pub struct ConnectionDeadline(pub Instant);
+
 impl agent_pool::connect::Connection for Socket {
 	fn connected(&self) -> agent_pool::connect::Connected {
 		let mut con = agent_pool::connect::Connected::new();
@@ -143,6 +147,9 @@ impl agent_pool::connect::Connection for Socket {
 			Some(Alpn::H2) => con = con.negotiated_h2(),
 			Some(Alpn::Http11) => con = con.negotiated_h1(),
 			_ => {},
+		}
+		if let Some(ConnectionDeadline(deadline)) = self.ext.get::<ConnectionDeadline>() {
+			con = con.valid_until(*deadline);
 		}
 		con
 	}

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2292,6 +2292,7 @@ fn backend_policy_from_proto(
 					HttpVersion::Http2 => Some(::http::Version::HTTP_2),
 				},
 				request_timeout: bhttp.request_timeout.map(convert_duration),
+				max_connection_duration: bhttp.max_connection_duration.map(convert_duration),
 			})
 		},
 		Some(bps::Kind::BackendTcp(btcp)) => BackendTrafficPolicy::TCP(backend::TCP {

--- a/crates/agentgateway/src/types/backend.rs
+++ b/crates/agentgateway/src/types/backend.rs
@@ -18,6 +18,16 @@ pub struct HTTP {
 	)]
 	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
 	pub request_timeout: Option<Duration>,
+	/// Maximum time a connection to the backend may stay open. A connection past this duration is
+	/// not reused for new requests; a fresh connection is established instead, while in-flight
+	/// requests are not interrupted.
+	#[serde(
+		default,
+		skip_serializing_if = "Option::is_none",
+		with = "serde_dur_option"
+	)]
+	#[cfg_attr(feature = "schema", schemars(with = "Option<String>"))]
+	pub max_connection_duration: Option<Duration>,
 }
 
 impl HTTP {

--- a/crates/pool/src/connect/mod.rs
+++ b/crates/pool/src/connect/mod.rs
@@ -63,6 +63,7 @@
 //! [`Write`]: hyper::rt::Write
 //! [`Connection`]: Connection
 use std::fmt;
+use std::time::Instant;
 
 use ::http::Extensions;
 
@@ -87,6 +88,7 @@ pub struct Connected {
 	pub(super) alpn: Alpn,
 	pub(super) is_proxied: bool,
 	pub(super) extra: Option<Extra>,
+	pub(super) valid_until: Option<Instant>,
 }
 
 pub(super) struct Extra(Box<dyn ExtraInner>);
@@ -111,6 +113,7 @@ impl Connected {
 			alpn: Alpn::None,
 			is_proxied: false,
 			extra: None,
+			valid_until: None,
 		}
 	}
 
@@ -159,6 +162,31 @@ impl Connected {
 		}
 	}
 
+	/// Set a deadline after which the connection is no longer used for new requests.
+	///
+	/// The pool treats a connection past its deadline like an idle-expired one at checkout:
+	/// it is dropped and a fresh connection is established instead. Requests already in
+	/// flight on the connection are not interrupted.
+	///
+	/// If a deadline is already set, the earlier of the two is kept.
+	pub fn valid_until(mut self, deadline: Instant) -> Connected {
+		self.valid_until = Some(match self.valid_until {
+			Some(existing) => existing.min(deadline),
+			None => deadline,
+		});
+		self
+	}
+
+	/// Returns the deadline after which the connection is no longer used for new requests, if any.
+	pub fn get_valid_until(&self) -> Option<Instant> {
+		self.valid_until
+	}
+
+	/// Returns whether the connection's reuse deadline has passed as of `now`.
+	pub fn past_deadline(&self, now: Instant) -> bool {
+		self.valid_until.is_some_and(|deadline| now >= deadline)
+	}
+
 	/// Set that the connected transport negotiated HTTP/2 as its next protocol.
 	pub fn negotiated_h2(mut self) -> Connected {
 		self.alpn = Alpn::H2;
@@ -178,6 +206,7 @@ impl Connected {
 			alpn: self.alpn,
 			is_proxied: self.is_proxied,
 			extra: self.extra.clone(),
+			valid_until: self.valid_until,
 		}
 	}
 }

--- a/crates/pool/src/pool.rs
+++ b/crates/pool/src/pool.rs
@@ -116,6 +116,11 @@ impl<K: Key> Pool<K> {
 					return false;
 				}
 
+				if entry.value.past_deadline(now) {
+					trace!("evicting past-deadline for {:?}", key);
+					return false;
+				}
+
 				// Otherwise, keep this value...
 				true
 			});
@@ -283,12 +288,18 @@ impl H2Pool {
 			conn
 		}
 	}
-	fn reserve(&mut self) -> Option<ReservedHttp2Connection> {
+	fn reserve(&mut self, now: Instant) -> Option<ReservedHttp2Connection> {
 		while let Some(h) = self.0.front() {
 			if !h.tx.is_ready() {
 				// Connection is dead... remove it.
 				let _ = self.0.pop_front();
 				debug!("removing dead http2 connection");
+				continue;
+			}
+			if h.info.past_deadline(now) {
+				// expired, do not attach new streams.
+				let _ = self.0.pop_front();
+				debug!("removing past-deadline http2 connection");
 				continue;
 			}
 			match h.load.try_reserve_stream_slot() {
@@ -385,6 +396,9 @@ impl HttpConnection {
 			HttpConnection::Http1(h1) => h1.tx.is_ready(),
 			HttpConnection::Http2(h2) => h2.tx.is_ready(),
 		}
+	}
+	pub fn past_deadline(&self, now: Instant) -> bool {
+		self.conn_info().past_deadline(now)
 	}
 }
 
@@ -633,6 +647,12 @@ impl<K: Key> HostPool<K> {
 		key: K,
 		conn: HttpConnection,
 	) {
+		// do not put expired conns back into the idle pool handing them
+		// to a request waiting for a connection
+		if conn.past_deadline(settings.timer.now()) {
+			debug!("dropping past-deadline connection for {:?}", key);
+			return;
+		}
 		trace!(waiters=%self.waiters.len(), "return idle");
 		// we are returning, so there should only ever been 1 additional spot free
 		let capacity = 1;
@@ -925,8 +945,9 @@ impl<K: Key> Pool<K> {
 
 	pub(crate) fn checkout_or_register_waker(&self, key: K) -> CheckoutResult<K> {
 		let mut host = self.host(&key);
+		let now = self.settings.timer.now();
 		// First attempt: find any active H2 streams with available capacity and attach to that.
-		if let Some(reserved) = host.active_h2.reserve() {
+		if let Some(reserved) = host.active_h2.reserve(now) {
 			trace!("found active h2 connection with capacity");
 			let p = Pooled {
 				value: Some((key, HttpConnection::Http2(reserved))),
@@ -939,7 +960,6 @@ impl<K: Key> Pool<K> {
 
 		{
 			let expiration = Expiration::new(self.settings.timeout);
-			let now = self.settings.timer.now();
 			let popper = IdlePopper {
 				key: &key,
 				list: &mut host.idle,
@@ -1018,6 +1038,10 @@ impl<'a, K: Debug> IdlePopper<'a, K> {
 			// whole list...
 			if expiration.expires(entry.idle_at, now) {
 				trace!("removing expired connection for {:?}", self.key);
+				continue;
+			}
+			if entry.value.past_deadline(now) {
+				trace!("removing past-deadline connection for {:?}", self.key);
 				continue;
 			}
 
@@ -1550,8 +1574,32 @@ mod tests {
 		)
 	}
 
+	async fn mock_http1_connection_valid_until(deadline: Instant) -> HttpConnection {
+		let HttpConnection::Http1(c) = mock_http1_connection().await else {
+			unreachable!("mock is http1")
+		};
+		HttpConnection::Http1(ReservedHttp1Connection {
+			info: c.info.valid_until(deadline),
+			tx: c.tx,
+		})
+	}
+
 	async fn mock_http2_connection(max_streams: usize) -> HttpConnection {
 		mock_http2_connection_with_control(max_streams).await.0
+	}
+
+	async fn mock_http2_connection_valid_until(
+		max_streams: usize,
+		deadline: Instant,
+	) -> HttpConnection {
+		let HttpConnection::Http2(c) = mock_http2_connection(max_streams).await else {
+			unreachable!("mock is http2")
+		};
+		HttpConnection::Http2(ReservedHttp2Connection {
+			info: c.info.valid_until(deadline),
+			tx: c.tx,
+			load: c.load,
+		})
 	}
 
 	struct MockHttp2Control {
@@ -1861,6 +1909,66 @@ mod tests {
 		tokio::time::sleep(Duration::from_millis(8)).await;
 
 		let (_sc2, _w2) = must_want_new_connection(&pool, key.clone());
+	}
+
+	#[tokio::test]
+	async fn test_pool_checkout_reuses_connection_before_deadline() {
+		let pool = pool_with_idle_timeout(Duration::from_secs(10));
+		let key = host_key("foo");
+		let (sc, w) = must_want_new_connection(&pool, key.clone());
+
+		pool.insert_new_connection(
+			sc,
+			mock_http1_connection_valid_until(Instant::now() + Duration::from_secs(60)).await,
+		);
+		let pooled = w.await.expect("waiter should receive inserted connection");
+		drop(pooled);
+
+		let _ = must_checkout(&pool, key.clone());
+	}
+
+	#[tokio::test]
+	async fn test_pool_checkout_skips_idle_connection_past_deadline() {
+		let pool = pool_with_idle_timeout(Duration::from_secs(10));
+		let key = host_key("foo");
+		let (sc, w) = must_want_new_connection(&pool, key.clone());
+
+		// The connection parks idle before its deadline, then the deadline passes while it sits
+		// in the pool (the idle-eviction interval has not fired yet).
+		pool.insert_new_connection(
+			sc,
+			mock_http1_connection_valid_until(Instant::now() + Duration::from_millis(30)).await,
+		);
+		let pooled = w.await.expect("waiter should receive inserted connection");
+		drop(pooled);
+		tokio::time::sleep(Duration::from_millis(80)).await;
+
+		// Checkout must dial a new connection instead of reusing the parked one.
+		let (_sc2, _w2) = must_want_new_connection(&pool, key.clone());
+	}
+
+	#[tokio::test]
+	async fn test_pool_return_retires_past_deadline_connection() {
+		let pool = pool_with_idle_timeout(Duration::from_secs(10));
+		let key = host_key("foo");
+		let (sc, w) = must_want_new_connection(&pool, key.clone());
+
+		// A fresh connection still serves its first request even if the deadline already passed.
+		pool.insert_new_connection(sc, mock_http1_connection_valid_until(Instant::now()).await);
+		let pooled = w.await.expect("waiter should receive inserted connection");
+
+		// A second request queues while the first is in flight. When the first completes, the
+		// past-deadline connection must be retired, not renewed onto the waiter (which would
+		// keep it alive indefinitely under sustained load) or parked idle.
+		let (_sc2, mut w2) = must_want_new_connection(&pool, key.clone());
+		drop(pooled);
+		assert!(
+			w2.try_recv()
+				.expect("waiter should still be registered")
+				.is_none(),
+			"waiter must not receive the past-deadline connection"
+		);
+		assert!(pool.host(&key).idle.is_empty());
 	}
 
 	#[tokio::test]
@@ -2376,6 +2484,29 @@ mod tests {
 		tokio::time::sleep(Duration::from_millis(80)).await;
 
 		let _ = must_want_new_connection(&pool, key.clone());
+	}
+
+	#[tokio::test]
+	async fn test_h2_checkout_skips_active_connection_past_deadline() {
+		let pool = pool_with_expected_h2_capacity(2);
+		let key = host_key_h2("foo");
+		let (sc1, w1) = must_want_new_connection(&pool, key.clone());
+
+		pool.insert_new_connection(
+			sc1,
+			mock_http2_connection_valid_until(2, Instant::now()).await,
+		);
+		// The in-flight stream keeps working...
+		let pooled1 = w1.await.expect("get h2").unwrap();
+
+		// ...but even though the connection has spare capacity, it is past its deadline, so a
+		// checkout must dial a new connection instead of attaching another stream.
+		let (_sc2, _w2) = must_want_new_connection(&pool, key.clone());
+		assert!(
+			pool.host(&key).active_h2.0.is_empty(),
+			"past-deadline h2 connection should no longer be tracked for new streams"
+		);
+		drop(pooled1);
 	}
 
 	#[tokio::test]

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1622,6 +1622,7 @@ message BackendPolicySpec {
     }
     HttpVersion version = 1;
     google.protobuf.Duration request_timeout = 2;
+    google.protobuf.Duration max_connection_duration = 3;
   }
   message BackendTunnel {
     enum Mode {

--- a/schema/config.json
+++ b/schema/config.json
@@ -4519,6 +4519,13 @@
             "string",
             "null"
           ]
+        },
+        "maxConnectionDuration": {
+          "description": "Maximum time a connection to the backend may stay open. A connection past this duration is\nnot reused for new requests; a fresh connection is established instead, while in-flight\nrequests are not interrupted. Useful for even traffic distribution and DNS freshness when\nbackends change over time.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/schema/config.json
+++ b/schema/config.json
@@ -4521,7 +4521,7 @@
           ]
         },
         "maxConnectionDuration": {
-          "description": "Maximum time a connection to the backend may stay open. A connection past this duration is\nnot reused for new requests; a fresh connection is established instead, while in-flight\nrequests are not interrupted. Useful for even traffic distribution and DNS freshness when\nbackends change over time.",
+          "description": "Maximum time a connection to the backend may stay open. A connection past this duration is\nnot reused for new requests; a fresh connection is established instead, while in-flight\nrequests are not interrupted.",
           "type": [
             "string",
             "null"

--- a/schema/config.md
+++ b/schema/config.md
@@ -467,7 +467,7 @@
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -806,7 +806,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -1082,7 +1082,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -1358,7 +1358,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -1632,7 +1632,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -1944,7 +1944,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -2220,7 +2220,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -2494,7 +2494,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -2817,7 +2817,7 @@
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -2943,7 +2943,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -3060,7 +3060,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -3135,7 +3135,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -3473,7 +3473,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -3758,7 +3758,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -4125,7 +4125,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -4423,7 +4423,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -4724,7 +4724,7 @@
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -5012,7 +5012,7 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -5301,7 +5301,7 @@
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -5585,7 +5585,7 @@
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -5948,7 +5948,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6160,7 +6160,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6277,7 +6277,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6352,7 +6352,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6419,7 +6419,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6689,7 +6689,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6979,7 +6979,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -7289,7 +7289,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -7605,7 +7605,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -7881,7 +7881,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -8157,7 +8157,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -8431,7 +8431,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -8743,7 +8743,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9019,7 +9019,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9293,7 +9293,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9535,7 +9535,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9652,7 +9652,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9727,7 +9727,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9794,7 +9794,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -10064,7 +10064,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -10354,7 +10354,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -10664,7 +10664,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -10980,7 +10980,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -11256,7 +11256,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -11532,7 +11532,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -11806,7 +11806,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12118,7 +12118,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12394,7 +12394,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12668,7 +12668,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12873,7 +12873,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12990,7 +12990,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13065,7 +13065,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13132,7 +13132,7 @@
 |`binds[].listeners[].routes[].backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13402,7 +13402,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13692,7 +13692,7 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -14002,7 +14002,7 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -14318,7 +14318,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -14594,7 +14594,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -14870,7 +14870,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -15144,7 +15144,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -15456,7 +15456,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -15732,7 +15732,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -16006,7 +16006,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -16356,7 +16356,7 @@
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -16675,7 +16675,7 @@
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -16973,7 +16973,7 @@
 |`binds[].listeners[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -17274,7 +17274,7 @@
 |`binds[].listeners[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -17562,7 +17562,7 @@
 |`binds[].listeners[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`binds[].listeners[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`binds[].listeners[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`binds[].listeners[].policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -17962,7 +17962,7 @@
 |`frontendPolicies.networkExtAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.networkExtAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.networkExtAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`frontendPolicies.networkExtAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`frontendPolicies.networkExtAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`frontendPolicies.networkExtAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`frontendPolicies.networkExtAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`frontendPolicies.networkExtAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -18273,7 +18273,7 @@
 |`frontendPolicies.accessLog.otlp.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.accessLog.otlp.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.accessLog.otlp.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`frontendPolicies.accessLog.otlp.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`frontendPolicies.accessLog.otlp.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`frontendPolicies.accessLog.otlp.policies.tcp`|object|TCP protocol settings for this backend.|
 |`frontendPolicies.accessLog.otlp.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`frontendPolicies.accessLog.otlp.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -18563,7 +18563,7 @@
 |`frontendPolicies.logging.otlp.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.logging.otlp.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.logging.otlp.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`frontendPolicies.logging.otlp.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`frontendPolicies.logging.otlp.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`frontendPolicies.logging.otlp.policies.tcp`|object|TCP protocol settings for this backend.|
 |`frontendPolicies.logging.otlp.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`frontendPolicies.logging.otlp.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -18849,7 +18849,7 @@
 |`frontendPolicies.tracing.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.tracing.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.tracing.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`frontendPolicies.tracing.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`frontendPolicies.tracing.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`frontendPolicies.tracing.policies.tcp`|object|TCP protocol settings for this backend.|
 |`frontendPolicies.tracing.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`frontendPolicies.tracing.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -19222,7 +19222,7 @@
 |`policies[].policy.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -19561,7 +19561,7 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -19837,7 +19837,7 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -20113,7 +20113,7 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -20387,7 +20387,7 @@
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -20699,7 +20699,7 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -20975,7 +20975,7 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21249,7 +21249,7 @@
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21572,7 +21572,7 @@
 |`policies[].policy.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21698,7 +21698,7 @@
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21815,7 +21815,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21890,7 +21890,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -22228,7 +22228,7 @@
 |`policies[].policy.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -22513,7 +22513,7 @@
 |`policies[].policy.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -22880,7 +22880,7 @@
 |`policies[].policy.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -23178,7 +23178,7 @@
 |`policies[].policy.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -23479,7 +23479,7 @@
 |`policies[].policy.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -23767,7 +23767,7 @@
 |`policies[].policy.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -24056,7 +24056,7 @@
 |`policies[].policy.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -24340,7 +24340,7 @@
 |`policies[].policy.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`policies[].policy.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`policies[].policy.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`policies[].policy.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -24701,7 +24701,7 @@
 |`backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -24913,7 +24913,7 @@
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25030,7 +25030,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25105,7 +25105,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25172,7 +25172,7 @@
 |`backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25442,7 +25442,7 @@
 |`backends[].ai.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25732,7 +25732,7 @@
 |`backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -26042,7 +26042,7 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -26358,7 +26358,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -26634,7 +26634,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -26910,7 +26910,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -27184,7 +27184,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -27496,7 +27496,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -27772,7 +27772,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28046,7 +28046,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28288,7 +28288,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28405,7 +28405,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28480,7 +28480,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28547,7 +28547,7 @@
 |`backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28817,7 +28817,7 @@
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -29107,7 +29107,7 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -29417,7 +29417,7 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -29733,7 +29733,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -30009,7 +30009,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -30285,7 +30285,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -30559,7 +30559,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -30871,7 +30871,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31147,7 +31147,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31421,7 +31421,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31624,7 +31624,7 @@
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31741,7 +31741,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31816,7 +31816,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31883,7 +31883,7 @@
 |`backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -32153,7 +32153,7 @@
 |`backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -32443,7 +32443,7 @@
 |`backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -32753,7 +32753,7 @@
 |`backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -33069,7 +33069,7 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -33345,7 +33345,7 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -33621,7 +33621,7 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -33895,7 +33895,7 @@
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -34207,7 +34207,7 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -34483,7 +34483,7 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -34757,7 +34757,7 @@
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -35149,7 +35149,7 @@
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -35488,7 +35488,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -35764,7 +35764,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -36040,7 +36040,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -36314,7 +36314,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -36626,7 +36626,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -36902,7 +36902,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37176,7 +37176,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37499,7 +37499,7 @@
 |`routeGroups[].routes[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37625,7 +37625,7 @@
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37742,7 +37742,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37817,7 +37817,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -38155,7 +38155,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -38440,7 +38440,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -38807,7 +38807,7 @@
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -39105,7 +39105,7 @@
 |`routeGroups[].routes[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -39406,7 +39406,7 @@
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -39694,7 +39694,7 @@
 |`routeGroups[].routes[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -39983,7 +39983,7 @@
 |`routeGroups[].routes[].policies.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40267,7 +40267,7 @@
 |`routeGroups[].routes[].policies.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40630,7 +40630,7 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40842,7 +40842,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40959,7 +40959,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -41034,7 +41034,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -41101,7 +41101,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -41371,7 +41371,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -41661,7 +41661,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -41971,7 +41971,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -42287,7 +42287,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -42563,7 +42563,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -42839,7 +42839,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -43113,7 +43113,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -43425,7 +43425,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -43701,7 +43701,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -43975,7 +43975,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44217,7 +44217,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44334,7 +44334,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44409,7 +44409,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44476,7 +44476,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44746,7 +44746,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -45036,7 +45036,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -45346,7 +45346,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -45662,7 +45662,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -45938,7 +45938,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -46214,7 +46214,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -46488,7 +46488,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -46800,7 +46800,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47076,7 +47076,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47350,7 +47350,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47555,7 +47555,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47672,7 +47672,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47747,7 +47747,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47814,7 +47814,7 @@
 |`routeGroups[].routes[].backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -48084,7 +48084,7 @@
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -48374,7 +48374,7 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -48684,7 +48684,7 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -49000,7 +49000,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -49276,7 +49276,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -49552,7 +49552,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -49826,7 +49826,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -50138,7 +50138,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -50414,7 +50414,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -50688,7 +50688,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -51066,7 +51066,7 @@
 |`gateways.*.listeners[].extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`gateways.*.listeners[].extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`gateways.*.listeners[].extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -51364,7 +51364,7 @@
 |`gateways.*.listeners[].extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.listeners[].extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.listeners[].extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`gateways.*.listeners[].extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`gateways.*.listeners[].extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`gateways.*.listeners[].extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.listeners[].extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.listeners[].extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -51665,7 +51665,7 @@
 |`gateways.*.listeners[].extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.listeners[].extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.listeners[].extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`gateways.*.listeners[].extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`gateways.*.listeners[].extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`gateways.*.listeners[].extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.listeners[].extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.listeners[].extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -51953,7 +51953,7 @@
 |`gateways.*.listeners[].extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.listeners[].extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.listeners[].extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`gateways.*.listeners[].extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`gateways.*.listeners[].extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`gateways.*.listeners[].extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.listeners[].extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.listeners[].extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -52379,7 +52379,7 @@
 |`gateways.*.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`gateways.*.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`gateways.*.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`gateways.*.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -52677,7 +52677,7 @@
 |`gateways.*.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`gateways.*.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`gateways.*.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`gateways.*.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -52978,7 +52978,7 @@
 |`gateways.*.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`gateways.*.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`gateways.*.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`gateways.*.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -53266,7 +53266,7 @@
 |`gateways.*.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`gateways.*.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`gateways.*.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`gateways.*.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -53712,7 +53712,7 @@
 |`routes[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -54051,7 +54051,7 @@
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -54327,7 +54327,7 @@
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -54603,7 +54603,7 @@
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -54877,7 +54877,7 @@
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -55189,7 +55189,7 @@
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -55465,7 +55465,7 @@
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -55739,7 +55739,7 @@
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56062,7 +56062,7 @@
 |`routes[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56188,7 +56188,7 @@
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56305,7 +56305,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56380,7 +56380,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56718,7 +56718,7 @@
 |`routes[].policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -57003,7 +57003,7 @@
 |`routes[].policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -57370,7 +57370,7 @@
 |`routes[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -57668,7 +57668,7 @@
 |`routes[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -57969,7 +57969,7 @@
 |`routes[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -58257,7 +58257,7 @@
 |`routes[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -58546,7 +58546,7 @@
 |`routes[].policies.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -58830,7 +58830,7 @@
 |`routes[].policies.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].policies.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59193,7 +59193,7 @@
 |`routes[].backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59405,7 +59405,7 @@
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59522,7 +59522,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59597,7 +59597,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59664,7 +59664,7 @@
 |`routes[].backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59934,7 +59934,7 @@
 |`routes[].backends[].ai.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -60224,7 +60224,7 @@
 |`routes[].backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -60534,7 +60534,7 @@
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -60850,7 +60850,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -61126,7 +61126,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -61402,7 +61402,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -61676,7 +61676,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -61988,7 +61988,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62264,7 +62264,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62538,7 +62538,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62780,7 +62780,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62897,7 +62897,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62972,7 +62972,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -63039,7 +63039,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -63309,7 +63309,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -63599,7 +63599,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -63909,7 +63909,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -64225,7 +64225,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -64501,7 +64501,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -64777,7 +64777,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65051,7 +65051,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65363,7 +65363,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65639,7 +65639,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65913,7 +65913,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66118,7 +66118,7 @@
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66235,7 +66235,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66310,7 +66310,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66377,7 +66377,7 @@
 |`routes[].backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66647,7 +66647,7 @@
 |`routes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66937,7 +66937,7 @@
 |`routes[].backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -67247,7 +67247,7 @@
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -67563,7 +67563,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -67839,7 +67839,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -68115,7 +68115,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -68389,7 +68389,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -68701,7 +68701,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -68977,7 +68977,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69251,7 +69251,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69602,7 +69602,7 @@
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`tcpRoutes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`tcpRoutes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69803,7 +69803,7 @@
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.providers[].defaults.auth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.providers[].defaults.auth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69920,7 +69920,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69995,7 +69995,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70328,7 +70328,7 @@
 |`llm.providers[].defaults.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.providers[].defaults.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.providers[].defaults.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.providers[].defaults.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.providers[].defaults.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.providers[].defaults.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.providers[].defaults.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.providers[].defaults.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70528,7 +70528,7 @@
 |`llm.models[].auth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].auth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].auth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].auth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].auth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].auth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].auth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].auth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70645,7 +70645,7 @@
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].auth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].auth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70720,7 +70720,7 @@
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -71053,7 +71053,7 @@
 |`llm.models[].backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -71342,7 +71342,7 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].guardrails.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -71618,7 +71618,7 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -71894,7 +71894,7 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].guardrails.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -72168,7 +72168,7 @@
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].guardrails.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -72480,7 +72480,7 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -72756,7 +72756,7 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].guardrails.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -73030,7 +73030,7 @@
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.models[].guardrails.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -73398,7 +73398,7 @@
 |`llm.policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -73696,7 +73696,7 @@
 |`llm.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -73997,7 +73997,7 @@
 |`llm.policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -74285,7 +74285,7 @@
 |`llm.policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -74670,7 +74670,7 @@
 |`llm.policies.guardrails.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.guardrails.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -74946,7 +74946,7 @@
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -75222,7 +75222,7 @@
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.guardrails.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -75496,7 +75496,7 @@
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.guardrails.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -75808,7 +75808,7 @@
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -76084,7 +76084,7 @@
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.guardrails.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -76358,7 +76358,7 @@
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.guardrails.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -76655,7 +76655,7 @@
 |`llm.policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`llm.policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`llm.policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`llm.policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -76968,7 +76968,7 @@
 |`mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -77308,7 +77308,7 @@
 |`mcp.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -77647,7 +77647,7 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -77923,7 +77923,7 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -78199,7 +78199,7 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -78473,7 +78473,7 @@
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -78785,7 +78785,7 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79061,7 +79061,7 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79335,7 +79335,7 @@
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79658,7 +79658,7 @@
 |`mcp.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79784,7 +79784,7 @@
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79901,7 +79901,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79976,7 +79976,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -80314,7 +80314,7 @@
 |`mcp.policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -80599,7 +80599,7 @@
 |`mcp.policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -80966,7 +80966,7 @@
 |`mcp.policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -81264,7 +81264,7 @@
 |`mcp.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -81565,7 +81565,7 @@
 |`mcp.policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -81853,7 +81853,7 @@
 |`mcp.policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -82142,7 +82142,7 @@
 |`mcp.policies.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -82426,7 +82426,7 @@
 |`mcp.policies.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`mcp.policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`mcp.policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`mcp.policies.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -82813,7 +82813,7 @@
 |`ui.policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`ui.policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`ui.policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`ui.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`ui.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`ui.policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`ui.policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`ui.policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -83111,7 +83111,7 @@
 |`ui.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`ui.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`ui.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
-|`ui.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
+|`ui.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted.|
 |`ui.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`ui.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`ui.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -467,6 +467,7 @@
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -805,6 +806,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -1080,6 +1082,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -1355,6 +1358,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -1628,6 +1632,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -1939,6 +1944,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -2214,6 +2220,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -2487,6 +2494,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -2809,6 +2817,7 @@
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -2934,6 +2943,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -3050,6 +3060,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -3124,6 +3135,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -3461,6 +3473,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -3745,6 +3758,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -4111,6 +4125,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -4408,6 +4423,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -4708,6 +4724,7 @@
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -4995,6 +5012,7 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -5283,6 +5301,7 @@
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -5566,6 +5585,7 @@
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -5928,6 +5948,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6139,6 +6160,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6255,6 +6277,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6329,6 +6352,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6395,6 +6419,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6664,6 +6689,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -6953,6 +6979,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -7262,6 +7289,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -7577,6 +7605,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -7852,6 +7881,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -8127,6 +8157,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -8400,6 +8431,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -8711,6 +8743,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -8986,6 +9019,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9259,6 +9293,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9500,6 +9535,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9616,6 +9652,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9690,6 +9727,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -9756,6 +9794,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -10025,6 +10064,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -10314,6 +10354,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -10623,6 +10664,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -10938,6 +10980,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -11213,6 +11256,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -11488,6 +11532,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -11761,6 +11806,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12072,6 +12118,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12347,6 +12394,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12620,6 +12668,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12824,6 +12873,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -12940,6 +12990,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13014,6 +13065,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13080,6 +13132,7 @@
 |`binds[].listeners[].routes[].backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13349,6 +13402,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13638,6 +13692,7 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -13947,6 +14002,7 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -14262,6 +14318,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -14537,6 +14594,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -14812,6 +14870,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -15085,6 +15144,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -15396,6 +15456,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -15671,6 +15732,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -15944,6 +16006,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -16293,6 +16356,7 @@
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -16611,6 +16675,7 @@
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -16908,6 +16973,7 @@
 |`binds[].listeners[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -17208,6 +17274,7 @@
 |`binds[].listeners[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -17495,6 +17562,7 @@
 |`binds[].listeners[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`binds[].listeners[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`binds[].listeners[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`binds[].listeners[].policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`binds[].listeners[].policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`binds[].listeners[].policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -17894,6 +17962,7 @@
 |`frontendPolicies.networkExtAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.networkExtAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.networkExtAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`frontendPolicies.networkExtAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`frontendPolicies.networkExtAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`frontendPolicies.networkExtAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`frontendPolicies.networkExtAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -18204,6 +18273,7 @@
 |`frontendPolicies.accessLog.otlp.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.accessLog.otlp.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.accessLog.otlp.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`frontendPolicies.accessLog.otlp.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`frontendPolicies.accessLog.otlp.policies.tcp`|object|TCP protocol settings for this backend.|
 |`frontendPolicies.accessLog.otlp.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`frontendPolicies.accessLog.otlp.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -18493,6 +18563,7 @@
 |`frontendPolicies.logging.otlp.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.logging.otlp.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.logging.otlp.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`frontendPolicies.logging.otlp.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`frontendPolicies.logging.otlp.policies.tcp`|object|TCP protocol settings for this backend.|
 |`frontendPolicies.logging.otlp.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`frontendPolicies.logging.otlp.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -18778,6 +18849,7 @@
 |`frontendPolicies.tracing.policies.http`|object|HTTP protocol settings for this backend.|
 |`frontendPolicies.tracing.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`frontendPolicies.tracing.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`frontendPolicies.tracing.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`frontendPolicies.tracing.policies.tcp`|object|TCP protocol settings for this backend.|
 |`frontendPolicies.tracing.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`frontendPolicies.tracing.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -19150,6 +19222,7 @@
 |`policies[].policy.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -19488,6 +19561,7 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -19763,6 +19837,7 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -20038,6 +20113,7 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -20311,6 +20387,7 @@
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -20622,6 +20699,7 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -20897,6 +20975,7 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21170,6 +21249,7 @@
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21492,6 +21572,7 @@
 |`policies[].policy.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21617,6 +21698,7 @@
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21733,6 +21815,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -21807,6 +21890,7 @@
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -22144,6 +22228,7 @@
 |`policies[].policy.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -22428,6 +22513,7 @@
 |`policies[].policy.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -22794,6 +22880,7 @@
 |`policies[].policy.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -23091,6 +23178,7 @@
 |`policies[].policy.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -23391,6 +23479,7 @@
 |`policies[].policy.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -23678,6 +23767,7 @@
 |`policies[].policy.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -23966,6 +24056,7 @@
 |`policies[].policy.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -24249,6 +24340,7 @@
 |`policies[].policy.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`policies[].policy.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`policies[].policy.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`policies[].policy.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`policies[].policy.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`policies[].policy.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`policies[].policy.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -24609,6 +24701,7 @@
 |`backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -24820,6 +24913,7 @@
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -24936,6 +25030,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25010,6 +25105,7 @@
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25076,6 +25172,7 @@
 |`backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25345,6 +25442,7 @@
 |`backends[].ai.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25634,6 +25732,7 @@
 |`backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -25943,6 +26042,7 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -26258,6 +26358,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -26533,6 +26634,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -26808,6 +26910,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -27081,6 +27184,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -27392,6 +27496,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -27667,6 +27772,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -27940,6 +28046,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28181,6 +28288,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28297,6 +28405,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28371,6 +28480,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28437,6 +28547,7 @@
 |`backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28706,6 +28817,7 @@
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -28995,6 +29107,7 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -29304,6 +29417,7 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -29619,6 +29733,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -29894,6 +30009,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -30169,6 +30285,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -30442,6 +30559,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -30753,6 +30871,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31028,6 +31147,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31301,6 +31421,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31503,6 +31624,7 @@
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31619,6 +31741,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31693,6 +31816,7 @@
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -31759,6 +31883,7 @@
 |`backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -32028,6 +32153,7 @@
 |`backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -32317,6 +32443,7 @@
 |`backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -32626,6 +32753,7 @@
 |`backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -32941,6 +33069,7 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -33216,6 +33345,7 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -33491,6 +33621,7 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -33764,6 +33895,7 @@
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -34075,6 +34207,7 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -34350,6 +34483,7 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -34623,6 +34757,7 @@
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -35014,6 +35149,7 @@
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -35352,6 +35488,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -35627,6 +35764,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -35902,6 +36040,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -36175,6 +36314,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -36486,6 +36626,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -36761,6 +36902,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37034,6 +37176,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37356,6 +37499,7 @@
 |`routeGroups[].routes[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37481,6 +37625,7 @@
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37597,6 +37742,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -37671,6 +37817,7 @@
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -38008,6 +38155,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -38292,6 +38440,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -38658,6 +38807,7 @@
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -38955,6 +39105,7 @@
 |`routeGroups[].routes[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -39255,6 +39406,7 @@
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -39542,6 +39694,7 @@
 |`routeGroups[].routes[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -39830,6 +39983,7 @@
 |`routeGroups[].routes[].policies.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40113,6 +40267,7 @@
 |`routeGroups[].routes[].policies.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40475,6 +40630,7 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40686,6 +40842,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40802,6 +40959,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40876,6 +41034,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -40942,6 +41101,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -41211,6 +41371,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -41500,6 +41661,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -41809,6 +41971,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -42124,6 +42287,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -42399,6 +42563,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -42674,6 +42839,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -42947,6 +43113,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -43258,6 +43425,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -43533,6 +43701,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -43806,6 +43975,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44047,6 +44217,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44163,6 +44334,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44237,6 +44409,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44303,6 +44476,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44572,6 +44746,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -44861,6 +45036,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -45170,6 +45346,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -45485,6 +45662,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -45760,6 +45938,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -46035,6 +46214,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -46308,6 +46488,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -46619,6 +46800,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -46894,6 +47076,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47167,6 +47350,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47371,6 +47555,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47487,6 +47672,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47561,6 +47747,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47627,6 +47814,7 @@
 |`routeGroups[].routes[].backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -47896,6 +48084,7 @@
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -48185,6 +48374,7 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -48494,6 +48684,7 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -48809,6 +49000,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -49084,6 +49276,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -49359,6 +49552,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -49632,6 +49826,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -49943,6 +50138,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -50218,6 +50414,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -50491,6 +50688,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -50868,6 +51066,7 @@
 |`gateways.*.listeners[].extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`gateways.*.listeners[].extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -51165,6 +51364,7 @@
 |`gateways.*.listeners[].extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.listeners[].extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.listeners[].extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`gateways.*.listeners[].extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`gateways.*.listeners[].extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.listeners[].extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.listeners[].extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -51465,6 +51665,7 @@
 |`gateways.*.listeners[].extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.listeners[].extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.listeners[].extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`gateways.*.listeners[].extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`gateways.*.listeners[].extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.listeners[].extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.listeners[].extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -51752,6 +51953,7 @@
 |`gateways.*.listeners[].extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.listeners[].extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.listeners[].extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`gateways.*.listeners[].extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`gateways.*.listeners[].extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.listeners[].extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.listeners[].extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -52177,6 +52379,7 @@
 |`gateways.*.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`gateways.*.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`gateways.*.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -52474,6 +52677,7 @@
 |`gateways.*.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`gateways.*.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`gateways.*.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -52774,6 +52978,7 @@
 |`gateways.*.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`gateways.*.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`gateways.*.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -53061,6 +53266,7 @@
 |`gateways.*.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`gateways.*.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`gateways.*.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`gateways.*.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`gateways.*.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`gateways.*.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`gateways.*.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -53506,6 +53712,7 @@
 |`routes[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -53844,6 +54051,7 @@
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -54119,6 +54327,7 @@
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -54394,6 +54603,7 @@
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -54667,6 +54877,7 @@
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -54978,6 +55189,7 @@
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -55253,6 +55465,7 @@
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -55526,6 +55739,7 @@
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -55848,6 +56062,7 @@
 |`routes[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -55973,6 +56188,7 @@
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56089,6 +56305,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56163,6 +56380,7 @@
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56500,6 +56718,7 @@
 |`routes[].policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -56784,6 +57003,7 @@
 |`routes[].policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -57150,6 +57370,7 @@
 |`routes[].policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -57447,6 +57668,7 @@
 |`routes[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -57747,6 +57969,7 @@
 |`routes[].policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -58034,6 +58257,7 @@
 |`routes[].policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -58322,6 +58546,7 @@
 |`routes[].policies.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -58605,6 +58830,7 @@
 |`routes[].policies.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].policies.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].policies.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].policies.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].policies.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].policies.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -58967,6 +59193,7 @@
 |`routes[].backends[].mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59178,6 +59405,7 @@
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59294,6 +59522,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59368,6 +59597,7 @@
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59434,6 +59664,7 @@
 |`routes[].backends[].ai.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59703,6 +59934,7 @@
 |`routes[].backends[].ai.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -59992,6 +60224,7 @@
 |`routes[].backends[].ai.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -60301,6 +60534,7 @@
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -60616,6 +60850,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -60891,6 +61126,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -61166,6 +61402,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -61439,6 +61676,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -61750,6 +61988,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62025,6 +62264,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62298,6 +62538,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62539,6 +62780,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62655,6 +62897,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62729,6 +62972,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -62795,6 +63039,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -63064,6 +63309,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -63353,6 +63599,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -63662,6 +63909,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -63977,6 +64225,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -64252,6 +64501,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -64527,6 +64777,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -64800,6 +65051,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65111,6 +65363,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65386,6 +65639,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65659,6 +65913,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65863,6 +66118,7 @@
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -65979,6 +66235,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66053,6 +66310,7 @@
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66119,6 +66377,7 @@
 |`routes[].backends[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66388,6 +66647,7 @@
 |`routes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66677,6 +66937,7 @@
 |`routes[].backends[].policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -66986,6 +67247,7 @@
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -67301,6 +67563,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -67576,6 +67839,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -67851,6 +68115,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -68124,6 +68389,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -68435,6 +68701,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -68710,6 +68977,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -68983,6 +69251,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69333,6 +69602,7 @@
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`tcpRoutes[].backends[].policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69533,6 +69803,7 @@
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.providers[].defaults.auth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.providers[].defaults.auth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69649,6 +69920,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.providers[].defaults.auth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -69723,6 +69995,7 @@
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.providers[].defaults.auth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70055,6 +70328,7 @@
 |`llm.providers[].defaults.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.providers[].defaults.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.providers[].defaults.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.providers[].defaults.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.providers[].defaults.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.providers[].defaults.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.providers[].defaults.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70254,6 +70528,7 @@
 |`llm.models[].auth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].auth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].auth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].auth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].auth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].auth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].auth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70370,6 +70645,7 @@
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].auth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].auth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70444,6 +70720,7 @@
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].auth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -70776,6 +71053,7 @@
 |`llm.models[].backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -71064,6 +71342,7 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -71339,6 +71618,7 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -71614,6 +71894,7 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -71887,6 +72168,7 @@
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -72198,6 +72480,7 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -72473,6 +72756,7 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -72746,6 +73030,7 @@
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -73113,6 +73398,7 @@
 |`llm.policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -73410,6 +73696,7 @@
 |`llm.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -73710,6 +73997,7 @@
 |`llm.policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -73997,6 +74285,7 @@
 |`llm.policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -74381,6 +74670,7 @@
 |`llm.policies.guardrails.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -74656,6 +74946,7 @@
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -74931,6 +75222,7 @@
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -75204,6 +75496,7 @@
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -75515,6 +75808,7 @@
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -75790,6 +76084,7 @@
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -76063,6 +76358,7 @@
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -76359,6 +76655,7 @@
 |`llm.policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`llm.policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`llm.policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`llm.policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`llm.policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`llm.policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`llm.policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -76671,6 +76968,7 @@
 |`mcp.targets[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.targets[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.targets[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.targets[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.targets[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.targets[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.targets[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -77010,6 +77308,7 @@
 |`mcp.policies.mcpGuardrails.processors[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.mcpGuardrails.processors[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.mcpGuardrails.processors[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.mcpGuardrails.processors[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.mcpGuardrails.processors[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.mcpGuardrails.processors[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.mcpGuardrails.processors[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -77348,6 +77647,7 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -77623,6 +77923,7 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -77898,6 +78199,7 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -78171,6 +78473,7 @@
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -78482,6 +78785,7 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -78757,6 +79061,7 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79030,6 +79335,7 @@
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79352,6 +79658,7 @@
 |`mcp.policies.backendTunnel.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.backendTunnel.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.backendTunnel.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.backendTunnel.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.backendTunnel.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.backendTunnel.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.backendTunnel.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79477,6 +79784,7 @@
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.backendAuth.oauthTokenExchange.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.backendAuth.oauthTokenExchange.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79593,6 +79901,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.backendAuth.crossAppAccess.identityProvider.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -79667,6 +79976,7 @@
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.backendAuth.crossAppAccess.resourceAuthorizationServer.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -80004,6 +80314,7 @@
 |`mcp.policies.remoteRateLimit.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -80288,6 +80599,7 @@
 |`mcp.policies.remoteRateLimit.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.remoteRateLimit.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.remoteRateLimit.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.remoteRateLimit.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.remoteRateLimit.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.remoteRateLimit.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -80654,6 +80966,7 @@
 |`mcp.policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -80951,6 +81264,7 @@
 |`mcp.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -81251,6 +81565,7 @@
 |`mcp.policies.extProc.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extProc.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extProc.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.extProc.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.extProc.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.extProc.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.extProc.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -81538,6 +81853,7 @@
 |`mcp.policies.extProc.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.extProc.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.extProc.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.extProc.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.extProc.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.extProc.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.extProc.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -81826,6 +82142,7 @@
 |`mcp.policies.substrateIngress.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.substrateIngress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.substrateIngress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.substrateIngress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.substrateIngress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.substrateIngress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.substrateIngress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -82109,6 +82426,7 @@
 |`mcp.policies.substrateEgress.policies.http`|object|HTTP protocol settings for this backend.|
 |`mcp.policies.substrateEgress.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`mcp.policies.substrateEgress.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`mcp.policies.substrateEgress.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`mcp.policies.substrateEgress.policies.tcp`|object|TCP protocol settings for this backend.|
 |`mcp.policies.substrateEgress.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`mcp.policies.substrateEgress.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -82495,6 +82813,7 @@
 |`ui.policies.extAuthz.conditional[].policies.http`|object|HTTP protocol settings for this backend.|
 |`ui.policies.extAuthz.conditional[].policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`ui.policies.extAuthz.conditional[].policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`ui.policies.extAuthz.conditional[].policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`ui.policies.extAuthz.conditional[].policies.tcp`|object|TCP protocol settings for this backend.|
 |`ui.policies.extAuthz.conditional[].policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`ui.policies.extAuthz.conditional[].policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|
@@ -82792,6 +83111,7 @@
 |`ui.policies.extAuthz.policies.http`|object|HTTP protocol settings for this backend.|
 |`ui.policies.extAuthz.policies.http.version`|string|HTTP version to use when connecting to the backend.|
 |`ui.policies.extAuthz.policies.http.requestTimeout`|string|Maximum time allowed for a backend HTTP request.|
+|`ui.policies.extAuthz.policies.http.maxConnectionDuration`|string|Maximum time a connection to the backend may stay open. A connection past this duration is<br>not reused for new requests; a fresh connection is established instead, while in-flight<br>requests are not interrupted. Useful for even traffic distribution and DNS freshness when<br>backends change over time.|
 |`ui.policies.extAuthz.policies.tcp`|object|TCP protocol settings for this backend.|
 |`ui.policies.extAuthz.policies.tcp.keepalives`|object|TCP keepalive settings for backend connections.|
 |`ui.policies.extAuthz.policies.tcp.keepalives.enabled`|boolean|Enable TCP keepalive probes on backend connections. Defaults to true.|


### PR DESCRIPTION
Adds a max_connection_duration to the outbound side of HTTP, similar to cluster-level [max_connection_duration](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#:~:text=for%20HTTP_DOWNSTREAM_CONNECTION_IDLE.-,max_connection_duration,-(Duration)%20The) in Envoy.

The pool will not hand out connections older than this to new requests. 

