### PR TITLE
poc: guardrails intelligent passthrough (bedrock)

### DIFF
--- a/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
+++ b/crates/agentgateway/src/llm/policy/bedrock_guardrails.rs
@@ -120,6 +120,77 @@ impl ApplyGuardrailResponse {
 			_ => false,
 		}
 	}
+
+	/// Deduplicated BLOCKED categories for the caller
+	pub fn blocked_categories(&self) -> Vec<String> {
+		/// `type` values of the BLOCKED entries under `assessment[policy][list]`.
+		fn blocked_types<'a>(
+			assessment: &'a serde_json::Value,
+			policy: &str,
+			list: &str,
+		) -> impl Iterator<Item = &'a str> {
+			assessment
+				.get(policy)
+				.and_then(|p| p.get(list))
+				.and_then(|l| l.as_array())
+				.into_iter()
+				.flatten()
+				.filter(|e| e.get("action").and_then(|a| a.as_str()) == Some("BLOCKED"))
+				.filter_map(|e| e.get("type").and_then(|t| t.as_str()))
+		}
+		/// Whether any entry under `assessment[policy][list]` is BLOCKED.
+		fn any_blocked(assessment: &serde_json::Value, policy: &str, list: &str) -> bool {
+			assessment
+				.get(policy)
+				.and_then(|p| p.get(list))
+				.and_then(|l| l.as_array())
+				.is_some_and(|entries| {
+					entries
+						.iter()
+						.any(|e| e.get("action").and_then(|a| a.as_str()) == Some("BLOCKED"))
+				})
+		}
+
+		let mut categories: Vec<String> = Vec::new();
+		let mut push = |cat: String| {
+			if !categories.contains(&cat) {
+				categories.push(cat);
+			}
+		};
+		for assessment in &self.assessments {
+			if !Self::value_contains_action(assessment, "BLOCKED") {
+				continue;
+			}
+			// Well known AWS fields for response
+			// https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ApplyGuardrail.html
+			for ty in blocked_types(assessment, "contentPolicy", "filters")
+				.chain(blocked_types(
+					assessment,
+					"sensitiveInformationPolicy",
+					"piiEntities",
+				))
+				.chain(blocked_types(
+					assessment,
+					"contextualGroundingPolicy",
+					"filters",
+				))
+				.chain(blocked_types(assessment, "wordPolicy", "managedWordLists"))
+			{
+				push(ty.to_owned());
+			}
+			// Operator-authored or content-bearing — collapse to a generic marker.
+			if any_blocked(assessment, "topicPolicy", "topics") {
+				push("topic".to_owned());
+			}
+			if any_blocked(assessment, "wordPolicy", "customWords") {
+				push("word".to_owned());
+			}
+			if any_blocked(assessment, "sensitiveInformationPolicy", "regexes") {
+				push("regex".to_owned());
+			}
+		}
+		categories
+	}
 }
 
 /// Assessment keys that are safe to log. Top-level keys are policy names (fixed

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1167,11 +1167,21 @@ impl Policy {
 				"Bedrock guardrail masked output count mismatch; rejecting content"
 			);
 		}
+		// If no custom rejection content then we replace with content from bedrock
+		// Must be done early enough so as to have assessments accessible.
+		let categories = (!masked && resp.is_blocked() && rejection.body == default_body())
+			.then(|| resp.blocked_categories())
+			.filter(|cats| !cats.is_empty());
 		let detail = resp.build_detail(guardrails);
 		let outcome = if masked {
 			GuardrailOutcome::Masked(TextReplacements::replace_all(resp.into_output_texts()))
 		} else {
-			GuardrailOutcome::Rejected(rejection.as_response())
+			let mut response = rejection.as_response();
+			if let Some(cats) = categories {
+				*response.body_mut() =
+					http::Body::from(format!("Blocked by guardrail: {}", cats.join(", ")));
+			}
+			GuardrailOutcome::Rejected(response)
 		};
 		(outcome, Some(detail))
 	}

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1169,9 +1169,13 @@ impl Policy {
 		}
 		// If no custom rejection content then we replace with content from bedrock
 		// Must be done early enough so as to have assessments accessible.
