### PR TITLE
Fix OTLP status for provider HTTP errors

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2908,10 +2908,7 @@ async fn make_backend_call(
 	let resp = upstream.call(call).await;
 	if let Some(span) = span.as_deref_mut() {
 		match &resp {
-			Ok(response) => span.add_attribute(KeyValue::new(
-				"http.status",
-				i64::from(response.status().as_u16()),
-			)),
+			Ok(response) => span.record_http_client_status(response.status()),
 			Err(error) => span.set_error(error.as_reason().to_string(), error.to_string()),
 		}
 	}
@@ -4725,12 +4722,7 @@ impl PolicyClient {
 			return;
 		};
 		match result {
-			Ok(response) => {
-				span.add_attribute(KeyValue::new(
-					"http.status",
-					i64::from(response.status().as_u16()),
-				));
-			},
+			Ok(response) => span.record_http_client_status(response.status()),
 			Err(error) => span.set_error(error.as_reason().to_string(), error.to_string()),
 		}
 	}

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -2458,6 +2458,15 @@ impl SpanWriteOnDrop {
 		}
 	}
 
+	pub fn record_http_client_status(&mut self, status: http::StatusCode) {
+		self.add_attribute(KeyValue::new("http.status", i64::from(status.as_u16())));
+		if status.is_client_error() || status.is_server_error() {
+			// This is an outbound client span. A received error response is a successful
+			// transport result, but the operation represented by the span failed.
+			self.set_error(status.as_u16().to_string(), String::new());
+		}
+	}
+
 	pub fn record_grpc_result<T>(&mut self, result: &Result<tonic::Response<T>, tonic::Status>) {
 		match result {
 			Ok(_) => self.add_attribute(KeyValue::new("grpc.status", 0_i64)),
@@ -2835,6 +2844,48 @@ mod tests {
 			ProxyResponseReason::ExtAuth.to_string(),
 		)));
 		assert_eq!(child.status, Status::error("authorization denied"));
+	}
+
+	#[test]
+	fn outbound_client_span_classifies_http_response_status() {
+		let (tracer, _exporter) = test_tracer();
+		let mut request = test_request_log();
+		request.tracer = Some(tracer);
+		let mut outgoing = trc::TraceParent::new();
+		outgoing.flags = 1;
+		request.outgoing_span = Some(outgoing);
+
+		for (status, expected) in [
+			(http::StatusCode::OK, Status::default()),
+			(http::StatusCode::FOUND, Status::default()),
+			(http::StatusCode::TOO_MANY_REQUESTS, Status::error("")),
+			(http::StatusCode::INTERNAL_SERVER_ERROR, Status::error("")),
+		] {
+			let mut span = request.span_writer().start_outbound(OutboundCallLabels {
+				kind: OutboundCallKind::Primary,
+				subtype: OutboundCallSubtype::Llm,
+			});
+			span.record_http_client_status(status);
+
+			assert_eq!(span.status, expected, "status {status}");
+			assert!(
+				span
+					.attributes
+					.contains(&KeyValue::new("http.status", i64::from(status.as_u16()),))
+			);
+			let error_type = span
+				.attributes
+				.iter()
+				.find(|attribute| attribute.key.as_str() == "error.type");
+			if status.is_client_error() || status.is_server_error() {
+				assert_eq!(
+					error_type.map(|attribute| attribute.value.as_str().into_owned()),
+					Some(status.as_u16().to_string()),
+				);
+			} else {
+				assert!(error_type.is_none());
+			}
+		}
 	}
 
 	#[test]

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -364,9 +364,7 @@ fn request_span_status(request: &RequestLog, attributes: &mut Vec<KeyValue>) -> 
 				.unwrap_or_else(|| "_OTHER".to_string()),
 			error.clone(),
 		)
-	} else if let Some(status) = request.status.filter(|status| {
-		status.is_server_error() || (request.llm_request.is_some() && status.is_client_error())
-	}) {
+	} else if let Some(status) = request.status.filter(http::StatusCode::is_server_error) {
 		(status.as_u16().to_string(), String::new())
 	} else {
 		return Status::default();
@@ -959,10 +957,10 @@ mod tests {
 	}
 
 	#[test]
-	fn send_exports_gen_ai_http_error_status() {
+	fn send_exports_gen_ai_server_error_status() {
 		let (tracer, exporter) = test_tracer();
 		let mut request = test_request_log();
-		request.status = Some(http::StatusCode::TOO_MANY_REQUESTS);
+		request.status = Some(http::StatusCode::INTERNAL_SERVER_ERROR);
 		request.llm_request = Some(test_llm_request());
 		let mut outgoing = TraceParent::new();
 		outgoing.flags = 1;
@@ -993,7 +991,7 @@ mod tests {
 		assert!(
 			spans[0]
 				.attributes
-				.contains(&KeyValue::new("error.type", "429"))
+				.contains(&KeyValue::new("error.type", "500"))
 		);
 	}
 
@@ -1010,8 +1008,8 @@ mod tests {
 			(
 				http::StatusCode::TOO_MANY_REQUESTS,
 				true,
-				Status::error(""),
-				Some("429"),
+				Status::default(),
+				None,
 			),
 			(
 				http::StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -339,11 +339,7 @@ impl Tracer {
 				}
 			})
 		});
-		let status = if let Some(error) = &request.error {
-			Status::error(error.clone())
-		} else {
-			Status::default()
-		};
+		let status = request_span_status(request, &mut attributes);
 
 		let out_span = request.outgoing_span.as_ref().unwrap();
 		self.processor.emit(trace_span_data(
@@ -357,6 +353,32 @@ impl Tracer {
 			status,
 		));
 	}
+}
+
+fn request_span_status(request: &RequestLog, attributes: &mut Vec<KeyValue>) -> Status {
+	let (error_type, description) = if let Some(error) = &request.error {
+		(
+			request
+				.reason
+				.map(|reason| reason.to_string())
+				.unwrap_or_else(|| "_OTHER".to_string()),
+			error.clone(),
+		)
+	} else if let Some(status) = request.status.filter(|status| {
+		status.is_server_error() || (request.llm_request.is_some() && status.is_client_error())
+	}) {
+		(status.as_u16().to_string(), String::new())
+	} else {
+		return Status::default();
+	};
+
+	if !attributes
+		.iter()
+		.any(|attribute| attribute.key.as_str() == "error.type")
+	{
+		attributes.push(KeyValue::new("error.type", error_type));
+	}
+	Status::error(description)
 }
 
 /// Policy-aware OTLP gRPC exporter that routes via `GrpcReferenceChannel`, ensuring
