### PR TITLE
app: log that the UI is disabled instead of an unreachable URL

### DIFF
--- a/crates/agentgateway/src/app.rs
+++ b/crates/agentgateway/src/app.rs
@@ -9,7 +9,7 @@ use tokio::task::JoinSet;
 
 use crate::control::{caclient, spiffe};
 use crate::telemetry::trc;
-use crate::{Config, ProxyInputs, client, config_store, mcp, proxy, state_manager};
+use crate::{Address, Config, ProxyInputs, client, config_store, mcp, proxy, state_manager};
 
 pub async fn run(
 	config: Arc<Config>,
@@ -144,7 +144,11 @@ pub async fn run(
 	.await
 	.context("admin server starts")?;
 	if cfg!(feature = "ui") {
-		info!("serving UI at {}", ui_url(config.as_ref()).await);
+		if matches!(config.admin_addr, Address::Off) {
+			info!("UI disabled (adminAddr: off)");
+		} else {
+			info!("serving UI at {}", ui_url(config.as_ref()).await);
+		}
 	}
 
 	let pi = ProxyInputs {


### PR DESCRIPTION
## Problem

With the admin interface disabled, startup logs two lines that contradict each other:

```yaml
config:
  adminAddr: "off"
```

```
info app                        serving UI at http://off/ui
info management::hyper_helpers  listener disabled  component="admin"
```

`off` is the `Display` of `Address::Off`, so the URL points nowhere — `getent hosts off` returns nothing, and `/proc/net/tcp*` in the container shows only the configured data-plane, stats and readiness ports. No admin socket is bound on any interface.

This matters because the admin interface is usually disabled *for security*: it serves `POST /api/config` (which rewrites the running config, including auth policy), `POST /quitquitquit`, `/config_dump` and `/logging`, unauthenticated, on a localhost that untrusted in-pod code may share. A startup line announcing the UI is being served reads as though that hardening did not take effect, and costs an audit to disprove — which is how I ran into it.

Present on v1.3.1, v1.5.0 and `main`. On v1.5.0/`main` the line moved into `ui_url()`, which falls back to `format!("http://{}/ui", config.admin_addr)` when the config has no `ui:` block, so the output is the same. It looks like a leftover from #2032, which introduced `Address::Off`.

## Fix

Branch on the address so the log reports the real state. Reporting it explicitly, rather than dropping the line, keeps a positive confirmation that the operator's intent took effect — the same thing `hyper_helpers` already does with `listener disabled component="admin"`.

## Verification

Built with `--features agentgateway/ui` and run against both configs.

With `adminAddr: "off"`:

```
info app                        UI disabled (adminAddr: off)
info management::hyper_helpers  listener disabled  component="admin"
GET :15000/ui -> connection refused
```

With no `adminAddr` (default), unchanged:

```
info app                        serving UI at http://localhost:15000/ui
info management::hyper_helpers  listener established  address=127.0.0.1:15000 component="admin"
GET :15000/ui -> 200
```

`cargo check -p agentgateway` is clean.