-		let categories = (!masked && resp.is_blocked() && rejection.body == default_body())
-			.then(|| resp.blocked_categories())
-			.filter(|cats| !cats.is_empty());
+		let categories = (!masked
+			&& resp.is_blocked()
+			&& rejection.body == default_body()
+			&& rejection.status == default_code()
+			&& rejection.headers.is_none())
+		.then(|| resp.blocked_categories())
+		.filter(|cats| !cats.is_empty());
 		let detail = resp.build_detail(guardrails);
 		let outcome = if masked {
 			GuardrailOutcome::Masked(TextReplacements::replace_all(resp.into_output_texts()))

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -918,6 +918,129 @@ mod bedrock_guardrails_tests {
 		assert!(!response.is_anonymized());
 		assert!(response.is_intervened());
 	}
+
+	#[test]
+	fn bedrock_blocked_categories_content_policy() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "blocked"}],
+			"assessments": [{
+				"contentPolicy": {
+					"filters": [
+						{"action": "BLOCKED", "type": "HATE", "confidence": "HIGH"},
+						{"action": "BLOCKED", "type": "VIOLENCE", "confidence": "MEDIUM"}
+					]
+				}
+			}]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(response.is_blocked());
+		assert_eq!(response.blocked_categories(), vec!["HATE", "VIOLENCE"]);
+	}
+
+	#[test]
+	fn bedrock_blocked_categories_topic_is_generic_marker() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "blocked"}],
+			"assessments": [{
+				"topicPolicy": {
+					"topics": [
+						{"action": "BLOCKED", "name": "Finance", "type": "DENY"},
+						{"action": "BLOCKED", "name": "Weapons", "type": "DENY"}
+					]
+				}
+			}]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(response.is_blocked());
+		// Operator-authored topic names must never leak to the caller.
+		assert_eq!(response.blocked_categories(), vec!["topic"]);
+	}
+
+	/// Grounding filters and managed word lists surface verbatim; custom words and named regexes collapse to markers.
+	#[test]
+	fn bedrock_blocked_categories_word_grounding_and_regex() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "blocked"}],
+			"assessments": [{
+				"contextualGroundingPolicy": {
+					"filters": [{"action": "BLOCKED", "type": "GROUNDING", "score": 0.1}]
+				},
+				"wordPolicy": {
+					"managedWordLists": [{"action": "BLOCKED", "type": "PROFANITY", "match": "$#!%"}],
+					"customWords": [{"action": "BLOCKED", "match": "projectxyz"}]
+				},
+				"sensitiveInformationPolicy": {
+					"regexes": [{"action": "BLOCKED", "name": "internal-ticket", "match": "T-4242"}]
+				}
+			}]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(response.is_blocked());
+		let cats = response.blocked_categories();
+		assert!(cats.contains(&"GROUNDING".to_string()));
+		assert!(cats.contains(&"PROFANITY".to_string()));
+		assert!(cats.contains(&"word".to_string()));
+		assert!(cats.contains(&"regex".to_string()));
+		// The operator-authored word, regex name, and matched text must not leak.
+		let joined = cats.join(",");
+		assert!(!joined.contains("projectxyz"));
+		assert!(!joined.contains("internal-ticket"));
+		assert!(!joined.contains("T-4242"));
+	}
+
+	#[test]
+	fn bedrock_blocked_categories_mixed_policies_dedup() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "blocked"}],
+			"assessments": [
+				{"contentPolicy": {"filters": [{"action": "BLOCKED", "type": "HATE", "confidence": "HIGH"}]}},
+				{"topicPolicy": {"topics": [{"action": "BLOCKED", "name": "Politics", "type": "DENY"}]}},
+				{"sensitiveInformationPolicy": {"piiEntities": [{"action": "BLOCKED", "type": "SSN"}]}}
+			]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(response.is_blocked());
+		let cats = response.blocked_categories();
+		assert!(cats.contains(&"HATE".to_string()));
+		assert!(cats.contains(&"topic".to_string()));
+		assert!(cats.contains(&"SSN".to_string()));
+		assert!(!cats.iter().any(|t| t.contains("Politics")));
+	}
+
+	#[test]
+	fn bedrock_blocked_categories_empty_when_not_blocked() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "masked"}],
+			"assessments": [{
+				"sensitiveInformationPolicy": {
+					"piiEntities": [{"action": "ANONYMIZED", "match": "John", "type": "NAME"}]
+				}
+			}]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(!response.is_blocked());
+		assert!(response.blocked_categories().is_empty());
+	}
+
+	/// A BLOCKED action under a policy we don't extract from counts as blocked but yields no categories.
+	#[test]
+	fn bedrock_blocked_categories_empty_for_unhandled_policy() {
+		let json = json!({
+			"action": "GUARDRAIL_INTERVENED",
+			"outputs": [{"text": "blocked"}],
+			"assessments": [{
+				"futurePolicy": {"items": [{"action": "BLOCKED"}]}
+			}]
+		});
+		let response: ApplyGuardrailResponse = serde_json::from_value(json).unwrap();
+		assert!(response.is_blocked());
+		assert!(response.blocked_categories().is_empty());
+	}
 }
 
 /// Build an intervened ApplyGuardrail response from output texts and assessments JSON.
@@ -1094,6 +1217,86 @@ fn bedrock_blocked_intervention_with_canned_output_rejects() {
 		&bedrock_test_config(),
 	);
 	assert!(matches!(outcome, GuardrailOutcome::Rejected(_)));
