### PR TITLE
substrate: emit ate.router.resume so cold starts are visible

### DIFF
--- a/crates/agentgateway/src/http/substrate/ateattr.rs
+++ b/crates/agentgateway/src/http/substrate/ateattr.rs
@@ -1,0 +1,93 @@
+//! Telemetry conventions owned by Agent Substrate, not by agentgateway.
+//!
+//! Mirrors `internal/ateattr/ateattr.go` and `docs/metrics/registry/metrics.yaml` in
+//! agent-substrate/substrate, which are the source of truth. Strings agentgateway chose for itself
+//! do not belong here; see `telemetry/semconv.rs` for the OpenTelemetry conventions.
+
+use std::fmt::{Display, Formatter};
+
+pub(crate) const ATE_ATESPACE: &str = "ate.atespace";
+pub(crate) const ATE_ROUTER_RESUME: &str = "ate.router.resume";
+
+/// Whether this request experienced a cold actor activation.
+///
+/// Ordered weakest to strongest so `max` keeps the strongest disposition a request observed across
+/// stale-assignment retries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub(crate) enum ResumeDisposition {
+	#[default]
+	None,
+	Joined,
+	Triggered,
+}
+
+impl ResumeDisposition {
+	pub(crate) fn as_str(self) -> &'static str {
+		match self {
+			Self::None => "none",
+			Self::Joined => "joined",
+			Self::Triggered => "triggered",
+		}
+	}
+
+	pub(crate) fn for_resumed(resumed: bool, joined: bool) -> Self {
+		match (resumed, joined) {
+			(false, _) => Self::None,
+			(true, false) => Self::Triggered,
+			(true, true) => Self::Joined,
+		}
+	}
+}
+
+impl Display for ResumeDisposition {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::ResumeDisposition;
+
+	#[test]
+	fn disposition_values_match_upstream_ateattr() {
+		assert_eq!(ResumeDisposition::None.as_str(), "none");
+		assert_eq!(ResumeDisposition::Triggered.as_str(), "triggered");
+		assert_eq!(ResumeDisposition::Joined.as_str(), "joined");
+		assert_eq!(super::ATE_ROUTER_RESUME, "ate.router.resume");
+		assert_eq!(super::ATE_ATESPACE, "ate.atespace");
+	}
+
+	#[test]
+	fn resumed_gates_the_classification() {
+		// A leader whose resume was a no-op is not a cold start, and neither is a follower that
+		// waited on one.
+		assert_eq!(
+			ResumeDisposition::for_resumed(false, false),
+			ResumeDisposition::None
+		);
+		assert_eq!(
+			ResumeDisposition::for_resumed(false, true),
+			ResumeDisposition::None
+		);
+		assert_eq!(
+			ResumeDisposition::for_resumed(true, false),
+			ResumeDisposition::Triggered
+		);
+		assert_eq!(
+			ResumeDisposition::for_resumed(true, true),
+			ResumeDisposition::Joined
+		);
+	}
+
+	#[test]
+	fn triggered_outranks_joined_outranks_none() {
+		assert!(ResumeDisposition::Triggered > ResumeDisposition::Joined);
+		assert!(ResumeDisposition::Joined > ResumeDisposition::None);
+		assert_eq!(
+			ResumeDisposition::default(),
+			ResumeDisposition::None,
+			"an unresolved request must not read as an activation"
+		);
+	}
+}

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -9,6 +9,7 @@ use quick_cache::sync::Cache;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tonic::Code;
 
+use super::ateattr::ResumeDisposition;
 use super::{ActorRef, CACHE_CAPACITY, TRACE_POLICY_KIND, valid_resource_name};
 use crate::http::{PolicyResponse, Request, Response};
 use crate::proxy::dtrace::{Severity, pol_event};
@@ -90,6 +91,7 @@ struct CachedAssignment {
 	target: SocketAddr,
 	expires_at: Instant,
 	generation: u64,
+	resumed: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -113,8 +115,13 @@ impl ResolutionSource {
 	}
 }
 
