### PR TITLE
Record GenAI request duration failures

### DIFF
--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -720,7 +720,7 @@ impl HTTPProxy {
 		});
 
 		log.with(|l| l.error = error.as_ref().map(|e| e.message.clone()));
-		let reason = match &ret {
+		let mut reason = match &ret {
 			Ok(_) => ProxyResponseReason::Upstream,
 			Err(e) => e.as_reason(),
 		};
@@ -755,10 +755,8 @@ impl HTTPProxy {
 			Ok(_) => resp,
 			Err(e) => {
 				is_upstream_response = false;
-				match e {
-					ProxyResponse::Error(e) => e.into_response_with_grpc(is_grpc_request),
-					ProxyResponse::DirectResponse(dr) => *dr,
-				}
+				reason = e.as_reason();
+				response_policy_failure(log.as_mut().unwrap(), e, is_grpc_request)
 			},
 		};
 		// LLM buffering deliberately leaves decoded bodies plain so response policies can safely read
@@ -3594,6 +3592,36 @@ fn resolved_workload_target_hostname<'a>(
 	} else {
 		Some(workload_hostname)
 	}
+}
+
+pub(crate) fn response_policy_failure(
+	log: &mut RequestLog,
+	failure: ProxyResponse,
+	is_grpc_request: bool,
+) -> Response {
+	let reason = failure.as_reason();
+	let error = match &failure {
+		ProxyResponse::Error(error) => Some(cel::ErrorContext {
+			reason: reason.to_string(),
+			message: error.to_string(),
+		}),
+		ProxyResponse::DirectResponse(_) => None,
+	};
+	log.error = error.as_ref().map(|error| error.message.clone());
+	let mut response = match failure {
+		ProxyResponse::Error(error) => error.into_response_with_grpc(is_grpc_request),
+		ProxyResponse::DirectResponse(response) => *response,
+	};
+	if let Some(context) = response.extensions_mut().get_mut::<cel::ProxyContext>() {
+		context.error = error;
+	} else if error.is_some() {
+		response.extensions_mut().insert(cel::ProxyContext {
+			error,
+			..Default::default()
+		});
+	}
+	set_final_response_fields(log, &reason, &mut response);
+	response
 }
 
 fn set_final_response_fields(

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1374,10 +1374,16 @@ fn gen_ai_operation_failed(request: &RequestLog) -> bool {
 }
 
 fn gen_ai_operation_name(input_format: InputFormat) -> &'static str {
-	if input_format == InputFormat::Embeddings {
-		"embeddings"
-	} else {
-		"chat"
+	match input_format {
+		InputFormat::Completions | InputFormat::Messages | InputFormat::Responses => "chat",
+		InputFormat::Gemini => "generate_content",
+		InputFormat::Embeddings => "embeddings",
+		// These operations have no standard GenAI operation name. Keep the custom values bounded.
+		InputFormat::Realtime => "realtime",
+		InputFormat::Rerank => "rerank",
+		InputFormat::CountTokens | InputFormat::GeminiCountTokens => "count_tokens",
+		// Detection has not identified the operation; do not assume it is chat.
+		InputFormat::Detect => "unknown",
 	}
 }
 
@@ -3178,41 +3184,49 @@ mod tests {
 			(InputFormat::Completions, "chat"),
 			(InputFormat::Messages, "chat"),
 			(InputFormat::Responses, "chat"),
-			(InputFormat::Gemini, "chat"),
+			(InputFormat::Gemini, "generate_content"),
 			(InputFormat::Embeddings, "embeddings"),
+			(InputFormat::Realtime, "realtime"),
+			(InputFormat::Rerank, "rerank"),
+			(InputFormat::CountTokens, "count_tokens"),
+			(InputFormat::GeminiCountTokens, "count_tokens"),
+			(InputFormat::Detect, "unknown"),
 		] {
-			for has_response in [false, true] {
-				let (mut log, registry) = test_request_log_with_registry();
-				let mut request = metric_test_llm_request();
-				request.input_format = format;
-				log.llm_request = Some(request.clone());
-				if has_response {
-					log.llm_response.store(Some(llm::LLMInfo::new(
-						request,
-						llm::LLMResponse {
-							input_tokens: Some(10),
-							..Default::default()
-						},
-					)));
-					log.status = Some(http::StatusCode::OK);
-				} else {
-					log.error = Some("connection failed".to_string());
-				}
-				drop(DropOnLog::from(log));
-				let encoded = encoded_metrics(&registry);
-				let counts: Vec<_> = encoded
-					.lines()
-					.filter(|line| {
-						line.starts_with("gen_ai_server_request_duration_count")
-							|| line.starts_with("gen_ai_client_token_usage_count")
-					})
-					.collect();
-				assert_eq!(counts.len(), if has_response { 2 } else { 1 });
-				for count in counts {
-					assert!(
-						count.contains(&format!("gen_ai_operation_name=\"{operation}\"")),
-						"{count}"
-					);
+			for streaming in [false, true] {
+				for has_response in [false, true] {
+					let (mut log, registry) = test_request_log_with_registry();
+					let mut request = metric_test_llm_request();
+					request.input_format = format;
+					request.streaming = streaming;
+					log.llm_request = Some(request.clone());
+					if has_response {
+						log.llm_response.store(Some(llm::LLMInfo::new(
+							request,
+							llm::LLMResponse {
+								input_tokens: Some(10),
+								..Default::default()
+							},
+						)));
+						log.status = Some(http::StatusCode::OK);
+					} else {
+						log.error = Some("connection failed".to_string());
+					}
+					drop(DropOnLog::from(log));
+					let encoded = encoded_metrics(&registry);
+					let counts: Vec<_> = encoded
+						.lines()
+						.filter(|line| {
+							line.starts_with("gen_ai_server_request_duration_count")
+								|| line.starts_with("gen_ai_client_token_usage_count")
+						})
+						.collect();
+					assert_eq!(counts.len(), if has_response { 2 } else { 1 });
+					for count in counts {
+						assert!(
+							count.contains(&format!("gen_ai_operation_name=\"{operation}\"")),
+							"{count}"
+						);
+					}
 				}
 			}
 		}

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -42,7 +42,7 @@ use crate::llm::catalog::{CostLookupStatus, ModelCatalog};
 use crate::mcp::{MCPInfo, MCPOperation};
 use crate::proxy::{ProxyResponseReason, dtrace};
 use crate::telemetry::metrics::{
-	CostCatalogLookupLabels, ErrorTypeLabel, GenAILabels, GenAILabelsTokenUsage,
+	CostCatalogLookupLabels, ErrorTypeLabel, GenAIErrorType, GenAILabels, GenAILabelsTokenUsage,
 	GenAIRequestDurationLabels, HTTPLabels, MCPCall, Metrics, OutboundCallLabels, RouteIdentifier,
 	SubstrateRouteLabels,
 };
@@ -909,7 +909,10 @@ impl DropOnLog {
 			.map(|response| response.request_model.clone())
 			.or_else(|| request.map(|request| request.request_model.clone()));
 		let gen_ai_labels = Arc::new(GenAILabels {
-			gen_ai_operation_name: strng::literal!("chat").into(),
+			gen_ai_operation_name: request
+				.map(|request| gen_ai_operation_name(request.input_format))
+				.map(RichStrng::from)
+				.into(),
 			gen_ai_system: provider.into(),
 			gen_ai_request_model: request_model.into(),
 			gen_ai_response_model: llm_response
@@ -924,9 +927,9 @@ impl DropOnLog {
 			.gen_ai_request_duration
 			.get_or_create(&GenAIRequestDurationLabels {
 				common: gen_ai_labels.clone().into(),
-				error: request_error_type(log, true)
-					.map(|error_type| ErrorTypeLabel {
-						error_type: error_type.into(),
+				error: gen_ai_operation_failed(log)
+					.then_some(ErrorTypeLabel {
+						error_type: GenAIErrorType::Other,
 					})
 					.into(),
 			})
@@ -1360,24 +1363,21 @@ fn request_log_level(error: Option<&str>) -> &'static str {
 	if error.is_some() { "error" } else { "info" }
 }
 
-pub(crate) fn request_error_type(
-	request: &RequestLog,
-	include_http_client_errors: bool,
-) -> Option<String> {
-	if request.error.is_some() {
-		return Some(
-			request
-				.reason
-				.map(|reason| reason.to_string())
-				.unwrap_or_else(|| "_OTHER".to_string()),
-		);
+fn gen_ai_operation_failed(request: &RequestLog) -> bool {
+	// A provider 4xx (such as rate limiting) fails the GenAI operation even though
+	// an inbound HTTP server span does not classify client errors as server failures.
+	request.error.is_some()
+		|| request
+			.status
+			.is_some_and(|status| status.is_client_error() || status.is_server_error())
+}
+
+fn gen_ai_operation_name(input_format: InputFormat) -> &'static str {
+	if input_format == InputFormat::Embeddings {
+		"embeddings"
+	} else {
+		"chat"
 	}
-	request
-		.status
-		.filter(|status| {
-			status.is_server_error() || (include_http_client_errors && status.is_client_error())
-		})
-		.map(|status| status.as_u16().to_string())
 }
 
 impl Drop for DropOnLog {
@@ -2182,13 +2182,10 @@ impl Drop for DropOnLog {
 						span_id: span_id.map(|id| id.to_string()),
 						http_status: log.status.as_ref().map(|s| i64::from(s.as_u16())),
 						error: log.error.clone(),
-						gen_ai_operation_name: log.llm_request.as_ref().map(|request| {
-							if request.input_format == InputFormat::Embeddings {
-								"embeddings".to_string()
-							} else {
-								"chat".to_string()
-							}
-						}),
+						gen_ai_operation_name: log
+							.llm_request
+							.as_ref()
+							.map(|request| gen_ai_operation_name(request.input_format).to_string()),
 						gen_ai_provider_name: log
 							.llm_request
 							.as_ref()
@@ -3066,19 +3063,19 @@ mod tests {
 				http::StatusCode::TOO_MANY_REQUESTS,
 				None,
 				Some(ProxyResponseReason::Upstream),
-				Some("429"),
+				Some("_OTHER"),
 			),
 			(
 				http::StatusCode::INTERNAL_SERVER_ERROR,
 				None,
 				Some(ProxyResponseReason::Upstream),
-				Some("500"),
+				Some("_OTHER"),
 			),
 			(
 				http::StatusCode::BAD_GATEWAY,
 				Some("connection failed"),
 				Some(ProxyResponseReason::UpstreamFailure),
-				Some("UpstreamFailure"),
+				Some("_OTHER"),
 			),
 			(
 				http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -3109,6 +3106,52 @@ mod tests {
 					!count.contains("error_type="),
 					"successful request unexpectedly has error.type: {count}"
 				),
+			}
+		}
+	}
+
+	#[test]
+	fn gen_ai_metrics_use_the_request_operation() {
+		for (format, operation) in [
+			(InputFormat::Completions, "chat"),
+			(InputFormat::Messages, "chat"),
+			(InputFormat::Responses, "chat"),
+			(InputFormat::Gemini, "chat"),
+			(InputFormat::Embeddings, "embeddings"),
+		] {
+			for has_response in [false, true] {
+				let (mut log, registry) = test_request_log_with_registry();
+				let mut request = metric_test_llm_request();
+				request.input_format = format;
+				log.llm_request = Some(request.clone());
+				if has_response {
+					log.llm_response.store(Some(llm::LLMInfo::new(
+						request,
+						llm::LLMResponse {
+							input_tokens: Some(10),
+							..Default::default()
+						},
+					)));
+					log.status = Some(http::StatusCode::OK);
+				} else {
+					log.error = Some("connection failed".to_string());
+				}
+				drop(DropOnLog::from(log));
+				let encoded = encoded_metrics(&registry);
+				let counts: Vec<_> = encoded
+					.lines()
+					.filter(|line| {
+						line.starts_with("gen_ai_server_request_duration_count")
+							|| line.starts_with("gen_ai_client_token_usage_count")
+					})
+					.collect();
+				assert_eq!(counts.len(), if has_response { 2 } else { 1 });
+				for count in counts {
+					assert!(
+						count.contains(&format!("gen_ai_operation_name=\"{operation}\"")),
+						"{count}"
+					);
+				}
 			}
 		}
 	}
@@ -3153,7 +3196,7 @@ mod tests {
 			.lines()
 			.find(|line| line.starts_with("gen_ai_server_request_duration_count"))
 			.unwrap_or_else(|| panic!("no GenAI request duration count in:\n{encoded}"));
-		assert!(duration_count.contains("error_type=\"500\""));
+		assert!(duration_count.contains("error_type=\"_OTHER\""));
 		for token_line in encoded
 			.lines()
 			.filter(|line| line.starts_with("gen_ai_client_token_usage"))

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -42,8 +42,9 @@ use crate::llm::catalog::{CostLookupStatus, ModelCatalog};
 use crate::mcp::{MCPInfo, MCPOperation};
 use crate::proxy::{ProxyResponseReason, dtrace};
 use crate::telemetry::metrics::{
-	CostCatalogLookupLabels, GenAILabels, GenAILabelsTokenUsage, HTTPLabels, MCPCall, Metrics,
-	OutboundCallLabels, RouteIdentifier, SubstrateRouteLabels,
+	CostCatalogLookupLabels, ErrorTypeLabel, GenAILabels, GenAILabelsTokenUsage,
+	GenAIRequestDurationLabels, HTTPLabels, MCPCall, Metrics, OutboundCallLabels, RouteIdentifier,
+	SubstrateRouteLabels,
 };
 use crate::telemetry::trc::TraceParent;
 use crate::telemetry::{log_store, semconv, trc};
@@ -897,15 +898,41 @@ impl DropOnLog {
 		llm_response: Option<&LLMContext>,
 		custom_metric_fields: &CustomField,
 	) {
+		let request = log.llm_request.as_ref();
+		let Some(provider) = llm_response
+			.map(|response| response.provider.clone())
+			.or_else(|| request.map(|request| request.provider.clone()))
+		else {
+			return;
+		};
+		let request_model = llm_response
+			.map(|response| response.request_model.clone())
+			.or_else(|| request.map(|request| request.request_model.clone()));
+		let gen_ai_labels = Arc::new(GenAILabels {
+			gen_ai_operation_name: strng::literal!("chat").into(),
+			gen_ai_system: provider.into(),
+			gen_ai_request_model: request_model.into(),
+			gen_ai_response_model: llm_response
+				.and_then(|response| response.response_model.clone())
+				.into(),
+			custom: custom_metric_fields.clone(),
+			route: route_identifier.clone(),
+		});
+
+		log
+			.metrics
+			.gen_ai_request_duration
+			.get_or_create(&GenAIRequestDurationLabels {
+				common: gen_ai_labels.clone().into(),
+				error: request_error_type(log, true)
+					.map(|error_type| ErrorTypeLabel {
+						error_type: error_type.into(),
+					})
+					.into(),
+			})
+			.observe(duration.as_secs_f64());
+
 		if let Some(llm_response) = llm_response {
-			let gen_ai_labels = Arc::new(GenAILabels {
-				gen_ai_operation_name: strng::literal!("chat").into(),
-				gen_ai_system: llm_response.provider.clone().into(),
-				gen_ai_request_model: llm_response.request_model.clone().into(),
-				gen_ai_response_model: llm_response.response_model.clone().into(),
-				custom: custom_metric_fields.clone(),
-				route: route_identifier.clone(),
-			});
 			if let Some(status) = llm_response.cost_status {
 				log
 					.metrics
@@ -985,11 +1012,6 @@ impl DropOnLog {
 					})
 					.observe(cwt as f64)
 			}
-			log
-				.metrics
-				.gen_ai_request_duration
-				.get_or_create(&gen_ai_labels)
-				.observe(duration.as_secs_f64());
 			if let Some(ttft) = llm_response
 				.time_to_first_token
 				.and_then(|duration| duration.0.to_std().ok())
@@ -1336,6 +1358,26 @@ pub struct RequestLog {
 
 fn request_log_level(error: Option<&str>) -> &'static str {
 	if error.is_some() { "error" } else { "info" }
+}
+
+pub(crate) fn request_error_type(
+	request: &RequestLog,
+	include_http_client_errors: bool,
+) -> Option<String> {
+	if request.error.is_some() {
+		return Some(
+			request
+				.reason
+				.map(|reason| reason.to_string())
+				.unwrap_or_else(|| "_OTHER".to_string()),
+		);
+	}
+	request
+		.status
+		.filter(|status| {
+			status.is_server_error() || (include_http_client_errors && status.is_client_error())
+		})
+		.map(|status| status.as_u16().to_string())
 }
 
 impl Drop for DropOnLog {
@@ -2755,6 +2797,7 @@ mod tests {
 	use opentelemetry::trace::SpanKind;
 	use opentelemetry_sdk::error::OTelSdkResult;
 	use opentelemetry_sdk::trace::{SimpleSpanProcessor, SpanData, SpanExporter};
+	use prometheus_client::encoding::text::encode;
 	use prometheus_client::registry::Registry;
 
 	use super::*;
@@ -2841,10 +2884,6 @@ mod tests {
 		)
 	}
 
-	fn test_request_log() -> RequestLog {
-		test_request_log_with_registry().0
-	}
-
 	fn test_request_log_with_registry() -> (RequestLog, Registry) {
 		let cel = CelLogging {
 			cel_context: crate::cel::ContextBuilder::new(),
@@ -2874,6 +2913,30 @@ mod tests {
 			},
 		);
 		(log, registry)
+	}
+
+	fn test_request_log() -> RequestLog {
+		test_request_log_with_registry().0
+	}
+
+	fn metric_test_llm_request() -> llm::LLMRequest {
+		llm::LLMRequest {
+			input_tokens: None,
+			input_format: llm::InputFormat::Responses,
+			cache_convention: Default::default(),
+			request_model: "test-model".into(),
+			provider: "test-provider".into(),
+			streaming: false,
+			params: Default::default(),
+			prompt: None,
+			provider_state: None,
+		}
+	}
+
+	fn encoded_metrics(registry: &Registry) -> String {
+		let mut encoded = String::new();
+		encode(&mut encoded, registry).unwrap();
+		encoded
 	}
 
 	#[test]
@@ -2993,6 +3056,113 @@ mod tests {
 		let mut context = LLMContext::from(request);
 		context.completion = Some(vec!["world".to_string()]);
 		context
+	}
+
+	#[test]
+	fn gen_ai_request_duration_records_success_and_failure_outcomes() {
+		for (status, error, reason, expected_error_type) in [
+			(http::StatusCode::OK, None, None, None),
+			(
+				http::StatusCode::TOO_MANY_REQUESTS,
+				None,
+				Some(ProxyResponseReason::Upstream),
+				Some("429"),
+			),
+			(
+				http::StatusCode::INTERNAL_SERVER_ERROR,
+				None,
+				Some(ProxyResponseReason::Upstream),
+				Some("500"),
+			),
+			(
+				http::StatusCode::BAD_GATEWAY,
+				Some("connection failed"),
+				Some(ProxyResponseReason::UpstreamFailure),
+				Some("UpstreamFailure"),
+			),
+			(
+				http::StatusCode::INTERNAL_SERVER_ERROR,
+				Some("unclassified failure"),
+				None,
+				Some("_OTHER"),
+			),
+		] {
+			let (mut log, registry) = test_request_log_with_registry();
+			log.status = Some(status);
+			log.error = error.map(str::to_string);
+			log.reason = reason;
+			log.llm_request = Some(metric_test_llm_request());
+
+			drop(DropOnLog::from(log));
+
+			let encoded = encoded_metrics(&registry);
+			let count = encoded
+				.lines()
+				.find(|line| line.starts_with("gen_ai_server_request_duration_count"))
+				.unwrap_or_else(|| panic!("no GenAI request duration count in:\n{encoded}"));
+			match expected_error_type {
+				Some(expected) => assert!(
+					count.contains(&format!("error_type=\"{expected}\"")),
+					"expected error.type {expected} in: {count}"
+				),
+				None => assert!(
+					!count.contains("error_type="),
+					"successful request unexpectedly has error.type: {count}"
+				),
+			}
+		}
+	}
+
+	#[test]
+	fn gen_ai_request_duration_requires_a_recognized_llm_operation() {
+		let (mut log, registry) = test_request_log_with_registry();
+		log.status = Some(http::StatusCode::BAD_GATEWAY);
+		log.error = Some("connection failed".to_string());
+		log.reason = Some(ProxyResponseReason::UpstreamFailure);
+
+		drop(DropOnLog::from(log));
+
+		let encoded = encoded_metrics(&registry);
+		assert!(
+			!encoded
+				.lines()
+				.any(|line| line.starts_with("gen_ai_server_request_duration_count")),
+			"non-GenAI request emitted a GenAI duration observation:\n{encoded}"
+		);
+	}
+
+	#[test]
+	fn gen_ai_error_type_is_specific_to_request_duration() {
+		let (mut log, registry) = test_request_log_with_registry();
+		let request = metric_test_llm_request();
+		let response = llm::LLMResponse {
+			input_tokens: Some(10),
+			output_tokens: Some(5),
+			..Default::default()
+		};
+		log.status = Some(http::StatusCode::INTERNAL_SERVER_ERROR);
+		log.llm_request = Some(request.clone());
+		log
+			.llm_response
+			.store(Some(llm::LLMInfo::new(request, response)));
+
+		drop(DropOnLog::from(log));
+
+		let encoded = encoded_metrics(&registry);
+		let duration_count = encoded
+			.lines()
+			.find(|line| line.starts_with("gen_ai_server_request_duration_count"))
+			.unwrap_or_else(|| panic!("no GenAI request duration count in:\n{encoded}"));
+		assert!(duration_count.contains("error_type=\"500\""));
+		for token_line in encoded
+			.lines()
+			.filter(|line| line.starts_with("gen_ai_client_token_usage"))
+		{
+			assert!(
+				!token_line.contains("error_type="),
+				"token metric unexpectedly has error.type: {token_line}"
+			);
+		}
 	}
 
 	#[test]

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1367,9 +1367,10 @@ fn gen_ai_operation_failed(request: &RequestLog) -> bool {
 	// A provider 4xx (such as rate limiting) fails the GenAI operation even though
 	// an inbound HTTP server span does not classify client errors as server failures.
 	request.error.is_some()
-		|| request
-			.status
-			.is_some_and(|status| status.is_client_error() || status.is_server_error())
+		|| request.status.is_some_and(|status| {
+			status.is_server_error()
+				|| (status.is_client_error() && request.reason == Some(ProxyResponseReason::Upstream))
+		})
 }
 
 fn gen_ai_operation_name(input_format: InputFormat) -> &'static str {
@@ -3060,6 +3061,25 @@ mod tests {
 		for (status, error, reason, expected_error_type) in [
 			(http::StatusCode::OK, None, None, None),
 			(
+				http::StatusCode::BAD_REQUEST,
+				None,
+				Some(ProxyResponseReason::DirectResponse),
+				None,
+			),
+			(
+				http::StatusCode::TOO_MANY_REQUESTS,
+				None,
+				Some(ProxyResponseReason::DirectResponse),
+				None,
+			),
+			(http::StatusCode::TOO_MANY_REQUESTS, None, None, None),
+			(
+				http::StatusCode::BAD_REQUEST,
+				Some("invalid request"),
+				Some(ProxyResponseReason::InvalidRequest),
+				Some("_OTHER"),
+			),
+			(
 				http::StatusCode::TOO_MANY_REQUESTS,
 				None,
 				Some(ProxyResponseReason::Upstream),
@@ -3107,6 +3127,48 @@ mod tests {
 					"successful request unexpectedly has error.type: {count}"
 				),
 			}
+		}
+	}
+
+	#[test]
+	fn gen_ai_duration_uses_response_policy_replacement_outcome() {
+		use crate::proxy::{ProxyError, ProxyResponse};
+		for direct in [true, false] {
+			let (mut log, registry) = test_request_log_with_registry();
+			log.llm_request = Some(metric_test_llm_request());
+			log.status = Some(http::StatusCode::OK);
+			log.reason = Some(ProxyResponseReason::Upstream);
+			let failure = if direct {
+				ProxyResponse::DirectResponse(Box::new(
+					::http::Response::builder()
+						.status(http::StatusCode::TOO_MANY_REQUESTS)
+						.body(crate::http::Body::empty())
+						.unwrap(),
+				))
+			} else {
+				ProxyError::ProcessingString("response policy failed".to_string()).into()
+			};
+			let expected_reason = failure.as_reason();
+			let response = crate::proxy::httpproxy::response_policy_failure(&mut log, failure, false);
+			assert_eq!(log.reason, Some(expected_reason));
+			assert_ne!(log.reason, Some(ProxyResponseReason::Upstream));
+			assert_eq!(log.status, Some(response.status()));
+			assert_eq!(log.error.is_some(), !direct);
+			assert_eq!(
+				response
+					.extensions()
+					.get::<cel::ProxyContext>()
+					.and_then(|context| context.error.as_ref())
+					.is_some(),
+				!direct
+			);
+			drop(DropOnLog::from(log));
+			let encoded = encoded_metrics(&registry);
+			let count = encoded
+				.lines()
+				.find(|line| line.starts_with("gen_ai_server_request_duration_count"))
+				.unwrap();
+			assert_eq!(count.contains("error_type=\"_OTHER\""), !direct, "{count}");
 		}
 	}
 

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 
 use agent_core::metrics::{
 	CustomField, DefaultedUnknown, EncodeArc, EncodeDebug, EncodeDisplay, MetricRegistry,
+	OptionallyEncode,
 };
 use agent_core::strng::RichStrng;
 use agent_core::version;
@@ -125,6 +126,20 @@ pub struct GenAILabelsTokenUsage {
 
 	#[prometheus(flatten)]
 	pub common: EncodeArc<GenAILabels>,
+}
+
+#[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
+pub struct ErrorTypeLabel {
+	pub error_type: RichStrng,
+}
+
+#[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
+pub struct GenAIRequestDurationLabels {
+	#[prometheus(flatten)]
+	pub common: EncodeArc<GenAILabels>,
+
+	#[prometheus(flatten)]
+	pub error: OptionallyEncode<ErrorTypeLabel>,
 }
 
 #[derive(Clone, Hash, Default, Debug, PartialEq, Eq, EncodeLabelSet)]
@@ -280,7 +295,7 @@ pub struct Metrics {
 
 	pub gen_ai_token_usage: Histogram<GenAILabelsTokenUsage>,
 	pub gen_ai_cost: Family<GenAILabels, counter::Counter<f64>>,
-	pub gen_ai_request_duration: Histogram<GenAILabels>,
+	pub gen_ai_request_duration: Histogram<GenAIRequestDurationLabels>,
 	pub gen_ai_time_per_output_token: Histogram<GenAILabels>,
 	pub gen_ai_time_to_first_token: Histogram<GenAILabels>,
 	pub gen_ai_inter_chunk_latency: Histogram<GenAILabels>,
@@ -405,7 +420,6 @@ impl Metrics {
 			gen_ai_cost.clone(),
 		);
 
-		// TODO: add error attribute if it ends with an error
 		let gen_ai_request_duration = histogram_family(histogram_mode, &REQUEST_DURATION_BUCKET);
 		registry.register(
 			"gen_ai_server_request_duration",

--- a/crates/agentgateway/src/telemetry/metrics.rs
+++ b/crates/agentgateway/src/telemetry/metrics.rs
@@ -130,7 +130,23 @@ pub struct GenAILabelsTokenUsage {
 
 #[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
 pub struct ErrorTypeLabel {
-	pub error_type: RichStrng,
+	pub error_type: GenAIErrorType,
+}
+
+#[derive(Clone, Hash, Debug, PartialEq, Eq)]
+pub enum GenAIErrorType {
+	Other,
+}
+
+impl prometheus_client::encoding::EncodeLabelValue for GenAIErrorType {
+	fn encode(
+		&self,
+		encoder: &mut prometheus_client::encoding::LabelValueEncoder,
+	) -> Result<(), std::fmt::Error> {
+		match self {
+			Self::Other => "_OTHER".encode(encoder),
+		}
+	}
 }
 
 #[derive(Clone, Hash, Debug, PartialEq, Eq, EncodeLabelSet)]
@@ -423,7 +439,7 @@ impl Metrics {
 		let gen_ai_request_duration = histogram_family(histogram_mode, &REQUEST_DURATION_BUCKET);
 		registry.register(
 			"gen_ai_server_request_duration",
-			"Duration of generative AI request",
+			"Duration of a generative AI request in seconds; failed operations have error_type=\"_OTHER\" and successful operations omit the label",
 			gen_ai_request_duration.clone(),
 		);
 

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -16,7 +16,7 @@ use opentelemetry_sdk::trace::{
 pub use traceparent::TraceParent;
 
 use crate::cel;
-use crate::telemetry::log::{CelLoggingExecutor, LoggingFields, RequestLog};
+use crate::telemetry::log::{CelLoggingExecutor, LoggingFields, RequestLog, request_error_type};
 use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference, TracingConfig};
 
 #[derive(Clone, Debug)]
@@ -336,19 +336,10 @@ impl Tracer {
 }
 
 fn request_span_status(request: &RequestLog, attributes: &mut Vec<KeyValue>) -> Status {
-	let (error_type, description) = if let Some(error) = &request.error {
-		(
-			request
-				.reason
-				.map(|reason| reason.to_string())
-				.unwrap_or_else(|| "_OTHER".to_string()),
-			error.clone(),
-		)
-	} else if let Some(status) = request.status.filter(http::StatusCode::is_server_error) {
-		(status.as_u16().to_string(), String::new())
-	} else {
+	let Some(error_type) = request_error_type(request, false) else {
 		return Status::default();
 	};
+	let description = request.error.clone().unwrap_or_default();
 
 	if !attributes
 		.iter()

--- a/crates/agentgateway/src/telemetry/trc.rs
+++ b/crates/agentgateway/src/telemetry/trc.rs
@@ -16,7 +16,7 @@ use opentelemetry_sdk::trace::{
 pub use traceparent::TraceParent;
 
 use crate::cel;
-use crate::telemetry::log::{CelLoggingExecutor, LoggingFields, RequestLog, request_error_type};
+use crate::telemetry::log::{CelLoggingExecutor, LoggingFields, RequestLog};
 use crate::types::agent::{BackendTrafficPolicy, SimpleBackendReference, TracingConfig};
 
 #[derive(Clone, Debug)]
@@ -336,10 +336,19 @@ impl Tracer {
 }
 
 fn request_span_status(request: &RequestLog, attributes: &mut Vec<KeyValue>) -> Status {
-	let Some(error_type) = request_error_type(request, false) else {
+	let (error_type, description) = if let Some(error) = &request.error {
+		(
+			request
+				.reason
+				.map(|reason| reason.to_string())
+				.unwrap_or_else(|| "_OTHER".to_string()),
+			error.clone(),
+		)
+	} else if let Some(status) = request.status.filter(http::StatusCode::is_server_error) {
+		(status.as_u16().to_string(), String::new())
+	} else {
 		return Status::default();
 	};
-	let description = request.error.clone().unwrap_or_default();
 
 	if !attributes
 		.iter()

--- a/schema/metrics.md
+++ b/schema/metrics.md
@@ -45,7 +45,7 @@
 | `agentgateway_gen_ai_client_cost_usd_total` | Counter | usd | Cumulative USD cost of generative AI requests. |
 | `agentgateway_gen_ai_client_token_usage` | Histogram | — | Number of tokens used per request. |
 | `agentgateway_gen_ai_server_inter_chunk_latency` | Histogram | — | Time between consecutive output chunks for a given request. |
-| `agentgateway_gen_ai_server_request_duration` | Histogram | — | Duration of generative AI request. |
+| `agentgateway_gen_ai_server_request_duration` | Histogram | seconds | Duration of a generative AI request. Failed requests include a bounded `error_type` label (HTTP status code, gateway failure reason, or `_OTHER`); successful requests omit the label. |
 | `agentgateway_gen_ai_server_time_per_output_token` | Histogram | — | Time to generate each output token for a given request. |
 | `agentgateway_gen_ai_server_time_to_first_token` | Histogram | — | Time to generate the first token for a given request. |
 | `agentgateway_guardrail_checks_total` | Counter | — | Total number of guardrail checks. |

--- a/schema/metrics.md
+++ b/schema/metrics.md
@@ -45,7 +45,7 @@
 | `agentgateway_gen_ai_client_cost_usd_total` | Counter | usd | Cumulative USD cost of generative AI requests. |
 | `agentgateway_gen_ai_client_token_usage` | Histogram | — | Number of tokens used per request. |
 | `agentgateway_gen_ai_server_inter_chunk_latency` | Histogram | — | Time between consecutive output chunks for a given request. |
-| `agentgateway_gen_ai_server_request_duration` | Histogram | seconds | Duration of a generative AI request. Failed requests include a bounded `error_type` label (HTTP status code, gateway failure reason, or `_OTHER`); successful requests omit the label. |
+| `agentgateway_gen_ai_server_request_duration` | Histogram | — | Duration of a generative AI request in seconds; failed operations have error_type="_OTHER" and successful operations omit the label. |
 | `agentgateway_gen_ai_server_time_per_output_token` | Histogram | — | Time to generate each output token for a given request. |
 | `agentgateway_gen_ai_server_time_to_first_token` | Histogram | — | Time to generate the first token for a given request. |
 | `agentgateway_guardrail_checks_total` | Counter | — | Total number of guardrail checks. |


### PR DESCRIPTION
Recognized GenAI requests currently lose their duration observation when transport fails before a provider response arrives. Record these durations and split failed operations into a single `error_type="_OTHER"` series, with the label omitted on success. Provider 4xx/5xx responses and recorded gateway errors count as failures.

Part of #3296.

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
