### PR TITLE
Dockerfile: copy catalog for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ COPY Makefile Cargo.toml Cargo.lock ./
 COPY .cargo ./.cargo
 COPY crates ./crates
 COPY tools ./tools
+COPY catalog ./catalog
 COPY --from=node /app/dist ./ui/dist
 
 RUN \


### PR DESCRIPTION
c3f279072e286a91bff35859ed33a62f16afa58f added the base catalog to be included from the repo into the rust caller itself.
This works fine in ci but doesnt survive the dockerfiles copy semantics.

I thought about just moving where catalog is to be part of one of the existing paths we copy but none of them really made sense to me so figured the one line here was better.

Anyways this should fix our nightly builds https://github.com/agentgateway/agentgateway/actions/runs/33462543135