-type ResolutionResult =
-	Result<(CachedAssignment, ResolutionSource), (ResumeError, ResolutionSource)>;
+struct Resolved {
+	assignment: CachedAssignment,
+	source: ResolutionSource,
+	resume: ResumeDisposition,
+}
+
+type ResolutionResult = Result<Resolved, (ResumeError, ResolutionSource)>;
 
 struct AssignmentCache {
 	entries: Cache<ActorRef, Result<CachedAssignment, ResumeError>>,
@@ -143,6 +150,7 @@ pub(crate) struct SubstrateRequestState {
 	ingress: SubstrateIngress,
 	client: PolicyClient,
 	current: Arc<Mutex<Option<CachedAssignment>>>,
+	resume: Arc<Mutex<ResumeDisposition>>,
 }
 
 fn default_cache_ttl() -> Duration {
@@ -264,7 +272,7 @@ impl SubstrateIngress {
 		&self,
 		client: &PolicyClient,
 		actor: &ActorRef,
-	) -> Result<SocketAddr, ResumeError> {
+	) -> Result<(SocketAddr, bool), ResumeError> {
 		let budget = self.request_parking.budget();
 		let deadline = tokio::time::Instant::now() + budget;
 		let result = async {
@@ -295,7 +303,9 @@ impl SubstrateIngress {
 				.await;
 				match response {
 					Ok(Ok(response)) => {
-						let actor = response.into_inner().actor.ok_or_else(|| {
+						let response = response.into_inner();
+						let resumed = response.resumed;
+						let actor = response.actor.ok_or_else(|| {
 							ResumeError::InvalidResponse(
 								"ResumeActor response did not include an actor".to_owned(),
 							)
@@ -317,7 +327,7 @@ impl SubstrateIngress {
 									assignment.worker_pod_ip
 								))
 							})?;
-						return Ok(SocketAddr::new(ip, self.connect_target_port.get()));
+						return Ok((SocketAddr::new(ip, self.connect_target_port.get()), resumed));
 					},
 					Ok(Err(status)) if self.retryable_while_parked(status.code()) => {
 						let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -372,7 +382,11 @@ impl SubstrateIngress {
 		if let Some(cached) = self.cache.entries.get(&actor) {
 			match cached {
 				Ok(cached) if cached.expires_at > Instant::now() => {
-					return Ok((cached, ResolutionSource::Cache));
+					return Ok(Resolved {
+						assignment: cached,
+						source: ResolutionSource::Cache,
+						resume: ResumeDisposition::None,
+					});
 				},
 				Ok(expired) => self.cache.remove_generation(&actor, expired.generation),
 				Err(_) => {
@@ -386,7 +400,12 @@ impl SubstrateIngress {
 		loop {
 			match self.cache.entries.get_value_or_guard_async(&actor).await {
 				Ok(Ok(cached)) if cached.expires_at > Instant::now() => {
-					return Ok((cached, ResolutionSource::Cache));
+					let resume = ResumeDisposition::for_resumed(cached.resumed, true);
+					return Ok(Resolved {
+						assignment: cached,
+						source: ResolutionSource::Cache,
+						resume,
+					});
 				},
 				Ok(Ok(expired)) => {
 					self.cache.remove_generation(&actor, expired.generation);
@@ -399,10 +418,11 @@ impl SubstrateIngress {
 					let result = self
 						.resume_actor(client, &actor)
 						.await
-						.map(|target| CachedAssignment {
+						.map(|(target, resumed)| CachedAssignment {
 							target,
 							expires_at: Instant::now() + self.cache_ttl,
 							generation: self.cache.next_generation.fetch_add(1, Ordering::Relaxed),
+							resumed,
 						});
 					let _ = guard.insert(result.clone());
 					match &result {
@@ -415,7 +435,11 @@ impl SubstrateIngress {
 						Ok(_) => {},
 					}
 					return result
-						.map(|assignment| (assignment, ResolutionSource::AteApi))
+						.map(|assignment| Resolved {
+							resume: ResumeDisposition::for_resumed(assignment.resumed, false),
+							assignment,
+							source: ResolutionSource::AteApi,
+						})
 						.map_err(|error| (error, ResolutionSource::AteApi));
 				},
 			}
@@ -434,6 +458,17 @@ impl SubstrateRequestState {
 		)
 	}
 
+	pub(crate) fn resume_disposition(&self) -> ResumeDisposition {
+		*self.resume.lock().unwrap()
+	}
+
+	/// Policy events describe a single resolution attempt; this describes the request. A
+	/// stale-assignment retry can therefore log `triggered` while its last event says `none`.
+	fn record_resume(&self, observed: ResumeDisposition) {
+		let mut resume = self.resume.lock().unwrap();
+		*resume = (*resume).max(observed);
+	}
+
 	pub(crate) async fn resolve_target(&self) -> Result<Target, crate::proxy::ProxyResponse> {
 		if let Some(current) = self.current.lock().unwrap().as_ref() {
 			pol_event!(
@@ -446,13 +481,18 @@ impl SubstrateRequestState {
 					"source": ResolutionSource::Request.name(),
 					"cached": true,
 					"lookedUp": false,
+					"resume": ResumeDisposition::None.as_str(),
 					"target": current.target.to_string(),
 				}),
 			);
 			return Ok(Target::Address(current.target));
 		}
 		match self.ingress.resolve(&self.client, self.actor.clone()).await {
-			Ok((assignment, source)) => {
+			Ok(Resolved {
+				assignment,
+				source,
+				resume,
+			}) => {
 				let target = assignment.target;
 				pol_event!(
 					TRACE_POLICY_KIND,
@@ -464,9 +504,11 @@ impl SubstrateRequestState {
 						"source": source.name(),
 						"cached": source.cached(),
 						"lookedUp": matches!(source, ResolutionSource::AteApi),
+						"resume": resume.as_str(),
 						"target": target.to_string(),
 					}),
 				);
+				self.record_resume(resume);
 				*self.current.lock().unwrap() = Some(assignment);
 				Ok(Target::Address(target))
 			},
@@ -481,6 +523,7 @@ impl SubstrateRequestState {
 						"source": source.name(),
 						"cached": source.cached(),
 						"lookedUp": matches!(source, ResolutionSource::AteApi),
+						"resume": ResumeDisposition::None.as_str(),
 						"error": error.to_string(),
 					}),
 				);
@@ -609,6 +652,7 @@ impl RequestPolicyTrait for SubstrateIngress {
 			ingress: self.clone(),
 			client: client.clone(),
 			current: Arc::new(Mutex::new(None)),
+			resume: Arc::new(Mutex::new(ResumeDisposition::None)),
 		});
 		Ok(PolicyResponse::default())
 	}
@@ -645,6 +689,7 @@ mod tests {
 	struct MockControl {
 		pod_ip: String,
 		calls: Arc<AtomicUsize>,
+		resumed: bool,
 	}
 
 	#[tonic::async_trait]
@@ -675,6 +720,7 @@ mod tests {
 					}),
 					..Default::default()
 				}),
+				resumed: self.resumed,
 			}))
 		}
 	}
@@ -702,6 +748,7 @@ mod tests {
 		let control = crate::test_helpers::spawn_service(ControlServer::new(MockControl {
 			pod_ip: actor.address().ip().to_string(),
 			calls: control_calls.clone(),
+			resumed: true,
 		}))
 		.await;
 
@@ -751,6 +798,7 @@ mod tests {
 		let control = crate::test_helpers::spawn_service(ControlServer::new(MockControl {
 			pod_ip: actor.address().ip().to_string(),
 			calls: Arc::new(AtomicUsize::new(0)),
+			resumed: true,
 		}))
 		.await;
 

--- a/crates/agentgateway/src/http/substrate/mod.rs
+++ b/crates/agentgateway/src/http/substrate/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod ateattr;
 mod egress;
 mod ingress;
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2298,7 +2298,17 @@ async fn make_backend_call(
 		},
 		_ => (backend, base_policies),
 	};
-	Box::pin(handle_substrate_backend_selection(&mut req, backend)).await?;
+	let substrate_selection = Box::pin(handle_substrate_backend_selection(&mut req, backend))
+		.await
+		.map(|_| ());
+	if let Some(state) = req
+		.extensions()
+		.get::<http::substrate::SubstrateRequestState>()
+	{
+		let resume = state.resume_disposition().as_str();
+		log.add(|l| l.ate_router_resume = Some(resume));
+	}
+	substrate_selection?;
 
 	log.add(|l| {
 		l.backend_info = Some(backend.backend_info());

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -34,6 +34,7 @@ use tracing::{Level, debug, trace};
 use value_bag::visit::Visit;
 
 use crate::cel::{ContextBuilder, Expression, LLMContext};
+use crate::http::substrate::ateattr;
 use crate::http::{Request, health};
 use crate::llm::InputFormat;
 use crate::llm::catalog::{CostLookupStatus, ModelCatalog};
@@ -1112,6 +1113,7 @@ impl RequestLog {
 			inference_pool: None,
 			ate_actor_id: None,
 			ate_atespace: None,
+			ate_router_resume: None,
 			request_handle: None,
 			request_snapshot: None,
 			response_snapshot: None,
@@ -1289,6 +1291,7 @@ pub struct RequestLog {
 
 	pub ate_actor_id: Option<String>,
 	pub ate_atespace: Option<String>,
+	pub ate_router_resume: Option<&'static str>,
 
 	pub request_handle: Option<ActiveHandle>,
 	pub request_snapshot: Option<Arc<cel::RequestSnapshot>>,
@@ -1707,7 +1710,8 @@ impl Drop for DropOnLog {
 					log.inference_pool.display(),
 				),
 				("ate.actor.id", log.ate_actor_id.display()),
-				("ate.atespace", log.ate_atespace.display()),
+				(ateattr::ATE_ATESPACE, log.ate_atespace.display()),
+				(ateattr::ATE_ROUTER_RESUME, log.ate_router_resume.display()),
 				// OpenTelemetry Gen AI Semantic Conventions v1.40.0
 				(
 					"gen_ai.operation.name",

--- a/crates/agentgateway/src/telemetry/semconv.rs
+++ b/crates/agentgateway/src/telemetry/semconv.rs
@@ -1,3 +1,6 @@
+//! OpenTelemetry semantic conventions. Conventions owned by another project belong with the
+//! policy that emits them, not here; see `http/substrate/ateattr.rs`.
+
 use http::Version;
 
 pub(crate) mod attribute {

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -11,6 +11,7 @@ use crate::common::prelude::*;
 struct IngressHandler {
 	pod_ip: String,
 	calls: Arc<AtomicUsize>,
+	resumed: bool,
 }
 
 #[derive(Clone)]
@@ -67,6 +68,7 @@ impl ateapimock::Handler for IngressHandler {
 				}),
 				..Default::default()
 			}),
+			resumed: self.resumed,
 		})
 	}
 }
@@ -78,6 +80,7 @@ struct ParkingHandler {
 	failures_before_success: usize,
 	failure_code: tonic::Code,
 	entered: Option<Arc<Notify>>,
+	resumed: bool,
 }
 
 #[derive(Clone)]
@@ -87,6 +90,7 @@ struct SelectiveParkingHandler {
 	entered: Arc<Notify>,
 	release: Arc<Notify>,
 	calls: Arc<AtomicUsize>,
+	resumed: bool,
 }
 
 #[async_trait::async_trait]
@@ -111,6 +115,7 @@ impl ateapimock::Handler for SelectiveParkingHandler {
 				}),
 				..Default::default()
 			}),
+			resumed: self.resumed,
 		})
 	}
 }
