### PR TITLE
fix(llm): support HTTPS file URLs for Vertex Gemini

### DIFF
--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -458,8 +458,8 @@ pub mod from_completions {
 	/// Convert an OpenAI `file` content part into a Gemini part.
 	///
 	/// Mirrors [`image_part`]: inline `data:` payloads become `inlineData`, `gs://`
-	/// objects become `fileData`, and anything Vertex cannot fetch is rejected rather
-	/// than dropped.
+	/// objects and public `https://` URLs become `fileData`, and anything Vertex cannot
+	/// fetch is rejected rather than dropped.
 	fn file_part(file: Option<&Value>) -> Result<vg::Part, AIError> {
 		let field = |k: &str| {
 			file
@@ -469,6 +469,7 @@ pub mod from_completions {
 		};
 		let file_data = field("file_data");
 		let file_id = field("file_id");
+		let file_url = field("url");
 
 		if let Some((mime, data)) = parse_data_url(file_data) {
 			if !mime.is_empty() {
@@ -499,6 +500,20 @@ pub mod from_completions {
 				))));
 			};
 			return Ok(file_data_part(&mime, uri));
+		}
+
+		// Vertex can fetch public HTTPS URLs directly. The nested `url` field is the
+		// Responses-style file source; use the filename when the URL has no extension.
+		if file_url.starts_with("https://") {
+			let Some(mime) = explicit_mime_hint(file)
+				.or_else(|| mime_from_extension(field("filename")).map(str::to_string))
+				.or_else(|| mime_from_extension(file_url).map(str::to_string))
+			else {
+				return Err(AIError::UnsupportedConversion(strng::new(format!(
+					"https:// file ({file_url}) has no recognised extension or MIME hint; pass file.filename (or mime_type/content_type), or use a URL with a known extension"
+				))));
+			};
+			return Ok(file_data_part(&mime, file_url));
 		}
 
 		// Raw base64 without a data URL wrapper, as bedrock.rs also accepts; mime from filename.

--- a/crates/llm/src/conversion/vertex_gemini_tests.rs
+++ b/crates/llm/src/conversion/vertex_gemini_tests.rs
@@ -202,6 +202,30 @@ fn file_id_holding_a_gs_uri_becomes_file_data() {
 }
 
 #[test]
+fn file_url_https_becomes_file_data() {
+	let g = to_gemini(file_content(json!({
+		"url": "https://example.com/report.pdf"
+	})));
+	let part = &g["contents"][0]["parts"][1];
+	assert_eq!(
+		part["fileData"]["fileUri"],
+		"https://example.com/report.pdf"
+	);
+	assert_eq!(part["fileData"]["mimeType"], "application/pdf");
+}
+
+#[test]
+fn file_url_https_uses_filename_for_mime() {
+	let g = to_gemini(file_content(json!({
+		"filename": "report.pdf",
+		"url": "https://example.com/download"
+	})));
+	let part = &g["contents"][0]["parts"][1];
+	assert_eq!(part["fileData"]["fileUri"], "https://example.com/download");
+	assert_eq!(part["fileData"]["mimeType"], "application/pdf");
+}
+
+#[test]
 fn file_id_is_rejected_rather_than_dropped() {
 	// Vertex has no OpenAI Files store, so an opaque file_id cannot be resolved. It must
 	// error rather than silently vanish from the request (#3117).


### PR DESCRIPTION
## Summary

- Read the nested `file.url` field used by Responses-style file content parts.
- Translate public `https://` file URLs into Vertex `fileData.fileUri` parts.
- Infer the required MIME type from an explicit hint, filename, or URL extension while preserving existing `file_data` and `file_id` handling.

Fixes #3202

## Tests

- `cargo test -p agent-llm --lib --no-fail-fast`
- `cargo clippy -p agent-llm --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`