### PR TITLE
ui: warn when API key budgets lack database

### DIFF
--- a/ui/src/pages/Keys.tsx
+++ b/ui/src/pages/Keys.tsx
@@ -794,6 +794,11 @@ function KeyEditor(props: {
 					)
 				}
 			>
+				{!props.config?.config?.database ? (
+					<StatusBanner state="warn" title="Database required">
+						API key budgets require <code>config.database</code> to be configured.
+					</StatusBanner>
+				) : null}
 				<BudgetEditor budgets={budgets} apiKeyName={keyName(props.initial)} onChange={setBudgets} />
 				{submitted && invalidBudgets ? (
 					<StatusBanner state="bad" title="Invalid budgets">

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -1069,6 +1069,16 @@ test('reveals a virtual API key explicitly', async ({ page }) => {
 	await expect(page.getByText('agw_sk_testkey123456789')).toBeVisible();
 });
 
+test('warns that API key budgets require the primary database', async ({ page }) => {
+	await mockGateway(page);
+	await page.goto('/llm/keys');
+
+	await page.getByRole('button', { name: 'Edit key' }).click();
+	await page.getByRole('button', { name: /^Budgets/ }).click();
+	const warning = page.locator('.status-banner.warn').filter({ hasText: 'Database required' });
+	await expect(warning).toContainText('API key budgets require config.database to be configured.');
+});
+
 test('LLM playground sends selected virtual model name', async ({ page }) => {
 	const gateway = await mockGateway(page);
 	await page.goto('/llm/playground');


### PR DESCRIPTION
## Summary

- show a warning in the Virtual API Key budget editor when `config.database` is not configured
- reuse the existing warning `StatusBanner` styling
- add end-to-end coverage for the no-database state

fix #3188.

## Testing

- `cd ui && corepack pnpm lint`
- `cd ui && corepack pnpm build`
- `cd ui && corepack pnpm test:e2e --grep "warns that API key budgets require the primary database" --workers=1`

before & after look of ui
<img width="1273" height="408" alt="image" src="https://github.com/user-attachments/assets/caae4a7c-431c-4645-8d4f-81c6e078be4a" />

<img width="1301" height="345" alt="image" src="https://github.com/user-attachments/assets/bce5cb3a-e1b7-4ea9-aa61-16ead2c01a33" />
