### PR TITLE
helm: allow disabling the config checksum annotation

### DIFF
--- a/controller/install/helm/agentgateway-standalone/templates/_helpers.tpl
+++ b/controller/install/helm/agentgateway-standalone/templates/_helpers.tpl
@@ -169,6 +169,17 @@ mcp:
 {{ toYaml $renderedConfig }}
 {{- end }}
 
+{{/*
+Hash only configuration that agentgateway reads at startup. All other sections of the
+rendered configuration, plus config.modelCatalog, are reloaded without restarting the pod.
+*/}}
+{{- define "agentgateway-standalone.startupConfig" -}}
+{{- $renderedConfig := include "agentgateway-standalone.renderedConfig" . | fromYaml -}}
+{{- $config := get $renderedConfig "config" | default dict | deepCopy -}}
+{{- $_ := unset $config "modelCatalog" -}}
+{{ toYaml $config }}
+{{- end }}
+
 {{- define "agentgateway-standalone.validate" -}}
 {{- $mode := .Values.mode -}}
 {{- if not (has $mode (list "readonly" "database")) -}}

--- a/controller/install/helm/agentgateway-standalone/templates/deployment.yaml
+++ b/controller/install/helm/agentgateway-standalone/templates/deployment.yaml
@@ -20,9 +20,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.restartOnConfigChange }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- end }}
+        checksum/config: {{ include "agentgateway-standalone.startupConfig" . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/controller/install/helm/agentgateway-standalone/templates/deployment.yaml
+++ b/controller/install/helm/agentgateway-standalone/templates/deployment.yaml
@@ -20,7 +20,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.restartOnConfigChange }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/controller/install/helm/agentgateway-standalone/values.yaml
+++ b/controller/install/helm/agentgateway-standalone/values.yaml
@@ -51,6 +51,13 @@ podAnnotations:
   prometheus.io/port: "15020"
   prometheus.io/scrape: "true"
 
+# -- Restart the agentgateway proxy pods when the configuration changes, by stamping a
+# checksum of the ConfigMap onto the pod template. agentgateway watches its config file
+# and applies changes without a restart, so setting this to false lets a configuration
+# change take effect in place. A configuration that fails to load leaves the previous one
+# running and sets the 'config_synchronized' metric to 0, rather than restarting the pod.
+restartOnConfigChange: true
+
 # -- Labels to add to the agentgateway proxy pod.
 podLabels: {}
 

--- a/controller/install/helm/agentgateway-standalone/values.yaml
+++ b/controller/install/helm/agentgateway-standalone/values.yaml
@@ -51,13 +51,6 @@ podAnnotations:
   prometheus.io/port: "15020"
   prometheus.io/scrape: "true"
 
-# -- Restart the agentgateway proxy pods when the configuration changes, by stamping a
-# checksum of the ConfigMap onto the pod template. agentgateway watches its config file
-# and applies changes without a restart, so setting this to false lets a configuration
-# change take effect in place. A configuration that fails to load leaves the previous one
-# running and sets the 'config_synchronized' metric to 0, rather than restarting the pod.
-restartOnConfigChange: true
-
 # -- Labels to add to the agentgateway proxy pod.
 podLabels: {}
 
@@ -159,7 +152,7 @@ monitoring:
     # -- How often Prometheus scrapes the agentgateway proxy's metrics.
     interval: 15s
 
-# -- The standalone agentgateway configuration to serve, in the same format as a local agentgateway config file. The chart manages the 'config.storage' and 'config.database' sections for you based on the 'mode' value, so do not set them here.
+# -- The standalone agentgateway configuration to serve, in the same format as a local agentgateway config file. Changes outside the nested 'config' section, plus 'config.modelCatalog', are applied without restarting the pods. Changes to other nested 'config' settings restart the pods because agentgateway reads them only at startup. The chart manages the 'config.storage' and 'config.database' sections for you based on the 'mode' value, so do not set them here.
 config: {}
 
 # Postgres connection used by database mode.

--- a/controller/test/helm/standalone_chart_test.go
+++ b/controller/test/helm/standalone_chart_test.go
@@ -111,6 +111,7 @@ func TestStandaloneChartGoldenTemplate(t *testing.T) {
 		{
 			name: "workload-overrides",
 			valuesYAML: `revisionHistoryLimit: 3
+restartOnConfigChange: false
 resources:
   requests:
     cpu: 250m

--- a/controller/test/helm/standalone_chart_test.go
+++ b/controller/test/helm/standalone_chart_test.go
@@ -111,7 +111,6 @@ func TestStandaloneChartGoldenTemplate(t *testing.T) {
 		{
 			name: "workload-overrides",
 			valuesYAML: `revisionHistoryLimit: 3
-restartOnConfigChange: false
 resources:
   requests:
     cpu: 250m
@@ -252,6 +251,86 @@ func TestStandaloneChartInlineConfig(t *testing.T) {
 	require.NoError(t, err, "helm template failed: %s", stderr)
 	require.Contains(t, out, "gateways:")
 	require.Contains(t, out, "port: 3000")
+}
+
+func TestStandaloneChartConfigChecksum(t *testing.T) {
+	render := func(t *testing.T, values string) (string, string) {
+		t.Helper()
+		out, stderr, err := renderStandaloneChart(t, values)
+		require.NoError(t, err, "helm template failed: %s", stderr)
+
+		const prefix = "checksum/config: "
+		_, checksumAndRest, found := strings.Cut(out, prefix)
+		require.True(t, found, "rendered Deployment does not contain %q", prefix)
+		checksum, _, _ := strings.Cut(checksumAndRest, "\n")
+		return out, checksum
+	}
+
+	baseValues := `config:
+  gateways:
+    default:
+      port: 3000
+`
+	baseOutput, baseChecksum := render(t, baseValues)
+
+	t.Run("dynamic config does not restart pods", func(t *testing.T) {
+		output, checksum := render(t, `config:
+  gateways:
+    default:
+      port: 4000
+`)
+		require.NotEqual(t, baseOutput, output, "test must change the rendered ConfigMap")
+		require.Equal(t, baseChecksum, checksum)
+	})
+
+	t.Run("model catalog does not restart pods", func(t *testing.T) {
+		output, checksum := render(t, `config:
+  config:
+    modelCatalog:
+    - inline:
+        providers: {}
+  gateways:
+    default:
+      port: 3000
+`)
+		require.NotEqual(t, baseOutput, output, "test must change the rendered ConfigMap")
+		require.Equal(t, baseChecksum, checksum)
+	})
+
+	t.Run("startup config restarts pods", func(t *testing.T) {
+		_, checksum := render(t, `config:
+  config:
+    adminAddr: 127.0.0.1:15000
+  gateways:
+    default:
+      port: 3000
+`)
+		require.NotEqual(t, baseChecksum, checksum)
+	})
+
+	t.Run("storage and database config restart pods", func(t *testing.T) {
+		_, databaseChecksum := render(t, `mode: database
+database:
+  postgres:
+    url: postgres://agentgateway@example.com/agentgateway
+config:
+  gateways:
+    default:
+      port: 3000
+`)
+		require.NotEqual(t, baseChecksum, databaseChecksum)
+
+		_, changedDatabaseChecksum := render(t, `mode: database
+database:
+  postgres:
+    url: postgres://agentgateway@other.example.com/agentgateway
+config:
+  gateways:
+    default:
+      port: 3000
+`)
+		require.NotEqual(t, databaseChecksum, changedDatabaseChecksum)
+	})
 }
 
 func TestStandaloneChartDatabaseModeAllowsReplicas(t *testing.T) {

--- a/controller/test/helm/testdata/agentgateway-standalone/default.golden
+++ b/controller/test/helm/testdata/agentgateway-standalone/default.golden
@@ -89,7 +89,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a8a21268a2cbaefa819117a8b657dbab610aea9fddd3b2bd645115ba44922dc6
+        checksum/config: 8e07586cd2989abccf598c2095a30480f054b0c428d194b2aee2139263d130f7
         prometheus.io/path: /metrics
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"

--- a/controller/test/helm/testdata/agentgateway-standalone/monitoring-full-config.golden
+++ b/controller/test/helm/testdata/agentgateway-standalone/monitoring-full-config.golden
@@ -89,7 +89,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a8a21268a2cbaefa819117a8b657dbab610aea9fddd3b2bd645115ba44922dc6
+        checksum/config: 8e07586cd2989abccf598c2095a30480f054b0c428d194b2aee2139263d130f7
         prometheus.io/path: /metrics
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"

--- a/controller/test/helm/testdata/agentgateway-standalone/service-full-config.golden
+++ b/controller/test/helm/testdata/agentgateway-standalone/service-full-config.golden
@@ -150,7 +150,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a8a21268a2cbaefa819117a8b657dbab610aea9fddd3b2bd645115ba44922dc6
+        checksum/config: 8e07586cd2989abccf598c2095a30480f054b0c428d194b2aee2139263d130f7
         prometheus.io/path: /metrics
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"

--- a/controller/test/helm/testdata/agentgateway-standalone/workload-overrides.golden
+++ b/controller/test/helm/testdata/agentgateway-standalone/workload-overrides.golden
@@ -90,7 +90,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a8a21268a2cbaefa819117a8b657dbab610aea9fddd3b2bd645115ba44922dc6
         prometheus.io/path: /metrics
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"

--- a/controller/test/helm/testdata/agentgateway-standalone/workload-overrides.golden
+++ b/controller/test/helm/testdata/agentgateway-standalone/workload-overrides.golden
@@ -90,6 +90,7 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/config: 8e07586cd2989abccf598c2095a30480f054b0c428d194b2aee2139263d130f7
         prometheus.io/path: /metrics
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"


### PR DESCRIPTION
Adds `restartOnConfigChange` to the standalone chart, defaulting to `true`. When set to `false`, the `checksum/config` annotation is omitted from the pod template.

## Why

The chart stamps a checksum of the ConfigMap onto the pod template, so every configuration change rolls the Deployment. But agentgateway already watches its config file and applies changes in place — the running proxy logs:

```
info | Watching config file: /config/config.yaml
```

and `LocalClient::watch_config_file` calls `reload_config_after_change` when the file changes, including the removal/replace pattern a Kubernetes ConfigMap update produces.

This means adding a user to an `mcpAuthorization` CEL rule currently restarts the gateway and drops every in-flight MCP session, to apply a change the binary would have picked up on its own.

## Safety

Opting out does not risk a bad config taking the proxy down — `reload_config_after_change` already handles that:

```rust
Err(e) => {
    self.metrics.config_synchronized.set(0);
    error!("Failed to reload config: {}", e);
    prev          // keeps the previously loaded config
}
```

A config that fails to load is logged, leaves the previous one serving, and sets `config_synchronized` to 0. Operators who prefer a failed rollout as the signal keep the default.

## Testing

- `restartOnConfigChange: false` added to the existing `workload-overrides` golden case; the regenerated golden shows only the `checksum/config` line removed, with `podAnnotations` intact.
- Verified the annotations block still renders correctly with the value false *and* `podAnnotations` unset.
- `go test ./test/helm/...` passes; all other goldens are unchanged, confirming the default preserves current behaviour exactly.
