### PR TITLE
test(e2e): make multicontroller fixture configurable

### DIFF
--- a/controller/test/e2e/base/manifest_interceptor.go
+++ b/controller/test/e2e/base/manifest_interceptor.go
@@ -8,14 +8,17 @@ import (
 	"istio.io/istio/pkg/test"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/agentgateway/agentgateway/controller/pkg/utils/helmutils"
 	"github.com/agentgateway/agentgateway/controller/pkg/wellknown"
 )
 
 var (
-	AgentgatewayControllerName = wellknown.DefaultAgwControllerName
-	agentgatewayBackendGVK     = wellknown.AgentgatewayBackendGVK
-	agentgatewayParametersGVK  = wellknown.AgentgatewayParametersGVK
-	agentgatewayPolicyGVK      = wellknown.AgentgatewayPolicyGVK
+	AgentgatewayControllerName           = wellknown.DefaultAgwControllerName
+	AgentgatewayClassName                = wellknown.DefaultAgwClassName
+	AgentgatewayControllerDeploymentName = helmutils.AgentgatewayChartName
+	agentgatewayBackendGVK               = wellknown.AgentgatewayBackendGVK
+	agentgatewayParametersGVK            = wellknown.AgentgatewayParametersGVK
+	agentgatewayPolicyGVK                = wellknown.AgentgatewayPolicyGVK
 )
 
 var configureTest = func(t *testing.T) {}

