### PR TITLE
Parse MCP context for CEL early

### DIFF
--- a/crates/agentgateway/src/cel/mod.rs
+++ b/crates/agentgateway/src/cel/mod.rs
@@ -307,6 +307,10 @@ impl ContextBuilder {
 	pub fn needs_llm_tool_calls(&self) -> bool {
 		self.any_has(Attributes::LlmToolCalls)
 	}
+
+	pub fn needs_mcp(&self) -> bool {
+		self.before_log_has(Attributes::Mcp)
+	}
 }
 
 impl Expression {

--- a/crates/agentgateway/src/cel/types.rs
+++ b/crates/agentgateway/src/cel/types.rs
@@ -573,6 +573,7 @@ impl<'a> Executor<'a> {
 		self.api_key = ExtensionOrDirect::Extension(ext);
 		self.jwt = ExtensionOrDirect::Extension(ext);
 		self.llm = ExtensionOrDirect::Extension(ext);
+		self.mcp = ext.get::<MCPInfo>();
 		self.basic_auth = ExtensionOrDirect::Extension(ext);
 		self.extauthz = ExtensionOrDirect::Extension(ext);
 		self.extproc = ExtensionOrDirect::Extension(ext);

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -6280,16 +6280,20 @@ async fn mcp_local_ratelimit() {
 		.with_bind(simple_bind())
 		.with_route(basic_route(mock.addr));
 
-	// Attach local rate limit policy
-	// MCP protocol overhead: initialize + notification + SSE GET = 3 requests
-	// Allow 5 total: overhead (3) + tool calls (2), then rate limit the 6th
+	// Only tool calls consume this limit; MCP initialization traffic does not match.
 	t.attach_route_policy(serde_json::json!({
-		"localRateLimit": [{
-			"maxTokens": 5,
-			"tokensPerFill": 1,
-			"fillInterval": "10s",
-			"type": "requests"
-		}]
+		"localRateLimit": {
+			"conditional": [{
+				"condition": format!(
+					"backend.name == '/{}' && backend.type == 'mcp' && mcp.tool.name == 'echo' && mcp.tool.arguments.n > 0",
+					mock.addr,
+				),
+				"maxTokens": 2,
+				"tokensPerFill": 1,
+				"fillInterval": "10s",
+				"type": "requests"
+			}]
+		}
 	}))
 	.await;
 
@@ -6329,7 +6333,7 @@ async fn mcp_local_ratelimit() {
 		"rate limit should map to RESOURCE_EXHAUSTED"
 	);
 	let data = e.data.as_ref().expect("error should carry retry data");
-	assert_eq!(data["limit"], 5);
+	assert_eq!(data["limit"], 2);
 	assert!(data.get("retryAfterSeconds").is_some());
 }
 

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -6338,6 +6338,55 @@ async fn mcp_local_ratelimit() {
 }
 
 #[tokio::test]
+async fn mcp_cached_request_reparsed_after_body_transformation() {
+	let mock = mock_streamable_http_server(true).await;
+	let mut t = setup_proxy_test("{}")
+		.unwrap()
+		.with_mcp_backend(mock.addr, true, false)
+		.with_bind(simple_bind())
+		.with_route(basic_route(mock.addr));
+
+	t.attach_route_policy(serde_json::json!({
+		"transformations": {
+			"conditional": [{
+				"condition": "mcp.tool.name == 'echo'",
+				"request": {
+					"body": r#"{
+						"jsonrpc": "2.0",
+						"id": json(request.body).id,
+						"method": "tools/call",
+						"params": {
+							"name": mcp.tool.name,
+							"arguments": {"after": true}
+						}
+					}"#
+				}
+			}]
+		}
+	}))
+	.await;
+
+	let io = t.serve_real_listener(BIND_KEY).await;
+	let client = mcp_streamable_client(io).await;
+	let result = client
+		.call_tool(
+			rmcp::model::CallToolRequestParams::new("echo").with_arguments(
+				serde_json::json!({"before": true})
+					.as_object()
+					.cloned()
+					.unwrap(),
+			),
+		)
+		.await
+		.expect("transformed tool call should succeed");
+
+	assert_eq!(
+		&result.content[0].as_text().unwrap().text,
+		r#"{"after":true}"#
+	);
+}
+
+#[tokio::test]
 async fn mcp_extauth_deny() {
 	struct DenyAllAuthz;
 

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -264,8 +264,7 @@ impl Error {
 // guardrail rejections. anything we can't extract a request id for keeps the plain error.
 pub(crate) async fn maybe_convert_mcp_error<T>(
 	res: Result<T, crate::proxy::ProxyResponse>,
-	inputs: &crate::ProxyInputs,
-	backend: Option<&crate::types::agent::RouteBackendReference>,
+	request_protocol: crate::proxy::httpproxy::RequestProtocol,
 	req: &mut crate::http::Request,
 ) -> Result<T, crate::proxy::ProxyResponse> {
 	use crate::proxy::ProxyResponse;
@@ -280,23 +279,7 @@ pub(crate) async fn maybe_convert_mcp_error<T>(
 	) {
 		return Err(ProxyResponse::Error(err));
 	}
-	// avoid converting errors for non-JSON RPC requests
-	// best effort; worst case scenario we find no request id
-	// at the MCP layer and fallback to the origial HTTP error
-	let path = req.uri().path();
-	if req.method() != ::http::Method::POST
-		|| path == "/sse"
-		|| auth::is_well_known_endpoint(path)
-		|| path.ends_with("client-registration")
-		|| crate::http::is_grpc_request(req)
-	{
-		return Err(ProxyResponse::Error(err));
-	}
-	let is_mcp = backend
-		.cloned()
-		.and_then(|b| crate::proxy::httpproxy::resolve_backend(b, inputs).ok())
-		.is_some_and(|b| matches!(b.backend.backend, crate::types::agent::Backend::MCP(_, _)));
-	if !is_mcp {
+	if request_protocol != crate::proxy::httpproxy::RequestProtocol::MCP {
 		return Err(ProxyResponse::Error(err));
 	}
 	let limit = crate::http::buffer_limit(req);

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -458,6 +458,75 @@ pub struct MCPInfo {
 }
 
 impl MCPInfo {
+	/// Builds the MCP information available to HTTP request policies. Response-derived
+	/// fields are populated later by MCP processing.
+	pub(crate) fn from_request(
+		headers: &crate::http::HeaderMap,
+		message: &rmcp::model::ClientJsonRpcMessage,
+		backend: &crate::types::agent::McpBackend,
+	) -> Self {
+		use rmcp::model::{ClientJsonRpcMessage, ClientRequest};
+		use rmcp::transport::common::http_header::HEADER_SESSION_ID;
+
+		let mut info = Self {
+			method_name: streamablehttp::message_method(message).map(Into::into),
+			session_id: headers
+				.get(HEADER_SESSION_ID)
+				.and_then(|value| value.to_str().ok())
+				.map(str::to_owned),
+			..Default::default()
+		};
+		let ClientJsonRpcMessage::Request(request) = message else {
+			return info;
+		};
+
+		match &request.request {
+			ClientRequest::CallToolRequest(request) => {
+				if let Some((target, name)) = mcp_request_name(backend, &request.params.name) {
+					info.set_tool(target, name);
+					info.capture_call_arguments(request.params.arguments.clone());
+				}
+			},
+			ClientRequest::GetPromptRequest(request) => {
+				if let Some((target, name)) = mcp_request_name(backend, &request.params.name) {
+					info.set_prompt(target, name);
+				}
+			},
+			ClientRequest::ReadResourceRequest(request) => {
+				if let Some((target, uri)) = mcp_request_uri(backend, &request.params.uri) {
+					info.set_resource(target, uri);
+				}
+			},
+			ClientRequest::SubscribeRequest(request) => {
+				if let Some((target, uri)) = mcp_request_uri(backend, &request.params.uri) {
+					info.set_resource(target, uri);
+				}
+			},
+			ClientRequest::UnsubscribeRequest(request) => {
+				if let Some((target, uri)) = mcp_request_uri(backend, &request.params.uri) {
+					info.set_resource(target, uri);
+				}
+			},
+			ClientRequest::GetTaskRequest(request) => {
+				if let Some((target, id)) = mcp_request_task(backend, &request.params.task_id) {
+					info.set_task(target, id);
+				}
+			},
+			ClientRequest::UpdateTaskRequest(request) => {
+				if let Some((target, id)) = mcp_request_task(backend, &request.params.task_id) {
+					info.set_task(target, id);
+				}
+			},
+			ClientRequest::CancelTaskRequest(request) => {
+				if let Some((target, id)) = mcp_request_task(backend, &request.params.task_id) {
+					info.set_task(target, id);
+				}
+			},
+			_ => {},
+		}
+		info
+	}
+
 	pub fn is_empty(&self) -> bool {
 		self.method_name.is_none()
 			&& self.session_id.is_none()
@@ -579,6 +648,72 @@ impl MCPInfo {
 			tool.error = serde_json::to_value(error).ok();
 		}
 	}
+}
+
+fn mcp_request_name(
+	backend: &crate::types::agent::McpBackend,
+	name: &str,
+) -> Option<(String, String)> {
+	use crate::types::agent::McpPrefixMode;
+
+	if backend.targets.len() == 1 && !matches!(backend.prefix_mode, McpPrefixMode::Always) {
+		return Some((backend.targets[0].name.to_string(), name.to_owned()));
+	}
+	// With prefixMode=never and multiple targets, the owner is discovered by querying
+	// the upstreams later in MCP processing. Preserve the name for request policies,
+	// but leave the target empty until that resolution happens.
+	if matches!(backend.prefix_mode, McpPrefixMode::Never) {
+		return Some((String::new(), name.to_owned()));
+	}
+	let (target, name) = name.split_once('_')?;
+	backend
+		.targets
+		.iter()
+		.any(|candidate| candidate.name.as_str() == target)
+		.then(|| (target.to_owned(), name.to_owned()))
+}
+
+fn mcp_request_uri(
+	backend: &crate::types::agent::McpBackend,
+	uri: &str,
+) -> Option<(String, String)> {
+	if backend.targets.len() == 1
+		&& !matches!(
+			backend.prefix_mode,
+			crate::types::agent::McpPrefixMode::Always
+		) {
+		return Some((backend.targets[0].name.to_string(), uri.to_owned()));
+	}
+	let (target, uri) = if apps::is_ui_uri(uri) {
+		apps::decode_ui_uri(uri)?
+	} else {
+		let (target, uri) = uri.split_once('+')?;
+		(target, uri.to_owned())
+	};
+	backend
+		.targets
+		.iter()
+		.any(|candidate| candidate.name.as_str() == target)
+		.then(|| (target.to_owned(), uri))
+}
+
+fn mcp_request_task(
+	backend: &crate::types::agent::McpBackend,
+	id: &str,
+) -> Option<(String, String)> {
+	if backend.targets.len() == 1
+		&& !matches!(
+			backend.prefix_mode,
+			crate::types::agent::McpPrefixMode::Always
+		) {
+		return Some((backend.targets[0].name.to_string(), id.to_owned()));
+	}
+	let (target, id) = id.split_once('+')?;
+	backend
+		.targets
+		.iter()
+		.any(|candidate| candidate.name.as_str() == target)
+		.then(|| (target.to_owned(), id.to_owned()))
 }
 
 impl From<&ResourceType> for MCPInfo {

--- a/crates/agentgateway/src/mcp/mod.rs
+++ b/crates/agentgateway/src/mcp/mod.rs
@@ -53,6 +53,43 @@ pub enum FailureMode {
 
 pub(crate) const DEFAULT_SESSION_IDLE_TTL: Duration = Duration::from_mins(30);
 
+/// An early parse paired with the exact body bytes it represents.
+#[derive(Clone)]
+pub(crate) struct CachedRequest {
+	source_body: bytes::Bytes,
+	message: rmcp::model::ClientJsonRpcMessage,
+}
+
+impl CachedRequest {
+	pub fn new(source_body: bytes::Bytes, message: rmcp::model::ClientJsonRpcMessage) -> Self {
+		Self {
+			source_body,
+			message,
+		}
+	}
+
+	pub fn parse_body(
+		cached: Option<Self>,
+		body: &[u8],
+	) -> serde_json::Result<rmcp::model::ClientJsonRpcMessage> {
+		// Policies may have replaced the body after the early CEL parse. Exact byte equality makes
+		// reuse safe without requiring every possible body mutation to invalidate the cache.
+		match cached {
+			Some(cached) if cached.source_body.as_ref() == body => {
+				tracing::warn!("reusing early MCP request parse");
+				Ok(cached.message)
+			},
+			cached => {
+				tracing::warn!(
+					body_changed = cached.is_some(),
+					"not reusing early MCP request parse"
+				);
+				serde_json::from_slice(body)
+			},
+		}
+	}
+}
+
 /// Application-defined "over quota" code (MCP defines none); shared with the guardrail mapping.
 pub(crate) const RESOURCE_EXHAUSTED: ErrorCode = ErrorCode(-32003);
 
@@ -279,7 +316,7 @@ pub(crate) async fn maybe_convert_mcp_error<T>(
 	) {
 		return Err(ProxyResponse::Error(err));
 	}
-	if request_protocol != crate::proxy::httpproxy::RequestProtocol::MCP {
+	if request_protocol != crate::proxy::httpproxy::RequestProtocol::Mcp {
 		return Err(ProxyResponse::Error(err));
 	}
 	let limit = crate::http::buffer_limit(req);

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -132,7 +132,8 @@ impl StreamableHttpService {
 			Ok(b) => b,
 			Err(e) => return mcp::Error::Deserialize(e).into(),
 		};
-		let message = match serde_json::from_slice::<ClientJsonRpcMessage>(&bytes) {
+		let cached = part.extensions.remove::<mcp::CachedRequest>();
+		let message = match mcp::CachedRequest::parse_body(cached, &bytes) {
 			Ok(m) => m,
 			Err(e) => {
 				return match unknown_method_error(&part.headers, &bytes) {

--- a/crates/agentgateway/src/mcp/streamablehttp.rs
+++ b/crates/agentgateway/src/mcp/streamablehttp.rs
@@ -396,7 +396,7 @@ pub(crate) fn request_id(message: &ClientJsonRpcMessage) -> Option<RequestId> {
 	}
 }
 
-fn message_method(message: &ClientJsonRpcMessage) -> Option<&str> {
+pub(crate) fn message_method(message: &ClientJsonRpcMessage) -> Option<&str> {
 	match message {
 		ClientJsonRpcMessage::Request(req) => Some(req.request.method()),
 		ClientJsonRpcMessage::Notification(notification) => Some(match &notification.notification {

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -1022,7 +1022,7 @@ impl Gateway {
 						dtrace::DebugTracer::maybe_scope(req, |req| async move {
 							proxy.proxy(connection, req).map(Ok::<_, Infallible>).await
 						})
-						.assert_size::<{ 17 * 1024 }>(),
+						.assert_size::<{ 18 * 1024 }>(),
 					)
 					.await?;
 					Ok(response.map(|body| crate::http::DropBody::new(body, request_permit)))

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -73,8 +73,8 @@ struct SelectedRouteChain {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum RequestProtocol {
-	HTTP,
-	MCP,
+	Http,
+	Mcp,
 	AI,
 }
 
@@ -89,10 +89,10 @@ fn classify_request_protocol(req: &Request, backend: &Backend) -> RequestProtoco
 				&& !req.uri().path().ends_with("client-registration")
 				&& !crate::http::is_grpc_request(req) =>
 		{
-			RequestProtocol::MCP
+			RequestProtocol::Mcp
 		},
 		Backend::AI(_, _) | Backend::LLMRouter(_, _) => RequestProtocol::AI,
-		_ => RequestProtocol::HTTP,
+		_ => RequestProtocol::Http,
 	}
 }
 
@@ -105,6 +105,9 @@ async fn set_mcp_cel_context(req: &mut Request, backend: &McpBackend) {
 	};
 	let info = mcp::MCPInfo::from_request(req.headers(), &message, backend);
 	req.extensions_mut().insert(info);
+	req
+		.extensions_mut()
+		.insert(mcp::CachedRequest::new(body, message));
 }
 
 fn select_route_chain(
@@ -985,7 +988,7 @@ impl HTTPProxy {
 			.ok()
 			.and_then(Option::as_ref)
 			.map(|backend| classify_request_protocol(&req, &backend.backend.backend))
-			.unwrap_or(RequestProtocol::HTTP);
+			.unwrap_or(RequestProtocol::Http);
 		if let Ok(Some(selected_backend)) = selected_backend.as_ref() {
 			let backend = &selected_backend.backend.backend;
 			let info = backend.backend_info();
@@ -996,7 +999,7 @@ impl HTTPProxy {
 					.backend_protocol()
 					.unwrap_or(cel::BackendProtocol::http),
 			});
-			if request_protocol == RequestProtocol::MCP
+			if request_protocol == RequestProtocol::Mcp
 				&& log.cel.ctx().needs_mcp()
 				&& let Backend::MCP(_, backend) = backend
 			{
@@ -1038,7 +1041,7 @@ impl HTTPProxy {
 		// Backend-policy expressions are registered only after route policies run, so they may
 		// introduce an MCP dependency that was not known at the earlier parsing point. Avoid
 		// parsing again when a route-policy expression already required MCP context.
-		if request_protocol == RequestProtocol::MCP
+		if request_protocol == RequestProtocol::Mcp
 			&& log.cel.ctx().needs_mcp()
 			&& req.extensions().get::<mcp::MCPInfo>().is_none()
 			&& let Backend::MCP(_, backend) = &selected_backend.backend.backend

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -71,6 +71,31 @@ struct SelectedRouteChain {
 	backend: Option<RouteBackendReference>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RequestProtocol {
+	HTTP,
+	MCP,
+	AI,
+}
+
+fn classify_request_protocol(req: &Request, backend: &Backend) -> RequestProtocol {
+	match backend {
+		// Only JSON-RPC traffic is handled as MCP; transport and discovery endpoints
+		// continue through the ordinary HTTP path.
+		Backend::MCP(_, _)
+			if req.method() == ::http::Method::POST
+				&& req.uri().path() != "/sse"
+				&& !mcp::auth::is_well_known_endpoint(req.uri().path())
+				&& !req.uri().path().ends_with("client-registration")
+				&& !crate::http::is_grpc_request(req) =>
+		{
+			RequestProtocol::MCP
+		},
+		Backend::AI(_, _) | Backend::LLMRouter(_, _) => RequestProtocol::AI,
+		_ => RequestProtocol::HTTP,
+	}
+}
+
 fn select_route_chain(
 	inputs: &ProxyInputs,
 	target_address: SocketAddr,
@@ -942,9 +967,14 @@ impl HTTPProxy {
 		// must still be allowed to terminate the request successfully.
 		let selected_backend = selected_route_chain
 			.backend
-			.clone()
 			.map(|backend| resolve_backend(backend, self.inputs.as_ref()))
 			.transpose();
+		let request_protocol = selected_backend
+			.as_ref()
+			.ok()
+			.and_then(Option::as_ref)
+			.map(|backend| classify_request_protocol(&req, &backend.backend.backend))
+			.unwrap_or(RequestProtocol::HTTP);
 
 		let policy_client = self.policy_client().with_parent(&req);
 		let route_retry = apply_request_policies(
@@ -955,13 +985,7 @@ impl HTTPProxy {
 			response_policies,
 		)
 		.await;
-		let route_retry = mcp::maybe_convert_mcp_error(
-			route_retry,
-			self.inputs.as_ref(),
-			selected_route_chain.backend.as_ref(),
-			&mut req,
-		)
-		.await;
+		let route_retry = mcp::maybe_convert_mcp_error(route_retry, request_protocol, &mut req).await;
 		let route_retry = route_retry.snapshot_on_err(log, &mut req)?;
 		dtrace::snapshot!(Request, "route policies", &req);
 		// With no explicit retry policy, Substrate only retries stale actor assignments.

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -96,6 +96,17 @@ fn classify_request_protocol(req: &Request, backend: &Backend) -> RequestProtoco
 	}
 }
 
+async fn set_mcp_cel_context(req: &mut Request, backend: &McpBackend) {
+	let Ok(http::BodyInspection::Complete(body)) = http::inspect_body(req).await else {
+		return;
+	};
+	let Ok(message) = serde_json::from_slice::<rmcp::model::ClientJsonRpcMessage>(&body) else {
+		return;
+	};
+	let info = mcp::MCPInfo::from_request(req.headers(), &message, backend);
+	req.extensions_mut().insert(info);
+}
+
 fn select_route_chain(
 	inputs: &ProxyInputs,
 	target_address: SocketAddr,
@@ -975,6 +986,23 @@ impl HTTPProxy {
 			.and_then(Option::as_ref)
 			.map(|backend| classify_request_protocol(&req, &backend.backend.backend))
 			.unwrap_or(RequestProtocol::HTTP);
+		if let Ok(Some(selected_backend)) = selected_backend.as_ref() {
+			let backend = &selected_backend.backend.backend;
+			let info = backend.backend_info();
+			req.extensions_mut().insert(BackendContext {
+				name: info.backend_name,
+				backend_type: info.backend_type,
+				protocol: backend
+					.backend_protocol()
+					.unwrap_or(cel::BackendProtocol::http),
+			});
+			if request_protocol == RequestProtocol::MCP
+				&& log.cel.ctx().needs_mcp()
+				&& let Backend::MCP(_, backend) = backend
+			{
+				set_mcp_cel_context(&mut req, backend).await;
+			}
+		}
 
 		let policy_client = self.policy_client().with_parent(&req);
 		let route_retry = apply_request_policies(
@@ -1007,6 +1035,16 @@ impl HTTPProxy {
 			Some(route_path.clone()),
 		));
 		backend_policies.register_cel_expressions(log.cel.ctx());
+		// Backend-policy expressions are registered only after route policies run, so they may
+		// introduce an MCP dependency that was not known at the earlier parsing point. Avoid
+		// parsing again when a route-policy expression already required MCP context.
+		if request_protocol == RequestProtocol::MCP
+			&& log.cel.ctx().needs_mcp()
+			&& req.extensions().get::<mcp::MCPInfo>().is_none()
+			&& let Backend::MCP(_, backend) = &selected_backend.backend.backend
+		{
+			set_mcp_cel_context(&mut req, backend).await;
+		}
 		log.cel.ctx().maybe_buffer_request_body(&mut req).await;
 		log.health_policy = backend_policies.health.clone();
 		log.backend_info = Some(selected_backend.backend.backend.backend_info());

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -937,6 +937,15 @@ impl HTTPProxy {
 		let explicit_route_retry = !route_policies.retry.is_empty();
 		log.cel.ctx().maybe_buffer_request_body(&mut req).await;
 
+		// Resolve early so request policies can use the backend protocol. Defer any
+		// error because backendless policies such as redirects and direct responses
+		// must still be allowed to terminate the request successfully.
+		let selected_backend = selected_route_chain
+			.backend
+			.clone()
+			.map(|backend| resolve_backend(backend, self.inputs.as_ref()))
+			.transpose();
+
 		let policy_client = self.policy_client().with_parent(&req);
 		let route_retry = apply_request_policies(
 			&route_policies,
@@ -962,12 +971,11 @@ impl HTTPProxy {
 				.get::<http::substrate::SubstrateRequestState>()
 				.is_some();
 
-		let selected_backend_ref = selected_route_chain
-			.backend
+		// No policy terminated the request, so forwarding now requires a valid backend.
+		let selected_backend = selected_backend
+			.snapshot_on_err(log, &mut req)?
 			.ok_or(ProxyError::NoValidBackends)
 			.snapshot_on_err(log, &mut req)?;
-		let selected_backend =
-			resolve_backend(selected_backend_ref, self.inputs.as_ref()).snapshot_on_err(log, &mut req)?;
 		let backend_policies = Arc::new(get_backend_policies(
 			self.inputs.as_ref(),
 			&selected_backend.backend,

--- a/crates/agentgateway/tests/tests/policy.rs
+++ b/crates/agentgateway/tests/tests/policy.rs
@@ -3,6 +3,27 @@ use agentgateway::test_helpers::extauthmock;
 use crate::common::prelude::*;
 
 #[tokio::test]
+async fn request_redirect_without_backend() {
+	let mut bind = setup_proxy_test("{}").unwrap().with_bind(simple_bind());
+	bind
+		.attach_route(json!({
+			"matches": [{"path": {"pathPrefix": "/redirect"}}],
+			"policies": {
+				"requestRedirect": {
+					"scheme": "https",
+					"status": 301,
+				},
+			},
+		}))
+		.await;
+
+	let io = bind.serve_http(BIND_KEY);
+	let res = send_request(io, Method::GET, "http://lo/redirect").await;
+	assert_eq!(res.status(), StatusCode::MOVED_PERMANENTLY);
+	assert_eq!(res.hdr("location"), "https://lo/redirect");
+}
+
+#[tokio::test]
 async fn response_policy_short_circuit() {
 	let (_mock, mut bind, io) = basic_setup().await;
 	bind


### PR DESCRIPTION
Closes #720
Closes #721
Closes #3284
Related to #3092
Related to #2713

This add support for `mcp` attributes in CEL during **post**routing policies.

Before:
```
listener selection
pre-routing policies
route selection picks a route + set of weighted backends
post-routing policies
resolve specific backend
backend policies
MCP parsed and processed
```

After
```
listener selection
pre-routing policies
route selection picks a route + set of weighted backends
resolve specific backend # moved
(conditionally) MCP parsed # new
post-routing policies
backend policies
MCP parsed/re-used and processed
```

The only real risk of resolving the backend is if it doesn't exist. Today, this can be fine in many cases (redirect, direct response, etc). To handle this we defer the error post-policies.

Note: we can do the same with `llmRequest` but didn't want to bloat this too much