### PR TITLE
fix: report AddResourceExtension fields contributed by two plugins

### DIFF
--- a/controller/pkg/agentgateway/plugins/registry.go
+++ b/controller/pkg/agentgateway/plugins/registry.go
@@ -2,6 +2,9 @@ package plugins
 
 import (
 	"maps"
+	"reflect"
+	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -12,6 +15,9 @@ type AgwPlugin struct {
 	ContributesBackends  map[schema.GroupKind]BackendPlugin
 }
 
+// MergePlugins combines the contributions of every plugin into a single AgwPlugin.
+// AddResourcesPlugin collection fields must be disjoint across the set; compose two
+// plugins yourself if one adds to the other's contribution.
 func MergePlugins(plug ...AgwPlugin) AgwPlugin {
 	ret := AgwPlugin{
 		ContributesPolicies: make(map[schema.GroupKind]PolicyPlugin),
@@ -47,5 +53,35 @@ func MergePlugins(plug ...AgwPlugin) AgwPlugin {
 			}
 		}
 	}
+	if contested := contestedResourceExtensionFields(plug); len(contested) > 0 {
+		logger.Error("addResourceExtension fields contributed by more than one plugin, all but one contribution is discarded",
+			"fields", strings.Join(contested, ", "))
+	}
 	return ret
+}
+
+// contestedResourceExtensionFields names the collection fields more than one plugin
+// populates. Collection fields are interfaces; ParentResolvers is a slice and
+// accumulates across plugins by design.
+func contestedResourceExtensionFields(plug []AgwPlugin) []string {
+	contributors := map[string]int{}
+	for _, p := range plug {
+		if p.AddResourceExtension == nil {
+			continue
+		}
+		v := reflect.ValueOf(*p.AddResourceExtension)
+		for i := range v.NumField() {
+			if f := v.Field(i); f.Kind() == reflect.Interface && !f.IsNil() {
+				contributors[v.Type().Field(i).Name]++
+			}
+		}
+	}
+	var contested []string
+	for name, n := range contributors {
+		if n > 1 {
+			contested = append(contested, name)
+		}
+	}
+	slices.Sort(contested)
+	return contested
 }

--- a/controller/pkg/agentgateway/plugins/registry_test.go
+++ b/controller/pkg/agentgateway/plugins/registry_test.go
@@ -1,9 +1,14 @@
 package plugins
 
 import (
+	"slices"
 	"testing"
 
+	"istio.io/istio/pkg/kube/krt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/ir"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
 )
 
 func TestMergePluginsMergesBackendContributions(t *testing.T) {
@@ -17,5 +22,64 @@ func TestMergePluginsMergesBackendContributions(t *testing.T) {
 
 	if _, ok := merged.ContributesBackends[backendGK]; !ok {
 		t.Fatalf("expected backend contribution %v to be preserved", backendGK)
+	}
+}
+
+func TestContestedResourceExtensionFields(t *testing.T) {
+	resources := func() krt.Collection[ir.AgwResource] {
+		return krt.NewStaticCollection[ir.AgwResource](nil, nil)
+	}
+	ancestors := func() krt.Collection[*utils.AncestorBackend] {
+		return krt.NewStaticCollection[*utils.AncestorBackend](nil, nil)
+	}
+
+	cases := []struct {
+		name string
+		plug []AgwPlugin
+		want []string
+	}{
+		{
+			name: "no extensions",
+			plug: []AgwPlugin{{}, {}},
+		},
+		{
+			name: "disjoint fields are not contested",
+			plug: []AgwPlugin{
+				{AddResourceExtension: &AddResourcesPlugin{Binds: resources()}},
+				{AddResourceExtension: &AddResourcesPlugin{Listeners: resources()}},
+			},
+		},
+		{
+			name: "same field from two plugins",
+			plug: []AgwPlugin{
+				{AddResourceExtension: &AddResourcesPlugin{Routes: resources()}},
+				{AddResourceExtension: &AddResourcesPlugin{Routes: resources()}},
+			},
+			want: []string{"Routes"},
+		},
+		{
+			name: "reported sorted",
+			plug: []AgwPlugin{
+				{AddResourceExtension: &AddResourcesPlugin{AncestorBackends: ancestors(), Binds: resources()}},
+				{AddResourceExtension: &AddResourcesPlugin{AncestorBackends: ancestors(), Binds: resources()}},
+			},
+			want: []string{"AncestorBackends", "Binds"},
+		},
+		{
+			// ParentResolvers accumulates by design, so two contributors is not a conflict.
+			name: "parent resolvers are not contested",
+			plug: []AgwPlugin{
+				{AddResourceExtension: &AddResourcesPlugin{ParentResolvers: []ParentResolver{nil}}},
+				{AddResourceExtension: &AddResourcesPlugin{ParentResolvers: []ParentResolver{nil}}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := contestedResourceExtensionFields(tc.plug); !slices.Equal(got, tc.want) {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Two plugins populating the same `AddResourceExtension` field is a wiring bug, and a silent one. `MergePlugins` keeps one contribution and discards the other, and the discarded one produces no error anywhere: its binds, listeners or routes are simply never programmed, so it surfaces as missing data plane config with nothing pointing at the cause.

Log the fields that have more than one contributor. The merge itself is unchanged, and the fix for a genuine conflict is to compose the plugins before registering them.

Fields are found by reflection rather than a hardcoded list, so one added to `AddResourcesPlugin` later is covered without updating this.