@@ -144,6 +149,7 @@ impl ateapimock::Handler for ParkingHandler {
 				}),
 				..Default::default()
 			}),
+			resumed: self.resumed,
 		})
 	}
 }
@@ -158,6 +164,7 @@ async fn actor_ingress_resolves_the_dynamic_backend() {
 		move || IngressHandler {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
+			resumed: true,
 		}
 	})
 	.spawn()
@@ -206,6 +213,7 @@ async fn actor_ingress_parks_while_worker_capacity_recovers() {
 			failures_before_success: 2,
 			failure_code: tonic::Code::ResourceExhausted,
 			entered: None,
+			resumed: true,
 		}
 	})
 	.spawn()
@@ -257,6 +265,7 @@ async fn actor_ingress_sheds_when_request_parking_is_full() {
 			failures_before_success: 2,
 			failure_code: tonic::Code::FailedPrecondition,
 			entered: Some(entered.clone()),
+			resumed: true,
 		}
 	})
 	.spawn()
@@ -316,6 +325,7 @@ async fn actor_ingress_keeps_cached_actor_available_when_parking_is_full() {
 			entered: entered.clone(),
 			release: release.clone(),
 			calls: calls.clone(),
+			resumed: true,
 		}
 	})
 	.spawn()
@@ -367,6 +377,257 @@ async fn actor_ingress_keeps_cached_actor_available_when_parking_is_full() {
 	assert_eq!(cold.await.unwrap().status(), StatusCode::OK);
 }
 