@@ -920,6 +942,125 @@ mod tests {
 		assert_eq!(span.parent_span_id, incoming.span_id.into());
 		assert!(span.parent_span_is_remote);
 		assert!(span.links.iter().next().is_none());
+	}
+
+	fn test_llm_request() -> crate::llm::LLMRequest {
+		crate::llm::LLMRequest {
+			input_tokens: None,
+			input_format: crate::llm::InputFormat::Responses,
+			cache_convention: Default::default(),
+			request_model: "test-model".into(),
+			provider: "test-provider".into(),
+			streaming: false,
+			params: Default::default(),
+			prompt: None,
+			provider_state: None,
+		}
+	}
+
+	#[test]
+	fn send_exports_gen_ai_http_error_status() {
+		let (tracer, exporter) = test_tracer();
+		let mut request = test_request_log();
+		request.status = Some(http::StatusCode::TOO_MANY_REQUESTS);
+		request.llm_request = Some(test_llm_request());
+		let mut outgoing = TraceParent::new();
+		outgoing.flags = 1;
+		request.outgoing_span = Some(outgoing);
+
+		let filter = None;
+		let fields = LoggingFields::default();
+		let otlp_filter = None;
+		let otlp_fields = LoggingFields::default();
+		let metric_fields = Arc::new(MetricFields::default());
+		let database_fields = LoggingFields::default();
+		let cel_exec = CelLoggingExecutor {
+			executor: crate::cel::Executor::new_empty(),
+			filter: &filter,
+			fields: &fields,
+			otlp_filter: &otlp_filter,
+			otlp_fields: &otlp_fields,
+			metric_fields: &metric_fields,
+			database_fields: &database_fields,
+		};
+
+		tracer.send(&request, &Timestamp::now(), &cel_exec, None, &[]);
+		let _ = tracer.provider.force_flush();
+
+		let spans = exporter.finished_spans();
+		assert_eq!(spans.len(), 1);
+		assert_eq!(spans[0].status, Status::error(""));
+		assert!(
+			spans[0]
+				.attributes
+				.contains(&KeyValue::new("error.type", "429"))
+		);
+	}
+
+	#[test]
+	fn request_span_classifies_http_and_gen_ai_errors() {
+		for (status, gen_ai, expected, expected_error_type) in [
+			(http::StatusCode::OK, false, Status::default(), None),
+			(
+				http::StatusCode::TOO_MANY_REQUESTS,
+				false,
+				Status::default(),
+				None,
+			),
+			(
+				http::StatusCode::TOO_MANY_REQUESTS,
+				true,
+				Status::error(""),
+				Some("429"),
+			),
+			(
+				http::StatusCode::INTERNAL_SERVER_ERROR,
+				false,
+				Status::error(""),
+				Some("500"),
+			),
+		] {
+			let mut request = test_request_log();
+			request.status = Some(status);
+			if gen_ai {
+				request.llm_request = Some(test_llm_request());
+			}
+			let mut attributes = Vec::new();
+
+			assert_eq!(
+				request_span_status(&request, &mut attributes),
+				expected,
+				"status {status}, gen_ai {gen_ai}",
+			);
+			assert_eq!(
+				attributes
+					.iter()
+					.find(|attribute| attribute.key.as_str() == "error.type")
+					.map(|attribute| attribute.value.as_str().into_owned()),
+				expected_error_type.map(str::to_string),
+			);
+		}
+	}
+
+	#[test]
+	fn request_span_preserves_recorded_error_and_custom_error_type() {
+		let mut request = test_request_log();
+		request.error = Some("connection failed".to_string());
+		request.reason = Some(crate::proxy::ProxyResponseReason::UpstreamFailure);
+		let mut attributes = vec![KeyValue::new("error.type", "custom")];
+
+		assert_eq!(
+			request_span_status(&request, &mut attributes),
+			Status::error("connection failed"),
+		);
+		assert_eq!(
+			attributes
+				.iter()
+				.filter(|attribute| attribute.key.as_str() == "error.type")
+				.count(),
+			1,
+		);
+		assert!(attributes.contains(&KeyValue::new("error.type", "custom")));
 	}
 
 	#[test]


### PR DESCRIPTION
## Description

Provider HTTP error responses recorded an HTTP status attribute but left the OTLP span status unset. This marks outbound HTTP client spans as errors for 4xx and 5xx responses and records the numeric status as `error.type`.

The inbound HTTP server span now classifies 5xx responses as errors while preserving the OpenTelemetry requirement that server-side 4xx responses remain unset. Existing transport error descriptions and custom error types are preserved.

A separate logical GenAI inference span is tracked in #3272.

## Testing

- `make lint`
- `cargo test -p agentgateway telemetry::`
- Exported-span regression for a GenAI request returning HTTP 500

Fixes: #3260
