### PR TITLE
refactor: make listener protocol/TLS mapping reusable

### DIFF
--- a/controller/pkg/agentgateway/translator/conversion.go
+++ b/controller/pkg/agentgateway/translator/conversion.go
@@ -1219,6 +1219,100 @@ func listenerProtocolToAgw(p gwv1.ProtocolType) (string, error) {
 	return "", fmt.Errorf("protocol %q is unsupported", p)
 }
 
+// ListenerProtocolAndTLSConfig maps a Gateway listener to its agentgateway protocol and
+// TLS configuration. The final return is false when the listener cannot be programmed,
+// either because the protocol is unsupported or because it requires TLS that is missing.
+func ListenerProtocolAndTLSConfig(obj *GatewayListener) (api.Protocol, *api.TLSConfig, bool) {
+	var tlsConfig *api.TLSConfig
+
+	// Build TLS config if needed
+	if obj.TLSInfo != nil {
+		tlsConfig = &api.TLSConfig{
+			Cert:       obj.TLSInfo.Cert,
+			PrivateKey: obj.TLSInfo.Key,
+		}
+		if obj.TLSInfo.IstioWorkloadCert {
+			tlsConfig.CertificateSource = api.TLSConfig_ISTIO_WORKLOAD
+		} else if obj.TLSInfo.DynamicCA {
+			tlsConfig.CertificateSource = api.TLSConfig_DYNAMIC_CA
+		} else if obj.TLSInfo.Spiffe {
+			tlsConfig.CertificateSource = api.TLSConfig_SPIFFE
+		}
+		if len(obj.TLSInfo.CaCert) > 0 {
+			tlsConfig.Root = obj.TLSInfo.CaCert
+		}
+		if obj.TLSInfo.IstioMutual {
+			tlsConfig.Root = nil
+			tlsConfig.MtlsMode = api.TLSConfig_STRICT
+		} else if obj.TLSInfo.IstioWorkloadCert {
+			tlsConfig.MtlsMode = api.TLSConfig_DISABLE
+		} else if obj.TLSInfo.Spiffe {
+			tlsConfig.MtlsMode = api.TLSConfig_STRICT
+		} else if obj.TLSInfo.MtlsFallbackEnabled {
+			tlsConfig.MtlsMode = api.TLSConfig_ALLOW_INSECURE_FALLBACK
+		}
+	}
+
+	switch obj.ParentInfo.Protocol {
+	case gwv1.HTTPProtocolType:
+		return api.Protocol_HTTP, nil, true
+	case gwv1.HTTPSProtocolType:
+		if tlsConfig == nil {
+			return api.Protocol_HTTPS, nil, false // TLS required but not configured
+		}
+		return api.Protocol_HTTPS, tlsConfig, true
+	case gwv1.TLSProtocolType:
+		if tlsConfig == nil {
+			if obj.ParentInfo.TLSPassthrough {
+				// For passthrough, we don't want TLS config
+				return api.Protocol_TLS, nil, true
+			} else {
+				// TLS required but not configured
+				return api.Protocol_TLS, nil, false
+			}
+		}
+		return api.Protocol_TLS, tlsConfig, true
+	case gwv1.TCPProtocolType:
+		return api.Protocol_TCP, nil, true
+	case gwv1.ProtocolType(protocol.HBONE):
+		return api.Protocol_HBONE, nil, true
+	default:
+		return api.Protocol_HTTP, nil, false // Unsupported protocol
+	}
+}
+
+// BindProtocol maps a Gateway listener protocol to the protocol of the bind it shares
+// with the other listeners on its port.
+func BindProtocol(p gwv1.ProtocolType) api.Bind_Protocol {
+	switch p {
+	case gwv1.HTTPProtocolType:
+		return api.Bind_HTTP
+	case gwv1.HTTPSProtocolType, gwv1.TLSProtocolType:
+		return api.Bind_TLS
+	case gwv1.TCPProtocolType:
+		return api.Bind_TCP
+	case gwv1.ProtocolType(protocol.HBONE):
+		// The bind protocol is not used for HBONE_GATEWAY in the data plane;
+		// the actual inner protocol is determined at runtime from the other
+		// listeners on the same port. Return HTTP as a placeholder.
+		return api.Bind_HTTP
+	default:
+		return api.Bind_HTTP
+	}
+}
+
+// TunnelProtocol maps a Gateway listener protocol to its tunnel protocol.
+// HBONE listeners use HBONE_GATEWAY mode: the proxy terminates inbound HBONE
+// and routes CONNECT requests to local binds.
+func TunnelProtocol(p gwv1.ProtocolType) api.Bind_TunnelProtocol {
+	switch p {
+	case gwv1.ProtocolType(protocol.HBONE):
+		return api.Bind_HBONE_GATEWAY
+	default:
+		return api.Bind_DIRECT
+	}
+}
+
 // dummyTls is a sentinel value to send to agentgateway to signal that it should reject TLS connects due to invalid config
 var dummyTls = &TLSInfo{
 	Cert: []byte("invalid"),

--- a/controller/pkg/syncer/syncer.go
+++ b/controller/pkg/syncer/syncer.go
@@ -10,7 +10,6 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/ambient"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/mesh"
-	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/maps"
 	"istio.io/istio/pkg/slices"
@@ -590,8 +589,8 @@ func (s *Syncer) buildBindsFromGateway(listeners []*translator.GatewayListener) 
 		// non-overlapping. This case doesn't need to be handled here since the generated bind is independent of
 		// hostname
 		if listener.Conflict == "" {
-			bi.protocol = s.getBindProtocol(listener)
-			if tp := s.getTunnelProtocol(listener); tp != api.Bind_DIRECT {
+			bi.protocol = translator.BindProtocol(listener.ParentInfo.Protocol)
+			if tp := translator.TunnelProtocol(listener.ParentInfo.Protocol); tp != api.Bind_DIRECT {
 				bi.tunnelProtocol = tp
 			}
 			// A bind is internal if any contributing listener marks it internal. Translation
@@ -640,7 +639,7 @@ func (s *Syncer) buildListenerFromGateway(obj *translator.GatewayListener) *agwi
 	}
 
 	// Set protocol and TLS configuration
-	protocol, tlsConfig, ok := s.getProtocolAndTLSConfig(obj)
+	protocol, tlsConfig, ok := translator.ListenerProtocolAndTLSConfig(obj)
 	if !ok {
 		return nil // Unsupported protocol or missing TLS config
 	}
@@ -652,99 +651,6 @@ func (s *Syncer) buildListenerFromGateway(obj *translator.GatewayListener) *agwi
 		Namespace: obj.ParentGateway.Namespace,
 		Name:      obj.ParentGateway.Name,
 	}, translator.AgwListener{Listener: l}))