--- a/controller/test/e2e/multicontroller_test.go
+++ b/controller/test/e2e/multicontroller_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"istio.io/istio/pkg/test/util/retry"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,11 +32,12 @@ const (
 func TestMultipleControllers(tt *testing.T) {
 	t := New(tt)
 
-	assertGatewayClassController(t, "agentgateway", base.AgentgatewayControllerName)
+	assertGatewayClassController(t, base.AgentgatewayClassName, base.AgentgatewayControllerName)
 
 	secondary := e2e.CreateSharedTestInstallation(
 		secondaryControllerNamespace,
 		e2e.ManifestPath("agent-gateway-secondary.yaml"),
+		e2e.WithManagedLifecycle(),
 	)
 	secondary.ExtraHelmArgs = primaryImageHelmArgs(t)
 	testutils.Cleanup(t, func() {
@@ -45,7 +47,7 @@ func TestMultipleControllers(tt *testing.T) {
 	secondary.InstallAgentgatewayCoreFromLocalChart(t.Ctx, tt)
 
 	assertGatewayClassController(t, secondaryGatewayClass, secondaryControllerName)
-	assertGatewayClassController(t, "agentgateway", base.AgentgatewayControllerName)
+	assertGatewayClassController(t, base.AgentgatewayClassName, base.AgentgatewayControllerName)
 
 	t.Apply(manifest("multicontroller", "setup.yaml"))
 	t.GatewayReady("secondary-gateway", secondaryWorkloadNamespace)
@@ -77,7 +79,7 @@ func TestMultipleControllers(tt *testing.T) {
 		curl.WithPath("/status/200"),
 	)
 
-	assertGatewayClassController(t, "agentgateway", base.AgentgatewayControllerName)
+	assertGatewayClassController(t, base.AgentgatewayClassName, base.AgentgatewayControllerName)
 }
 
 func applyWithoutResourceWait(t base.Test, manifest string) {
@@ -94,7 +96,7 @@ func primaryImageHelmArgs(t base.Test) []string {
 	t.Helper()
 	deployment, err := t.TestInstallation.ClusterContext.Client.Kube().AppsV1().Deployments(
 		t.TestInstallation.InstallNamespace,
-	).Get(t.Ctx, "agentgateway", metav1.GetOptions{})
+	).Get(t.Ctx, base.AgentgatewayControllerDeploymentName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("get primary controller deployment: %v", err)
 	}
@@ -102,17 +104,112 @@ func primaryImageHelmArgs(t base.Test) []string {
 		t.Fatal("primary controller deployment has no containers")
 	}
 
-	image := deployment.Spec.Template.Spec.Containers[0].Image
+	controller := deployment.Spec.Template.Spec.Containers[0]
+	helmArgs, err := installationImageHelmArgs(controller.Image, controller.Env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return helmArgs
+}
+
+func installationImageHelmArgs(image string, env []corev1.EnvVar) ([]string, error) {
 	lastSlash := strings.LastIndex(image, "/")
 	lastColon := strings.LastIndex(image, ":")
 	if lastSlash < 0 || lastColon <= lastSlash || lastColon == len(image)-1 {
-		t.Fatalf("primary controller image %q does not contain a registry, repository, and tag", image)
+		return nil, fmt.Errorf("primary controller image %q does not contain a registry, repository, and tag", image)
 	}
 
-	return []string{
-		"--set-string", "image.registry=" + image[:lastSlash],
-		"--set-string", "image.tag=" + image[lastColon+1:],
+	registry := image[:lastSlash]
+	tag := image[lastColon+1:]
+	args := []string{
+		"--set-string", "controller.image.registry=" + registry,
+		"--set-string", "controller.image.repository=" + image[lastSlash+1:lastColon],
+		"--set-string", "controller.image.tag=" + tag,
 	}
+
+	proxyImage := map[string]string{
+		"registry":   registry,
+		"repository": "",
+		"tag":        tag,
+	}
+	for _, variable := range env {
+		switch variable.Name {
+		case "AGW_PROXY_IMAGE_REGISTRY":
+			proxyImage["registry"] = variable.Value
+		case "AGW_PROXY_IMAGE_REPOSITORY":
+			proxyImage["repository"] = variable.Value
+		case "AGW_PROXY_IMAGE_TAG":
+			proxyImage["tag"] = variable.Value
+		}
+	}
+	if proxyImage["repository"] == "" {
+		return nil, fmt.Errorf("primary controller deployment does not configure AGW_PROXY_IMAGE_REPOSITORY")
+	}
+
+	args = append(args,
+		"--set-string", "proxy.image.registry="+proxyImage["registry"],
+		"--set-string", "proxy.image.repository="+proxyImage["repository"],
+		"--set-string", "proxy.image.tag="+proxyImage["tag"],
+	)
+	return args, nil
+}
+
+func TestInstallationImageHelmArgs(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+		env   []corev1.EnvVar
+		want  []string
+	}{
+		{
+			name:  "default registry",
+			image: "cr.agentgateway.dev/agentgateway/controller:v1.2.3",
+			env: []corev1.EnvVar{
+				{Name: "AGW_PROXY_IMAGE_REGISTRY", Value: "cr.agentgateway.dev/agentgateway"},
+				{Name: "AGW_PROXY_IMAGE_REPOSITORY", Value: "agentgateway"},
+				{Name: "AGW_PROXY_IMAGE_TAG", Value: "v1.2.3"},
+			},
+			want: []string{
+				"--set-string", "controller.image.registry=cr.agentgateway.dev/agentgateway",
+				"--set-string", "controller.image.repository=controller",
+				"--set-string", "controller.image.tag=v1.2.3",
+				"--set-string", "proxy.image.registry=cr.agentgateway.dev/agentgateway",
+				"--set-string", "proxy.image.repository=agentgateway",
+				"--set-string", "proxy.image.tag=v1.2.3",
+			},
+		},
+		{
+			name:  "registry with port and alternate repository",
+			image: "localhost:5000/team/enterprise-controller:test",
+			env: []corev1.EnvVar{
+				{Name: "AGW_PROXY_IMAGE_REGISTRY", Value: "localhost:5000/team"},
+				{Name: "AGW_PROXY_IMAGE_REPOSITORY", Value: "enterprise-proxy"},
+				{Name: "AGW_PROXY_IMAGE_TAG", Value: "test"},
+			},
+			want: []string{
+				"--set-string", "controller.image.registry=localhost:5000/team",
+				"--set-string", "controller.image.repository=enterprise-controller",
+				"--set-string", "controller.image.tag=test",
+				"--set-string", "proxy.image.registry=localhost:5000/team",
+				"--set-string", "proxy.image.repository=enterprise-proxy",
+				"--set-string", "proxy.image.tag=test",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := installationImageHelmArgs(tt.image, tt.env)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	_, err := installationImageHelmArgs("controller:latest", nil)
+	assert.EqualError(t, err, `primary controller image "controller:latest" does not contain a registry, repository, and tag`)
+
+	_, err = installationImageHelmArgs("registry.example/controller:latest", nil)
+	assert.EqualError(t, err, "primary controller deployment does not configure AGW_PROXY_IMAGE_REPOSITORY")
 }
 
 func assertGatewayClassController(t base.Test, name, controllerName string) {

--- a/controller/test/e2e/test.go
+++ b/controller/test/e2e/test.go
@@ -36,11 +36,23 @@ import (
 func CreateSharedTestInstallation(
 	installNamespace string,
 	valuesManifestFile string,
+	opts ...TestInstallationOption,
 ) *TestInstallation {
 	runtimeContext := testruntime.NewContext()
 	clusterContext := cluster.MustKindContext(runtimeContext.ClusterName)
 
-	return createTestInstallationForCluster(runtimeContext, clusterContext, installNamespace, valuesManifestFile)
+	return createTestInstallationForCluster(runtimeContext, clusterContext, installNamespace, valuesManifestFile, opts...)
+}
+
+// TestInstallationOption configures a TestInstallation.
+type TestInstallationOption func(*TestInstallation)
+
+// WithManagedLifecycle makes this installation manage its own Helm lifecycle
+// even when SKIP_INSTALL is set for a shared, externally managed installation.
+func WithManagedLifecycle() TestInstallationOption {
+	return func(i *TestInstallation) {
+		i.manageLifecycle = true
+	}
 }
 
 func createTestInstallationForCluster(
@@ -48,6 +60,7 @@ func createTestInstallationForCluster(
 	clusterContext *cluster.Context,
 	installNamespace string,
 	valuesManifestFile string,
+	opts ...TestInstallationOption,
 ) *TestInstallation {
 	if installNamespace == "" {
 		panic("install namespace must not be empty")
@@ -55,7 +68,7 @@ func createTestInstallationForCluster(
 	if valuesManifestFile == "" {
 		panic("values manifest file must not be empty")
 	}
-	return &TestInstallation{
+	installation := &TestInstallation{
 		// RuntimeContext contains the set of properties that are defined at runtime by whoever is invoking tests
 		RuntimeContext: runtimeContext,
 
@@ -73,6 +86,10 @@ func createTestInstallationForCluster(
 		// between TestInstallation outputs per CI run
 		GeneratedFiles: MustGeneratedFiles(installNamespace, clusterContext.Name),
 	}
+	for _, opt := range opts {
+		opt(installation)
+	}
+	return installation
 }
 
 // TestInstallation is the structure around a set of tests that validate behavior for an installation
@@ -90,6 +107,10 @@ type TestInstallation struct {
 	ValuesManifestFile string
 	ExtraHelmArgs      []string
 
+	// manageLifecycle allows an installation created within a test to opt out
+	// of the suite-wide SKIP_INSTALL setting used to reuse a primary install.
+	manageLifecycle bool
+
 	Helm *helmutils.Client
 
 	// GeneratedFiles is the collection of directories and files that this test installation _may_ create
@@ -98,6 +119,10 @@ type TestInstallation struct {
 
 func (i *TestInstallation) String() string {
 	return i.InstallNamespace
+}
+
+func (i *TestInstallation) shouldSkipInstallAndTeardown() bool {
+	return !i.manageLifecycle && testutils.ShouldSkipInstallAndTeardown()
 }
 
 func (i *TestInstallation) Finalize() {
@@ -130,7 +155,7 @@ func (i *TestInstallation) InstallFromLocalChart(ctx context.Context, t *testing
 
 // InstallAgentgatewayCRDsFromLocalChart installs the agentgateway CRD chart from the local filesystem
 func (i *TestInstallation) InstallAgentgatewayCRDsFromLocalChart(ctx context.Context, t *testing.T) {
-	if testutils.ShouldSkipInstallAndTeardown() {
+	if i.shouldSkipInstallAndTeardown() {
 		return
 	}
 
@@ -157,7 +182,7 @@ func (i *TestInstallation) InstallAgentgatewayCRDsFromLocalChart(ctx context.Con
 
 // InstallAgentgatewayCoreFromLocalChart installs the agentgateway main chart from the local filesystem
 func (i *TestInstallation) InstallAgentgatewayCoreFromLocalChart(ctx context.Context, t *testing.T) {
-	if testutils.ShouldSkipInstallAndTeardown() {
+	if i.shouldSkipInstallAndTeardown() {
 		return
 	}
 
@@ -203,7 +228,7 @@ func (i *TestInstallation) Uninstall(ctx context.Context, t *testing.T) {
 
 // UninstallAgentgatewayCore uninstalls the agentgateway main chart
 func (i *TestInstallation) UninstallAgentgatewayCore(ctx context.Context, t *testing.T) {
-	if testutils.ShouldSkipInstallAndTeardown() || testutils.ShouldPersistInstall() {
+	if i.shouldSkipInstallAndTeardown() || testutils.ShouldPersistInstall() {
 		return
 	}
 
@@ -228,7 +253,7 @@ func (i *TestInstallation) UninstallAgentgatewayCore(ctx context.Context, t *tes
 
 // UninstallAgentgatewayCRDs uninstalls the agentgateway CRD chart
 func (i *TestInstallation) UninstallAgentgatewayCRDs(ctx context.Context, t *testing.T) {
-	if testutils.ShouldSkipInstallAndTeardown() || testutils.ShouldPersistInstall() {
+	if i.shouldSkipInstallAndTeardown() || testutils.ShouldPersistInstall() {
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Make the multi-controller E2E fixture use configurable primary GatewayClass and controller deployment names.
- Allow the nested secondary installation to manage its lifecycle while the primary installation is reused.
- Propagate the exact controller and proxy image coordinates to the secondary Helm installation.

## Testing

```console
go test -tags=e2e ./controller/test/e2e/... \
  -run '^TestInstallationImageHelmArgs$' -count=1
```

Fixes: #3223
