### PR TITLE
catalog: use github as source of truth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ gen: generate-apis generate-schema format
 
 .PHONY: refresh-model-catalog
 refresh-model-catalog:
-	go run ./controller/cmd/agctl catalog import --exclude-providers openrouter --overlay ./catalog/model-catalog-overrides.yaml --out ./catalog/model-catalog.json --pretty
+	go run ./controller/cmd/agctl catalog import --source models.dev --exclude-providers openrouter --overlay ./catalog/model-catalog-overrides.yaml --out ./catalog/model-catalog.json --pretty
 
 .PHONY: generate-schema
 generate-schema:

--- a/catalog/model-catalog-overrides.yaml
+++ b/catalog/model-catalog-overrides.yaml
@@ -1,2 +1,2 @@
-# Hand-maintained model catalog data merged over the generated models.dev catalog.
+# Hand-maintained model catalog data merged over the generated base catalog.
 providers: {}

--- a/catalog/model-catalog.json
+++ b/catalog/model-catalog.json
@@ -1,7 +1,6 @@
 {
   "metadata": {
-    "source": "models.dev",
-    "generatedAt": "2026-08-31T23:15:21Z"
+    "generatedAt": "2026-09-01T20:25:15Z"
   },
   "providers": {
     "anthropic": {
@@ -11,6 +10,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -146,6 +153,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -380,6 +395,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "global.anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -881,6 +904,14 @@
             "cacheWrite": "12.5"
           }
         },
+        "us.anthropic.claude-fable-5-1": {
+          "rates": {
+            "input": "11",
+            "output": "55",
+            "cacheRead": "0.275",
+            "cacheWrite": "13.75"
+          }
+        },
         "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
           "rates": {
             "input": "1",
@@ -1024,6 +1055,14 @@
             "input": "10",
             "output": "50",
             "cacheRead": "1",
+            "cacheWrite": "12.5"
+          }
+        },
+        "claude-fable-5-1": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
             "cacheWrite": "12.5"
           }
         },