+/// Asserts the access log emitted `ate.router.resume` for the request that used `path`. Every
+/// caller needs its own path: the capture buffer is process-global.
+async fn assert_logged_resume(path: &str, want: &str) {
+	agent_core::telemetry::testing::eventually_find(&[
+		("scope", "request"),
+		("http.path", path),
+		("ate.router.resume", want),
+	])
+	.await
+	.unwrap();
+}
+
+fn actor_url(actor: &str, path: &str) -> String {
+	format!("http://{actor}.demo.actors.resources.substrate.ate.dev{path}")
+}
+
+async fn resume_disposition_gateway(
+	api_address: std::net::SocketAddr,
+	actor_port: u16,
+) -> agentgateway::test_helpers::proxymock::TestBind {
+	let dynamic = Backend::Dynamic(ResourceName::new("dynamic".into(), "".into()), None);
+	let mut gateway = setup_proxy_test("{}")
+		.unwrap()
+		.with_raw_backend(dynamic.into())
+		.with_bind(simple_bind())
+		.with_route(basic_named_route(strng::literal!("/dynamic")));
+	gateway
+		.attach_route_policy(json!({
+			"substrateIngress": {
+				"host": api_address.to_string(),
+				"connectTargetPort": actor_port,
+			}
+		}))
+		.await;
+	gateway
+}
+
+#[tokio::test]
+async fn actor_ingress_reports_a_triggered_resume_as_a_cold_start() {
+	const PATH: &str = "/resume-triggered";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || IngressHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+			resumed: true,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let mut trace_rx = agentgateway::proxy::dtrace::track_expression(Some(
+		agentgateway::cel::Expression::new_strict(format!("request.path == '{PATH}'")).unwrap(),
+	));
+	let response = send_request(
+		gateway.serve_http(BIND_KEY),
+		Method::GET,
+		&actor_url("my-actor", PATH),
+	)
+	.await;
+	assert_eq!(response.status(), StatusCode::OK);
+	assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+	assert_logged_resume(PATH, "triggered").await;
+
+	let mut events = Vec::new();
+	while let Ok(Some(msg)) = tokio::time::timeout(Duration::from_millis(50), trace_rx.recv()).await {
+		events.push(serde_json::to_value(msg).unwrap())
+	}
+	let resumes: Vec<&serde_json::Value> = events
+		.iter()
+		.filter(|event| event["message"]["type"] == "policyEvent")
+		.filter(|event| event["message"]["kind"] == "substrate")
+		.map(|event| &event["message"]["details"]["resume"])
+		.collect();
+	assert_eq!(resumes, vec!["triggered"], "{events:#?}");
+}
+
+#[tokio::test]
+async fn actor_ingress_reports_no_resume_when_the_actor_is_already_running() {
+	const PATH: &str = "/resume-already-running";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || IngressHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+			resumed: false,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let response = send_request(
+		gateway.serve_http(BIND_KEY),
+		Method::GET,
+		&actor_url("my-actor", PATH),
+	)
+	.await;
+	assert_eq!(response.status(), StatusCode::OK);
+	assert_eq!(calls.load(Ordering::Relaxed), 1);
+	assert_logged_resume(PATH, "none").await;
+}
+
+#[tokio::test]
+async fn actor_ingress_reports_no_resume_for_a_cache_hit_after_a_cold_start() {
+	const COLD_PATH: &str = "/resume-cache-cold";
+	const WARM_PATH: &str = "/resume-cache-warm";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || IngressHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+			resumed: true,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	for path in [COLD_PATH, WARM_PATH] {
+		let response = send_request(
+			gateway.serve_http(BIND_KEY),
+			Method::GET,
+			&actor_url("my-actor", path),
+		)
+		.await;
+		assert_eq!(response.status(), StatusCode::OK);
+	}
+
+	assert_eq!(
+		calls.load(Ordering::Relaxed),
+		1,
+		"the second request must be served from the assignment cache"
+	);
+	assert_logged_resume(COLD_PATH, "triggered").await;
+	assert_logged_resume(WARM_PATH, "none").await;
+}
+
+#[tokio::test]
+async fn actor_ingress_reports_a_joined_resume_for_a_follower_on_an_in_flight_resume() {
+	const LEADER_PATH: &str = "/resume-join-leader";
+	const FOLLOWER_PATH: &str = "/resume-join-follower";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let entered = Arc::new(Notify::new());
+	let release = Arc::new(Notify::new());
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let entered = entered.clone();
+		let release = release.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || SelectiveParkingHandler {
+			pod_ip: pod_ip.clone(),
+			parked_actor: "my-actor".to_string(),
+			entered: entered.clone(),
+			release: release.clone(),
+			calls: calls.clone(),
+			resumed: true,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let leader = tokio::spawn({
+		let io = gateway.serve_http(BIND_KEY);
+		let url = actor_url("my-actor", LEADER_PATH);
+		async move { send_request(io, Method::GET, &url).await }
+	});
+	// The leader is inside ResumeActor, so the singleflight placeholder exists and the follower
+	// cannot become a second leader or read a warm cache entry.
+	entered.notified().await;
+	let follower = tokio::spawn({
+		let io = gateway.serve_http(BIND_KEY);
+		let url = actor_url("my-actor", FOLLOWER_PATH);
+		async move { send_request(io, Method::GET, &url).await }
+	});
+	tokio::time::sleep(Duration::from_millis(200)).await;
+	release.notify_one();
+
+	assert_eq!(leader.await.unwrap().status(), StatusCode::OK);
+	assert_eq!(follower.await.unwrap().status(), StatusCode::OK);
+	assert_eq!(
+		calls.load(Ordering::Relaxed),
+		1,
+		"the follower must have joined the leader's resume, not started its own"
+	);
+
+	assert_logged_resume(LEADER_PATH, "triggered").await;
+	assert_logged_resume(FOLLOWER_PATH, "joined").await;
+}
+
+#[tokio::test]
+async fn actor_ingress_reports_no_resume_when_the_resume_fails() {
+	const PATH: &str = "/resume-failed";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || ParkingHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+			failures_before_success: 1,
+			failure_code: tonic::Code::NotFound,
+			entered: None,
+			resumed: true,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let mut trace_rx = agentgateway::proxy::dtrace::track_expression(Some(
+		agentgateway::cel::Expression::new_strict(format!("request.path == '{PATH}'")).unwrap(),
+	));
+	let response = send_request(
+		gateway.serve_http(BIND_KEY),
+		Method::GET,
+		&actor_url("my-actor", PATH),
+	)
+	.await;
+	assert_eq!(response.status(), StatusCode::NOT_FOUND);
+	assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+	assert_logged_resume(PATH, "none").await;
+
+	let mut events = Vec::new();
+	while let Ok(Some(msg)) = tokio::time::timeout(Duration::from_millis(50), trace_rx.recv()).await {
+		events.push(serde_json::to_value(msg).unwrap())
+	}
+	let resumes: Vec<&serde_json::Value> = events
+		.iter()
+		.filter(|event| event["message"]["type"] == "policyEvent")
+		.filter(|event| event["message"]["kind"] == "substrate")
+		.map(|event| &event["message"]["details"]["resume"])
+		.collect();
+	assert_eq!(resumes, vec!["none"], "{events:#?}");
+}
+
 #[tokio::test]
 async fn actor_ingress_uses_the_original_connect_authority() {
 	let actor = simple_mock().await;
@@ -377,6 +638,7 @@ async fn actor_ingress_uses_the_original_connect_authority() {
 		move || IngressHandler {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
+			resumed: true,
 		}
 	})
 	.spawn()
@@ -490,6 +752,7 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 		move || IngressHandler {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
+			resumed: true,
 		}
 	})
 	.spawn()

--- a/crates/protos/proto/ateapi.proto
+++ b/crates/protos/proto/ateapi.proto
@@ -53,6 +53,9 @@ message ResumeActorRequest {
 
 message ResumeActorResponse {
   Actor actor = 1;
+  // True if a resume workflow was executed to activate the actor.
+  // False if the actor was already RUNNING.
+  bool resumed = 2;
 }
 
 message GetActorRequest {


### PR DESCRIPTION
`substrateIngress` logs every actor resolution, but it dropped `ResumeActorResponse.resumed`. So `source: ateApi` meant both "actor was already running" and "we just cold-started it", meaning no way to get cold-start rate out of what we emit.

Now we keep that bit and map it to `ate.router.resume` = `none` | `triggered` | `joined`, on the access log and on the policy debug events.

I am also establishing an attribute registry for substrate in `src/http/substrate/ateattr.rs`
