### PR TITLE
fix: add HTTP/2 PING keepalive for upstream connection pool

### DIFF
--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -552,6 +552,11 @@ impl Client {
 		if let Some(pool_max) = backend_config.pool_max_size {
 			b.pool_max_idle_per_host(pool_max);
 		};
+		if !backend_config.h2_keepalive_interval.is_zero() {
+			b.http2_keep_alive_interval(Some(backend_config.h2_keepalive_interval));
+			b.http2_keep_alive_timeout(backend_config.h2_keepalive_timeout);
+			b.http2_keep_alive_while_idle(true);
+		}
 
 		let connector = Connector {
 			resolver: Arc::new(resolver),

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -294,6 +294,16 @@ pub struct BackendConfig {
 	/// If unset, there is no limit
 	#[serde(default)]
 	pool_max_size: Option<usize>,
+	/// Interval between HTTP/2 PING frames sent to upstream connections for liveness detection.
+	/// PINGs are sent even on idle connections to proactively evict dead connections from the pool.
+	/// Set to "0s" to disable.
+	#[serde(default = "defaults::h2_keepalive_interval", with = "serde_dur")]
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	h2_keepalive_interval: Duration,
+	/// Timeout waiting for a PING ACK before considering the connection dead and closing it.
+	#[serde(default = "defaults::h2_keepalive_timeout", with = "serde_dur")]
+	#[cfg_attr(feature = "schema", schemars(with = "String"))]
+	h2_keepalive_timeout: Duration,
 }
 
 #[derive(serde::Serialize, Clone, Debug, Eq, PartialEq)]
@@ -320,6 +330,8 @@ impl Default for BackendConfig {
 			connect_timeout: defaults::connect_timeout(),
 			pool_idle_timeout: defaults::pool_idle_timeout(),
 			pool_max_size: None,
+			h2_keepalive_interval: defaults::h2_keepalive_interval(),
+			h2_keepalive_timeout: defaults::h2_keepalive_timeout(),
 		}
 	}
 }
@@ -334,6 +346,12 @@ mod defaults {
 	}
 	pub fn pool_idle_timeout() -> Duration {
 		Duration::from_secs(90)
+	}
+	pub fn h2_keepalive_interval() -> Duration {
+		Duration::from_secs(30)
+	}
+	pub fn h2_keepalive_timeout() -> Duration {
+		Duration::from_secs(5)
 	}
 
 	pub fn max_buffer_size() -> usize {

--- a/crates/agentgateway/src/lib.rs
+++ b/crates/agentgateway/src/lib.rs
@@ -296,11 +296,13 @@ pub struct BackendConfig {
 	pool_max_size: Option<usize>,
 	/// Interval between HTTP/2 PING frames sent to upstream connections for liveness detection.
 	/// PINGs are sent even on idle connections to proactively evict dead connections from the pool.
-	/// Set to "0s" to disable.
-	#[serde(default = "defaults::h2_keepalive_interval", with = "serde_dur")]
+	/// Disabled by default ("0s"). Note: many gRPC servers enforce a minimum ping interval
+	/// and will reject connections that ping more frequently.
+	#[serde(default, with = "serde_dur")]
 	#[cfg_attr(feature = "schema", schemars(with = "String"))]
 	h2_keepalive_interval: Duration,
 	/// Timeout waiting for a PING ACK before considering the connection dead and closing it.
+	/// Only applies when h2_keepalive_interval is set. Defaults to 5s.
 	#[serde(default = "defaults::h2_keepalive_timeout", with = "serde_dur")]
 	#[cfg_attr(feature = "schema", schemars(with = "String"))]
 	h2_keepalive_timeout: Duration,
@@ -330,7 +332,7 @@ impl Default for BackendConfig {
 			connect_timeout: defaults::connect_timeout(),
 			pool_idle_timeout: defaults::pool_idle_timeout(),
 			pool_max_size: None,
-			h2_keepalive_interval: defaults::h2_keepalive_interval(),
+			h2_keepalive_interval: Duration::ZERO,
 			h2_keepalive_timeout: defaults::h2_keepalive_timeout(),
 		}
 	}
@@ -346,9 +348,6 @@ mod defaults {
 	}
 	pub fn pool_idle_timeout() -> Duration {
 		Duration::from_secs(90)
-	}
-	pub fn h2_keepalive_interval() -> Duration {
-		Duration::from_secs(30)
 	}
 	pub fn h2_keepalive_timeout() -> Duration {
 		Duration::from_secs(5)

--- a/schema/config.json
+++ b/schema/config.json
@@ -421,7 +421,9 @@
             },
             "connectTimeout": "11s",
             "poolIdleTimeout": "1m30s",
-            "poolMaxSize": null
+            "poolMaxSize": null,
+            "h2KeepaliveInterval": "0s",
+            "h2KeepaliveTimeout": "5s"
           }
         },
         "hbone": {
@@ -1079,6 +1081,16 @@
           "format": "uint",
           "minimum": 0,
           "default": null
+        },
+        "h2KeepaliveInterval": {
+          "description": "Interval between HTTP/2 PING frames sent to upstream connections for liveness detection.\nPINGs are sent even on idle connections to proactively evict dead connections from the pool.\nDisabled by default (\"0s\"). Note: many gRPC servers enforce a minimum ping interval\nand will reject connections that ping more frequently.",
+          "type": "string",
+          "default": "0s"
+        },
+        "h2KeepaliveTimeout": {
+          "description": "Timeout waiting for a PING ACK before considering the connection dead and closing it.\nOnly applies when h2_keepalive_interval is set. Defaults to 5s.",
+          "type": "string",
+          "default": "5s"
         }
       },
       "additionalProperties": false

