### PR TITLE
ui: embed generated schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,10 @@ controller/testbox
 # JavaScript / TypeScript dependencies and generated artifacts
 node_modules/
 ui/dist/
-ui/public/*-schema.json
 ui/src/cel.d.ts
 ui/src/gateway-admin.d.ts
 ui/src/gateway-config.d.ts
+ui/src/generated/cel-schema.json
 ui/src/generated/schema.json
 coverage/
 test-results/

--- a/ui/scripts/generate-schema.mjs
+++ b/ui/scripts/generate-schema.mjs
@@ -28,10 +28,11 @@ try {
 	rmSync(sanitizedAdminSchemaPath, { force: true });
 }
 
-copyFileSync(join(rootDir, 'schema/config.json'), join(uiDir, 'public/config-schema.json'));
+rmSync(join(uiDir, 'public/config-schema.json'), { force: true });
+rmSync(join(uiDir, 'public/admin-schema.json'), { force: true });
+rmSync(join(uiDir, 'public/cel-schema.json'), { force: true });
 copyFileSync(join(rootDir, 'schema/config.json'), join(uiDir, 'src/generated/schema.json'));
-copyFileSync(join(rootDir, 'schema/admin.json'), join(uiDir, 'public/admin-schema.json'));
-copyFileSync(join(rootDir, 'schema/cel.json'), join(uiDir, 'public/cel-schema.json'));
+copyFileSync(join(rootDir, 'schema/cel.json'), join(uiDir, 'src/generated/cel-schema.json'));
 
 function sanitizeSchemaForTypes(value) {
 	if (Array.isArray(value)) {

--- a/ui/src/basePath.ts
+++ b/ui/src/basePath.ts
@@ -1,9 +1,3 @@
-export function publicAssetPath(path: string) {
-	const base = import.meta.env.BASE_URL || './';
-	const normalizedBase = base.endsWith('/') ? base : `${base}/`;
-	return `${normalizedBase}${path.replace(/^\/+/, '')}`;
-}
-
 export function routerBasePath() {
 	const configured = import.meta.env.VITE_ROUTER_BASE_PATH;
 	const base = configured || import.meta.env.BASE_URL || '';

--- a/ui/src/celMonaco.ts
+++ b/ui/src/celMonaco.ts
@@ -1,9 +1,9 @@
 import type * as Monaco from 'monaco-editor';
 
-import { publicAssetPath } from '@/basePath';
+import celSchema from '@/generated/cel-schema.json';
 
 let celConfigured = false;
-let schemaPromise: Promise<CelSchemaIndex> | null = null;
+let schemaIndex: CelSchemaIndex | null = null;
 
 export const celLanguage = 'cel';
 
@@ -601,13 +601,8 @@ function expressionPathAtPosition(model: Monaco.editor.ITextModel, position: Mon
 }
 
 function loadCelSchemaIndex() {
-	schemaPromise ??= fetch(publicAssetPath('cel-schema.json'))
-		.then(response =>
-			response.ok ? (response.json() as Promise<JsonSchemaNode>) : { properties: {} }
-		)
-		.then(buildSchemaIndex)
-		.catch(() => ({ globals: [], propertiesByPath: {} }));
-	return schemaPromise;
+	schemaIndex ??= buildSchemaIndex(celSchema as unknown as JsonSchemaNode);
+	return schemaIndex;
 }
 
 function buildSchemaIndex(schema: JsonSchemaNode): CelSchemaIndex {

--- a/ui/src/schemaHelp.ts
+++ b/ui/src/schemaHelp.ts
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
-import { publicAssetPath } from '@/basePath';
+import configSchema from '@/generated/schema.json';
 
 type JsonObject = { [key: string]: unknown };
+const schema = configSchema as JsonObject;
 type Primitive =
 	| string
 	| number
@@ -74,23 +75,6 @@ const helpOverrides: Record<string, string> = {
 };
 
 export function useSchemaHelp(): SchemaHelp {
-	const [schema, setSchema] = useState<JsonObject | null>(null);
-
-	useEffect(() => {
-		let cancelled = false;
-		fetch(publicAssetPath('config-schema.json'))
-			.then(response => (response.ok ? (response.json() as Promise<JsonObject>) : null))
-			.then(value => {
-				if (!cancelled) setSchema(value);
-			})
-			.catch(() => {
-				if (!cancelled) setSchema(null);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, []);
-
 	return useMemo(
 		() => ({
 			node(path: Array<string | number>) {
@@ -126,7 +110,7 @@ export function useSchemaHelp(): SchemaHelp {
 				return Object.keys(properties);
 			}
 		}),
-		[schema]
+		[]
 	);
 }
 


### PR DESCRIPTION
Use the generated config and CEL schemas directly from the UI bundle instead of fetching public JSON assets. Stop publishing the config, CEL, and unused admin schema files, and clean up stale generated copies.

Signed-off-by: John Howard <john.howard@solo.io>
