### PR TITLE
Record usage from incomplete Responses streams

### DIFF
--- a/crates/llm/src/conversion/responses.rs
+++ b/crates/llm/src/conversion/responses.rs
@@ -19,6 +19,43 @@ enum StreamResponse {
 	Raw(detect::StreamResponse),
 }
 
+fn record_response(log: &StreamingUsageGuard, response: &types::responses::typed::Response) {
+	log.update(|r| {
+		r.response.provider_model = Some(strng::new(&response.model));
+		r.response.service_tier = response
+			.service_tier
+			.as_ref()
+			.and_then(types::serialize_str);
+		if let Some(usage) = &response.usage {
+			r.response.input_tokens = Some(usage.input_tokens as u64);
+			r.response.output_tokens = Some(usage.output_tokens as u64);
+			r.response.total_tokens = Some(usage.total_tokens as u64);
+			r.response.cached_input_tokens = Some(usage.input_tokens_details.cached_tokens as u64);
+			r.response.cache_creation_input_tokens = usage
+				.input_tokens_details
+				.cache_write_tokens
+				.map(|tokens| tokens as u64);
+			r.response.reasoning_tokens = Some(usage.output_tokens_details.reasoning_tokens as u64);
+		}
+	});
+}
+
+fn record_terminal_response(
+	log: &StreamingUsageGuard,
+	response: &types::responses::typed::Response,
+	completion: &mut Option<String>,
+	tool_calls: &mut Option<BTreeMap<u32, OutputMessagePart>>,
+) {
+	record_response(log, response);
+	let finish_reason = types::serialize_str(&response.status);
+	log.update(|r| {
+		if let Some(c) = completion.take() {
+			r.response.completion = Some(vec![c]);
+		}
+		r.response.output_messages = take_output_messages(tool_calls, finish_reason.clone());
+	});
+}
+
 pub fn passthrough_stream(
 	b: Body,
 	buffer_limit: usize,
@@ -52,25 +89,7 @@ pub fn passthrough_stream(
 		};
 		match event {
 			types::responses::typed::ResponseStreamEvent::ResponseCreated(created) => {
-				log.update(|r| {
-					r.response.provider_model = Some(strng::new(&created.response.model));
-					r.response.service_tier = created
-						.response
-						.service_tier
-						.as_ref()
-						.and_then(types::serialize_str);
-					if let Some(usage) = &created.response.usage {
-						r.response.input_tokens = Some(usage.input_tokens as u64);
-						r.response.output_tokens = Some(usage.output_tokens as u64);
-						r.response.total_tokens = Some(usage.total_tokens as u64);
-						r.response.cached_input_tokens = Some(usage.input_tokens_details.cached_tokens as u64);
-						r.response.cache_creation_input_tokens = usage
-							.input_tokens_details
-							.cache_write_tokens
-							.map(|tokens| tokens as u64);
-						r.response.reasoning_tokens = Some(usage.output_tokens_details.reasoning_tokens as u64);
-					}
-				});
+				record_response(&log, &created.response);
 			},
 			types::responses::typed::ResponseStreamEvent::ResponseOutputTextDelta(ref delta) => {
 				if !saw_token {
@@ -91,30 +110,10 @@ pub fn passthrough_stream(
 				}
 			},
 			types::responses::typed::ResponseStreamEvent::ResponseCompleted(completed) => {
-				let finish_reason = types::serialize_str(&completed.response.status);
-				log.update(|r| {
-					r.response.provider_model = Some(strng::new(&completed.response.model));
-					r.response.service_tier = completed
-						.response
-						.service_tier
-						.as_ref()
-						.and_then(types::serialize_str);
-					if let Some(usage) = &completed.response.usage {
-						r.response.input_tokens = Some(usage.input_tokens as u64);
-						r.response.output_tokens = Some(usage.output_tokens as u64);
-						r.response.total_tokens = Some(usage.total_tokens as u64);
-						r.response.cached_input_tokens = Some(usage.input_tokens_details.cached_tokens as u64);
-						r.response.cache_creation_input_tokens = usage
-							.input_tokens_details
-							.cache_write_tokens
-							.map(|tokens| tokens as u64);
-						r.response.reasoning_tokens = Some(usage.output_tokens_details.reasoning_tokens as u64);
-					}
-					if let Some(c) = completion.take() {
-						r.response.completion = Some(vec![c]);
-					}
-					r.response.output_messages = take_output_messages(&mut tool_calls, finish_reason.clone());
-				});
+				record_terminal_response(&log, &completed.response, &mut completion, &mut tool_calls);
+			},
+			types::responses::typed::ResponseStreamEvent::ResponseIncomplete(incomplete) => {
+				record_terminal_response(&log, &incomplete.response, &mut completion, &mut tool_calls);
 			},
 			_ => {},
 		}

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -1371,6 +1371,50 @@ data: {"type":"message_stop"}
 		assert_eq!(arguments, "{}");
 	}
 
+	#[tokio::test]
+	async fn responses_passthrough_records_incomplete_usage() {
+		let input = r#"data: {"type":"response.output_text.delta","sequence_number":1,"item_id":"item","output_index":0,"content_index":0,"delta":"partial"}
+
+data: {"type":"response.incomplete","sequence_number":2,"response":{"created_at":1,"id":"response","model":"gpt-5","object":"response","output":[],"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":4},"output_tokens":7,"output_tokens_details":{"reasoning_tokens":2},"total_tokens":17}}}
+
+data: [DONE]
+
+"#;
+		let info = Arc::new(Mutex::new(LLMInfo::new(
+			LLMRequest {
+				input_tokens: None,
+				input_format: InputFormat::Responses,
+				cache_convention: CacheTokenConvention::pending(),
+				request_model: strng::literal!("input-model"),
+				provider: Default::default(),
+				streaming: true,
+				params: Default::default(),
+				prompt: None,
+				provider_state: None,
+			},
+			LLMResponse::default(),
+		)));
+		let reporter = TestStreamingReporter { info: info.clone() };
+
+		conversion::responses::passthrough_stream(
+			axum_core::body::Body::from(input),
+			1024 * 1024,
+			StreamingUsageGuard::new(Box::new(reporter)),
+			LogContentFields::default(),
+		)
+		.collect()
+		.await
+		.unwrap();
+
+		let response = &info.lock().unwrap().response;
+		assert_eq!(response.input_tokens, Some(10));
+		assert_eq!(response.output_tokens, Some(7));
+		assert_eq!(response.total_tokens, Some(17));
+		assert_eq!(response.cached_input_tokens, Some(4));
+		assert_eq!(response.reasoning_tokens, Some(2));
+		assert!(response.first_token.is_some());
+	}
+
 	#[test]
 	fn responses_usage_allows_missing_cache_write_tokens() {
 		let event = serde_json::from_value::<types::responses::typed::ResponseStreamEvent>(json!({


### PR DESCRIPTION
## Summary

- process `response.incomplete` as a terminal Responses API event
- retain provider model, service tier, token usage, completion, and tool-call metadata
- share terminal accounting with `response.completed`

This allows time-per-output-token telemetry to be emitted when a streamed response reaches an output-token limit.

## Test

- `cargo test -p agent-llm`
- `cargo clippy -p agent-llm --all-targets --all-features -- -D warnings`