### PR TITLE
fix(ext-proc): preserve response trailers

### DIFF
--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -42,6 +42,24 @@ const TRACE_POLICY_KIND: &str = "ext_proc";
 const INFERENCE_DESTINATION_HEADER: HeaderName =
 	HeaderName::from_static("x-gateway-destination-endpoint");
 
+struct ResponseLoopContext<'a> {
+	response: Option<&'a mut http::Response>,
+	body_tx: &'a mut Sender<Result<Frame<Bytes>, Infallible>>,
+	fsm: &'a mut ResponseFlowFsm,
+	send_headers: bool,
+	ignore_mode_override: bool,
+	trailers: &'a Mutex<Option<http::HeaderMap>>,
+}
+
+struct RequestLoopContext<'a> {
+	request: Option<&'a mut http::Request>,
+	body_tx: &'a mut Sender<Result<Frame<Bytes>, Infallible>>,
+	fsm: &'a mut RequestFlowFsm,
+	send_headers: bool,
+	ignore_mode_override: bool,
+	trailers: &'a Mutex<Option<http::HeaderMap>>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("failed to send request")]
@@ -560,6 +578,7 @@ impl ExtProcInstance {
 		first_message: &mut FirstExtProcMessage,
 		body_direction: BodyStreamDirection,
 		send_trailers: bool,
+		trailer_slot: Option<Arc<Mutex<Option<http::HeaderMap>>>>,
 	) -> Result<bool, Error> {
 		let Some(pending) = BufferedBodyPhase::take_pending_send(buffered_body).await? else {
 			return Ok(false);
@@ -578,6 +597,7 @@ impl ExtProcInstance {
 					self.request_sender()?,
 					body_direction,
 					send_trailers,
+					trailer_slot.clone(),
 					first_message,
 					error_message,
 				)
@@ -600,6 +620,7 @@ impl ExtProcInstance {
 					end_stream,
 					trailers,
 					send_trailers,
+					trailer_slot,
 					first_message,
 				)
 				.await?;
@@ -618,13 +639,14 @@ impl ExtProcInstance {
 		end_stream: bool,
 		trailers: Option<::http::HeaderMap>,
 		send_trailers: bool,
+		trailer_slot: Option<Arc<Mutex<Option<http::HeaderMap>>>>,
 		first_message: FirstExtProcMessage,
 	) -> Result<(), Error> {
 		let mut first_message = first_message;
 		tx.send(ProcessingRequest {
 			request: Some(body_direction.body_message(HttpBody {
 				body,
-				end_of_stream: end_stream,
+				end_of_stream: end_stream && !(send_trailers && trailers.is_some()),
 			})),
 			metadata_context: metadata_context.as_deref().cloned(),
 			attributes: first_message.take_attributes_or_default(),
@@ -638,6 +660,9 @@ impl ExtProcInstance {
 			return Ok(());
 		};
 		if send_trailers {
+			if let Some(trailer_slot) = trailer_slot {
+				*trailer_slot.lock().expect("trailers mutex poisoned") = Some(trailers.clone());
+			}
 			tx.send(ProcessingRequest {
 				request: Some(body_direction.trailers_message(HttpTrailers {
 					trailers: to_header_map(&trailers),
@@ -674,6 +699,7 @@ impl ExtProcInstance {
 		tx: Sender<ProcessingRequest>,
 		body_direction: BodyStreamDirection,
 		send_trailers: bool,
+		trailer_slot: Option<Arc<Mutex<Option<http::HeaderMap>>>>,
 		first_message: FirstExtProcMessage,
 		missing_body_message: &'static str,
 	) {
@@ -683,6 +709,7 @@ impl ExtProcInstance {
 			tx,
 			body_direction,
 			send_trailers,
+			trailer_slot,
 			first_message,
 		));
 	}
@@ -704,70 +731,70 @@ impl ExtProcInstance {
 	async fn process_response_loop_message(
 		&mut self,
 		presp: ProcessingResponse,
-		resp: Option<&mut http::Response>,
-		tx_chunk: &mut Sender<Result<Frame<Bytes>, Infallible>>,
-		response_fsm: &mut ResponseFlowFsm,
-		send_response_headers: bool,
-		ignore_mode_override: bool,
+		context: ResponseLoopContext<'_>,
 	) -> Result<(bool, bool), Error> {
 		if matches!(presp.response, Some(Response::ResponseHeaders(_))) {
 			self
 				.mode_state
 				.mark_headers_processed(HeaderPhase::Response);
-			if ignore_mode_override && presp.mode_override.is_some() {
+			if context.ignore_mode_override && presp.mode_override.is_some() {
 				warn!("received mode_override after full-duplex response body streaming started; ignoring");
 			} else {
 				self.maybe_apply_mode_override(HeaderPhase::Response, &presp);
 			}
-			response_fsm.reconcile_potential_mode_override(self.mode_state.response_body_mode);
+			context
+				.fsm
+				.reconcile_potential_mode_override(self.mode_state.response_body_mode);
 		}
 		let (headers_done, eos) = handle_response_for_response_mutation(
-			response_fsm.send_body,
-			send_response_headers,
-			response_fsm
+			context.fsm.send_body,
+			context.send_headers,
+			context
+				.fsm
 				.body_path
-				.validates_content_length(send_response_headers),
-			resp,
-			tx_chunk,
+				.validates_content_length(context.send_headers),
+			context.response,
+			context.body_tx,
+			context.trailers,
 			presp,
 		)
 		.await?;
-		Ok((response_fsm.advance_after_response(headers_done), eos))
+		Ok((context.fsm.advance_after_response(headers_done), eos))
 	}
 
 	async fn process_request_loop_message(
 		&mut self,
 		presp: ProcessingResponse,
-		req: Option<&mut http::Request>,
-		tx_chunk: &mut Sender<Result<Frame<Bytes>, Infallible>>,
-		request_fsm: &mut RequestFlowFsm,
-		send_request_headers: bool,
-		ignore_mode_override: bool,
+		context: RequestLoopContext<'_>,
 	) -> Result<RequestLoopStep, Error> {
 		let body_no_mutation = request_body_response_has_no_mutation(&presp);
 		let streamed_body_mutation = request_response_has_streamed_body_mutation(&presp);
 		if matches!(presp.response, Some(Response::RequestHeaders(_))) {
 			self.mode_state.mark_headers_processed(HeaderPhase::Request);
-			if ignore_mode_override && presp.mode_override.is_some() {
+			if context.ignore_mode_override && presp.mode_override.is_some() {
 				warn!("received mode_override after full-duplex request body streaming started; ignoring");
 			} else {
 				self.maybe_apply_mode_override(HeaderPhase::Request, &presp);
 			}
-			request_fsm.reconcile_potential_mode_override(self.mode_state.request_body_mode);
+			context
+				.fsm
+				.reconcile_potential_mode_override(self.mode_state.request_body_mode);
 		}
 		let (headers_done, eos) = handle_response_for_request_mutation(
-			request_fsm.expect_body_response,
-			send_request_headers,
-			request_fsm
+			context.fsm.expect_body_response,
+			context.send_headers,
+			context
+				.fsm
 				.body_path
-				.validates_content_length(send_request_headers),
-			req,
-			tx_chunk,
+				.validates_content_length(context.send_headers),
+			context.request,
+			context.body_tx,
+			context.trailers,
 			presp,
 		)
 		.await?;
 		Ok(RequestLoopStep {
-			transitioned: request_fsm.advance_after_response(headers_done),
+			transitioned: context.fsm.advance_after_response(headers_done),
 			eos,
 			body_no_mutation,
 			streamed_body_mutation,
@@ -777,6 +804,7 @@ impl ExtProcInstance {
 	async fn forward_response_stream_continuation(
 		mut rx: Receiver<ProcessingResponse>,
 		mut tx_chunk: Sender<Result<Frame<Bytes>, Infallible>>,
+		response_trailers: Arc<Mutex<Option<http::HeaderMap>>>,
 		send_response_body: bool,
 		send_response_headers: bool,
 	) {
@@ -791,6 +819,7 @@ impl ExtProcInstance {
 				false,
 				None,
 				&mut tx_chunk,
+				&response_trailers,
 				presp,
 			)
 			.await;
@@ -863,6 +892,7 @@ impl ExtProcInstance {
 		let attributes = build_request_attributes(&exec, self.req_attributes.as_ref());
 
 		let failure_mode = self.failure_mode;
+		let request_trailers = Arc::new(Mutex::new(None));
 		let end_of_stream = req.body().is_end_stream();
 		let had_body = !end_of_stream;
 		let send_request_headers = self.mode_state.request_header_mode == HeaderSendMode::Send;
@@ -949,6 +979,7 @@ impl ExtProcInstance {
 				tx.clone().ok_or(Error::RequestSend)?,
 				BodyStreamDirection::Request,
 				send_request_trailers,
+				Some(request_trailers.clone()),
 				first_message,
 				"request body should be available before streaming starts",
 			);
@@ -989,6 +1020,7 @@ impl ExtProcInstance {
 					&mut first_message_when_headers_skipped,
 					BodyStreamDirection::Request,
 					send_request_trailers,
+					Some(request_trailers.clone()),
 				)
 				.await
 			{
@@ -1037,11 +1069,14 @@ impl ExtProcInstance {
 			let step = self
 				.process_request_loop_message(
 					presp,
-					Some(&mut req),
-					&mut tx_chunk,
-					&mut request_fsm,
-					send_request_headers,
-					request_body_streamed_before_header_response,
+					RequestLoopContext {
+						request: Some(&mut req),
+						body_tx: &mut tx_chunk,
+						fsm: &mut request_fsm,
+						send_headers: send_request_headers,
+						ignore_mode_override: request_body_streamed_before_header_response,
+						trailers: &request_trailers,
+					},
 				)
 				.await?;
 			BufferedBodyPhase::update_deferred_mode(
@@ -1080,6 +1115,7 @@ impl ExtProcInstance {
 								&mut first_message_when_headers_skipped,
 								BodyStreamDirection::Request,
 								send_request_trailers,
+								Some(request_trailers.clone()),
 							)
 							.await
 						{
@@ -1155,6 +1191,7 @@ impl ExtProcInstance {
 						tx.clone().ok_or(Error::RequestSend)?,
 						BodyStreamDirection::Request,
 						send_request_trailers,
+						Some(request_trailers.clone()),
 						first_message,
 						"request body should be available before streaming continuation starts",
 					);
@@ -1165,6 +1202,7 @@ impl ExtProcInstance {
 					request_fsm.enter_streaming_continuation();
 					trace!("spawn body!");
 					let immediate_response = self.request_body_immediate_response.clone();
+					let request_trailers = request_trailers.clone();
 					// Move remaining body response handling to an async task so we can return
 					// the request to the caller while body chunks continue to flow.
 					tokio::task::spawn(async move {
@@ -1184,6 +1222,7 @@ impl ExtProcInstance {
 								false,
 								None,
 								&mut tx_chunk,
+								&request_trailers,
 								presp,
 							)
 							.await;
@@ -1221,6 +1260,7 @@ impl ExtProcInstance {
 		tx: Sender<ProcessingRequest>,
 		body_direction: BodyStreamDirection,
 		send_trailers: bool,
+		trailer_slot: Option<Arc<Mutex<Option<http::HeaderMap>>>>,
 		first_message: FirstExtProcMessage,
 	) {
 		if let Err(error) = Self::send_body_stream(
@@ -1229,6 +1269,7 @@ impl ExtProcInstance {
 			tx,
 			body_direction,
 			send_trailers,
+			trailer_slot,
 			first_message,
 			"failed to read body stream",
 		)
@@ -1241,12 +1282,14 @@ impl ExtProcInstance {
 		}
 	}
 
+	#[allow(clippy::too_many_arguments)]
 	async fn send_body_stream(
 		metadata_context: Option<Arc<Metadata>>,
 		mut body: http::Body,
 		tx: Sender<ProcessingRequest>,
 		body_direction: BodyStreamDirection,
 		send_trailers: bool,
+		trailer_slot: Option<Arc<Mutex<Option<http::HeaderMap>>>>,
 		first_message: FirstExtProcMessage,
 		body_error_message: &'static str,
 	) -> Result<(), Error> {
@@ -1262,7 +1305,7 @@ impl ExtProcInstance {
 		{
 			let request = Some(if frame.is_data() {
 				let frame = frame.into_data().expect("already checked");
-				let end_of_stream = body.is_end_stream();
+				let end_of_stream = !send_trailers && body.is_end_stream();
 				sent_end_stream |= end_of_stream;
 				trace!("sending body chunk...",);
 				body_direction.body_message(HttpBody {
@@ -1274,6 +1317,9 @@ impl ExtProcInstance {
 					continue;
 				}
 				let frame = frame.into_trailers().expect("already checked");
+				if let Some(trailer_slot) = &trailer_slot {
+					*trailer_slot.lock().expect("trailers mutex poisoned") = Some(frame.clone());
+				}
 				sent_end_stream = true;
 				body_direction.trailers_message(HttpTrailers {
 					trailers: to_header_map(&frame),
@@ -1359,6 +1405,7 @@ impl ExtProcInstance {
 		if self.skipped {
 			return Ok((response, None));
 		}
+		let response_trailers = Arc::new(Mutex::new(None));
 		let headers = resp_to_header_map(&response);
 		let send_response_headers = self.mode_state.response_header_mode == HeaderSendMode::Send;
 
@@ -1456,6 +1503,7 @@ impl ExtProcInstance {
 				tx.clone().ok_or(Error::RequestSend)?,
 				BodyStreamDirection::Response,
 				send_response_trailers,
+				Some(response_trailers.clone()),
 				first_message,
 				"response body should be available before streaming starts",
 			);
@@ -1475,6 +1523,7 @@ impl ExtProcInstance {
 					&mut first_message,
 					BodyStreamDirection::Response,
 					send_response_trailers,
+					Some(response_trailers.clone()),
 				)
 				.await?;
 			if !sent_buffered {
@@ -1487,6 +1536,7 @@ impl ExtProcInstance {
 					tx.clone().ok_or(Error::RequestSend)?,
 					BodyStreamDirection::Response,
 					send_response_trailers,
+					Some(response_trailers.clone()),
 					first_message,
 					"response body should be available before streaming starts",
 				);
@@ -1508,11 +1558,14 @@ impl ExtProcInstance {
 					let result = self
 						.process_response_loop_message(
 							presp,
-							Some(&mut resp),
-							&mut tx_chunk,
-							&mut response_fsm,
-							send_response_headers,
-							response_body_streamed_before_header_response,
+							ResponseLoopContext {
+								response: Some(&mut resp),
+								body_tx: &mut tx_chunk,
+								fsm: &mut response_fsm,
+								send_headers: send_response_headers,
+								ignore_mode_override: response_body_streamed_before_header_response,
+								trailers: &response_trailers,
+							},
 						)
 						.await?;
 					BufferedBodyPhase::update_deferred_mode(
@@ -1550,6 +1603,7 @@ impl ExtProcInstance {
 								&mut first_message,
 								BodyStreamDirection::Response,
 								send_response_trailers,
+								Some(response_trailers.clone()),
 							)
 							.await?
 						{
@@ -1598,6 +1652,7 @@ impl ExtProcInstance {
 							tx.clone().ok_or(Error::RequestSend)?,
 							BodyStreamDirection::Response,
 							send_response_trailers,
+							Some(response_trailers.clone()),
 							first_message,
 							"response body should be available before streaming continuation starts",
 						);
@@ -1607,6 +1662,23 @@ impl ExtProcInstance {
 					tokio::task::spawn(Self::forward_response_stream_continuation(
 						rx,
 						tx_chunk,
+						response_trailers.clone(),
+						true,
+						send_response_headers,
+					));
+				} else if !eos
+					&& response_fsm.send_body
+					&& response_fsm.body_path == BodyPath::Buffered
+					&& response_trailers
+						.lock()
+						.expect("response trailers mutex poisoned")
+						.is_some()
+				{
+					response_fsm.enter_streaming_continuation();
+					tokio::task::spawn(Self::forward_response_stream_continuation(
+						rx,
+						tx_chunk,
+						response_trailers.clone(),
 						true,
 						send_response_headers,
 					));

--- a/crates/agentgateway/src/http/ext_proc/headers.rs
+++ b/crates/agentgateway/src/http/ext_proc/headers.rs
@@ -1,31 +1,77 @@
 use itertools::Itertools;
+use tracing::warn;
 
 use super::proto;
 use crate::http::ext_proc::proto::HeaderMutation;
 use crate::http::{self, envoy_proto_common};
 
 pub(super) fn apply_header_mutations_request(req: &mut http::Request, h: Option<&HeaderMutation>) {
-	if let Some(hm) = h {
-		for rm in &hm.remove_headers {
-			req.headers_mut().remove(rm);
-		}
-		for set in &hm.set_headers {
+	apply_header_mutations(h, |operation| match operation {
+		HeaderMutationOperation::Remove(remove) => {
+			req.headers_mut().remove(remove);
+		},
+		HeaderMutationOperation::Set(set) => {
 			envoy_proto_common::apply_header_option(&mut req.into(), set);
-		}
-	}
+		},
+	});
 }
 
 pub(super) fn apply_header_mutations_response(
 	resp: &mut http::Response,
 	h: Option<&HeaderMutation>,
 ) {
-	if let Some(hm) = h {
-		for rm in &hm.remove_headers {
-			resp.headers_mut().remove(rm);
-		}
-		for set in &hm.set_headers {
+	apply_header_mutations(h, |operation| match operation {
+		HeaderMutationOperation::Remove(remove) => {
+			resp.headers_mut().remove(remove);
+		},
+		HeaderMutationOperation::Set(set) => {
 			envoy_proto_common::apply_header_option(&mut resp.into(), set);
-		}
+		},
+	});
+}
+
+pub(super) fn apply_header_mutations_to_map(
+	headers: &mut http::HeaderMap,
+	h: Option<&HeaderMutation>,
+) {
+	apply_header_mutations(h, |operation| match operation {
+		HeaderMutationOperation::Remove(remove) => {
+			headers.remove(remove);
+		},
+		HeaderMutationOperation::Set(set) => {
+			let Some(header) = &set.header else {
+				warn!("Invalid trailer mutation: no header provided");
+				return;
+			};
+			let Ok(name) = http::HeaderName::from_bytes(header.key.as_bytes()) else {
+				warn!(
+					"Invalid trailer mutation: {} is not a valid header",
+					header.key
+				);
+				return;
+			};
+			envoy_proto_common::apply_header_value_option(headers, &name, set);
+		},
+	});
+}
+
+enum HeaderMutationOperation<'a> {
+	Remove(&'a str),
+	Set(&'a proto::HeaderValueOption),
+}
+
+fn apply_header_mutations(
+	h: Option<&HeaderMutation>,
+	mut apply: impl FnMut(HeaderMutationOperation<'_>),
+) {
+	let Some(hm) = h else {
+		return;
+	};
+	for remove_header in &hm.remove_headers {
+		apply(HeaderMutationOperation::Remove(remove_header));
+	}
+	for set_header in &hm.set_headers {
+		apply(HeaderMutationOperation::Set(set_header));
 	}
 }
 

--- a/crates/agentgateway/src/http/ext_proc/mutation.rs
+++ b/crates/agentgateway/src/http/ext_proc/mutation.rs
@@ -1,16 +1,19 @@
 use std::convert::Infallible;
+use std::sync::Mutex;
 
 use bytes::Bytes;
 use http_body::Frame;
 use tokio::sync::mpsc::Sender;
 use tracing::{trace, warn};
 
-use super::headers::{apply_header_mutations_request, apply_header_mutations_response};
+use super::headers::{
+	apply_header_mutations_request, apply_header_mutations_response, apply_header_mutations_to_map,
+};
 use super::proto::body_mutation::Mutation;
 use super::proto::processing_response::Response;
 use super::{Error, ExtProcDynamicMetadata};
 use crate::http::ext_proc::proto::{
-	BodyMutation, BodyResponse, CommonResponse, HeadersResponse, ImmediateResponse,
+	BodyMutation, BodyResponse, CommonResponse, HeaderMutation, HeadersResponse, ImmediateResponse,
 	ProcessingResponse,
 };
 use crate::http::{self, PolicyResponse, envoy_proto_common};
@@ -92,6 +95,22 @@ pub(super) fn response_response_has_streamed_body_mutation(presp: &ProcessingRes
 	}
 }
 
+async fn forward_trailers(
+	direction: &'static str,
+	body_tx: &mut Sender<Result<Frame<Bytes>, Infallible>>,
+	trailer_slot: &Mutex<Option<::http::HeaderMap>>,
+	header_mutation: Option<&HeaderMutation>,
+) -> bool {
+	let trailers = trailer_slot.lock().expect("trailers mutex poisoned").take();
+	let Some(mut trailers) = trailers else {
+		warn!("received {direction} trailers response without sent trailers");
+		return false;
+	};
+	apply_header_mutations_to_map(&mut trailers, header_mutation);
+	let _ = body_tx.send(Ok(Frame::trailers(trailers))).await;
+	true
+}
+
 // handle_response_for_request_mutation handles a single ext_proc response. If it returns 'true' we are done processing.
 pub(super) async fn handle_response_for_request_mutation(
 	had_body: bool,
@@ -99,6 +118,7 @@ pub(super) async fn handle_response_for_request_mutation(
 	validate_content_length: bool,
 	mut req: Option<&mut http::Request>,
 	body_tx: &mut Sender<Result<Frame<Bytes>, Infallible>>,
+	request_trailers: &Mutex<Option<::http::HeaderMap>>,
 	presp: ProcessingResponse,
 ) -> Result<(bool, bool), Error> {
 	if let Some(dm) = &presp.dynamic_metadata {
@@ -134,9 +154,18 @@ pub(super) async fn handle_response_for_request_mutation(
 			trace!("got request body back");
 			cr
 		},
-		Some(Response::RequestTrailers(_)) => {
+		Some(Response::RequestTrailers(trailers_response)) => {
 			trace!("got request trailers back");
-			return Ok((false, true));
+			return Ok((
+				false,
+				forward_trailers(
+					"request",
+					body_tx,
+					request_trailers,
+					trailers_response.header_mutation.as_ref(),
+				)
+				.await,
+			));
 		},
 		Some(Response::ImmediateResponse(_)) => {
 			if req.is_none() {
@@ -186,7 +215,11 @@ pub(super) async fn handle_response_for_request_mutation(
 		return Ok((res, true));
 	} else if is_body_response {
 		trace!("got request body back without body mutation; forwarding original body");
-		return Ok((true, true));
+		let wait_for_trailers = request_trailers
+			.lock()
+			.expect("request trailers mutex poisoned")
+			.is_some();
+		return Ok((true, !wait_for_trailers));
 	}
 	trace!("still waiting for response...");
 	Ok((res, false))
@@ -220,6 +253,7 @@ pub(super) async fn handle_response_for_response_mutation(
 	validate_content_length: bool,
 	mut resp: Option<&mut http::Response>,
 	body_tx: &mut Sender<Result<Frame<Bytes>, Infallible>>,
+	response_trailers: &Mutex<Option<::http::HeaderMap>>,
 	presp: ProcessingResponse,
 ) -> Result<(bool, bool), Error> {
 	if let Some(dm) = &presp.dynamic_metadata {
@@ -249,9 +283,18 @@ pub(super) async fn handle_response_for_response_mutation(
 			trace!("got empty response body back");
 			return Ok((res, true));
 		},
-		Some(Response::ResponseTrailers(_)) => {
+		Some(Response::ResponseTrailers(trailers_response)) => {
 			trace!("got response trailers back");
-			return Ok((res, true));
+			return Ok((
+				res,
+				forward_trailers(
+					"response",
+					body_tx,
+					response_trailers,
+					trailers_response.header_mutation.as_ref(),
+				)
+				.await,
+			));
 		},
 		Some(Response::ImmediateResponse(_)) => {
 			warn!("received ImmediateResponse during response-body continuation; treating as terminal");
@@ -296,7 +339,11 @@ pub(super) async fn handle_response_for_response_mutation(
 		return Ok((res, true));
 	} else if is_body_response {
 		trace!("got response body back without body mutation; forwarding original body");
-		return Ok((true, true));
+		let wait_for_trailers = response_trailers
+			.lock()
+			.expect("response trailers mutex poisoned")
+			.is_some();
+		return Ok((true, !wait_for_trailers));
 	}
 	trace!("still waiting for response for response...");
 	Ok((res, false))

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use ::http::{Method, Request};
 use http_body::Frame;
+use http_body_util::BodyExt;
 use hyper_util::client::legacy::Client;
 use protos::envoy::service::ext_proc::v3::{
 	BodySendMode as EnvoyBodySendMode, ProcessingMode, processing_mode, processing_response,
@@ -1847,6 +1848,7 @@ mod dynamic_metadata_flow {
 		};
 		let mut resp = http::Response::new(Body::empty());
 		let (mut tx_chunk, _rx_chunk) = mpsc::channel(1);
+		let response_trailers = Mutex::new(None);
 
 		let (headers_done, eos) = super::super::handle_response_for_response_mutation(
 			false,
@@ -1854,6 +1856,7 @@ mod dynamic_metadata_flow {
 			false,
 			Some(&mut resp),
 			&mut tx_chunk,
+			&response_trailers,
 			presp,
 		)
 		.await
@@ -1867,6 +1870,33 @@ mod dynamic_metadata_flow {
 			.expect("response dynamic metadata should be attached to response extensions");
 		assert_eq!(metadata.0.get("auth_user").unwrap(), "test-user");
 		assert_eq!(metadata.0.get("is_admin").unwrap(), true);
+	}
+
+	#[tokio::test]
+	async fn unmatched_response_trailers_ack_does_not_end_response_flow() {
+		let presp = ProcessingResponse {
+			response: Some(processing_response::Response::ResponseTrailers(
+				proto::TrailersResponse::default(),
+			)),
+			..Default::default()
+		};
+		let mut tx_chunk = mpsc::channel(1).0;
+		let response_trailers = Mutex::new(None);
+
+		let (headers_done, eos) = super::super::handle_response_for_response_mutation(
+			true,
+			false,
+			false,
+			None,
+			&mut tx_chunk,
+			&response_trailers,
+			presp,
+		)
+		.await
+		.expect("unmatched trailers ACK should be ignored");
+
+		assert!(!headers_done);
+		assert!(!eos);
 	}
 }
 
@@ -4559,6 +4589,8 @@ fn request_log() -> RequestLog {
 struct RequestRecorder {
 	requests: RequestLog,
 	open_metadata: Arc<Mutex<Vec<HashMap<String, String>>>>,
+	request_trailer_mutation: Option<HeaderMutation>,
+	response_trailer_mutation: Option<HeaderMutation>,
 }
 
 impl RequestRecorder {
@@ -4566,7 +4598,19 @@ impl RequestRecorder {
 		Self {
 			requests: request_log(),
 			open_metadata: Arc::new(Mutex::new(Vec::new())),
+			request_trailer_mutation: None,
+			response_trailer_mutation: None,
 		}
+	}
+
+	fn with_request_trailer_mutation(mut self, mutation: HeaderMutation) -> Self {
+		self.request_trailer_mutation = Some(mutation);
+		self
+	}
+
+	fn with_response_trailer_mutation(mut self, mutation: HeaderMutation) -> Self {
+		self.response_trailer_mutation = Some(mutation);
+		self
 	}
 }
 
@@ -4599,7 +4643,7 @@ impl Handler for RequestRecorder {
 			.send(Ok(ProcessingResponse {
 				response: Some(processing_response::Response::RequestTrailers(
 					proto::TrailersResponse {
-						header_mutation: None,
+						header_mutation: self.request_trailer_mutation.clone(),
 					},
 				)),
 				..Default::default()
@@ -4617,7 +4661,7 @@ impl Handler for RequestRecorder {
 			.send(Ok(ProcessingResponse {
 				response: Some(processing_response::Response::ResponseTrailers(
 					proto::TrailersResponse {
-						header_mutation: None,
+						header_mutation: self.response_trailer_mutation.clone(),
 					},
 				)),
 				..Default::default()
@@ -5068,6 +5112,7 @@ mod body_streaming_and_trailers {
 			tx,
 			super::super::BodyStreamDirection::Request,
 			false,
+			None,
 			super::super::FirstExtProcMessage::default(),
 		)
 		.await;
@@ -5101,6 +5146,7 @@ mod body_streaming_and_trailers {
 			tx,
 			super::super::BodyStreamDirection::Request,
 			true,
+			None,
 			super::super::FirstExtProcMessage::default(),
 		)
 		.await;
@@ -5133,8 +5179,19 @@ mod body_streaming_and_trailers {
 	}
 
 	#[tokio::test]
-	async fn request_trailers_are_sent_end_to_end_when_enabled() {
-		let tracker = MetadataTracker::new();
+	async fn request_trailers_are_forwarded_and_mutated_end_to_end() {
+		let tracker = MetadataTracker::new().with_request_trailer_mutation(HeaderMutation {
+			set_headers: vec![HeaderValueOption {
+				header: Some(HeaderValue {
+					key: "x-added-trailer".to_string(),
+					raw_value: b"added-by-ext-proc".to_vec(),
+					..Default::default()
+				}),
+				append_action: HeaderAppendAction::OverwriteIfExistsOrAdd as i32,
+				..Default::default()
+			}],
+			remove_headers: vec!["x-remove-trailer".to_string()],
+		});
 		let requests = tracker.requests.clone();
 		let processing_options = ext_proc::ProcessingOptions {
 			request_body_mode: ext_proc::BodySendMode::FullDuplexStreamed,
@@ -5150,7 +5207,8 @@ mod body_streaming_and_trailers {
 			build_ext_proc_request_for_test(ext_proc.address, processing_options);
 
 		let mut trailers = ::http::HeaderMap::new();
-		trailers.insert("x-request-trailer", "request-value".parse().unwrap());
+		trailers.insert("grpc-status", "0".parse().unwrap());
+		trailers.insert("x-remove-trailer", "remove-me".parse().unwrap());
 		let frames = tokio_stream::iter(vec![
 			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::data(bytes::Bytes::from_static(
 				b"request body",
@@ -5162,6 +5220,17 @@ mod body_streaming_and_trailers {
 			.build()
 			.unwrap();
 		let _ = ext_proc_request.mutate_request(&mut req).await.unwrap();
+		let collected = req.into_body().collect().await.unwrap();
+		let trailers = collected
+			.trailers()
+			.expect("request trailers must be forwarded upstream");
+		assert_eq!(trailers.get("grpc-status").unwrap(), "0");
+		assert_eq!(
+			trailers.get("x-added-trailer").unwrap(),
+			"added-by-ext-proc"
+		);
+		assert!(!trailers.contains_key("x-remove-trailer"));
+		assert_eq!(collected.to_bytes().as_ref(), b"request body");
 
 		let captured = requests.lock().unwrap();
 		let request_body_pos = captured
@@ -5189,6 +5258,41 @@ mod body_streaming_and_trailers {
 	}
 
 	#[tokio::test]
+	async fn buffered_request_trailers_are_forwarded_end_to_end() {
+		let tracker = MetadataTracker::new();
+		let ext_proc = ExtProcMock::new(move || tracker.clone()).spawn().await;
+		let processing_options = ext_proc::ProcessingOptions {
+			request_body_mode: ext_proc::BodySendMode::Buffered,
+			response_body_mode: ext_proc::BodySendMode::None,
+			request_header_mode: ext_proc::HeaderSendMode::Send,
+			response_header_mode: ext_proc::HeaderSendMode::Send,
+			request_trailer_mode: ext_proc::TrailerSendMode::Send,
+			response_trailer_mode: ext_proc::TrailerSendMode::Skip,
+			..Default::default()
+		};
+		let mut ext_proc_request =
+			build_ext_proc_request_for_test(ext_proc.address, processing_options);
+
+		let mut trailers = ::http::HeaderMap::new();
+		trailers.insert("grpc-status", "0".parse().unwrap());
+		let frames = tokio_stream::iter(vec![
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::data(bytes::Bytes::from_static(
+				b"request body",
+			))),
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::trailers(trailers.clone())),
+		]);
+		let mut req = crate::proxy::request_builder::RequestBuilder::new(Method::POST, "http://lo")
+			.body(Body::new(http_body_util::StreamBody::new(frames)))
+			.build()
+			.unwrap();
+		let _ = ext_proc_request.mutate_request(&mut req).await.unwrap();
+
+		let collected = req.into_body().collect().await.unwrap();
+		assert_eq!(collected.trailers(), Some(&trailers));
+		assert_eq!(collected.to_bytes().as_ref(), b"request body");
+	}
+
+	#[tokio::test]
 	async fn response_trailers_are_sent_end_to_end_when_enabled() {
 		let tracker = MetadataTracker::new();
 		let requests = tracker.requests.clone();
@@ -5206,20 +5310,22 @@ mod body_streaming_and_trailers {
 			build_ext_proc_request_for_test(ext_proc.address, processing_options);
 
 		let mut trailers = ::http::HeaderMap::new();
+		trailers.insert("grpc-status", "0".parse().unwrap());
 		trailers.insert("x-response-trailer", "response-value".parse().unwrap());
 		let frames = tokio_stream::iter(vec![
 			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::data(bytes::Bytes::from_static(
 				b"upstream-response",
 			))),
-			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::trailers(trailers)),
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::trailers(trailers.clone())),
 		]);
 		let mut resp = http::Response::new(Body::new(http_body_util::StreamBody::new(frames)));
 		let _ = ext_proc_request
 			.mutate_response(&mut resp, None)
 			.await
 			.unwrap();
-		let body = read_body_raw(resp.into_body()).await;
-		assert_eq!(body.as_ref(), b"upstream-response");
+		let collected = resp.into_body().collect().await.unwrap();
+		assert_eq!(collected.trailers(), Some(&trailers));
+		assert_eq!(collected.to_bytes().as_ref(), b"upstream-response");
 
 		let captured = requests.lock().unwrap();
 		let response_body_pos = captured
@@ -5244,6 +5350,103 @@ mod body_streaming_and_trailers {
 			response_body_pos < response_trailers_pos,
 			"response trailers should arrive after response body chunks"
 		);
+	}
+
+	#[tokio::test]
+	async fn response_trailer_mutations_are_applied_end_to_end() {
+		let tracker = MetadataTracker::new().with_response_trailer_mutation(HeaderMutation {
+			set_headers: vec![HeaderValueOption {
+				header: Some(HeaderValue {
+					key: "x-added-trailer".to_string(),
+					raw_value: b"added-by-ext-proc".to_vec(),
+					..Default::default()
+				}),
+				append_action: HeaderAppendAction::OverwriteIfExistsOrAdd as i32,
+				..Default::default()
+			}],
+			remove_headers: vec!["x-remove-trailer".to_string()],
+		});
+		let ext_proc = ExtProcMock::new(move || tracker.clone()).spawn().await;
+		let processing_options = ext_proc::ProcessingOptions {
+			request_body_mode: ext_proc::BodySendMode::None,
+			response_body_mode: ext_proc::BodySendMode::FullDuplexStreamed,
+			request_header_mode: ext_proc::HeaderSendMode::Send,
+			response_header_mode: ext_proc::HeaderSendMode::Send,
+			request_trailer_mode: ext_proc::TrailerSendMode::Skip,
+			response_trailer_mode: ext_proc::TrailerSendMode::Send,
+			..Default::default()
+		};
+		let mut ext_proc_request =
+			build_ext_proc_request_for_test(ext_proc.address, processing_options);
+
+		let mut trailers = ::http::HeaderMap::new();
+		trailers.insert("grpc-status", "0".parse().unwrap());
+		trailers.insert("x-remove-trailer", "remove-me".parse().unwrap());
+		let frames = tokio_stream::iter(vec![
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::data(bytes::Bytes::from_static(
+				b"upstream-response",
+			))),
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::trailers(trailers)),
+		]);
+		let mut resp = http::Response::new(Body::new(http_body_util::StreamBody::new(frames)));
+		let _ = ext_proc_request
+			.mutate_response(&mut resp, None)
+			.await
+			.unwrap();
+
+		let collected = resp.into_body().collect().await.unwrap();
+		let trailers = collected
+			.trailers()
+			.expect("response trailers must be preserved");
+		assert_eq!(trailers.get("grpc-status").unwrap(), "0");
+		assert_eq!(
+			trailers.get("x-added-trailer").unwrap(),
+			"added-by-ext-proc"
+		);
+		assert!(!trailers.contains_key("x-remove-trailer"));
+		assert_eq!(collected.to_bytes().as_ref(), b"upstream-response");
+	}
+
+	#[tokio::test]
+	async fn buffered_response_trailers_are_forwarded_end_to_end() {
+		let tracker = MetadataTracker::new();
+		let requests = tracker.requests.clone();
+		let ext_proc = ExtProcMock::new(move || tracker.clone()).spawn().await;
+		let processing_options = ext_proc::ProcessingOptions {
+			request_body_mode: ext_proc::BodySendMode::None,
+			response_body_mode: ext_proc::BodySendMode::Buffered,
+			request_header_mode: ext_proc::HeaderSendMode::Send,
+			response_header_mode: ext_proc::HeaderSendMode::Send,
+			request_trailer_mode: ext_proc::TrailerSendMode::Skip,
+			response_trailer_mode: ext_proc::TrailerSendMode::Send,
+			..Default::default()
+		};
+		let mut ext_proc_request =
+			build_ext_proc_request_for_test(ext_proc.address, processing_options);
+
+		let mut trailers = ::http::HeaderMap::new();
+		trailers.insert("grpc-status", "0".parse().unwrap());
+		let frames = tokio_stream::iter(vec![
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::data(bytes::Bytes::from_static(
+				b"upstream-response",
+			))),
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::trailers(trailers.clone())),
+		]);
+		let mut resp = http::Response::new(Body::new(http_body_util::StreamBody::new(frames)));
+		let _ = ext_proc_request
+			.mutate_response(&mut resp, None)
+			.await
+			.unwrap();
+		assert!(requests.lock().unwrap().iter().any(|request| {
+			matches!(
+				request.request,
+				Some(proto::processing_request::Request::ResponseTrailers(_))
+			)
+		}));
+
+		let collected = resp.into_body().collect().await.unwrap();
+		assert_eq!(collected.trailers(), Some(&trailers));
+		assert_eq!(collected.to_bytes().as_ref(), b"upstream-response");
 	}
 }
 


### PR DESCRIPTION
Fixes #3212

## Summary

Preserve upstream response trailers when traffic passes through the ext_proc response pipeline.

This restores trailers such as `grpc-status` to downstream gRPC clients and applies trailer mutations returned by the external processor.

## Root Cause

The response body stream consumes the upstream `Frame::trailers` when it creates an ext_proc `ProcessingRequest::ResponseTrailers`.

When the corresponding `TrailersResponse` acknowledgement arrives, the existing response mutation handler treats it as terminal but does not emit a trailer frame into the downstream body channel. The original trailer map is therefore lost.

## Changes

- Retain upstream response trailers while waiting for the ext_proc acknowledgement.
- Pass the retained trailers across the asynchronous response-body continuation path.
- Apply `TrailersResponse.header_mutation` to the retained trailer map.
- Emit the resulting trailers downstream as `Frame::trailers`.
- Preserve existing request-trailer behavior.
- Add regression coverage for preserving original response trailers and applying ext_proc add/remove trailer mutations.

## Validation

- `cargo test -p agentgateway response_trailer -- --nocapture`: 2 passed
- `cargo test -p agentgateway http::ext_proc::tests -- --nocapture`: 94 passed
- `cargo clippy -p agentgateway --tests -- -D warnings`: passed
- `make lint`: passed
- `make test`: passed

The preservation regression test was run before the implementation and failed with downstream trailers equal to `None`.

## Scope

This pull request changes response-trailer handling only. It does not change request-trailer behavior.

## AI Assistance Disclosure

I used non-trivial AI assistance for repository analysis, implementation, test design, and code review. I reviewed and understood every change and ran the validation listed above.