### PR TITLE
messages: report matched stop sequences

### DIFF
--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -1240,6 +1240,7 @@ pub mod from_completions {
 							..Default::default()
 						};
 						let choice = completions::ChatChoiceStream {
+							rest: Default::default(),
 							index: 0,
 							logprobs: None,
 							delta: d,
@@ -1319,6 +1320,7 @@ pub mod from_completions {
 
 					if let Some(delta) = delta {
 						let choice = completions::ChatChoiceStream {
+							rest: Default::default(),
 							index: 0,
 							logprobs: None,
 							delta,
@@ -1338,6 +1340,7 @@ pub mod from_completions {
 				bedrock::ConverseStreamOutput::MessageStart(start) => {
 					// Just send a blob with the role
 					let choice = completions::ChatChoiceStream {
+						rest: Default::default(),
 						index: 0,
 						logprobs: None,
 						delta: completions::StreamResponseDelta {
@@ -1357,6 +1360,7 @@ pub mod from_completions {
 
 					// Just send a blob with the finish reason
 					let choice = completions::ChatChoiceStream {
+						rest: Default::default(),
 						index: 0,
 						logprobs: None,
 						delta: completions::StreamResponseDelta::default(),
@@ -3858,6 +3862,7 @@ impl ConverseResponseAdapter {
 		};
 
 		let choice = completions::ChatChoice {
+			rest: Default::default(),
 			index: 0,
 			message,
 			finish_reason: Some(from_completions::translate_stop_reason(&self.stop_reason)),

--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -118,7 +118,26 @@ pub mod from_messages {
 		Ok(Box::new(anthropic))
 	}
 
-	fn translate_response_internal(
+	/// First string among the candidate extension values, in precedence order.
+	/// Integers (stop token ids) and empty strings are not stop sequences.
+	pub(crate) fn stop_sequence_from_fields<'a>(
+		candidates: impl IntoIterator<Item = Option<&'a Value>>,
+	) -> Option<String> {
+		candidates
+			.into_iter()
+			.flatten()
+			.filter_map(|v| v.as_str())
+			.find(|s| !s.is_empty())
+			.map(str::to_owned)
+	}
+
+	/// The stop sequence an engine reports on a buffered or streamed choice, if
+	/// any: vLLM uses `stop_reason`; SGLang uses `matched_stop`.
+	pub(crate) fn choice_stop_sequence(rest: &Value) -> Option<String> {
+		stop_sequence_from_fields([rest.get("stop_reason"), rest.get("matched_stop")])
+	}
+
+	pub(crate) fn translate_response_internal(
 		resp: completions::Response,
 	) -> Result<messages::MessagesResponse, AIError> {
 		let completions::Response {
@@ -158,16 +177,23 @@ pub mod from_messages {
 			}));
 		}
 
-		let stop_reason = choice
-			.finish_reason
-			.map(|r| match r {
-				completions::FinishReason::Stop => messages::StopReason::EndTurn,
-				completions::FinishReason::Length => messages::StopReason::MaxTokens,
-				completions::FinishReason::ToolCalls => messages::StopReason::ToolUse,
-				completions::FinishReason::ContentFilter => messages::StopReason::EndTurn,
-				completions::FinishReason::FunctionCall => messages::StopReason::ToolUse,
-			})
-			.unwrap_or(messages::StopReason::EndTurn);
+		let (mut stop_reason, may_have_stop_sequence) = match choice.finish_reason {
+			Some(completions::FinishReason::Stop) => (messages::StopReason::EndTurn, true),
+			Some(completions::FinishReason::Length) => (messages::StopReason::MaxTokens, false),
+			Some(completions::FinishReason::ToolCalls) => (messages::StopReason::ToolUse, false),
+			Some(completions::FinishReason::ContentFilter) => (messages::StopReason::EndTurn, false),
+			Some(completions::FinishReason::FunctionCall) => (messages::StopReason::ToolUse, false),
+			None => (messages::StopReason::EndTurn, false),
+		};
+		// When the engine names the stop sequence that ended generation, the
+		// Messages contract is `stop_reason: "stop_sequence"` plus the matched
+		// string — not `end_turn`, which clients read as "the model finished".
+		let stop_sequence = may_have_stop_sequence
+			.then(|| choice_stop_sequence(&choice.rest))
+			.flatten();
+		if stop_sequence.is_some() {
+			stop_reason = messages::StopReason::StopSequence;
+		}
 
 		let cache_creation_input_tokens = usage.as_ref().and_then(|u| {
 			u.prompt_tokens_details
@@ -189,7 +215,7 @@ pub mod from_messages {
 			role: messages::Role::Assistant,
 			model,
 			stop_reason: Some(stop_reason),
-			stop_sequence: None,
+			stop_sequence,
 			usage: messages::Usage {
 				input_tokens: usage
 					.as_ref()
@@ -246,6 +272,7 @@ pub mod from_messages {
 			open_tool_blocks: HashSet<u32>,
 			pending_tool_calls: HashMap<u32, PendingToolCall>,
 			pending_stop_reason: Option<messages::StopReason>,
+			pending_stop_sequence: Option<String>,
 			pending_usage: Option<completions::Usage>,
 		}
 
@@ -423,7 +450,7 @@ pub mod from_messages {
 				messages::MessagesStreamEvent::MessageDelta {
 					delta: messages::MessageDelta {
 						stop_reason: Some(stop_reason),
-						stop_sequence: None,
+						stop_sequence: state.pending_stop_sequence.take(),
 					},
 					usage: messages::MessageDeltaUsage {
 						input_tokens: Some(input_tokens),
@@ -590,13 +617,21 @@ pub mod from_messages {
 						}
 
 						if let Some(finish_reason) = &choice.finish_reason {
-							let stop_reason = match finish_reason {
+							let mut stop_reason = match finish_reason {
 								completions::FinishReason::Stop => messages::StopReason::EndTurn,
 								completions::FinishReason::Length => messages::StopReason::MaxTokens,
 								completions::FinishReason::ToolCalls => messages::StopReason::ToolUse,
 								completions::FinishReason::ContentFilter => messages::StopReason::Refusal,
 								completions::FinishReason::FunctionCall => messages::StopReason::ToolUse,
 							};
+							// Same contract as the buffered path: a named stop sequence is
+							// `stop_sequence`, not `end_turn`.
+							if stop_reason == messages::StopReason::EndTurn
+								&& let Some(seq) = choice_stop_sequence(&choice.rest)
+							{
+								stop_reason = messages::StopReason::StopSequence;
+								state.pending_stop_sequence = Some(seq);
+							}
 							state.pending_stop_reason = Some(stop_reason);
 						}
 					}

--- a/crates/llm/src/conversion/completions_tests.rs
+++ b/crates/llm/src/conversion/completions_tests.rs
@@ -37,3 +37,150 @@ fn non_data_urls_are_rejected() {
 	assert_eq!(parse_data_url("https://example.com/cat.png"), None);
 	assert_eq!(parse_data_url("data:no-comma"), None);
 }
+
+#[test]
+fn messages_stop_sequences_are_forwarded_as_chat_completions_stop() {
+	let request: crate::types::messages::Request = serde_json::from_value(serde_json::json!({
+		"model": "test-model",
+		"max_tokens": 64,
+		"stop_sequences": ["STOPPROBE", "DONE"],
+		"messages": [{"role": "user", "content": "hello"}]
+	}))
+	.unwrap();
+	let translated = super::from_messages::translate(&request).unwrap();
+	let translated: serde_json::Value = serde_json::from_slice(&translated).unwrap();
+	assert_eq!(translated["stop"], serde_json::json!(["STOPPROBE", "DONE"]));
+}
+
+mod stop_sequence_reporting {
+	use super::super::from_messages::{choice_stop_sequence, translate_response_internal};
+	use crate::types::completions::typed as completions;
+	use crate::types::messages::typed as messages;
+
+	fn raw(choice_extra: &str) -> String {
+		format!(
+			r#"{{"id":"chatcmpl-1","object":"chat.completion","created":0,"model":"m",
+			"choices":[{{"index":0,"finish_reason":"stop",
+			"message":{{"role":"assistant","content":"A\nB\nC\nD\nE\n"}}{choice_extra}}}],
+			"usage":{{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}}}"#
+		)
+	}
+
+	fn translate(body: &str) -> messages::MessagesResponse {
+		let typed: completions::Response = serde_json::from_str(body).expect("valid chat completion");
+		translate_response_internal(typed).unwrap()
+	}
+
+	#[test]
+	fn extensions_accept_only_string_values_from_the_known_engine_fields() {
+		let seq = |choice_extra: &str| {
+			let typed: completions::Response =
+				serde_json::from_str(&raw(choice_extra)).expect("valid chat completion");
+			choice_stop_sequence(&typed.choices[0].rest)
+		};
+		// vLLM: a matched stop *string* is a string; a stop *token* is an integer.
+		assert_eq!(seq(r#","stop_reason":"F""#), Some("F".into()));
+		assert_eq!(seq(r#","stop_reason":128001"#), None);
+		// SGLang
+		assert_eq!(seq(r#","matched_stop":"END""#), Some("END".into()));
+		assert_eq!(seq(r#","matched_stop":154827"#), None);
+		// nothing reported or empty
+		assert_eq!(seq(""), None);
+		assert_eq!(seq(r#","stop_reason":"""#), None);
+		assert_eq!(
+			seq(r#","stop_reason":"","matched_stop":"END""#),
+			Some("END".into())
+		);
+	}
+
+	#[test]
+	fn matched_stop_string_becomes_stop_sequence_with_the_sequence_named() {
+		for (choice_extra, want) in [
+			(r#","stop_reason":"F""#, "F"),
+			(r#","matched_stop":"END""#, "END"),
+		] {
+			let out = translate(&raw(choice_extra));
+			assert_eq!(
+				out.stop_reason,
+				Some(messages::StopReason::StopSequence),
+				"{choice_extra}"
+			);
+			assert_eq!(out.stop_sequence.as_deref(), Some(want), "{choice_extra}");
+		}
+	}
+
+	#[test]
+	fn natural_end_of_turn_is_unchanged() {
+		// No extension field, or a stop *token id* (integer): both stay end_turn.
+		for choice_extra in ["", r#","stop_reason":128001"#, r#","matched_stop":154827"#] {
+			let out = translate(&raw(choice_extra));
+			assert_eq!(
+				out.stop_reason,
+				Some(messages::StopReason::EndTurn),
+				"{choice_extra}"
+			);
+			assert_eq!(out.stop_sequence, None, "{choice_extra}");
+		}
+	}
+
+	#[test]
+	fn other_finish_reasons_never_report_a_stop_sequence() {
+		let body = r#"{"id":"x","object":"chat.completion","created":0,"model":"m",
+			"choices":[{"index":0,"finish_reason":"length","stop_reason":"F",
+			"message":{"role":"assistant","content":"..."}}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
+		let out = translate(body);
+		assert_eq!(out.stop_reason, Some(messages::StopReason::MaxTokens));
+		assert_eq!(out.stop_sequence, None);
+
+		let body = r#"{"id":"x","object":"chat.completion","created":0,"model":"m",
+			"choices":[{"index":0,"finish_reason":"content_filter","stop_reason":"F",
+			"message":{"role":"assistant","content":"..."}}],
+			"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
+		let out = translate(body);
+		assert_eq!(out.stop_reason, Some(messages::StopReason::EndTurn));
+		assert_eq!(out.stop_sequence, None);
+	}
+}
+
+mod stop_sequence_reporting_streaming {
+	use super::super::from_messages::stop_sequence_from_fields;
+	use crate::types::completions::typed as completions;
+
+	#[test]
+	fn stream_chunk_types_keep_engine_extension_fields() {
+		// Without `rest` these were dropped at parse time, so the streaming path
+		// could never see them.
+		let chunk: completions::StreamResponse = serde_json::from_str(
+			r#"{"id":"c","object":"chat.completion.chunk","created":0,"model":"m",
+			"choices":[{"index":0,"delta":{},"finish_reason":"stop","stop_reason":"F","matched_stop":"F"}]}"#,
+		)
+		.unwrap();
+		assert_eq!(chunk.choices[0].rest["stop_reason"], "F");
+		assert_eq!(chunk.choices[0].rest["matched_stop"], "F");
+		// ...and a plain chunk serialises exactly as before: no phantom fields.
+		let plain: completions::StreamResponse = serde_json::from_str(
+			r#"{"id":"c","object":"chat.completion.chunk","created":0,"model":"m",
+			"choices":[{"index":0,"delta":{"content":"hi"}}]}"#,
+		)
+		.unwrap();
+		let out = serde_json::to_value(&plain).unwrap();
+		assert!(out["choices"][0].get("rest").is_none());
+	}
+
+	#[test]
+	fn precedence_and_type_rules_are_shared_with_the_buffered_path() {
+		let v = |s: &str| serde_json::from_str::<serde_json::Value>(s).unwrap();
+		let (a, b, c) = (v(r#""F""#), v("128001"), v(r#""GREEN""#));
+		assert_eq!(
+			stop_sequence_from_fields([Some(&a), None, None]),
+			Some("F".into())
+		);
+		assert_eq!(
+			stop_sequence_from_fields([Some(&b), None, Some(&c)]),
+			Some("GREEN".into())
+		);
+		assert_eq!(stop_sequence_from_fields([Some(&b), None, None]), None);
+		assert_eq!(stop_sequence_from_fields([None, None, None]), None);
+	}
+}

--- a/crates/llm/src/conversion/messages.rs
+++ b/crates/llm/src/conversion/messages.rs
@@ -593,6 +593,7 @@ pub mod from_completions {
 		let finish_reason = resp.stop_reason.as_ref().map(super::translate_stop_reason);
 		// Only one choice for anthropic
 		let choice = completions::ChatChoice {
+			rest: Default::default(),
 			index: 0,
 			message,
 			finish_reason,
@@ -755,6 +756,7 @@ pub mod from_completions {
 						);
 
 						let choice = completions::ChatChoiceStream {
+							rest: Default::default(),
 							index: 0,
 							logprobs: None,
 							delta: completions::StreamResponseDelta {
@@ -820,6 +822,7 @@ pub mod from_completions {
 					};
 					if emit_chunk {
 						let choice = completions::ChatChoiceStream {
+							rest: Default::default(),
 							index: 0,
 							logprobs: None,
 							delta: dr,
@@ -861,6 +864,7 @@ pub mod from_completions {
 					});
 					let choices = finish_reason.map_or_else(Vec::new, |finish_reason| {
 						vec![completions::ChatChoiceStream {
+							rest: Default::default(),
 							index: 0,
 							logprobs: None,
 							delta: completions::StreamResponseDelta::default(),
@@ -901,6 +905,7 @@ pub mod from_completions {
 							// If no arguments were emitted for a tool call, send a synthetic `{}`
 							// for compatibility.
 							let choice = completions::ChatChoiceStream {
+								rest: Default::default(),
 								index: 0,
 								logprobs: None,
 								delta: completions::StreamResponseDelta {

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -1210,6 +1210,7 @@ pub mod to_completions {
 				completions::FinishReason::Stop
 			};
 			vec![completions::ChatChoice {
+				rest: Default::default(),
 				index: 0,
 				message: assistant_message(Some(String::new()), None, None),
 				finish_reason: Some(finish),
@@ -1277,6 +1278,7 @@ pub mod to_completions {
 		let tool_calls = has_tool_calls.then_some(tool_calls);
 
 		completions::ChatChoice {
+			rest: Default::default(),
 			index,
 			message: assistant_message(content, reasoning, tool_calls),
 			finish_reason: Some(finish),
@@ -1438,6 +1440,7 @@ pub mod to_completions {
 				.map(build_usage);
 			let choices = if has_delta || finish.is_some() {
 				vec![completions::ChatChoiceStream {
+					rest: Default::default(),
 					index: 0,
 					delta,
 					finish_reason: finish,

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -816,6 +816,7 @@ mod responses {
 	];
 	const COMPLETIONS_RESPONSES: &[(&str, &[&str])] = &[
 		("basic", ALL_COMPLETIONS),
+		("stop_sequence", &[COMPLETIONS_TO_MESSAGES]),
 		("audio", ALL_COMPLETIONS),
 		(
 			"cache_write",
@@ -1338,6 +1339,42 @@ data: [DONE]
 				"output_tokens": 5,
 				"cache_creation_input_tokens": 30,
 				"cache_read_input_tokens": 20,
+			})
+		);
+	}
+
+	#[tokio::test]
+	async fn completions_to_messages_stream_reports_matched_stop_sequence() {
+		let input = r#"data: {"id":"chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop","matched_stop":"STOPPROBE"}],"model":"gpt-5","usage":null}
+
+data: {"id":"chunk","choices":[],"model":"gpt-5","usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}}
+
+data: [DONE]
+
+"#;
+		let output = conversion::completions::from_messages::translate_stream(
+			axum_core::body::Body::from(input),
+			1024 * 1024,
+			StreamingUsageGuard::default(),
+			LogContentFields::default(),
+		)
+		.collect()
+		.await
+		.unwrap()
+		.to_bytes();
+		let delta = String::from_utf8(output.to_vec())
+			.unwrap()
+			.lines()
+			.filter_map(|line| line.strip_prefix("data: "))
+			.filter_map(|data| serde_json::from_str::<Value>(data).ok())
+			.find(|event| event["type"] == "message_delta")
+			.unwrap();
+
+		assert_eq!(
+			delta["delta"],
+			json!({
+				"stop_reason": "stop_sequence",
+				"stop_sequence": "STOPPROBE",
 			})
 		);
 	}

--- a/crates/llm/src/tests/response/completions/stop_sequence.completions-messages.snap
+++ b/crates/llm/src/tests/response/completions/stop_sequence.completions-messages.snap
@@ -1,0 +1,46 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/completions/stop_sequence.json
+info:
+  id: chatcmpl-stop-sequence
+  object: chat.completion
+  created: 1772656915
+  model: test-model
+  choices:
+    - index: 0
+      message:
+        role: assistant
+        content: before stop
+      finish_reason: stop
+      stop_reason: STOPPROBE
+  usage:
+    prompt_tokens: 4
+    completion_tokens: 2
+    total_tokens: 6
+---
+{
+  "response": {
+    "id": "[id]",
+    "type": "message",
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "before stop"
+      }
+    ],
+    "model": "test-model",
+    "stop_reason": "stop_sequence",
+    "stop_sequence": "STOPPROBE",
+    "usage": {
+      "input_tokens": 4,
+      "output_tokens": 2
+    }
+  },
+  "parsed": {
+    "input_tokens": 4,
+    "output_tokens": 2,
+    "total_tokens": 6,
+    "provider_model": "test-model"
+  }
+}

--- a/crates/llm/src/tests/response/completions/stop_sequence.json
+++ b/crates/llm/src/tests/response/completions/stop_sequence.json
@@ -1,0 +1,22 @@
+{
+  "id": "chatcmpl-stop-sequence",
+  "object": "chat.completion",
+  "created": 1772656915,
+  "model": "test-model",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "before stop"
+      },
+      "finish_reason": "stop",
+      "stop_reason": "STOPPROBE"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 4,
+    "completion_tokens": 2,
+    "total_tokens": 6
+  }
+}

--- a/crates/llm/src/types/completions.rs
+++ b/crates/llm/src/types/completions.rs
@@ -768,6 +768,10 @@ pub mod typed {
 
 	#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 	pub struct ChatChoiceStream {
+		/// Fields outside the standard schema (engine extensions such as vLLM's `stop_reason` or SGLang's `matched_stop`),
+		/// preserved so conversions can read them.
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
 		/// The index of the choice in the list of choices.
 		#[serde(default)]
 		pub index: u32,
@@ -830,6 +834,10 @@ pub mod typed {
 
 	#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 	pub struct ChatChoice {
+		/// Fields outside the standard schema (engine extensions such as vLLM's `stop_reason` or SGLang's `matched_stop`),
+		/// preserved so conversions can read them.
+		#[serde(flatten, default)]
+		pub rest: serde_json::Value,
 		/// The index of the choice in the list of choices.
 		#[serde(default)]
 		pub index: u32,


### PR DESCRIPTION
## Summary

- Translate vLLM `choices[].stop_reason` and SGLang `choices[].matched_stop` into Anthropic `stop_reason: "stop_sequence"` and the matched `stop_sequence`.
- Support matched stop sequences in both buffered and streaming Messages responses.
- Ignore numeric stop-token IDs and preserve the existing `end_turn` behavior for natural EOS.
- Add regression coverage confirming Anthropic `stop_sequences` are forwarded as Chat Completions `stop`.

## Context

Anthropic clients use stop_reason: "stop_sequence" and stop_sequence to distinguish a caller-provided stop from a natural end of turn. Agentgateway already forwards stop_sequences to the backend as Chat Completions stop.

However, Chat Completions’ standard finish_reason: "stop" does not identify whether generation ended naturally or matched a custom stop sequence. vLLM and SGLang can expose the exact match through stop_reason and matched_stop, respectively. Agentgateway previously discarded that metadata and returned end_turn; preserving it when reported allows agentgateway to return the correct Anthropic response.

## Test plan

- Verified request translation from `stop_sequences` to `stop`.
- Added buffered-response golden coverage.
- Added focused coverage for vLLM and SGLang extension fields.
- Added streaming-response coverage.
- Confirmed numeric EOS token IDs continue to produce `end_turn`.
- All 372 LLM tests pass.