@@ -3027,6 +3066,14 @@
     },
     "gcp.vertex_ai": {
       "models": {
+        "claude-fable-5-1@default": {
+          "rates": {
+            "input": "10",
+            "output": "50",
+            "cacheRead": "0.25",
+            "cacheWrite": "12.5"
+          }
+        },
         "claude-fable-5@default": {
           "rates": {
             "input": "10",

--- a/controller/pkg/cli/catalog/cmd.go
+++ b/controller/pkg/cli/catalog/cmd.go
@@ -57,7 +57,7 @@ func importSourceList() string {
 
 func importCmd() *cobra.Command {
 	f := &importFlags{
-		source: modelsDevSourceName,
+		source: githubSourceName,
 	}
 	cmd := &cobra.Command{
 		Use:   "import",
@@ -118,9 +118,10 @@ func runImport(cmd *cobra.Command, f *importFlags) error {
 		}
 		cat.overlayWith(&overlay)
 	}
-	cat.Metadata = &CatalogMetadata{
-		Source:      f.source,
-		GeneratedAt: time.Now().UTC().Truncate(time.Second),
+	if cat.Metadata == nil {
+		cat.Metadata = &CatalogMetadata{
+			GeneratedAt: time.Now().UTC().Truncate(time.Second),
+		}
 	}
 	if err := cat.Validate(); err != nil {
 		return fmt.Errorf("invalid catalog: %w", err)

--- a/controller/pkg/cli/catalog/model_catalog.go
+++ b/controller/pkg/cli/catalog/model_catalog.go
@@ -16,7 +16,8 @@ type ModelCatalog struct {
 }
 
 type CatalogMetadata struct {
-	Source      string    `json:"source"`
+	// Source is accepted for compatibility with older catalogs.
+	Source      string    `json:"source,omitempty"`
 	GeneratedAt time.Time `json:"generatedAt"`
 }
 
@@ -44,9 +45,6 @@ func (c *ModelCatalog) overlayWith(overlay *ModelCatalog) {
 
 func (c *ModelCatalog) Validate() error {
 	if c.Metadata != nil {
-		if c.Metadata.Source == "" {
-			return fmt.Errorf("metadata source is required")
-		}
 		if c.Metadata.GeneratedAt.IsZero() {
 			return fmt.Errorf("metadata generatedAt is required")
 		}

--- a/controller/pkg/cli/catalog/source_github.go
+++ b/controller/pkg/cli/catalog/source_github.go
@@ -1,0 +1,66 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	githubSourceName = "github"
+	githubCatalogURL = "https://agentgateway.dev/model-catalog"
+)
+
+func init() {
+	importSources[githubSourceName] = func(ctx context.Context, opts importOptions) (*ModelCatalog, []string, error) {
+		catalog, err := fetchGitHubCatalog(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		selected := make(map[string]struct{}, len(opts.providers))
+		for _, provider := range opts.providers {
+			selected[provider] = struct{}{}
+		}
+		excluded := make(map[string]struct{}, len(opts.excludeProviders))
+		for _, provider := range opts.excludeProviders {
+			excluded[provider] = struct{}{}
+		}
+		for provider := range catalog.Providers {
+			_, include := selected[provider]
+			_, exclude := excluded[provider]
+			if (len(selected) > 0 && !include) || exclude {
+				delete(catalog.Providers, provider)
+			}
+		}
+		return catalog, nil, nil
+	}
+}
+
+func fetchGitHubCatalog(ctx context.Context) (*ModelCatalog, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubCatalogURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request for GitHub model catalog: %w", err)
+	}
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch GitHub model catalog: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch GitHub model catalog: unexpected status %d", resp.StatusCode)
+	}
+	var catalog ModelCatalog
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 64<<20)).Decode(&catalog); err != nil {
+		return nil, fmt.Errorf("decode GitHub model catalog: %w", err)
+	}
+	if err := catalog.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid GitHub model catalog: %w", err)
+	}
+	if catalog.Metadata != nil {
+		catalog.Metadata.Source = ""
+	}
+	return &catalog, nil
+}

--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -797,7 +797,7 @@ pub fn merge_model_catalog_sources(
 		let mut inline: crate::llm::catalog::Catalog = serde_json::from_value(base.clone())?;
 		if inline.metadata.is_none() {
 			inline.metadata = Some(crate::llm::catalog::CatalogMetadata {
-				source: "models.dev".to_string(),
+				source: None,
 				// Legacy base catalogs predate generatedAt. Treat them as older than every
 				// timestamped catalog rather than guessing from the resource timestamp,
 				// which may also reflect an unrelated custom-overlay edit.
@@ -1864,7 +1864,7 @@ mod tests {
 		assert_eq!(
 			inline.metadata,
 			Some(crate::llm::catalog::CatalogMetadata {
-				source: "models.dev".to_string(),
+				source: None,
 				generated_at: DateTime::<Utc>::UNIX_EPOCH,
 			})
 		);

--- a/crates/agentgateway/src/llm/catalog/mod.rs
+++ b/crates/agentgateway/src/llm/catalog/mod.rs
@@ -1140,7 +1140,7 @@ mod tests {
 	fn newest_generated_base_wins_before_user_overlays() {
 		let generated = |day: u8, rate: &str| {
 			model::from_json(&format!(
-				r#"{{"metadata":{{"source":"models.dev","generatedAt":"2026-08-{day:02}T00:00:00Z"}},"providers":{{"openai":{{"models":{{"my-model":{{"rates":{{"input":"{rate}"}}}}}}}}}}}}"#
+				r#"{{"metadata":{{"generatedAt":"2026-08-{day:02}T00:00:00Z"}},"providers":{{"openai":{{"models":{{"my-model":{{"rates":{{"input":"{rate}"}}}}}}}}}}}}"#
 			))
 			.unwrap()
 		};

--- a/crates/agentgateway/src/llm/catalog/model.rs
+++ b/crates/agentgateway/src/llm/catalog/model.rs
@@ -22,13 +22,6 @@ pub struct Catalog {
 
 impl Catalog {
 	pub fn validate(&self) -> anyhow::Result<()> {
-		if self
-			.metadata
-			.as_ref()
-			.is_some_and(|metadata| metadata.source.is_empty())
-		{
-			anyhow::bail!("metadata source is required");
-		}
 		for (pid, p) in &self.providers {
 			for (mid, m) in &p.models {
 				let mut prev: Option<u64> = None;
@@ -77,8 +70,9 @@ impl Catalog {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CatalogMetadata {
-	/// Upstream used to generate this base catalog, such as `models.dev`.
-	pub source: String,
+	/// Legacy provenance field retained for compatibility with older generated catalogs.
+	#[serde(default, skip_serializing)]
+	pub source: Option<String>,
 	/// Time the generated catalog contents last changed.
 	pub generated_at: DateTime<Utc>,
 }

--- a/crates/agentgateway/src/llm/catalog/refresh.rs
+++ b/crates/agentgateway/src/llm/catalog/refresh.rs
@@ -1,13 +1,11 @@
-use std::collections::BTreeMap;
 use std::path::Path;
-use std::str::FromStr;
 
-use anyhow::{Context, bail};
-use chrono::Utc;
-use rust_decimal::Decimal;
-use serde::{Deserialize, Serialize};
+use anyhow::Context;
+use serde::Serialize;
 
 use crate::llm::catalog::{ModelCatalog, model};
+
+const CATALOG_URL: &str = "https://agentgateway.dev/model-catalog";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,13 +16,12 @@ pub struct RefreshBaseCatalogResponse {
 	pub catalog: model::Catalog,
 }
 
-pub async fn refresh_models_dev_base_catalog(
+pub async fn refresh_base_catalog(
 	file: &Path,
 	model_catalog: Option<&ModelCatalog>,
 ) -> anyhow::Result<RefreshBaseCatalogResponse> {
-	let refreshed = fetch_models_dev_base_catalog().await?;
-	let catalog = refreshed.catalog.clone();
-	let json = serde_json::to_vec_pretty(&catalog).context("marshal models.dev catalog")?;
+	let refreshed = fetch_base_catalog().await?;
+	let json = serde_json::to_vec_pretty(&refreshed.catalog).context("marshal model catalog")?;
 	if let Some(parent) = file.parent() {
 		fs_err::tokio::create_dir_all(parent).await?;
 	}
@@ -35,12 +32,21 @@ pub async fn refresh_models_dev_base_catalog(
 	Ok(refreshed)
 }
 
-pub async fn fetch_models_dev_base_catalog() -> anyhow::Result<RefreshBaseCatalogResponse> {
-	let mut catalog = fetch_models_dev_catalog().await?;
-	catalog.metadata = Some(model::CatalogMetadata {
-		source: MODELS_DEV_SOURCE.to_string(),
-		generated_at: Utc::now(),
-	});
+pub async fn fetch_base_catalog() -> anyhow::Result<RefreshBaseCatalogResponse> {
+	let client = reqwest::Client::builder()
+		.redirect(reqwest::redirect::Policy::limited(10))
+		.build()?;
+	let catalog: model::Catalog = client
+		.get(CATALOG_URL)
+		.send()
+		.await
+		.context("fetch model catalog from GitHub")?
+		.error_for_status()
+		.context("fetch model catalog from GitHub")?
+		.json()
+		.await
+		.context("decode model catalog from GitHub")?;
+	catalog.validate()?;
 	let providers = catalog.providers.len();
 	let models = catalog
 		.providers
@@ -53,166 +59,3 @@ pub async fn fetch_models_dev_base_catalog() -> anyhow::Result<RefreshBaseCatalo
 		catalog,
 	})
 }
-
-const MODELS_DEV_SOURCE: &str = "models.dev";
-
-async fn fetch_models_dev_catalog() -> anyhow::Result<model::Catalog> {
-	let response = reqwest::get("https://models.dev/api.json")
-		.await
-		.context("fetch models.dev api.json")?
-		.error_for_status()
-		.context("fetch models.dev api.json")?;
-	let api: BTreeMap<String, ModelsDevProvider> = response
-		.json()
-		.await
-		.context("decode models.dev api.json")?;
-	models_dev_transform(api)
-}
-
-fn models_dev_transform(
-	api: BTreeMap<String, ModelsDevProvider>,
-) -> anyhow::Result<model::Catalog> {
-	let mut catalog = model::Catalog::default();
-	for (source_id, gateway_id) in MODELS_DEV_PROVIDER_IDS {
-		let Some(source) = api.get(*source_id) else {
-			continue;
-		};
-		for (model_id, model) in &source.models {
-			if model.status == "deprecated" {
-				continue;
-			}
-			let Some(cost) = &model.cost else {
-				continue;
-			};
-			let entry = model::Model {
-				rates: models_dev_rates(&cost.rates).with_context(|| format!("{gateway_id}/{model_id}"))?,
-				tiers: models_dev_tiers(&cost.tiers).with_context(|| format!("{gateway_id}/{model_id}"))?,
-				..Default::default()
-			};
-			if entry.rates.is_empty() && entry.tiers.is_empty() {
-				continue;
-			}
-			catalog
-				.providers
-				.entry((*gateway_id).to_string())
-				.or_default()
-				.models
-				.insert(model_id.clone(), entry);
-		}
-	}
-	if catalog.providers.is_empty() {
-		bail!("models.dev did not contain any supported priced models");
-	}
-	catalog.validate()?;
-	Ok(catalog)
-}
-
-#[derive(Debug, Deserialize)]
-struct ModelsDevProvider {
-	#[serde(default)]
-	models: BTreeMap<String, ModelsDevModel>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ModelsDevModel {
-	#[serde(default)]
-	status: String,
-	cost: Option<ModelsDevCost>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ModelsDevCost {
-	#[serde(flatten)]
-	rates: ModelsDevRates,
-	#[serde(default)]
-	tiers: Vec<ModelsDevTier>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-struct ModelsDevRates {
-	input: Option<serde_json::Number>,
-	output: Option<serde_json::Number>,
-	cache_read: Option<serde_json::Number>,
-	cache_write: Option<serde_json::Number>,
-	reasoning: Option<serde_json::Number>,
-	input_audio: Option<serde_json::Number>,
-	output_audio: Option<serde_json::Number>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ModelsDevTier {
-	#[serde(flatten)]
-	rates: ModelsDevRates,
-	tier: ModelsDevTierKind,
-}
-
-#[derive(Debug, Deserialize)]
-struct ModelsDevTierKind {
-	#[serde(rename = "type")]
-	kind: String,
-	size: u64,
-}
-
-fn models_dev_tiers(tiers: &[ModelsDevTier]) -> anyhow::Result<Vec<model::Tier>> {
-	let mut converted = Vec::new();
-	for tier in tiers {
-		if tier.tier.kind != "context" || tier.tier.size == 0 {
-			continue;
-		}
-		converted.push(model::Tier {
-			context_over: tier.tier.size,
-			rates: models_dev_rates(&tier.rates)?,
-		});
-	}
-	converted.sort_by_key(|tier| tier.context_over);
-	Ok(converted)
-}
-
-fn models_dev_rates(rates: &ModelsDevRates) -> anyhow::Result<model::Rates> {
-	Ok(model::Rates {
-		input: models_dev_money(&rates.input)?,
-		output: models_dev_money(&rates.output)?,
-		cache_read: models_dev_money(&rates.cache_read)?,
-		cache_write: models_dev_money(&rates.cache_write)?,
-		reasoning: models_dev_money(&rates.reasoning)?,
-		input_audio: models_dev_money(&rates.input_audio)?,
-		output_audio: models_dev_money(&rates.output_audio)?,
-	})
-}
-
-fn models_dev_money(value: &Option<serde_json::Number>) -> anyhow::Result<Option<model::Money>> {
-	let Some(value) = value else {
-		return Ok(None);
-	};
-	let decimal = Decimal::from_str(&value.to_string()).map_err(|e| anyhow::anyhow!("{e}"))?;
-	let rounded = if decimal.scale() > 6 {
-		decimal.round_dp(6)
-	} else {
-		decimal
-	};
-	model::Money::parse(&rounded.to_string())
-		.map(Some)
-		.map_err(anyhow::Error::msg)
-}
-
-const MODELS_DEV_PROVIDER_IDS: &[(&str, &str)] = &[
-	("openai", "openai"),
-	("anthropic", "anthropic"),
-	("amazon-bedrock", "aws.bedrock"),
-	("google", "gcp.gemini"),
-	("google-vertex", "gcp.vertex_ai"),
-	("azure", "azure"),
-	("github-copilot", "copilot"),
-	("cohere", "cohere"),
-	("baseten", "baseten"),
-	("cerebras", "cerebras"),
-	("deepinfra", "deepinfra"),
-	("deepseek", "deepseek"),
-	("groq", "groq"),
-	("huggingface", "huggingface"),
-	("mistral", "mistral"),
-	("openrouter", "openrouter"),
-	("togetherai", "togetherai"),
-	("xai", "xai"),
-	("fireworks-ai", "fireworks"),
-];

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -682,7 +682,7 @@ async fn refresh_base_costs(State(app): State<App>) -> Result<Json<Value>, Error
 		}
 	});
 	if configured_file.is_none() && app.state.storage.mode == ConfigStoreMode::Hybrid {
-		let refreshed = crate::llm::catalog::refresh::fetch_models_dev_base_catalog().await?;
+		let refreshed = crate::llm::catalog::refresh::fetch_base_catalog().await?;
 		let resources = app
 			.config_resource_store()?
 			.list(None)
@@ -733,7 +733,7 @@ async fn refresh_base_costs(State(app): State<App>) -> Result<Json<Value>, Error
 		dir.join(BASE_COSTS_FILE)
 	};
 
-	let refreshed = crate::llm::catalog::refresh::refresh_models_dev_base_catalog(
+	let refreshed = crate::llm::catalog::refresh::refresh_base_catalog(
 		&base_costs_file,
 		configured_file.map(|_| app.model_catalog.as_ref()),
 	)

--- a/schema/config.json
+++ b/schema/config.json
@@ -564,8 +564,12 @@
       "type": "object",
       "properties": {
         "source": {
-          "description": "Upstream used to generate this base catalog, such as `models.dev`.",
-          "type": "string"
+          "description": "Legacy provenance field retained for compatibility with older generated catalogs.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "writeOnly": true
         },
         "generatedAt": {
           "description": "Time the generated catalog contents last changed.",
@@ -575,7 +579,6 @@
       },
       "additionalProperties": false,
       "required": [
-        "source",
         "generatedAt"
       ]
     },

--- a/schema/config.md
+++ b/schema/config.md
@@ -13,7 +13,7 @@
 |`config.modelCatalog[].inline`|string|Model cost catalog provided inline as a string.|
 |`config.modelCatalog[].inline`|object|Model cost catalog provided inline as structured data.|
 |`config.modelCatalog[].inline.metadata`|object|Identifies a generated base catalog and when its contents last changed.|
-|`config.modelCatalog[].inline.metadata.source`|string|Upstream used to generate this base catalog, such as `models.dev`.|
+|`config.modelCatalog[].inline.metadata.source`|string|Legacy provenance field retained for compatibility with older generated catalogs.|
 |`config.modelCatalog[].inline.metadata.generatedAt`|string|Time the generated catalog contents last changed.|
 |`config.modelCatalog[].inline.providers`|object|Map of provider name to its supported models and pricing.|
 |`config.modelCatalog[].inline.providers.*.models`|object|Map of model ID to its pricing rates and tiers.|

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -176,7 +176,7 @@ export function CostsPage() {
 				) : (
 					<EmptyState
 						title="No cost catalogs configured"
-						description="Refresh the base catalog to add pricing data from models.dev."
+						description="Refresh the base catalog with the latest pricing data from agentgateway."
 					/>
 				)}
 			</Panel>


### PR DESCRIPTION

**Background**:
Previously we pulled from models.dev as the catalog source, both in Go CLI and rust code.
Now, we use the models.dev source for checking a file into github.

**Changes** 

1. Our CLI tool defaults to pulling from github.
3. The rust code should ONLY pull from github; no models.dev at all