### PR TITLE
standalone: allow disabling audience validation for mcp auth

### DIFF
--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2987,7 +2987,8 @@ pub struct LocalMcpAuthentication {
 	/// Expected token issuer, matched against the JWT `iss` claim.
 	pub issuer: String,
 	/// Accepted token audiences, matched against the JWT `aud` claim.
-	pub audiences: Vec<String>,
+	/// If unset, audience validation is disabled.
+	pub audiences: Option<Vec<String>>,
 	/// Identity provider type used to derive MCP authorization metadata and default JWKS URLs.
 	pub provider: Option<McpIDP>,
 	/// Protected resource metadata returned to MCP clients.
@@ -3080,7 +3081,7 @@ impl LocalMcpAuthentication {
 			location: self.authorization_location.clone(),
 			preserve_token: false,
 			issuer: self.issuer.clone(),
-			audiences: Some(self.audiences.clone()),
+			audiences: self.audiences.clone(),
 			jwks,
 			jwt_validation_options: self.jwt_validation_options.clone(),
 		})
@@ -3095,7 +3096,7 @@ impl LocalMcpAuthentication {
 		let jwt = jwt_cfg.try_into(resources).await?;
 		Ok(McpAuthentication {
 			issuer: self.issuer.clone(),
-			audiences: self.audiences.clone(),
+			audiences: self.audiences.clone().unwrap_or_default(),
 			provider: self.provider.clone(),
 			resource_metadata: self.resource_metadata.clone(),
 			jwt_validator: Arc::new(jwt),
@@ -3650,6 +3651,24 @@ resourceMetadata:
 		assert_eq!(auth.client_id.as_deref(), Some("client-id-guid"));
 		assert!(auth.client_secret.is_some());
 		assert!(auth.as_jwt().is_ok());
+	}
+
+	#[test]
+	fn test_local_mcp_authentication_without_audiences() {
+		let yaml = r#"
+issuer: "https://example.com"
+jwks: '{"keys":[]}'
+resourceMetadata: {}
+"#;
+		let auth: LocalMcpAuthentication = serde_yaml::from_str(yaml).unwrap();
+		assert_eq!(auth.audiences, None);
+
+		match auth.as_jwt().unwrap() {
+			http::jwt::LocalJwtConfig::Single { audiences, .. } => {
+				assert_eq!(audiences, None);
+			},
+			_ => panic!("Expected LocalJwtConfig::Single"),
+		}
 	}
 
 	#[test]

--- a/schema/config.json
+++ b/schema/config.json
@@ -4632,8 +4632,11 @@
           "type": "string"
         },
         "audiences": {
-          "description": "Accepted token audiences, matched against the JWT `aud` claim.",
-          "type": "array",
+          "description": "Accepted token audiences, matched against the JWT `aud` claim.\nIf unset, audience validation is disabled.",
+          "type": [
+            "array",
+            "null"
+          ],
           "items": {
             "type": "string"
           }
@@ -4701,7 +4704,6 @@
       "additionalProperties": false,
       "required": [
         "issuer",
-        "audiences",
         "resourceMetadata"
       ]
     },

--- a/schema/config.md
+++ b/schema/config.md
@@ -497,7 +497,7 @@
 |`binds[].listeners[].routes[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication`|object|Authenticate MCP clients.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
-|`binds[].listeners[].routes[].policies.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.|
+|`binds[].listeners[].routes[].policies.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.<br>If unset, audience validation is disabled.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider`|object|Identity provider type used to derive MCP authorization metadata and default JWKS URLs.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.auth0`|object||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.keycloak`|object||
@@ -19180,7 +19180,7 @@
 |`policies[].policy.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`policies[].policy.mcpAuthentication`|object|Authenticate MCP clients.|
 |`policies[].policy.mcpAuthentication.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
-|`policies[].policy.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.|
+|`policies[].policy.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.<br>If unset, audience validation is disabled.|
 |`policies[].policy.mcpAuthentication.provider`|object|Identity provider type used to derive MCP authorization metadata and default JWKS URLs.|
 |`policies[].policy.mcpAuthentication.provider.auth0`|object||
 |`policies[].policy.mcpAuthentication.provider.keycloak`|object||
@@ -35044,7 +35044,7 @@
 |`routeGroups[].routes[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`routeGroups[].routes[].policies.mcpAuthentication`|object|Authenticate MCP clients.|
 |`routeGroups[].routes[].policies.mcpAuthentication.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
-|`routeGroups[].routes[].policies.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.|
+|`routeGroups[].routes[].policies.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.<br>If unset, audience validation is disabled.|
 |`routeGroups[].routes[].policies.mcpAuthentication.provider`|object|Identity provider type used to derive MCP authorization metadata and default JWKS URLs.|
 |`routeGroups[].routes[].policies.mcpAuthentication.provider.auth0`|object||
 |`routeGroups[].routes[].policies.mcpAuthentication.provider.keycloak`|object||
@@ -53536,7 +53536,7 @@
 |`routes[].policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`routes[].policies.mcpAuthentication`|object|Authenticate MCP clients.|
 |`routes[].policies.mcpAuthentication.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
-|`routes[].policies.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.|
+|`routes[].policies.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.<br>If unset, audience validation is disabled.|
 |`routes[].policies.mcpAuthentication.provider`|object|Identity provider type used to derive MCP authorization metadata and default JWKS URLs.|
 |`routes[].policies.mcpAuthentication.provider.auth0`|object||
 |`routes[].policies.mcpAuthentication.provider.keycloak`|object||
@@ -77040,7 +77040,7 @@
 |`mcp.policies.authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`mcp.policies.mcpAuthentication`|object|Authenticate MCP clients.|
 |`mcp.policies.mcpAuthentication.issuer`|string|Expected token issuer, matched against the JWT `iss` claim.|
-|`mcp.policies.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.|
+|`mcp.policies.mcpAuthentication.audiences`|[]string|Accepted token audiences, matched against the JWT `aud` claim.<br>If unset, audience validation is disabled.|
 |`mcp.policies.mcpAuthentication.provider`|object|Identity provider type used to derive MCP authorization metadata and default JWKS URLs.|
 |`mcp.policies.mcpAuthentication.provider.auth0`|object||
 |`mcp.policies.mcpAuthentication.provider.keycloak`|object||


### PR DESCRIPTION
Fixes https://github.com/agentgateway/agentgateway/issues/1986

This aligns with other jwt policies

Signed-off-by: John Howard <john.howard@solo.io>
