### PR TITLE
Docs: optional TOA verify for upstream MCP promote

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 Depending on your deployment environment, check out the following docs:
 
 - [agentgateway.dev/docs](https://agentgateway.dev/docs/standalone/latest): For deployments without the full Kubernetes controller, driven by flat yaml config.
+- [Optional TOA upstream gate](architecture/toa-optional-upstream-gate.md): offline delivery-evidence verify before promoting an upstream MCP backend (not on every `tools/call`).
 - [agentgateway.dev/docs/kubernetes/latest](https://agentgateway.dev/docs/kubernetes/latest): For Kubernetes-based deployments using the built-in Kubernetes controller and Gateway API support.
 
 Agentgateway has a built-in UI for you to explore agentgateway connecting agent-to-agent or agent-to-tool:

--- a/architecture/README.md
+++ b/architecture/README.md
@@ -5,3 +5,4 @@ This folder contains developer-facing documentation on the project architecture.
 Recommended reading order:
 1. [Configuration](configuration.md)
 1. [CEL](cel.md)
+1. [Optional TOA upstream gate](toa-optional-upstream-gate.md)

--- a/architecture/toa-optional-upstream-gate.md
+++ b/architecture/toa-optional-upstream-gate.md
@@ -6,7 +6,7 @@ Agentgateway already authenticates clients and authorizes MCP tools with CEL (`m
 
 ## Suggested fit (optional, off by default)
 
-Before promoting or attaching a new upstream MCP backend in CI or change control, require a recent attestation and verify it offline with a pinned emitter public key.
+Before promoting or attaching a new upstream MCP backend in CI or change control, require an attestation and verify it offline with `--require-emitter` and optional `--max-age`.
 
 - Any party can emit if they sign the schema.
 - AgentStatus is one optional emitter.
@@ -17,8 +17,8 @@ Before promoting or attaching a new upstream MCP backend in CI or change control
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Copy-paste example: [`examples/mcp-toa-verify`](../examples/mcp-toa-verify/README.md).

--- a/architecture/toa-optional-upstream-gate.md
+++ b/architecture/toa-optional-upstream-gate.md
@@ -17,7 +17,7 @@ Before promoting or attaching a new upstream MCP backend in CI or change control
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/architecture/toa-optional-upstream-gate.md
+++ b/architecture/toa-optional-upstream-gate.md
@@ -1,0 +1,32 @@
+# Optional Tool Outcome Attestation (TOA) for upstream MCP
+
+Agentgateway already authenticates clients and authorizes MCP tools with CEL (`mcpAuthorization`, JWT, and related policies). That answers *who may call what*. It does not answer whether an upstream MCP tool recently delivered a real result under an outside probe.
+
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is an Apache-2.0 signed JSON evidence format for MCP tool delivery (reach, invoke, functional, shape, and related layers). It is not a wire protocol. It is not meant to run on every live `tools/call`.
+
+## Suggested fit (optional, off by default)
+
+Before promoting or attaching a new upstream MCP backend in CI or change control, require a recent attestation and verify it offline with a pinned emitter public key.
+
+- Any party can emit if they sign the schema.
+- AgentStatus is one optional emitter.
+- No AgentStatus account is required to verify.
+
+```yaml
+      # After your existing MCP smoke / auth policy checks.
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Copy-paste example: [`examples/mcp-toa-verify`](../examples/mcp-toa-verify/README.md).
+
+## Out of scope for this doc
+
+- Replacing JWT / CEL `mcpAuthorization`
+- Signing every production `tools/call`
+- Changing the proxy hot path
+
+This is documentation of an adjacent gate only.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,7 @@ are named `<type>-<name>`, where `type` is one of `mcp`, `llm`, or `traffic`.
 * [mcp-basic](mcp-basic/README.md): the simplest way to get started with agentgateway, exposing a single MCP server over Stdio.
 * [mcp-multiplex](mcp-multiplex/README.md): multiplex multiple MCP targets on a single listener.
 * [mcp-authorization](mcp-authorization/README.md): apply JWT authentication and MCP authorization policies to incoming requests.
+* [mcp-toa-verify](mcp-toa-verify/README.md): optional offline Tool Outcome Attestation (`toa-verify`) before promoting an upstream MCP backend.
 * [mcp-authentication](mcp-authentication/README.md): authenticate MCP clients and protect MCP traffic.
 * [mcp-tls](mcp-tls/README.md): terminate TLS connections.
 * [mcp-openapi](mcp-openapi/README.md): serve an OpenAPI specification as MCP tools.

--- a/examples/mcp-toa-verify/README.md
+++ b/examples/mcp-toa-verify/README.md
@@ -1,0 +1,10 @@
+# Optional TOA verify for upstream MCP
+
+Example only. Copy into a workflow that promotes or attaches an upstream MCP server behind agentgateway.
+
+Agentgateway handles transport, auth, and CEL authorization ([mcp-authorization](../mcp-authorization/README.md)).
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) verifies signed tool delivery evidence when `toa.json` is present.
+
+TOA does not replace `mcpAuthorization`. No AgentStatus account is required to verify.
+
+See [`toa-after-upstream.yml`](./toa-after-upstream.yml) and [architecture/toa-optional-upstream-gate.md](../../architecture/toa-optional-upstream-gate.md).

--- a/examples/mcp-toa-verify/toa-after-upstream.yml
+++ b/examples/mcp-toa-verify/toa-after-upstream.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/mcp-toa-verify/toa-after-upstream.yml
+++ b/examples/mcp-toa-verify/toa-after-upstream.yml
@@ -1,0 +1,25 @@
+# Example only. Copy into your repo as needed.
+# Policy / smoke checks for an upstream MCP target, then optional TOA verify.
+name: Upstream MCP and optional TOA
+
+on:
+  pull_request:
+    paths:
+      - "examples/mcp-*/**"
+      - "toa.json"
+  workflow_dispatch:
+
+jobs:
+  upstream-toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Your existing agentgateway config lint / MCP smoke tests go here.
+      # For local auth examples see ../mcp-authorization and ../mcp-basic.
+
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass

--- a/examples/mcp-toa-verify/toa-after-upstream.yml
+++ b/examples/mcp-toa-verify/toa-after-upstream.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d


### PR DESCRIPTION
## Summary

Docs-only. Optional offline `toa-verify` before promoting or attaching an upstream MCP backend.

- `architecture/toa-optional-upstream-gate.md`
- `examples/mcp-toa-verify/` (README + sample workflow)
- Pointers in `architecture/README.md`, `examples/README.md`, and root `README.md`

Does not change proxy runtime or CEL `mcpAuthorization`. TOA (`toa/0.1`) is adjacent delivery evidence, not a wire protocol and not per-call signing. No AgentStatus account is required to verify.

## Test plan

- [ ] Architecture / example docs render and link correctly
- [ ] Example YAML is clearly optional / gated on `toa.json`
- [ ] Copy does not claim TOA replaces JWT or CEL policies


Made with [Cursor](https://cursor.com)