--- a/schema/config.md
+++ b/schema/config.md
@@ -101,6 +101,8 @@
 |`config.backend.connectTimeout`|string|Maximum time to wait when establishing a connection to an upstream. Defaults to 11 seconds.|
 |`config.backend.poolIdleTimeout`|string|The maximum duration to keep an idle connection alive.|
 |`config.backend.poolMaxSize`|integer|The maximum number of connections allowed in the pool, per hostname. If set, this will limit<br>the total number of connections kept alive to any given host.<br>Note: excess connections will still be created, they will just not remain idle.<br>If unset, there is no limit|
+|`config.backend.h2KeepaliveInterval`|string|Interval between HTTP/2 PING frames sent to upstream connections for liveness detection.<br>PINGs are sent even on idle connections to proactively evict dead connections from the pool.<br>Disabled by default ("0s"). Note: many gRPC servers enforce a minimum ping interval<br>and will reject connections that ping more frequently.|
+|`config.backend.h2KeepaliveTimeout`|string|Timeout waiting for a PING ACK before considering the connection dead and closing it.<br>Only applies when h2_keepalive_interval is set. Defaults to 5s.|
 |`config.hbone`|object|HBONE (HTTP/2 CONNECT tunnel) protocol configuration.|
 |`config.hbone.windowSize`|integer|HTTP/2 per-stream flow-control window size in bytes. Defaults to 4 MiB.|
 |`config.hbone.connectionWindowSize`|integer|HTTP/2 connection-level flow-control window size in bytes. Defaults to 16 MiB.|


### PR DESCRIPTION
When proxying through L4 load balancers, upstream H2 connections can silently go dead. The TCP socket remains open but the remote is no longer processing frames. The requests sent on these pooled connections hang for the full `backendRequestTimeout` then fail with `status=0`.

This change configures the hyper H2 client to send periodic PING frames on upstream connections. When a PING ACK is not received in time, the entire H2 connection is torn down and evicted from the pool and subsequent retries establish fresh connections.

The fix was tested in a production deployment proxying to AWS Bedrock Mantle. Before the change, stale connections would cause these hangs. After the change, dead connections are detected and evicted within ~35s and retries succeed on fresh connections.

