### PR TITLE
fix(resource_manager): reschedule failed HTTP refresh so retries actually fire

### DIFF
--- a/crates/agentgateway/src/resource_manager.rs
+++ b/crates/agentgateway/src/resource_manager.rs
@@ -477,6 +477,22 @@ impl ResourceManager {
 					return;
 				}
 				let next = Instant::now() + FAILED_HTTP_REFRESH;
+				// Keep the cached entry's `next_refresh` in sync with the retry being
+				// scheduled below. `should_refresh` gates the scheduler's eventual
+				// retry on this timestamp matching exactly; leaving it at the last
+				// success's (now past-due) value makes that retry silently no-op
+				// when it fires, and since only a `should_refresh`-approved refresh
+				// schedules the next one, this resource would never be refreshed
+				// again until the process restarts.
+				if let Some(entry) = self
+					.inner
+					.entries
+					.lock()
+					.expect("resource cache mutex poisoned")
+					.get_mut(&resource)
+				{
+					entry.next_refresh = Some(next);
+				}
 				let _ = self
 					.inner
 					.scheduler_tx
@@ -961,5 +977,59 @@ mod tests {
 			.await
 			.expect("resource deletion should notify")
 			.expect("change channel should remain open");
+	}
+
+	#[tokio::test]
+	async fn failed_http_refresh_reschedules_a_retry_that_will_actually_fire() {
+		// A closed local port fails at connect time (like a real transient
+		// network blip), rather than a non-2xx status -- `fetch_direct` only
+		// treats transport-level failures as errors, not HTTP error statuses.
+		let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+		let addr = listener.local_addr().unwrap();
+		drop(listener);
+
+		let manager = ResourceManager::new(test_client()).unwrap();
+		let url: http::Uri = format!("http://{addr}/resource").parse().unwrap();
+		let resource = normalize_resource(ResourceRef::Http {
+			url,
+			kind: ResourceKind::Generic,
+		})
+		.unwrap();
+
+		// Simulate steady state after a prior successful fetch: cached content,
+		// active, with its next scheduled refresh far in the future.
+		let far_future = Instant::now() + Duration::from_secs(9_999);
+		manager.retain_resources(HashSet::from([resource.clone()]));
+		manager.store(
+			resource.clone(),
+			Bytes::from_static(b"v1"),
+			Some(far_future),
+		);
+
+		// This is the periodic scheduler's refresh attempt firing, exactly as
+		// `start_http_scheduler` invokes it -- it hits the closed port above.
+		manager
+			.refetch_and_notify_if_changed(resource.clone())
+			.await;
+
+		let entries = manager
+			.inner
+			.entries
+			.lock()
+			.expect("resource cache mutex poisoned");
+		let entry = entries.get(&resource).expect("entry should remain cached");
+		// A failed refresh must not touch the last-known-good content.
+		assert_eq!(entry.content, Bytes::from_static(b"v1"));
+		// The retry scheduled after the failure must be reflected in the cached
+		// entry's `next_refresh`, because `should_refresh` gates the scheduler's
+		// eventual retry on that value matching exactly. Before the fix,
+		// `next_refresh` here is still `far_future` (untouched by the failure
+		// path), so when the scheduler later pops the retry it never matches,
+		// the retry is silently dropped, and no refresh is ever scheduled again.
+		let scheduled_retry = entry.next_refresh.expect("a retry should be scheduled");
+		assert!(
+			scheduled_retry < far_future,
+			"failed refresh should reschedule sooner than the stale next_refresh from the last success"
+		);
 	}
 }


### PR DESCRIPTION
## Summary

- The periodic HTTP resource refresh (used for remote JWKS, OIDC discovery, etc.) gates each scheduled retry on the cached entry's `next_refresh` timestamp matching exactly (`should_refresh`). The failure branch of `refetch_and_notify_if_changed` scheduled a retry via `scheduler_tx` but never updated the cached entry's `next_refresh` to match — it stayed at the stale value written by the last success.
- When that retry later fired from the scheduler heap, `should_refresh` compared the retry's timestamp against the stale `next_refresh` and rejected it. Since only an accepted refresh re-arms the *next* scheduled refresh, this silently and permanently stopped all future refreshes of that resource — success or failure — until the process restarted.
- Fix: update the cached entry's `next_refresh` in the failure branch too, so the next scheduler pop matches and the retry loop keeps going until it actually succeeds again.

## Relation to #2798

This explains the standalone-mode half of #2798's report: *"With a config file (standalone), the JWKS is read once at startup and never again ... I left it failing for 10 minutes and the JWKS was never read a second time."* The 15-minute periodic refetch (`JWKS_TTL`) the maintainer pointed at in that thread does exist and does fire once — but any single transient fetch error (a network blip, a brief DNS hiccup, etc.) permanently disables it from then on, long after the underlying issue clears. Concretely: our JWKS endpoint had exactly one transient fetch failure, and every OIDC login failed with `token uses the unknown key ...` for 5+ hours afterward until we restarted the process, well after the IdP's normal key rotation.

This PR does **not** add the eager refetch-on-unknown-kid behavior (with rate limiting) that #2798 also requests — that's a separate, legitimate enhancement. This just makes the existing periodic refresh mechanism work as designed, bounding a signing-key rotation to one TTL window instead of an indefinite outage.

## Test plan

- Added `resource_manager::tests::failed_http_refresh_reschedules_a_retry_that_will_actually_fire`, which reproduces the bug directly (fails without the fix, passes with it) by:
  1. Seeding a cache entry via `store()` as if a prior fetch succeeded, with `next_refresh` far in the future (steady state).
  2. Invoking `refetch_and_notify_if_changed` against a closed local port (a genuine connect-time failure, not a scriptable HTTP status — `fetch_direct` only treats transport failures as errors).
  3. Asserting the entry's `next_refresh` moved to the newly scheduled retry time rather than staying at the stale value.
- `cargo test -p agentgateway --lib resource_manager::` — 6 passed.
- `cargo test -p agentgateway --lib http::oidc::` — 15 passed (no regressions in the JWKS/OIDC consumer).
- `cargo clippy -p agentgateway --lib -- -D warnings` — clean.
- `cargo fmt -p agentgateway -- --check` — clean.