### PR TITLE
cargo: use string for rustflags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,10 +4,7 @@ xtask = "run --package xtask --"
 # Enable tokio_unstable for task dump
 # Not supported for non-linux
 [target.'cfg(target_os = "linux")']
-rustflags = [
-    "--cfg", "tokio_unstable",
-    "-C", "force-frame-pointers",
-]
+rustflags = "--cfg tokio_unstable -C force-frame-pointers"
 
 [env]
 CXXFLAGS = "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"


### PR DESCRIPTION
If you use an array, and you have nested repos (.worktree) then the flags merge, and then caching is busted. This makes it a replace.