### PR TITLE
llm: preserve error on count tokens error

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -2373,6 +2373,23 @@ impl AIProvider {
 		let BufferedResponse {
 			mut parts, bytes, ..
 		} = buffered;
+		parts.headers.remove(header::CONTENT_LENGTH);
+		if !parts.status.is_success() {
+			let body = self.process_error(
+				&req,
+				parts.status,
+				&bytes,
+				model_catalog.map(|c| c.as_handle()),
+			)?;
+			return Ok(Self::finalize_response(
+				parts,
+				body.into(),
+				req,
+				LLMResponse::default(),
+				model_catalog,
+				log,
+			));
+		}
 		let (bytes, count) = match self {
 			AIProvider::Anthropic(_) | AIProvider::Vertex(_) | AIProvider::Bedrock(_) => {
 				types::count_tokens::Response::translate_response(bytes)?
@@ -2394,7 +2411,6 @@ impl AIProvider {
 			},
 		};
 
-		parts.headers.remove(header::CONTENT_LENGTH);
 		Ok(Self::finalize_response(
 			parts,
 			bytes.into(),
@@ -2929,6 +2945,7 @@ impl AIProvider {
 				// the Google shape the client expects.
 				Ok(bytes.clone())
 			},
+			(_, InputFormat::CountTokens) => Ok(bytes.clone()),
 			(AIProvider::Bedrock(_), InputFormat::Embeddings) => {
 				conversion::bedrock::from_embeddings::translate_error(bytes)
 			},

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -1379,6 +1379,41 @@ fn gemini_count_tokens_response_reports_total_tokens() {
 }
 
 #[tokio::test]
+async fn anthropic_count_tokens_preserves_upstream_errors() {
+	let provider = AIProvider::bedrock(bedrock::Provider {
+		model: None,
+		region: strng::new("us-east-1"),
+		guardrail_identifier: None,
+		guardrail_version: None,
+	});
+	let req = LLMRequest {
+		input_tokens: None,
+		input_format: InputFormat::CountTokens,
+		cache_convention: CacheTokenConvention::pending(),
+		request_model: "us.anthropic.claude-haiku-4-5-20251001-v1:0".into(),
+		provider: "aws.bedrock".into(),
+		streaming: false,
+		params: Default::default(),
+		prompt: None,
+		provider_state: None,
+	};
+	let body =
+		bytes::Bytes::from_static(br#"{"message":"The provided model does not support CountTokens"}"#);
+	let mut parts = ::http::Response::new(()).into_parts().0;
+	parts.status = ::http::StatusCode::BAD_REQUEST;
+	let buffered = BufferedResponse {
+		parts,
+		bytes: body.clone(),
+	};
+
+	let resp = provider
+		.process_count_tokens_response(req, buffered, None, &Default::default())
+		.expect("error response should process");
+	assert_eq!(resp.status(), ::http::StatusCode::BAD_REQUEST);
+	assert_eq!(resp.into_body().collect().await.unwrap().to_bytes(), body);
+}
+
+#[tokio::test]
 async fn vertex_anthropic_messages_prepares_vertex_body() {
 	use crate::http::auth::BackendInfo;
 	use crate::test_helpers::proxymock::setup_proxy_test;


### PR DESCRIPTION
After/before

```
$ curl -i http://localhost:4000/v1/messages/count_tokens -H 'content-type: application/json' -H 'anthropic-version: 2023-06-01' -d '{
      "model": "aws/us.anthropic.claude-haiku-4-5-20251001-v1:0",
      "messages": [
        {
          "role": "user",
          "content": "hello"
        }
      ],
      "tools": [
        {
          "name": "get_weather",
          "description": "Get weather",
          "input_schema": {
            "type": "object",
            "properties": {}
          }
        }
      ]
    }'
HTTP/1.1 400 Bad Request
date: Mon, 31 Aug 2026 21:11:20 GMT
content-type: application/json
x-amzn-errortype: ValidationException:http://internal.amazon.com/coral/com.amazon.bedrock/
x-amzn-requestid: 327d4493-03c5-455f-9776-78b9e3c24f26
x-ratelimit-limit: 100
x-ratelimit-remaining: 98
x-ratelimit-reset: 17
content-length: 65

{"message":"The provided model doesn't support counting tokens."}%

$ curl -i http://localhost:4000/v1/messages/count_tokens -H 'content-type: application/json' -H 'anthropic-version: 2023-06-01' -d '{
      "model": "aws/us.anthropic.claude-haiku-4-5-20251001-v1:0",
      "messages": [
        {
          "role": "user",
          "content": "hello"
        }
      ],
      "tools": [
        {
          "name": "get_weather",
          "description": "Get weather",
          "input_schema": {
            "type": "object",
            "properties": {}
          }
        }
      ]
    }'
HTTP/1.1 502 Bad Gateway
content-type: text/plain
x-ratelimit-limit: 100
x-ratelimit-remaining: 99
x-ratelimit-reset: 55
content-length: 106
date: Mon, 31 Aug 2026 21:11:31 GMT

failed to process LLM response: failed to parse response: missing field `input_tokens` at line 1 column 65
```