### PR TITLE
docs: emit `*` for fields that take arbitrary fields

### DIFF
--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -2139,6 +2139,8 @@ pub struct ExecutorSerde {
 	pub jwt: Option<jwt::Claims>,
 
 	/// `apiKey` contains the claims from a verified API Key. This is only present if the API Key policy is enabled.
+	/// In addition to `key`, user-supplied metadata fields are flattened into this object; for example,
+	/// `apiKey.group`. Metadata values are plain JSON and are not treated as secrets.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub api_key: Option<apikey::Claims>,
 

--- a/schema/cel.json
+++ b/schema/cel.json
@@ -294,7 +294,7 @@
       "additionalProperties": true
     },
     "apiKey": {
-      "description": "`apiKey` contains the claims from a verified API Key. This is only present if the API Key policy is enabled.",
+      "description": "`apiKey` contains the claims from a verified API Key. This is only present if the API Key policy is enabled.\nIn addition to `key`, user-supplied metadata fields are flattened into this object; for example,\n`apiKey.group`. Metadata values are plain JSON and are not treated as secrets.",
       "type": [
         "object",
         "null"

--- a/schema/cel.md
+++ b/schema/cel.md
@@ -42,8 +42,10 @@
 |`env.gateway`|string|The Gateway we are running as (when running on Kubernetes)|
 |`jwt`|object|`jwt` contains the claims from a verified JWT token. This is only present if the JWT policy is enabled.|
 |`jwt.rawToken`|string|The raw bearer token. Redacted by default; use `jwt.rawToken.unredacted()` to access the actual value.|
-|`apiKey`|object|`apiKey` contains the claims from a verified API Key. This is only present if the API Key policy is enabled.|
+|`jwt.*`|any||
+|`apiKey`|object|`apiKey` contains the claims from a verified API Key. This is only present if the API Key policy is enabled.<br>In addition to `key`, user-supplied metadata fields are flattened into this object; for example,<br>`apiKey.group`. Metadata values are plain JSON and are not treated as secrets.|
 |`apiKey.key`|string|The API key value. Redacted by default; use `apiKey.key.unredacted()` to access the actual value.|
+|`apiKey.*`|any||
 |`basicAuth`|object|`basicAuth` contains the claims from a verified basic authentication Key. This is only present if the Basic authentication policy is enabled.|
 |`basicAuth.username`|string||
 |`llm`|object|`llm` contains attributes about an LLM request or response. This is only present when using an `ai` backend.|
@@ -135,6 +137,7 @@
 |`mcp.tool.target`|string|The target handling the tool call after multiplexing resolution.|
 |`mcp.tool.name`|string|The resolved tool name sent to the upstream target.|
 |`mcp.tool.arguments`|object|The JSON arguments passed to the tool call.|
+|`mcp.tool.arguments.*`|any||
 |`mcp.tool.result`|any|The terminal tool result payload, if available.|
 |`mcp.tool.error`|any|The terminal JSON-RPC error payload, if available.|
 |`mcp.prompt`|object||
@@ -151,8 +154,11 @@
 |`backend.type`|enum|The type of backend.<br>Possible values: `ai`, `mcp`, `static`, `dynamic`, `service`, `unknown`.|
 |`backend.protocol`|enum|The protocol of backend.<br>Possible values: `http`, `tcp`, `a2a`, `mcp`, `llm`.|
 |`extauthz`|object|`extauthz` contains dynamic metadata from ext_authz filters|
+|`extauthz.*`|any||
 |`extproc`|object|`extproc` contains dynamic metadata from ext_proc filters|
+|`extproc.*`|any||
 |`mcpGuardrails`|object|`mcpGuardrails` contains dynamic metadata returned by mcpGuardrails policy processors.|
+|`mcpGuardrails.*`|any||
 |`guardrails`|[]object|`guardrails` contains one entry per prompt-guard guardrail intervention, in either the<br>request or response phase. Only present in CEL that runs after the request completes,<br>such as log and metric fields.|
 |`guardrails[].phase`|string|The phase the guardrail intervened in: `request` or `response`.|
 |`guardrails[].guard`|string|The guard kind that intervened, such as `bedrockGuardrails`.|
@@ -162,3 +168,4 @@
 |`guardrails[].actionReason`|string|The reason the guardrail reported for its action.|
 |`guardrails[].assessments`|array|Assessment detail reported by the guardrail provider, redacted to metadata<br>only. Content-bearing fields (such as the matched text) are never included.|
 |`metadata`|object|`metadata` contains values set by transformation metadata expressions.|
+|`metadata.*`|any||

--- a/schema/config.md
+++ b/schema/config.md
@@ -310,6 +310,7 @@
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -507,6 +508,7 @@
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.authentik`|object||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.provider.entra`|object||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
+|`binds[].listeners[].routes[].policies.mcpAuthentication.resourceMetadata.*`|any||
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.jwks.url`|string||
@@ -649,6 +651,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -925,6 +928,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -1201,6 +1205,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -1475,6 +1480,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -1787,6 +1793,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -2063,6 +2070,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -2337,6 +2345,7 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -2526,7 +2535,9 @@
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`binds[].listeners[].routes[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`binds[].listeners[].routes[].policies.ai.defaults.*`|any||
 |`binds[].listeners[].routes[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`binds[].listeners[].routes[].policies.ai.overrides.*`|any||
 |`binds[].listeners[].routes[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`binds[].listeners[].routes[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`binds[].listeners[].routes[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -2660,6 +2671,7 @@
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -2892,6 +2904,7 @@
 |`binds[].listeners[].routes[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -3316,6 +3329,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -3601,6 +3615,7 @@
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -3968,6 +3983,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -4266,6 +4282,7 @@
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -4567,6 +4584,7 @@
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -4855,6 +4873,7 @@
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -5144,6 +5163,7 @@
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -5428,6 +5448,7 @@
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -5791,6 +5812,7 @@
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -6109,6 +6131,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -6532,6 +6555,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -6822,6 +6846,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -7132,6 +7157,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -7448,6 +7474,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -7724,6 +7751,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -8000,6 +8028,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -8274,6 +8303,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -8586,6 +8616,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -8862,6 +8893,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -9136,6 +9168,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -9325,7 +9358,9 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.defaults.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`binds[].listeners[].routes[].backends[].ai.policies.ai.overrides.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`binds[].listeners[].routes[].backends[].ai.policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -9484,6 +9519,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -9907,6 +9943,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -10197,6 +10234,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -10507,6 +10545,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -10823,6 +10862,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -11099,6 +11139,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -11375,6 +11416,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -11649,6 +11691,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -11961,6 +12004,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -12237,6 +12281,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -12511,6 +12556,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -12700,7 +12746,9 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.defaults.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.overrides.*`|any||
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -12822,6 +12870,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -13245,6 +13294,7 @@
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -13535,6 +13585,7 @@
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -13845,6 +13896,7 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -14161,6 +14213,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -14437,6 +14490,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -14713,6 +14767,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -14987,6 +15042,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -15299,6 +15355,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -15575,6 +15632,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -15849,6 +15907,7 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -16038,7 +16097,9 @@
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`binds[].listeners[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`binds[].listeners[].routes[].backends[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`binds[].listeners[].routes[].backends[].policies.ai.defaults.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`binds[].listeners[].routes[].backends[].policies.ai.overrides.*`|any||
 |`binds[].listeners[].routes[].backends[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`binds[].listeners[].routes[].backends[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`binds[].listeners[].routes[].backends[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -16199,6 +16260,7 @@
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -16518,6 +16580,7 @@
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -16816,6 +16879,7 @@
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -17117,6 +17181,7 @@
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].policies.extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -17405,6 +17470,7 @@
 |`binds[].listeners[].policies.extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`binds[].listeners[].policies.extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`binds[].listeners[].policies.extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`binds[].listeners[].policies.extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -17805,6 +17871,7 @@
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`frontendPolicies.networkExtAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`frontendPolicies.networkExtAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -18116,6 +18183,7 @@
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`frontendPolicies.accessLog.otlp.policies.backendAuth.jwtSign.claims.*`|any||
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`frontendPolicies.accessLog.otlp.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -18406,6 +18474,7 @@
 |`frontendPolicies.logging.otlp.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`frontendPolicies.logging.otlp.policies.backendAuth.jwtSign.claims.*`|any||
 |`frontendPolicies.logging.otlp.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`frontendPolicies.logging.otlp.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -18692,6 +18761,7 @@
 |`frontendPolicies.tracing.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`frontendPolicies.tracing.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`frontendPolicies.tracing.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`frontendPolicies.tracing.policies.backendAuth.jwtSign.claims.*`|any||
 |`frontendPolicies.tracing.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`frontendPolicies.tracing.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`frontendPolicies.tracing.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -19065,6 +19135,7 @@
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -19262,6 +19333,7 @@
 |`policies[].policy.mcpAuthentication.provider.authentik`|object||
 |`policies[].policy.mcpAuthentication.provider.entra`|object||
 |`policies[].policy.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
+|`policies[].policy.mcpAuthentication.resourceMetadata.*`|any||
 |`policies[].policy.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`policies[].policy.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`policies[].policy.mcpAuthentication.jwks.url`|string||
@@ -19404,6 +19476,7 @@
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -19680,6 +19753,7 @@
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -19956,6 +20030,7 @@
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -20230,6 +20305,7 @@
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -20542,6 +20618,7 @@
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -20818,6 +20895,7 @@
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -21092,6 +21170,7 @@
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -21281,7 +21360,9 @@
 |`policies[].policy.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`policies[].policy.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`policies[].policy.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`policies[].policy.ai.defaults.*`|any||
 |`policies[].policy.ai.overrides`|object|Request body values that replace client-provided values.|
+|`policies[].policy.ai.overrides.*`|any||
 |`policies[].policy.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`policies[].policy.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`policies[].policy.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -21415,6 +21496,7 @@
 |`policies[].policy.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -21647,6 +21729,7 @@
 |`policies[].policy.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -22071,6 +22154,7 @@
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -22356,6 +22440,7 @@
 |`policies[].policy.remoteRateLimit.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.remoteRateLimit.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.remoteRateLimit.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.remoteRateLimit.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -22723,6 +22808,7 @@
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -23021,6 +23107,7 @@
 |`policies[].policy.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -23322,6 +23409,7 @@
 |`policies[].policy.extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -23610,6 +23698,7 @@
 |`policies[].policy.extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -23899,6 +23988,7 @@
 |`policies[].policy.substrateIngress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.substrateIngress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.substrateIngress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.substrateIngress.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.substrateIngress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.substrateIngress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.substrateIngress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -24183,6 +24273,7 @@
 |`policies[].policy.substrateEgress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`policies[].policy.substrateEgress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`policies[].policy.substrateEgress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`policies[].policy.substrateEgress.policies.backendAuth.jwtSign.claims.*`|any||
 |`policies[].policy.substrateEgress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`policies[].policy.substrateEgress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`policies[].policy.substrateEgress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -24409,7 +24500,9 @@
 |`policies[].policy.delay`|object|Inject artificial latency before forwarding requests.|
 |`policies[].policy.delay.duration`|string|Artificial latency injected before the request is forwarded to the backend. Either a duration<br>string such as `2s`, or a CEL expression evaluated against the request that returns a duration<br>(e.g. `duration("500ms")`) or a number interpreted as milliseconds (e.g.<br>`random() < 0.1 ? 500 : 0` for probabilistic delay, or `int(random() * 500)` for jitter). A<br>non-positive result injects no delay.|
 |`workloads`|[]object|workloads defines the set of workloads that the proxy can serve. These are selected by `services`.<br>This is an advanced feature that is mostly for testing; usage of inline `backends` on routes and<br>policies is typically preferred.|
+|`workloads[].*`|any||
 |`services`|[]object|services defines the set of services that the proxy can route to. These consist of `workloads`.<br>This is an advanced feature that is mostly for testing; usage of inline `backends` on routes and<br>policies is typically preferred.|
+|`services[].*`|any||
 |`backends`|[]object|backends defines explicit backends that can be referenced by routes and policies.<br>Typically, inline backends are used on the routes/policies, but this allows re-using the same backend<br>across different configurations.|
 |`backends[].host`|string|Hostname or IP address of the upstream to route to.|
 |`backends[].dynamic`|object|Resolve the dial target from request metadata using a CEL expression.|
@@ -24544,6 +24637,7 @@
 |`backends[].mcp.targets[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].mcp.targets[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].mcp.targets[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].mcp.targets[].policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].mcp.targets[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].mcp.targets[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].mcp.targets[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -24862,6 +24956,7 @@
 |`backends[].ai.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -25285,6 +25380,7 @@
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -25575,6 +25671,7 @@
 |`backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -25885,6 +25982,7 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -26201,6 +26299,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -26477,6 +26576,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -26753,6 +26853,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -27027,6 +27128,7 @@
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -27339,6 +27441,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -27615,6 +27718,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -27889,6 +27993,7 @@
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -28078,7 +28183,9 @@
 |`backends[].ai.policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`backends[].ai.policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`backends[].ai.policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`backends[].ai.policies.ai.defaults.*`|any||
 |`backends[].ai.policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`backends[].ai.policies.ai.overrides.*`|any||
 |`backends[].ai.policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`backends[].ai.policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`backends[].ai.policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -28237,6 +28344,7 @@
 |`backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -28660,6 +28768,7 @@
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -28950,6 +29059,7 @@
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -29260,6 +29370,7 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -29576,6 +29687,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -29852,6 +29964,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -30128,6 +30241,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -30402,6 +30516,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -30714,6 +30829,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -30990,6 +31106,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -31264,6 +31381,7 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -31453,7 +31571,9 @@
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`backends[].ai.groups[].providers[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`backends[].ai.groups[].providers[].policies.ai.defaults.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`backends[].ai.groups[].providers[].policies.ai.overrides.*`|any||
 |`backends[].ai.groups[].providers[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`backends[].ai.groups[].providers[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`backends[].ai.groups[].providers[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -31573,6 +31693,7 @@
 |`backends[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -31996,6 +32117,7 @@
 |`backends[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -32286,6 +32408,7 @@
 |`backends[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -32596,6 +32719,7 @@
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -32912,6 +33036,7 @@
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -33188,6 +33313,7 @@
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -33464,6 +33590,7 @@
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -33738,6 +33865,7 @@
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -34050,6 +34178,7 @@
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -34326,6 +34455,7 @@
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -34600,6 +34730,7 @@
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -34789,7 +34920,9 @@
 |`backends[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`backends[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`backends[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`backends[].policies.ai.defaults.*`|any||
 |`backends[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`backends[].policies.ai.overrides.*`|any||
 |`backends[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`backends[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`backends[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -34992,6 +35125,7 @@
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -35189,6 +35323,7 @@
 |`routeGroups[].routes[].policies.mcpAuthentication.provider.authentik`|object||
 |`routeGroups[].routes[].policies.mcpAuthentication.provider.entra`|object||
 |`routeGroups[].routes[].policies.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
+|`routeGroups[].routes[].policies.mcpAuthentication.resourceMetadata.*`|any||
 |`routeGroups[].routes[].policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`routeGroups[].routes[].policies.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`routeGroups[].routes[].policies.mcpAuthentication.jwks.url`|string||
@@ -35331,6 +35466,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -35607,6 +35743,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -35883,6 +36020,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -36157,6 +36295,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -36469,6 +36608,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -36745,6 +36885,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -37019,6 +37160,7 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -37208,7 +37350,9 @@
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`routeGroups[].routes[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`routeGroups[].routes[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`routeGroups[].routes[].policies.ai.defaults.*`|any||
 |`routeGroups[].routes[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`routeGroups[].routes[].policies.ai.overrides.*`|any||
 |`routeGroups[].routes[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`routeGroups[].routes[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`routeGroups[].routes[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -37342,6 +37486,7 @@
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -37574,6 +37719,7 @@
 |`routeGroups[].routes[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -37998,6 +38144,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -38283,6 +38430,7 @@
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -38650,6 +38798,7 @@
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -38948,6 +39097,7 @@
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -39249,6 +39399,7 @@
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -39537,6 +39688,7 @@
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -39826,6 +39978,7 @@
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.substrateIngress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -40110,6 +40263,7 @@
 |`routeGroups[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].policies.substrateEgress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -40473,6 +40627,7 @@
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -40791,6 +40946,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -41214,6 +41370,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -41504,6 +41661,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -41814,6 +41972,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -42130,6 +42289,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -42406,6 +42566,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -42682,6 +42843,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -42956,6 +43118,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -43268,6 +43431,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -43544,6 +43708,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -43818,6 +43983,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -44007,7 +44173,9 @@
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.defaults.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`routeGroups[].routes[].backends[].ai.policies.ai.overrides.*`|any||
 |`routeGroups[].routes[].backends[].ai.policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`routeGroups[].routes[].backends[].ai.policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -44166,6 +44334,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -44589,6 +44758,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -44879,6 +45049,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -45189,6 +45360,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -45505,6 +45677,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -45781,6 +45954,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -46057,6 +46231,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -46331,6 +46506,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -46643,6 +46819,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -46919,6 +47096,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -47193,6 +47371,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -47382,7 +47561,9 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.defaults.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.overrides.*`|any||
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -47504,6 +47685,7 @@
 |`routeGroups[].routes[].backends[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -47927,6 +48109,7 @@
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -48217,6 +48400,7 @@
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -48527,6 +48711,7 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -48843,6 +49028,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -49119,6 +49305,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -49395,6 +49582,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -49669,6 +49857,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -49981,6 +50170,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -50257,6 +50447,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -50531,6 +50722,7 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -50720,7 +50912,9 @@
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`routeGroups[].routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`routeGroups[].routes[].backends[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`routeGroups[].routes[].backends[].policies.ai.defaults.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`routeGroups[].routes[].backends[].policies.ai.overrides.*`|any||
 |`routeGroups[].routes[].backends[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`routeGroups[].routes[].backends[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`routeGroups[].routes[].backends[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -50909,6 +51103,7 @@
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`gateways.*.listeners[].extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -51207,6 +51402,7 @@
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`gateways.*.listeners[].extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`gateways.*.listeners[].extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -51508,6 +51704,7 @@
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`gateways.*.listeners[].extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -51796,6 +51993,7 @@
 |`gateways.*.listeners[].extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`gateways.*.listeners[].extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`gateways.*.listeners[].extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`gateways.*.listeners[].extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -52222,6 +52420,7 @@
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`gateways.*.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`gateways.*.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -52520,6 +52719,7 @@
 |`gateways.*.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`gateways.*.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`gateways.*.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`gateways.*.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`gateways.*.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`gateways.*.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`gateways.*.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -52821,6 +53021,7 @@
 |`gateways.*.extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`gateways.*.extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`gateways.*.extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`gateways.*.extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -53109,6 +53310,7 @@
 |`gateways.*.extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`gateways.*.extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`gateways.*.extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`gateways.*.extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`gateways.*.extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`gateways.*.extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`gateways.*.extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -53555,6 +53757,7 @@
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -53752,6 +53955,7 @@
 |`routes[].policies.mcpAuthentication.provider.authentik`|object||
 |`routes[].policies.mcpAuthentication.provider.entra`|object||
 |`routes[].policies.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
+|`routes[].policies.mcpAuthentication.resourceMetadata.*`|any||
 |`routes[].policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`routes[].policies.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`routes[].policies.mcpAuthentication.jwks.url`|string||
@@ -53894,6 +54098,7 @@
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -54170,6 +54375,7 @@
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -54446,6 +54652,7 @@
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -54720,6 +54927,7 @@
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -55032,6 +55240,7 @@
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -55308,6 +55517,7 @@
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -55582,6 +55792,7 @@
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -55771,7 +55982,9 @@
 |`routes[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`routes[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`routes[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`routes[].policies.ai.defaults.*`|any||
 |`routes[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`routes[].policies.ai.overrides.*`|any||
 |`routes[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`routes[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`routes[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -55905,6 +56118,7 @@
 |`routes[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -56137,6 +56351,7 @@
 |`routes[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -56561,6 +56776,7 @@
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -56846,6 +57062,7 @@
 |`routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.remoteRateLimit.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -57213,6 +57430,7 @@
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -57511,6 +57729,7 @@
 |`routes[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -57812,6 +58031,7 @@
 |`routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -58100,6 +58320,7 @@
 |`routes[].policies.extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -58389,6 +58610,7 @@
 |`routes[].policies.substrateIngress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.substrateIngress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.substrateIngress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.substrateIngress.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.substrateIngress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.substrateIngress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.substrateIngress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -58673,6 +58895,7 @@
 |`routes[].policies.substrateEgress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].policies.substrateEgress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].policies.substrateEgress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].policies.substrateEgress.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].policies.substrateEgress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].policies.substrateEgress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].policies.substrateEgress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -59036,6 +59259,7 @@
 |`routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].mcp.targets[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -59354,6 +59578,7 @@
 |`routes[].backends[].ai.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -59777,6 +60002,7 @@
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -60067,6 +60293,7 @@
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -60377,6 +60604,7 @@
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -60693,6 +60921,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -60969,6 +61198,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -61245,6 +61475,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -61519,6 +61750,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -61831,6 +62063,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -62107,6 +62340,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -62381,6 +62615,7 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -62570,7 +62805,9 @@
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`routes[].backends[].ai.policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`routes[].backends[].ai.policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`routes[].backends[].ai.policies.ai.defaults.*`|any||
 |`routes[].backends[].ai.policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`routes[].backends[].ai.policies.ai.overrides.*`|any||
 |`routes[].backends[].ai.policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`routes[].backends[].ai.policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`routes[].backends[].ai.policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -62729,6 +62966,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -63152,6 +63390,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -63442,6 +63681,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -63752,6 +63992,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -64068,6 +64309,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -64344,6 +64586,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -64620,6 +64863,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -64894,6 +65138,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -65206,6 +65451,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -65482,6 +65728,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -65756,6 +66003,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -65945,7 +66193,9 @@
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.defaults.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`routes[].backends[].ai.groups[].providers[].policies.ai.overrides.*`|any||
 |`routes[].backends[].ai.groups[].providers[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`routes[].backends[].ai.groups[].providers[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -66067,6 +66317,7 @@
 |`routes[].backends[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -66490,6 +66741,7 @@
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -66780,6 +67032,7 @@
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -67090,6 +67343,7 @@
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -67406,6 +67660,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -67682,6 +67937,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -67958,6 +68214,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -68232,6 +68489,7 @@
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -68544,6 +68802,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -68820,6 +69079,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -69094,6 +69354,7 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`routes[].backends[].policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -69283,7 +69544,9 @@
 |`routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`routes[].backends[].policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`routes[].backends[].policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`routes[].backends[].policies.ai.defaults.*`|any||
 |`routes[].backends[].policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`routes[].backends[].policies.ai.overrides.*`|any||
 |`routes[].backends[].policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`routes[].backends[].policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`routes[].backends[].policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -69445,6 +69708,7 @@
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`tcpRoutes[].backends[].policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -69654,7 +69918,9 @@
 |`llm.providers[].provider.custom.formats[].path`|string|Optional path override for this specific upstream format.|
 |`llm.providers[].defaults`|object|defaults defines provider-level policy defaults. Model-level policy fields override these.|
 |`llm.providers[].defaults.defaults`|object|Request payload fields to set when not already present in the request.|
+|`llm.providers[].defaults.defaults.*`|any||
 |`llm.providers[].defaults.overrides`|object|Request payload fields to set, overriding any existing values in the request.|
+|`llm.providers[].defaults.overrides.*`|any||
 |`llm.providers[].defaults.transformation`|object|CEL expressions that compute request payload fields, overriding existing values.|
 |`llm.providers[].defaults.requestHeaders`|object|Headers to add, set, or remove on requests to the LLM provider.|
 |`llm.providers[].defaults.requestHeaders.add`|object|Headers to append without replacing existing values.|
@@ -69752,6 +70018,7 @@
 |`llm.providers[].defaults.auth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.providers[].defaults.auth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.providers[].defaults.auth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.providers[].defaults.auth.jwtSign.claims.*`|any||
 |`llm.providers[].defaults.auth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.providers[].defaults.auth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.providers[].defaults.auth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -70171,6 +70438,7 @@
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.providers[].defaults.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.providers[].defaults.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -70378,7 +70646,9 @@
 |`llm.models[].authorization.rules[].deny`|string|Deny the request when this CEL expression is true. This mode is not<br>recommended because expression failures fail to deny; prefer `Allow` or<br>`Require`. If used, design expressions defensively against evaluation errors.|
 |`llm.models[].authorization.rules[].require`|string|Require this CEL expression to be true.|
 |`llm.models[].defaults`|object|defaults allows setting default values for the request. If these are not present in the request body, they will be set.<br>To override even when set, use `overrides`.|
+|`llm.models[].defaults.*`|any||
 |`llm.models[].overrides`|object|overrides allows setting values for the request, overriding any existing values|
+|`llm.models[].overrides.*`|any||
 |`llm.models[].transformation`|object|transformation allows setting values from CEL expressions for the request, overriding any existing values.|
 |`llm.models[].finalTransformation`|object|final_transformation allows setting values from CEL expressions for the request, overriding any existing values.<br>Occurs after conversion of the request to the provider format, allowing for provider-specific transformations.|
 |`llm.models[].requestHeaders`|object|requestHeaders modifies headers in requests to the LLM provider.|
@@ -70477,6 +70747,7 @@
 |`llm.models[].auth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].auth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].auth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].auth.jwtSign.claims.*`|any||
 |`llm.models[].auth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].auth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].auth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -70896,6 +71167,7 @@
 |`llm.models[].backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.models[].backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -71185,6 +71457,7 @@
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -71461,6 +71734,7 @@
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -71737,6 +72011,7 @@
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -72011,6 +72286,7 @@
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -72323,6 +72599,7 @@
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -72599,6 +72876,7 @@
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -72873,6 +73151,7 @@
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.models[].guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -73241,6 +73520,7 @@
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -73539,6 +73819,7 @@
 |`llm.policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -73840,6 +74121,7 @@
 |`llm.policies.extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -74128,6 +74410,7 @@
 |`llm.policies.extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -74513,6 +74796,7 @@
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.guardrails.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -74789,6 +75073,7 @@
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.guardrails.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -75065,6 +75350,7 @@
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.guardrails.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -75339,6 +75625,7 @@
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.guardrails.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -75651,6 +75938,7 @@
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.guardrails.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -75927,6 +76215,7 @@
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.guardrails.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -76201,6 +76490,7 @@
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.guardrails.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -76498,6 +76788,7 @@
 |`llm.policies.remoteRateLimit.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`llm.policies.remoteRateLimit.policies.backendAuth.jwtSign.claims.*`|any||
 |`llm.policies.remoteRateLimit.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`llm.policies.remoteRateLimit.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -76811,6 +77102,7 @@
 |`mcp.targets[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.targets[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.targets[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.targets[].policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.targets[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.targets[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.targets[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -77151,6 +77443,7 @@
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.mcpGuardrails.processors[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -77348,6 +77641,7 @@
 |`mcp.policies.mcpAuthentication.provider.authentik`|object||
 |`mcp.policies.mcpAuthentication.provider.entra`|object||
 |`mcp.policies.mcpAuthentication.resourceMetadata`|object|Protected resource metadata returned to MCP clients.|
+|`mcp.policies.mcpAuthentication.resourceMetadata.*`|any||
 |`mcp.policies.mcpAuthentication.jwks`|object|JSON Web Key Set used to verify token signatures. Can be inline, from a file, or fetched remotely.<br>If omitted, the JWKS URL is derived from the issuer and provider.|
 |`mcp.policies.mcpAuthentication.jwks.file`|string|Path to a file on disk to load the value from.|
 |`mcp.policies.mcpAuthentication.jwks.url`|string||
@@ -77490,6 +77784,7 @@
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.ai.promptGuard.request[].openAIModeration.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -77766,6 +78061,7 @@
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.ai.promptGuard.request[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -78042,6 +78338,7 @@
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.ai.promptGuard.request[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -78316,6 +78613,7 @@
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.ai.promptGuard.request[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -78628,6 +78926,7 @@
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.ai.promptGuard.response[].bedrockGuardrails.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -78904,6 +79203,7 @@
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.ai.promptGuard.response[].googleModelArmor.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -79178,6 +79478,7 @@
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.ai.promptGuard.response[].azureContentSafety.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -79367,7 +79668,9 @@
 |`mcp.policies.ai.promptGuard.response[].rejection.headers.set`|object|Headers to set, replacing any existing values.|
 |`mcp.policies.ai.promptGuard.response[].rejection.headers.remove`|[]string|Header names to remove.|
 |`mcp.policies.ai.defaults`|object|Default request body values added only when the client did not provide them.|
+|`mcp.policies.ai.defaults.*`|any||
 |`mcp.policies.ai.overrides`|object|Request body values that replace client-provided values.|
+|`mcp.policies.ai.overrides.*`|any||
 |`mcp.policies.ai.transformations`|object|Request body values computed from CEL expressions.|
 |`mcp.policies.ai.finalTransformations`|object|Request body values computed from CEL expressions.<br>These are applied after conversion to the provider's request format.|
 |`mcp.policies.ai.prompts`|object|Messages to add before or after the client prompt.|
@@ -79501,6 +79804,7 @@
 |`mcp.policies.backendTunnel.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.backendTunnel.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.backendTunnel.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.backendTunnel.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.backendTunnel.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.backendTunnel.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.backendTunnel.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -79733,6 +80037,7 @@
 |`mcp.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -80157,6 +80462,7 @@
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.remoteRateLimit.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -80442,6 +80748,7 @@
 |`mcp.policies.remoteRateLimit.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.remoteRateLimit.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.remoteRateLimit.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.remoteRateLimit.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -80809,6 +81116,7 @@
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -81107,6 +81415,7 @@
 |`mcp.policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -81408,6 +81717,7 @@
 |`mcp.policies.extProc.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.extProc.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.extProc.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.extProc.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -81696,6 +82006,7 @@
 |`mcp.policies.extProc.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.extProc.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.extProc.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.extProc.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.extProc.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.extProc.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.extProc.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -81985,6 +82296,7 @@
 |`mcp.policies.substrateIngress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.substrateIngress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.substrateIngress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.substrateIngress.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.substrateIngress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.substrateIngress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.substrateIngress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -82269,6 +82581,7 @@
 |`mcp.policies.substrateEgress.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`mcp.policies.substrateEgress.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`mcp.policies.substrateEgress.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`mcp.policies.substrateEgress.policies.backendAuth.jwtSign.claims.*`|any||
 |`mcp.policies.substrateEgress.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`mcp.policies.substrateEgress.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`mcp.policies.substrateEgress.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -82656,6 +82969,7 @@
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`ui.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.claims.*`|any||
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`ui.policies.extAuthz.conditional[].policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|
@@ -82954,6 +83268,7 @@
 |`ui.policies.extAuthz.policies.backendAuth.jwtSign.alg`|enum|JWS signing algorithm. Defaults to RS256.<br>Possible values: `RS256`, `RS384`, `RS512`, `PS256`, `ES256`, `ES384`.|
 |`ui.policies.extAuthz.policies.backendAuth.jwtSign.kid`|string|Optional JWS key ID header.|
 |`ui.policies.extAuthz.policies.backendAuth.jwtSign.claims`|object|Static claims added to every token (e.g. iss, sub, aud). Values may be<br>any JSON value (e.g. a string, number, bool, or array). `iat`, `exp`,<br>and `nbf` are reserved for the signer and cannot be configured here.|
+|`ui.policies.extAuthz.policies.backendAuth.jwtSign.claims.*`|any||
 |`ui.policies.extAuthz.policies.backendAuth.jwtSign.ttl`|string|Token lifetime used for `exp`. Defaults to 300s.|
 |`ui.policies.extAuthz.policies.backendAuth.jwtSign.location`|object|Where the signed token is written. Defaults to the Authorization<br>header with a `Bearer ` prefix.|
 |`ui.policies.extAuthz.policies.backendAuth.jwtSign.location.header`|object|Read the credential from an HTTP header.|

--- a/tools/schema_paths.jq
+++ b/tools/schema_paths.jq
@@ -224,6 +224,12 @@ def schema_paths(prefix):
     (.value | schema_paths($path + "."))
   else
     empty
+  end),
+
+  (if (.type // [] | if type == "array" then . else [.] end | contains(["object"])) and .additionalProperties == true then
+    [prefix + "*", "", "any"]
+  else
+    empty
   end);
 
 [schema_paths("")] | .[]  | ["|`" + .[0] + "`|" + .[2] + "|" + .[1] + "|"] | join(",")


### PR DESCRIPTION
fixes https://github.com/agentgateway/agentgateway/issues/3084

Signed-off-by: John Howard <john.howard@solo.io>
