### PR TITLE
bedrock guardrails: allow passthrough by default

### DIFF
--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1192,9 +1192,9 @@ impl Policy {
 		else {
 			return rejection.as_response();
 		};
-		let mut rejection = rejection.clone();
-		rejection.body = Bytes::from(body.to_owned());
-		rejection.as_response()
+		let mut response = rejection.as_response();
+		*response.body_mut() = http::Body::from(Bytes::from(body.to_owned()));
+		response
 	}
 
 	async fn evaluate_google_model_armor_request(

--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1167,13 +1167,34 @@ impl Policy {
 				"Bedrock guardrail masked output count mismatch; rejecting content"
 			);
 		}
+		let blocked = resp.is_blocked();
 		let detail = resp.build_detail(guardrails);
 		let outcome = if masked {
 			GuardrailOutcome::Masked(TextReplacements::replace_all(resp.into_output_texts()))
 		} else {
-			GuardrailOutcome::Rejected(rejection.as_response())
+			GuardrailOutcome::Rejected(Self::bedrock_reject_response(rejection, blocked, &resp))
 		};
 		(outcome, Some(detail))
+	}
+	fn bedrock_reject_response(
+		rejection: &RequestRejection,
+		blocked: bool,
+		resp: &bedrock_guardrails::ApplyGuardrailResponse,
+	) -> Response {
+		if rejection.body != default_body() || !blocked {
+			return rejection.as_response();
+		}
+		let Some(body) = resp
+			.outputs
+			.iter()
+			.map(|o| o.text.as_str())
+			.find(|t| !t.trim().is_empty())
+		else {
+			return rejection.as_response();
+		};
+		let mut rejection = rejection.clone();
+		rejection.body = Bytes::from(body.to_owned());
+		rejection.as_response()
 	}
 
 	async fn evaluate_google_model_armor_request(

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -1096,6 +1096,68 @@ fn bedrock_blocked_intervention_with_canned_output_rejects() {
 	assert!(matches!(outcome, GuardrailOutcome::Rejected(_)));
 }
 
+async fn bedrock_rejected_body(outcome: GuardrailOutcome<TextReplacements>) -> Bytes {
+	let GuardrailOutcome::Rejected(resp) = outcome else {
+		panic!("expected a rejection outcome");
+	};
+	resp.into_body().collect().await.unwrap().to_bytes()
+}
+
+fn bedrock_blocked_response() -> bedrock_guardrails::ApplyGuardrailResponse {
+	bedrock_intervened(
+		&["Sorry, I can't help with that."],
+		serde_json::json!([{
+			"topicPolicy": {"topics": [{"action": "BLOCKED", "name": "Finance", "type": "DENY"}]}
+		}]),
+	)
+}
+
+#[tokio::test]
+async fn bedrock_block_passes_block_message_through() {
+	let (outcome, _) = Policy::bedrock_guardrail_outcome(
+		bedrock_blocked_response(),
+		1,
+		&RequestRejection::default(),
+		&bedrock_test_config(),
+	);
+	assert_eq!(
+		bedrock_rejected_body(outcome).await,
+		Bytes::from("Sorry, I can't help with that.")
+	);
+}
+
+/// A configured custom rejection body always wins over Bedrock's block message.
+#[tokio::test]
+async fn bedrock_blocked_custom_rejection_body_wins() {
+	let rejection = RequestRejection {
+		body: Bytes::from("custom denied"),
+		..Default::default()
+	};
+	let (outcome, _) = Policy::bedrock_guardrail_outcome(
+		bedrock_blocked_response(),
+		1,
+		&rejection,
+		&bedrock_test_config(),
+	);
+	assert_eq!(
+		bedrock_rejected_body(outcome).await,
+		Bytes::from("custom denied")
+	);
+}
+
+/// A non-block intervention keeps the default body; masked content never leaks.
+#[tokio::test]
+async fn bedrock_anonymize_mismatch_keeps_default_body() {
+	let resp = bedrock_intervened(&["Email {EMAIL}"], bedrock_anonymized_assessments());
+	let (outcome, _) = Policy::bedrock_guardrail_outcome(
+		resp,
+		2,
+		&RequestRejection::default(),
+		&bedrock_test_config(),
+	);
+	assert_eq!(bedrock_rejected_body(outcome).await, default_body());
+}
+
 /// Automated reasoning findings carry no `action` field; even when the output count
 /// happens to match, the canned message must not be applied as a mask.
 #[test]


### PR DESCRIPTION
originally i felt that a more complex parsing for non-statically set responses made sense and put up https://github.com/agentgateway/agentgateway/pull/3211

however that felt a bit fragile and wouldnt make the transfer from direct to agw would be more painful so i backed this out to a full passthrough