### PR TITLE
fix(cel): handle function-style receiver arguments

### DIFF
--- a/crates/cel-fork/cel/src/functions.rs
+++ b/crates/cel-fork/cel/src/functions.rs
@@ -1105,6 +1105,7 @@ mod tests {
 			("map", "{1: true, 2: true, 3: true}.contains(3) == true"),
 			("string", "'foobar'.contains('bar') == true"),
 			("bytes", "b'foobar'.contains(b'o') == true"),
+			("function", "contains('foobar', 'bar') == true"),
 		];
 
 		for (name, script) in tests {

--- a/crates/cel-fork/cel/src/magic.rs
+++ b/crates/cel-fork/cel/src/magic.rs
@@ -152,7 +152,10 @@ impl<'a, 'rf> FromContext<'a, 'rf> for Argument {
 }
 
 impl<'a, 'rf> FromContext<'a, 'rf> for This {
-	fn from_context(_ctx: &mut FunctionContext<'a, 'rf>) -> Self {
+	fn from_context(ctx: &mut FunctionContext<'a, 'rf>) -> Self {
+		if ctx.this.is_none() {
+			ctx.arg_idx += 1;
+		}
 		This
 	}
 }


### PR DESCRIPTION
## Summary

- Advance the positional-argument cursor when a receiver-style CEL parameter is loaded from a function-style call.
- Preserve the existing method-call behavior while ensuring contains(a, b) evaluates b as the search value.
- Add regression coverage for function-style contains.

Fixes #2863

## Verification

- cargo fmt --all -- --check
- cargo test -p cel
- cargo clippy -p cel --all-targets -- -D warnings
- cargo test -p agentgateway --lib cel -- --nocapture (98 tests passed; two telemetry tests fail identically on a clean main checkout)