+}
+
+/// A default rejection body is replaced with the sanitized block categories.
+#[tokio::test]
+async fn bedrock_blocked_rejection_body_includes_categories() {
+	use http_body_util::BodyExt as _;
+	let resp = bedrock_intervened(
+		&["Sorry, I can't help with that."],
+		serde_json::json!([{
+			"contentPolicy": {
+				"filters": [
+					{"action": "BLOCKED", "type": "HATE", "confidence": "HIGH"},
+					{"action": "BLOCKED", "type": "VIOLENCE", "confidence": "MEDIUM"}
+				]
+			}
+		}]),
+	);
+	let (outcome, _) = Policy::bedrock_guardrail_outcome(
+		resp,
+		1,
+		&RequestRejection::default(),
+		&bedrock_test_config(),
+	);
+	let GuardrailOutcome::Rejected(response) = outcome else {
+		panic!("expected GuardrailOutcome::Rejected");
+	};
+	let body = response.into_body().collect().await.unwrap().to_bytes();
+	let body = std::str::from_utf8(&body).unwrap();
+	assert!(body.contains("Blocked by guardrail"));
+	assert!(body.contains("HATE"));
+	assert!(body.contains("VIOLENCE"));
+}
+
+/// A configured (non-default) rejection body wins over the derived categories.
+#[tokio::test]
+async fn bedrock_blocked_rejection_prefers_custom_body() {
+	use http_body_util::BodyExt as _;
+	let resp = bedrock_intervened(
+		&["Sorry, I can't help with that."],
+		serde_json::json!([{
+			"contentPolicy": {
+				"filters": [{"action": "BLOCKED", "type": "HATE", "confidence": "HIGH"}]
+			}
+		}]),
+	);
+	let rejection = RequestRejection {
+		body: Bytes::from_static(b"Denied by policy."),
+		..RequestRejection::default()
+	};
+	let (outcome, _) = Policy::bedrock_guardrail_outcome(resp, 1, &rejection, &bedrock_test_config());
+	let GuardrailOutcome::Rejected(response) = outcome else {
+		panic!("expected GuardrailOutcome::Rejected");
+	};
+	let body = response.into_body().collect().await.unwrap().to_bytes();
+	let body = std::str::from_utf8(&body).unwrap();
+	assert_eq!(body, "Denied by policy.");
+	assert!(!body.contains("HATE"));
+}
+
+/// A block with no derivable category falls back to the default body, not a bare "Blocked by guardrail:".
+#[tokio::test]
+async fn bedrock_blocked_rejection_falls_back_to_default_body() {
+	use http_body_util::BodyExt as _;
+	let resp = bedrock_intervened(
+		&["Sorry, I can't help with that."],
+		serde_json::json!([{"futurePolicy": {"items": [{"action": "BLOCKED"}]}}]),
+	);
+	assert!(resp.is_blocked());
+	assert!(resp.blocked_categories().is_empty());
+	let (outcome, _) = Policy::bedrock_guardrail_outcome(
+		resp,
+		1,
+		&RequestRejection::default(),
+		&bedrock_test_config(),
+	);
+	let GuardrailOutcome::Rejected(response) = outcome else {
+		panic!("expected GuardrailOutcome::Rejected");
+	};
+	let body = response.into_body().collect().await.unwrap().to_bytes();
+	assert_eq!(body, default_body());
 }
 
 /// Automated reasoning findings carry no `action` field; even when the output count

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -1276,6 +1276,29 @@ async fn bedrock_blocked_rejection_prefers_custom_body() {
 	assert!(!body.contains("HATE"));
 }
 
+/// A configured status (or headers) counts as a static rejection response, so the default body is left untouched.
+#[tokio::test]
+async fn bedrock_blocked_rejection_skips_when_status_configured() {
+	use http_body_util::BodyExt as _;
+	let resp = bedrock_intervened(
+		&["Sorry, I can't help with that."],
+		serde_json::json!([{
+			"contentPolicy": {"filters": [{"action": "BLOCKED", "type": "HATE", "confidence": "HIGH"}]}
+		}]),
+	);
+	let rejection = RequestRejection {
+		status: StatusCode::BAD_REQUEST,
+		..RequestRejection::default()
+	};
+	let (outcome, _) = Policy::bedrock_guardrail_outcome(resp, 1, &rejection, &bedrock_test_config());
+	let GuardrailOutcome::Rejected(response) = outcome else {
+		panic!("expected GuardrailOutcome::Rejected");
+	};
+	assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+	let body = response.into_body().collect().await.unwrap().to_bytes();
+	assert_eq!(body, default_body());
+}
+
 /// A block with no derivable category falls back to the default body, not a bare "Blocked by guardrail:".
 #[tokio::test]
 async fn bedrock_blocked_rejection_falls_back_to_default_body() {


### PR DESCRIPTION
The idea here is that guard rails already return alot so if we can scope passthrough to well known pieces of the third party guard rail we can give richer content as long as a static response is not configured.

One might ask for a version of this that combines user defined response plus the bedrock response but thats a future piece of work imo.