-}
-
-// getProtocolAndTLSConfig extracts protocol and TLS configuration from a gateway
-func (s *Syncer) getProtocolAndTLSConfig(obj *translator.GatewayListener) (api.Protocol, *api.TLSConfig, bool) {
-	var tlsConfig *api.TLSConfig
-
-	// Build TLS config if needed
-	if obj.TLSInfo != nil {
-		tlsConfig = &api.TLSConfig{
-			Cert:       obj.TLSInfo.Cert,
-			PrivateKey: obj.TLSInfo.Key,
-		}
-		if obj.TLSInfo.IstioWorkloadCert {
-			tlsConfig.CertificateSource = api.TLSConfig_ISTIO_WORKLOAD
-		} else if obj.TLSInfo.DynamicCA {
-			tlsConfig.CertificateSource = api.TLSConfig_DYNAMIC_CA
-		} else if obj.TLSInfo.Spiffe {
-			tlsConfig.CertificateSource = api.TLSConfig_SPIFFE
-		}
-		if len(obj.TLSInfo.CaCert) > 0 {
-			tlsConfig.Root = obj.TLSInfo.CaCert
-		}
-		if obj.TLSInfo.IstioMutual {
-			tlsConfig.Root = nil
-			tlsConfig.MtlsMode = api.TLSConfig_STRICT
-		} else if obj.TLSInfo.IstioWorkloadCert {
-			tlsConfig.MtlsMode = api.TLSConfig_DISABLE
-		} else if obj.TLSInfo.Spiffe {
-			tlsConfig.MtlsMode = api.TLSConfig_STRICT
-		} else if obj.TLSInfo.MtlsFallbackEnabled {
-			tlsConfig.MtlsMode = api.TLSConfig_ALLOW_INSECURE_FALLBACK
-		}
-	}
-
-	switch obj.ParentInfo.Protocol {
-	case gwv1.HTTPProtocolType:
-		return api.Protocol_HTTP, nil, true
-	case gwv1.HTTPSProtocolType:
-		if tlsConfig == nil {
-			return api.Protocol_HTTPS, nil, false // TLS required but not configured
-		}
-		return api.Protocol_HTTPS, tlsConfig, true
-	case gwv1.TLSProtocolType:
-		if tlsConfig == nil {
-			if obj.ParentInfo.TLSPassthrough {
-				// For passthrough, we don't want TLS config
-				return api.Protocol_TLS, nil, true
-			} else {
-				// TLS required but not configured
-				return api.Protocol_TLS, nil, false
-			}
-		}
-		return api.Protocol_TLS, tlsConfig, true
-	case gwv1.TCPProtocolType:
-		return api.Protocol_TCP, nil, true
-	case gwv1.ProtocolType(protocol.HBONE):
-		return api.Protocol_HBONE, nil, true
-	default:
-		return api.Protocol_HTTP, nil, false // Unsupported protocol
-	}
-}
-
-// getProtocolAndTLSConfig extracts protocol and TLS configuration from a gateway
-func (s *Syncer) getBindProtocol(obj *translator.GatewayListener) api.Bind_Protocol {
-	switch obj.ParentInfo.Protocol {
-	case gwv1.HTTPProtocolType:
-		return api.Bind_HTTP
-	case gwv1.HTTPSProtocolType:
-		return api.Bind_TLS
-	case gwv1.TLSProtocolType:
-		return api.Bind_TLS
-	case gwv1.TCPProtocolType:
-		return api.Bind_TCP
-	case gwv1.ProtocolType(protocol.HBONE):
-		// The bind protocol is not used for HBONE_GATEWAY in the data plane;
-		// the actual inner protocol is determined at runtime from the other
-		// listeners on the same port. Return HTTP as a placeholder.
-		return api.Bind_HTTP
-	default:
-		return api.Bind_HTTP
-	}
-}
-
-// getTunnelProtocol maps a Gateway listener protocol to its tunnel protocol.
-// HBONE listeners use HBONE_GATEWAY mode: the proxy terminates inbound HBONE
-// and routes CONNECT requests to local binds.
-func (s *Syncer) getTunnelProtocol(obj *translator.GatewayListener) api.Bind_TunnelProtocol {
-	switch obj.ParentInfo.Protocol {
-	case gwv1.ProtocolType(protocol.HBONE):
-		return api.Bind_HBONE_GATEWAY
-	default:
-		return api.Bind_DIRECT
-	}
 }
 
 // defaultBuildAddressCollections is the default implementation for building address collections


### PR DESCRIPTION
`getProtocolAndTLSConfig`, `getBindProtocol` and `getTunnelProtocol` are methods on `*Syncer`, but none of them reads the receiver. Since `Syncer` is unexported, that hides the single source of truth for how a Gateway API listener protocol becomes an `api.Protocol` / `api.Bind_Protocol` / `api.Bind_TunnelProtocol`, plus the whole `TLSInfo` → `api.TLSConfig` translation, behind a type nothing outside `pkg/syncer` can hold.

Moved to `pkg/agentgateway/translator`, next to the `GatewayListener` and `TLSInfo` types they map, as plain functions. The two bind helpers take a `gwv1.ProtocolType` since that's all they ever read.

Pure move otherwise. Two things folded in while touching them: `getBindProtocol` carried a copy-pasted doc comment naming the wrong function, and its `HTTPS`/`TLS` cases were separate arms returning the same value.
