### PR TITLE
fix(controller): add InferencePool status re-merge in StatusSyncer like other resources

### DIFF
--- a/controller/pkg/syncer/status_syncer.go
+++ b/controller/pkg/syncer/status_syncer.go
@@ -188,8 +188,9 @@ func NewAgwStatusSyncer(
 	}
 	if enableInference {
 		syncer.inferencePools = StatusSyncer[*inf.InferencePool, inf.InferencePoolStatus]{
-			Name:   "inferencePools",
-			Client: kclient.NewFilteredDelayed[*inf.InferencePool](client, wellknown.InferencePoolGVR, f),
+			Name:           "inferencePools",
+			ControllerName: controllerName,
+			Client:         kclient.NewFilteredDelayed[*inf.InferencePool](client, wellknown.InferencePoolGVR, f),
 			Build: func(om metav1.ObjectMeta, s inf.InferencePoolStatus) *inf.InferencePool {
 				return &inf.InferencePool{
 					ObjectMeta: om,
@@ -403,6 +404,13 @@ func (s StatusSyncer[O, S]) ApplyStatus(ctx context.Context, obj status.Resource
 				merged.Parents = mergeRouteParentStatuses(s.ControllerName, cur.Status.Parents, desired.Parents)
 				mergedAny = &merged
 			}
+		case inf.InferencePoolStatus:
+			cur, ok := any(current).(*inf.InferencePool)
+			if ok {
+				merged := desired
+				merged.Parents = mergeInferencePoolParentStatuses(s.ControllerName, cur.Status.Parents, desired.Parents)
+				mergedAny = merged
+			}
 		}
 
 		merged, ok := mergedAny.(S)
@@ -510,6 +518,37 @@ func mergeRouteParentStatuses(ourControllerName string, existing []gwv1.RoutePar
 			return c
 		}
 		return compareParentReference(a.ParentRef, b.ParentRef)
+	})
+
+	out = append(out, ours...)
+	return out
+}
+
+func mergeInferencePoolParentStatuses(ourControllerName string, existing []inf.ParentStatus, desired []inf.ParentStatus) []inf.ParentStatus {
+	out := make([]inf.ParentStatus, 0, len(existing)+len(desired))
+
+	// Preserve any entries not owned by our controller.
+	for _, p := range existing {
+		if string(p.ControllerName) != ourControllerName {
+			out = append(out, p)
+		}
+	}
+
+	// Only add entries owned by our controller from the desired status.
+	// This ensures we can clear stale entries by publishing an empty desired list.
+	ours := make([]inf.ParentStatus, 0, len(desired))
+	for _, p := range desired {
+		if string(p.ControllerName) == ourControllerName {
+			ours = append(ours, p)
+		}
+	}
+
+	// Ensure stable ordering of our entries so status doesn't flap due to map/set iteration upstream.
+	slices.SortFunc(ours, func(a, b inf.ParentStatus) int {
+		if c := cmp.Compare(string(a.ControllerName), string(b.ControllerName)); c != 0 {
+			return c
+		}
+		return compareInferencePoolParentReference(a.ParentRef, b.ParentRef)
 	})
 
 	out = append(out, ours...)
@@ -697,6 +736,37 @@ func compareParentReference(a, b gwv1.ParentReference) int {
 		return c
 	}
 	return comparePortNumberPtr(a.Port, b.Port)
+}
+
+func compareInferencePoolParentReference(a, b inf.ParentReference) int {
+	// ParentReference includes fields with defaults. Canonicalize those defaults so omitted vs explicitly-set
+	// default values don't introduce ordering churn.
+	if c := cmp.Compare(inferencePoolParentRefGroupOrDefault(a.Group), inferencePoolParentRefGroupOrDefault(b.Group)); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(inferencePoolParentRefKindOrDefault(a.Kind), inferencePoolParentRefKindOrDefault(b.Kind)); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(string(a.Namespace), string(b.Namespace)); c != 0 {
+		return c
+	}
+	return cmp.Compare(string(a.Name), string(b.Name))
+}
+
+func inferencePoolParentRefGroupOrDefault(g *inf.Group) string {
+	if g == nil {
+		// ParentReference.Group default.
+		return "gateway.networking.k8s.io"
+	}
+	return string(*g)
+}
+
+func inferencePoolParentRefKindOrDefault(k inf.Kind) string {
+	if k == "" {
+		// ParentReference.Kind default.
+		return "Gateway"
+	}
+	return string(k)
 }
 
 func parentRefGroupOrDefault(g *gwv1.Group) string {

--- a/controller/pkg/syncer/status_syncer_test.go
+++ b/controller/pkg/syncer/status_syncer_test.go
@@ -1,14 +1,18 @@
 package syncer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"istio.io/istio/pkg/kube/kclient"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	inf "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/pkg/reports"
+	syncstatus "github.com/agentgateway/agentgateway/controller/pkg/syncer/status"
 )
 
 func TestMergePolicyAncestorStatuses_SortsOurEntriesOnly(t *testing.T) {
@@ -67,6 +71,94 @@ func TestMergeRouteParentStatuses_SortsOurEntriesOnly(t *testing.T) {
 	require.Equal(t, string(out[3].ControllerName), our)
 	require.Equal(t, string(out[2].ParentRef.Name), "m")
 	require.Equal(t, string(out[3].ParentRef.Name), "z")
+}
+
+func TestMergeInferencePoolParentStatuses_ClearsOurEntries(t *testing.T) {
+	our := "agentgateway.dev/agentgateway"
+	existing := []inf.ParentStatus{
+		{ControllerName: "", ParentRef: inf.ParentReference{Name: "istio"}},
+		{ControllerName: inf.ControllerName(our), ParentRef: inf.ParentReference{Name: "stale"}},
+	}
+
+	out := mergeInferencePoolParentStatuses(our, existing, nil)
+	require.Equal(t, existing[:1], out)
+}
+
+func TestStatusSyncerApplyStatus_MergesInferencePoolParents(t *testing.T) {
+	our := "agentgateway.dev/agentgateway"
+	other := "kgateway.dev/kgateway"
+	current := &inf.InferencePool{
+		Name:            "pool",
+		Namespace:       "default",
+		ResourceVersion: "2",
+		Status: inf.InferencePoolStatus{Parents: []inf.ParentStatus{
+			{
+				ControllerName: "",
+				ParentRef:      inf.ParentReference{Name: "istio"},
+				Conditions:     []metav1.Condition{{Type: "Accepted", Message: "current istio status"}},
+			},
+			{
+				ControllerName: inf.ControllerName(other),
+				ParentRef:      inf.ParentReference{Name: "other"},
+				Conditions:     []metav1.Condition{{Type: "Accepted", Message: "current other status"}},
+			},
+			{ControllerName: inf.ControllerName(our), ParentRef: inf.ParentReference{Name: "stale"}},
+		}},
+	}
+	desired := inf.InferencePoolStatus{Parents: []inf.ParentStatus{
+		{
+			ControllerName: "",
+			ParentRef:      inf.ParentReference{Name: "istio"},
+			Conditions:     []metav1.Condition{{Type: "Accepted", Message: "stale istio status"}},
+		},
+		{
+			ControllerName: inf.ControllerName(other),
+			ParentRef:      inf.ParentReference{Name: "other"},
+			Conditions:     []metav1.Condition{{Type: "Accepted", Message: "stale other status"}},
+		},
+		{ControllerName: "deleted.example/controller", ParentRef: inf.ParentReference{Name: "deleted"}},
+		{ControllerName: inf.ControllerName(our), ParentRef: inf.ParentReference{Name: "z"}},
+		{ControllerName: inf.ControllerName(our), ParentRef: inf.ParentReference{Name: "m"}},
+	}}
+	client := &inferencePoolStatusClient{current: current}
+	syncer := StatusSyncer[*inf.InferencePool, inf.InferencePoolStatus]{
+		Name:           "inferencePool",
+		ControllerName: our,
+		Client:         client,
+		Build: func(om metav1.ObjectMeta, status inf.InferencePoolStatus) *inf.InferencePool {
+			return &inf.InferencePool{ObjectMeta: om, Status: status}
+		},
+	}
+	statusAny := any(desired)
+
+	syncer.ApplyStatus(context.Background(), syncstatus.Resource{
+		Name: current.Name, Namespace: current.Namespace,
+		ResourceVersion: "1",
+	}, &statusAny)
+
+	require.NotNil(t, client.updated)
+	require.Equal(t, current.ResourceVersion, client.updated.ResourceVersion)
+	require.Equal(t, []inf.ParentStatus{
+		current.Status.Parents[0],
+		current.Status.Parents[1],
+		desired.Parents[4],
+		desired.Parents[3],
+	}, client.updated.Status.Parents)
+}
+
+type inferencePoolStatusClient struct {
+	kclient.Client[*inf.InferencePool]
+	current *inf.InferencePool
+	updated *inf.InferencePool
+}
+
+func (c *inferencePoolStatusClient) Get(_, _ string) *inf.InferencePool {
+	return c.current.DeepCopy()
+}
+
+func (c *inferencePoolStatusClient) UpdateStatus(pool *inf.InferencePool) (*inf.InferencePool, error) {
+	c.updated = pool.DeepCopy()
+	return pool, nil
 }
 
 func TestMergeGatewayAddresses_SortsOutput(t *testing.T) {


### PR DESCRIPTION
## What

Add InferencePool support for StatusSyncer because it was missing from the `case` list.
And, add controllerName to make it compatible to use with another gateway-api implementation.


## Note

This PR was assisted by generative AI tools.