### PR TITLE
fix(controller): propagate Gateway ancestry through virtual model failover targets

### DIFF
--- a/controller/pkg/agentgateway/translator/model_collections.go
+++ b/controller/pkg/agentgateway/translator/model_collections.go
@@ -62,43 +62,91 @@ func AgwModelCollection(
 // extractModelAncestorBackends mirrors extractAncestorBackends for AgentgatewayModels, so
 // backends referenced only by a model (spec.custom.backendRef) still resolve to their
 // Gateways in the reference index.
+// It also handles the indirect relationship: virtualModel.failover → concrete model → backendRef.
+// When a virtual model uses failover to reference a concrete model whose Custom provider
+// targets a backend (e.g. InferencePool), the virtual model's Gateways are propagated to
+// that backend's ancestor index.
 func extractModelAncestorBackends(ctx RouteContext, model *agentgateway.AgentgatewayModel) []*utils.AncestorBackend {
-	custom := model.Spec.Custom
-	if custom == nil || custom.BackendRef == nil {
-		return nil
-	}
 	source := utils.TypedNamespacedName{
 		Namespace: model.Namespace,
 		Name:      model.Name,
 		Kind:      wellknown.AgentgatewayModelGVK.Kind,
 	}
+
+	// Collect the model's parent gateways (shared by both direct and indirect cases).
 	gateways := sets.Set[types.NamespacedName]{}
 	for _, parent := range FilteredReferences(extractModelParentReferenceInfo(ctx, model)) {
 		gateways.Insert(parent.ParentGateway)
 	}
-	kind := wellknown.ServiceKind
-	if custom.BackendRef.Kind != nil {
-		kind = *custom.BackendRef.Kind
+	if len(gateways) == 0 {
+		return nil
 	}
-	backend := utils.TypedNamespacedName{
-		// backendRef may target only namespace-local resources.
-		Namespace: model.Namespace,
-		Name:      custom.BackendRef.Name,
-		Kind:      kind,
+
+	// Collect all reachable backends (deduplicated).
+	backends := sets.Set[utils.TypedNamespacedName]{}
+
+	// Case 1: Direct Custom provider backendRef (existing behavior).
+	if custom := model.Spec.Custom; custom != nil && custom.BackendRef != nil {
+		backends.Insert(backendRefToTypedNamespacedName(model.Namespace, custom.BackendRef))
 	}
+
+	// Case 2: Virtual model failover → concrete model → Custom backendRef.
+	// Failover targets must be concrete models (enforced by modelFailoverBackend runtime check).
+	// Concrete models' Custom.backendRef can only target Service or InferencePool (CEL constraint).
+	if vm := model.Spec.VirtualModel; vm != nil && vm.Failover != nil {
+		for _, target := range vm.Failover.Targets {
+			refModel, _, err := resolveModelTarget(ctx, model.Namespace, target.ModelTargetReference)
+			if err != nil {
+				continue // Unresolvable targets are skipped; modelFailoverBackend reports the error.
+			}
+			if refModel.Spec.Provider == nil {
+				continue // Not a concrete model; skip.
+			}
+			if refCustom := refModel.Spec.Custom; refCustom != nil && refCustom.BackendRef != nil {
+				// backendRef is namespace-local; use the concrete model's namespace.
+				backends.Insert(backendRefToTypedNamespacedName(refModel.Namespace, refCustom.BackendRef))
+			}
+		}
+	}
+
+	if len(backends) == 0 {
+		return nil
+	}
+
+	// Generate sorted cartesian product of gateways × backends.
 	gtw := gateways.UnsortedList()
 	slices.SortFunc(gtw, func(a, b types.NamespacedName) int {
 		return strings.Compare(a.String(), b.String())
 	})
-	res := make([]*utils.AncestorBackend, 0, len(gtw))
+	bes := backends.UnsortedList()
+	slices.SortFunc(bes, func(a, b utils.TypedNamespacedName) int {
+		return strings.Compare(a.String(), b.String())
+	})
+	res := make([]*utils.AncestorBackend, 0, len(gtw)*len(bes))
 	for _, gw := range gtw {
-		res = append(res, &utils.AncestorBackend{
-			Gateway: gw,
-			Backend: backend,
-			Source:  source,
-		})
+		for _, be := range bes {
+			res = append(res, &utils.AncestorBackend{
+				Gateway: gw,
+				Backend: be,
+				Source:  source,
+			})
+		}
 	}
 	return res
+}
+
+// backendRefToTypedNamespacedName converts a LocalBackendObjectReference to a TypedNamespacedName.
+// backendRef can only target Service or InferencePool (CEL constraint); Kind defaults to Service.
+func backendRefToTypedNamespacedName(namespace string, ref *agentgateway.LocalBackendObjectReference) utils.TypedNamespacedName {
+	kind := wellknown.ServiceKind
+	if ref.Kind != nil {
+		kind = *ref.Kind
+	}
+	return utils.TypedNamespacedName{
+		Namespace: namespace,
+		Name:      ref.Name,
+		Kind:      kind,
+	}
 }
 
 // extractModelParentReferenceInfo resolves an HTTPRoute parent to that route's

--- a/controller/pkg/agentgateway/translator/testdata/models/failover-inferencepool-ancestry.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/models/failover-inferencepool-ancestry.yaml
@@ -1,0 +1,497 @@
+# This test reproduces the bug described in issue #3050
+# A virtual model with failover references a concrete model that targets an InferencePool
+# The bug: the virtual model's Gateway is not recorded as an ancestor of the InferencePool
+
+# Public Gateway - will use virtual model with failover
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: public-gateway
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - name: llm
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      kinds:
+      - group: agentgateway.dev
+        kind: AgentgatewayModel
+      namespaces:
+        from: Same
+---
+# Internal Gateway - will use concrete model directly
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: internal-gateway
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+  - name: llm
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      kinds:
+      - group: agentgateway.dev
+        kind: AgentgatewayModel
+      namespaces:
+        from: Same
+---
+# InferencePool endpoint picker service
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-pool-endpoint-picker
+  namespace: default
+spec:
+  ports:
+  - name: grpc
+    port: 9002
+    targetPort: 9002
+  selector:
+    app: llama
+---
+# InferencePool - the backend that both gateways should reach
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: llama-pool
+  namespace: default
+spec:
+  endpointPickerRef:
+    failureMode: FailClose
+    group: ""
+    kind: Service
+    name: llama-pool-endpoint-picker
+    port:
+      number: 9002
+  selector:
+    matchLabels:
+      app: llama
+  targetPorts:
+  - number: 8000
+---
+# Concrete Custom-provider model - attached ONLY to internal-gateway
+# This model has a backendRef to the InferencePool
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: local-llama
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: internal-gateway
+    sectionName: llm
+  provider: Custom
+  custom:
+    providerOverride: team-a
+    backendRef:
+      group: inference.networking.k8s.io
+      kind: InferencePool
+      name: llama-pool
+    formats:
+    - type: Completions
+---
+# Virtual model with failover - attached ONLY to public-gateway
+# This model references the concrete model as a failover target
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayModel
+metadata:
+  name: resilient-model
+  namespace: default
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: public-gateway
+    sectionName: llm
+  virtualModel:
+    failover:
+      targets:
+      - modelRef:
+          name: local-llama
+        priority: 0
+
+---
+# Output
+output:
+- gateway:
+    Name: internal-gateway
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - custom:
+              formats:
+              - format: COMPLETIONS
+              providerOverride: team-a
+            name: backend
+            providerBackend:
+              port: 8000
+              service:
+                hostname: llama-pool.default.inference.cluster.local
+                namespace: default
+      key: default/local-llama/backend.llm
+      name:
+        name: local-llama
+        namespace: default
+- gateway:
+    Name: internal-gateway
+    Namespace: default
+  resource:
+    bind:
+      key: 80/default/internal-gateway
+      port: 80
+- gateway:
+    Name: internal-gateway
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 80/default/internal-gateway
+      key: default/internal-gateway.llm
+      name:
+        gatewayName: internal-gateway
+        gatewayNamespace: default
+        listenerName: llm
+      protocol: HTTP
+- gateway:
+    Name: internal-gateway
+    Namespace: default
+  resource:
+    modelRoute:
+      concreteModel:
+        backend:
+          backend: default/local-llama/backend.llm
+      key: default/local-llama.llm
+      listenerKey: default/internal-gateway.llm
+      match:
+        model: local-llama
+- gateway:
+    Name: internal-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker:
+            port: 9002
+            service:
+              hostname: llama-pool-endpoint-picker.default.svc.cluster.local
+              namespace: default
+          failureMode: FAIL_CLOSED
+      key: default/llama-pool:inference
+      name:
+        kind: InferencePool
+        name: llama-pool
+        namespace: default
+      target:
+        service:
+          hostname: llama-pool.default.inference.cluster.local
+          namespace: default
+- gateway:
+    Name: internal-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          verification: INSECURE_ALL
+      key: default/llama-pool:inferencetls
+      name:
+        kind: InferencePool
+        name: llama-pool
+        namespace: default
+      target:
+        service:
+          hostname: llama-pool-endpoint-picker.default.svc.cluster.local
+          namespace: default
+          port: 9002
+- gateway:
+    Name: public-gateway
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - custom:
+              formats:
+              - format: COMPLETIONS
+              model: local-llama
+              providerOverride: team-a
+            name: local-llama
+            providerBackend:
+              port: 8000
+              service:
+                hostname: llama-pool.default.inference.cluster.local
+                namespace: default
+      key: default/resilient-model/failover.llm
+      name:
+        name: resilient-model
+        namespace: default
+- gateway:
+    Name: public-gateway
+    Namespace: default
+  resource:
+    bind:
+      key: 80/default/public-gateway
+      port: 80
+- gateway:
+    Name: public-gateway
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 80/default/public-gateway
+      key: default/public-gateway.llm
+      name:
+        gatewayName: public-gateway
+        gatewayNamespace: default
+        listenerName: llm
+      protocol: HTTP
+- gateway:
+    Name: public-gateway
+    Namespace: default
+  resource:
+    modelRoute:
+      key: default/resilient-model.llm
+      listenerKey: default/public-gateway.llm
+      match:
+        model: resilient-model
+      virtualModel:
+        failover:
+          backend:
+            backend: default/resilient-model/failover.llm
+- gateway:
+    Name: public-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        inferenceRouting:
+          endpointPicker:
+            port: 9002
+            service:
+              hostname: llama-pool-endpoint-picker.default.svc.cluster.local
+              namespace: default
+          failureMode: FAIL_CLOSED
+      key: default/llama-pool:inference
+      name:
+        kind: InferencePool
+        name: llama-pool
+        namespace: default
+      target:
+        service:
+          hostname: llama-pool.default.inference.cluster.local
+          namespace: default
+- gateway:
+    Name: public-gateway
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          verification: INSECURE_ALL
+      key: default/llama-pool:inferencetls
+      name:
+        kind: InferencePool
+        name: llama-pool
+        namespace: default
+      target:
+        service:
+          hostname: llama-pool-endpoint-picker.default.svc.cluster.local
+          namespace: default
+          port: 9002
+status:
+- apiVersion: inference.networking.k8s.io/v1
+  kind: InferencePool
+  metadata:
+    name: llama-pool
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: All InferencePool references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: internal-gateway
+        namespace: default
+    - conditions:
+      - lastTransitionTime: fake
+        message: InferencePool has been accepted by controller agentgateway.dev/agentgateway
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: All InferencePool references have been resolved
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: public-gateway
+        namespace: default
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayModel
+  metadata:
+    name: local-llama
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: Successfully accepted AgentgatewayModel
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: ""
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: internal-gateway
+        namespace: default
+        sectionName: llm
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayModel
+  metadata:
+    name: resilient-model
+    namespace: default
+  spec: null
+  status:
+    parents:
+    - conditions:
+      - lastTransitionTime: fake
+        message: Successfully accepted AgentgatewayModel
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: ""
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+      parentRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: public-gateway
+        namespace: default
+        sectionName: llm
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: internal-gateway
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: llm
+      supportedKinds:
+      - group: agentgateway.dev
+        kind: AgentgatewayModel
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: public-gateway
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 0
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 1
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: llm
+      supportedKinds:
+      - group: agentgateway.dev
+        kind: AgentgatewayModel


### PR DESCRIPTION
## Summary

An `AgentgatewayModel` using `virtualModel.failover` can reference a concrete `AgentgatewayModel` whose Custom provider targets an `InferencePool`. The failover translator embeds the referenced model's provider configuration into the virtual model's generated backend, but the ancestor index did not follow this indirect relationship.

As a result, Gateways attached to the virtual model were not credited as ancestors of the referenced `InferencePool`, and the pool's inference-routing/EPP policies were not generated for those Gateways.

## Fix

Extend `extractModelAncestorBackends()` to traverse failover targets. For each concrete model referenced by a failover target, if that model has a Custom provider with `backendRef`, the virtual model's parent Gateways are added to the backend's ancestor index.

The function is restructured into a collect-then-product pattern (gateways × backends cartesian product) that supports both direct Custom provider references (existing behavior) and indirect failover references (new behavior), with proper deduplication via `sets.Set`.

## Safety

- Failover targets must be concrete models (enforced by runtime check in `modelFailoverBackend`; CEL `ExactlyOneOf=provider;virtualModel` prevents virtual-to-virtual chains).
- `backendRef` can only target `Service` or `InferencePool` (CEL `XValidation`).
- `backendRef` is namespace-local; no cross-namespace concerns.
- Multiple failover targets referencing the same backend are deduplicated.

## Test

Added a golden fixture (`failover-inferencepool-ancestry.yaml`) covering:
- A `public-gateway` attached to a failover virtual model.
- An `internal-gateway` attached to a concrete Custom-provider model targeting an `InferencePool`.
- The concrete model as a failover target of the virtual model.
- `InferencePool.status.parents` now contains both Gateways.
- InferencePool/EPP policies are generated for both Gateway scopes.

Fixes #3050.
