### PR TITLE
fix(llm): validate credit-card matches with Luhn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "libc",
+ "luhn",
  "mediatype",
  "mimalloc",
  "multer",
@@ -2447,6 +2448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "digits_iterator"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af83450b771231745d43edf36dc9b7813ab83be5e8cbea344ccced1a09dfebcd"
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,6 +4220,15 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "luhn"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d10b831402a3b10e018c8bc7f0ec3344a67d0725919cbaf393accb9baf8700b"
+dependencies = [
+ "digits_iterator",
+]
 
 [[package]]
 name = "macro_rules_attribute"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ itertools = "0.15"
 jsonwebtoken = { version = "10.4" }
 lazy_static = "1.5"
 libc = "0.2"
+luhn = "1.0"
 notify = "8.2"
 notify-debouncer-full = "0.7"
 md-5 = "0.11"

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -86,6 +86,7 @@ ipnet.workspace = true
 itertools.workspace = true
 jsonwebtoken.workspace = true
 lazy_static.workspace = true
+luhn.workspace = true
 mediatype = "0.21.0"
 notify-debouncer-full.workspace = true
 notify.workspace = true

--- a/crates/agentgateway/src/llm/policy/pii/credit_card_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/credit_card_recognizer.rs
@@ -57,9 +57,18 @@ impl CreditCardRecognizer {
 
 impl Recognizer for CreditCardRecognizer {
 	fn recognize(&self, text: &str) -> Vec<super::recognizer_result::RecognizerResult> {
-		self.recognizer.recognize(text)
+		self
+			.recognizer
+			.recognize(text)
+			.into_iter()
+			.filter(|result| luhn::valid(&normalize_card_number(&result.matched)))
+			.collect()
 	}
 	fn name(&self) -> &str {
 		self.recognizer.name()
 	}
+}
+
+fn normalize_card_number(value: &str) -> String {
+	value.chars().filter(|c| *c != ' ' && *c != '-').collect()
 }

--- a/crates/agentgateway/src/llm/policy/pii/credit_card_recognizer.rs
+++ b/crates/agentgateway/src/llm/policy/pii/credit_card_recognizer.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::llm::policy::pii::pattern_recognizer::PatternRecognizer;
 use crate::llm::policy::pii::recognizer::Recognizer;
 
@@ -69,6 +71,10 @@ impl Recognizer for CreditCardRecognizer {
 	}
 }
 
-fn normalize_card_number(value: &str) -> String {
-	value.chars().filter(|c| *c != ' ' && *c != '-').collect()
+fn normalize_card_number(value: &str) -> Cow<'_, str> {
+	if value.bytes().any(|byte| byte == b' ' || byte == b'-') {
+		Cow::Owned(value.chars().filter(|c| *c != ' ' && *c != '-').collect())
+	} else {
+		Cow::Borrowed(value)
+	}
 }

--- a/crates/agentgateway/src/llm/policy/pii/tests.rs
+++ b/crates/agentgateway/src/llm/policy/pii/tests.rs
@@ -105,6 +105,14 @@ fn test_url_recognizer() {
 	);
 }
 
+fn credit_card_matches(text: &str) -> Vec<(String, usize, usize)> {
+	credit_card_recognizer::CreditCardRecognizer::new()
+		.recognize(text)
+		.into_iter()
+		.map(|result| (result.matched, result.start, result.end))
+		.collect()
+}
+
 #[test]
 fn test_credit_card_recognizer() {
 	let recognizer = credit_card_recognizer::CreditCardRecognizer::new();
@@ -119,6 +127,66 @@ fn test_credit_card_recognizer() {
 		assert!(result.score > 0.0);
 		assert!(result.matched.contains("1111") || result.matched.contains("5555"));
 	}
+}
+
+#[test]
+fn test_credit_card_recognizer_valid_luhn_formats() {
+	let cases = [
+		("visa contiguous: 4111111111111111", "4111111111111111"),
+		("visa spaces: 4111 1111 1111 1111", "4111 1111 1111 1111"),
+		("visa hyphens: 4111-1111-1111-1111", "4111-1111-1111-1111"),
+		("mastercard: 5555555555554444", "5555555555554444"),
+		(
+			"mastercard hyphens: 5555-5555-5555-4444",
+			"5555-5555-5555-4444",
+		),
+		("amex contiguous: 378282246310005", "378282246310005"),
+		("amex spaces: 3782 8224 6310 005", "3782 8224 6310 005"),
+		("amex hyphens: 3782-8224-6310-005", "3782-8224-6310-005"),
+		("discover: 6011111111111117", "6011111111111117"),
+		(
+			"discover hyphens: 6011-1111-1111-1117",
+			"6011-1111-1111-1117",
+		),
+	];
+
+	for (text, expected) in cases {
+		let matches = credit_card_matches(text);
+		assert_eq!(matches.len(), 1, "{text}");
+		assert_eq!(matches[0].0, expected, "{text}");
+		assert_eq!(&text[matches[0].1..matches[0].2], expected, "{text}");
+	}
+}
+
+#[test]
+fn test_credit_card_recognizer_rejects_invalid_checksum() {
+	let cases = [
+		"visa: 4111111111111112",
+		"visa hyphens: 4111-1111-1111-1112",
+		"mastercard: 5555555555554445",
+		"amex: 378282246310006",
+		"discover: 6011111111111118",
+	];
+
+	for text in cases {
+		assert!(
+			credit_card_matches(text).is_empty(),
+			"expected no match for {text}"
+		);
+	}
+}
+
+#[test]
+fn test_credit_card_recognizer_ignores_surrounding_digits() {
+	assert!(credit_card_matches("41111111111111119").is_empty());
+	assert!(credit_card_matches("x4111111111111111y").is_empty());
+	assert_eq!(
+		credit_card_matches("prefix 4111111111111111 suffix")
+			.into_iter()
+			.map(|(matched, _, _)| matched)
+			.collect::<Vec<_>>(),
+		vec!["4111111111111111".to_string()]
+	);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Validate credit-card-shaped prompt-guard matches with the Luhn checksum before returning a `CREDIT_CARD` recognizer result.

## Changes

- Add the `luhn` dependency to the workspace and agentgateway crate.
- Normalize spaces and hyphens before checksum validation while preserving the original matched value and byte span.
- Add regression coverage for valid Visa, Mastercard, American Express, and Discover formats, invalid checksums, and surrounding digits.

Shape matching remains bounded by the existing recognizer, and the existing masking and reject behavior is unchanged.

## Verification

```
cargo test -p agentgateway pii::tests::test_credit_card_recognizer -- --nocapture
```

The focused suite passes all four credit-card recognizer tests.
