### PR TITLE
fix(mcp): align Entra AS metadata endpoints with issuer path for RFC 8414 compliance

### DIFF
--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -93,12 +93,13 @@ pub(crate) async fn handle_mcp_request(
 			))
 		},
 		// Entra rejects the RFC 8707 `resource` parameter (AADSTS9010010), so the gateway
-		// advertises proxied authorization/token endpoints (under the served AS metadata path)
-		// that strip it before forwarding to Entra.
+		// advertises proxied authorization/token endpoints that strip it before forwarding to Entra.
+		// These endpoints can be under either the well-known AS metadata path or the issuer path.
 		path
 			if matches!(auth.provider, Some(McpIDP::Entra {}))
-				&& path.starts_with("/.well-known/oauth-authorization-server/")
-				&& path.ends_with("/authorize") =>
+				&& path.ends_with("/authorize")
+				&& (path.starts_with("/.well-known/oauth-authorization-server/")
+					|| !path.starts_with("/.well-known/")) =>
 		{
 			Ok(Some(
 				entra_authorize(req, auth)
@@ -111,8 +112,9 @@ pub(crate) async fn handle_mcp_request(
 		},
 		path
 			if matches!(auth.provider, Some(McpIDP::Entra {}))
-				&& path.starts_with("/.well-known/oauth-authorization-server/")
-				&& path.ends_with("/token") =>
+				&& path.ends_with("/token")
+				&& (path.starts_with("/.well-known/oauth-authorization-server/")
+					|| !path.starts_with("/.well-known/")) =>
 		{
 			Ok(Some(
 				entra_token(req, auth, client.clone())
@@ -430,7 +432,12 @@ pub(super) async fn authorization_server_metadata(
 			}
 		},
 		Some(McpIDP::Entra {}) => {
-			let current_uri = request_uri_for_oauth_metadata(req);
+			// Use the issuer (resource path) for constructing endpoints to ensure
+			// consistency between the issuer field and the endpoint URLs.
+			// This fixes RFC 8414 §3.3 issuer validation in strict MCP clients
+			// (e.g. GitHub Copilot CLI with typescript-sdk >= 2026-07-28).
+			let issuer = issuer_from_authorization_server_metadata_request(req)
+				.unwrap_or_else(|| request_uri_for_oauth_metadata(req).to_string());
 
 			// Entra rejects the RFC 8707 `resource` parameter (AADSTS9010010). Advertise
 			// gateway-proxied authorization/token endpoints that strip it before forwarding.
@@ -441,14 +448,14 @@ pub(super) async fn authorization_server_metadata(
 					"authorization_endpoint missing".to_string(),
 				));
 			};
-			*ae = format!("{current_uri}/authorize");
+			*ae = format!("{issuer}/authorize");
 			let Some(serde_json::Value::String(te)) = json::traverse_mut(&mut resp, &["token_endpoint"])
 			else {
 				return Err(ProxyError::ProcessingString(
 					"token_endpoint missing".to_string(),
 				));
 			};
-			*te = format!("{current_uri}/token");
+			*te = format!("{issuer}/token");
 
 			if let Some(obj) = resp.as_object_mut() {
 				// Entra does not implement RFC 7591 (no registration_endpoint in its metadata);
@@ -456,7 +463,7 @@ pub(super) async fn authorization_server_metadata(
 				// configured clientId.
 				obj.insert(
 					"registration_endpoint".to_string(),
-					serde_json::Value::String(format!("{current_uri}/client-registration")),
+					serde_json::Value::String(format!("{issuer}/client-registration")),
 				);
 				// Entra supports PKCE (S256) but omits it from its discovery document; MCP
 				// clients require it to be advertised.
@@ -876,6 +883,87 @@ mod tests {
 				"https://gateway.example.com/example/mcp"
 			);
 		}
+	}
+
+	#[test]
+	fn entra_metadata_endpoints_match_issuer_path() {
+		// RFC 8414 §3.3 requires the issuer in AS metadata to match the issuer identifier
+		// from authorization_servers. Strict MCP clients (e.g. GitHub Copilot CLI with
+		// typescript-sdk >= 2026-07-28) validate this. The endpoint URLs advertised in
+		// AS metadata must be consistent with the issuer to avoid client-side validation
+		// failures and ensure the endpoints are reachable under the issuer's authority.
+		let auth = entra_auth();
+		let req = ::http::Request::builder()
+			.uri("https://gateway.example.com/.well-known/oauth-authorization-server/entra/mcp")
+			.body(Body::empty())
+			.expect("request should build");
+
+		// Simulate Entra's OIDC discovery response
+		let mut metadata = serde_json::json!({
+			"issuer": "https://login.microsoftonline.com/tenant-id/v2.0",
+			"authorization_endpoint": "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/authorize",
+			"token_endpoint": "https://login.microsoftonline.com/tenant-id/oauth2/v2.0/token",
+		});
+
+		// Apply the same transformations as authorization_server_metadata
+		let issuer =
+			issuer_from_authorization_server_metadata_request(&req).expect("issuer should be extracted");
+
+		// Rewrite endpoints
+		if let Some(ae) = metadata["authorization_endpoint"].as_str() {
+			let _ = ae;
+			metadata["authorization_endpoint"] = serde_json::Value::String(format!("{issuer}/authorize"));
+		}
+		if let Some(te) = metadata["token_endpoint"].as_str() {
+			let _ = te;
+			metadata["token_endpoint"] = serde_json::Value::String(format!("{issuer}/token"));
+		}
+		if let Some(obj) = metadata.as_object_mut() {
+			obj.insert(
+				"registration_endpoint".to_string(),
+				serde_json::Value::String(format!("{issuer}/client-registration")),
+			);
+		}
+
+		// Rewrite issuer
+		rewrite_authorization_server_issuer(&req, &auth, &mut metadata)
+			.expect("issuer should be rewritten");
+
+		// Verify: issuer and endpoints should all be under the same base path
+		let expected_base = "https://gateway.example.com/entra/mcp";
+		assert_eq!(metadata["issuer"], expected_base);
+		assert_eq!(
+			metadata["authorization_endpoint"],
+			"https://gateway.example.com/entra/mcp/authorize"
+		);
+		assert_eq!(
+			metadata["token_endpoint"],
+			"https://gateway.example.com/entra/mcp/token"
+		);
+		assert_eq!(
+			metadata["registration_endpoint"],
+			"https://gateway.example.com/entra/mcp/client-registration"
+		);
+
+		// Verify: endpoints should be under the issuer path (consistent with RFC 8414)
+		assert!(
+			metadata["authorization_endpoint"]
+				.as_str()
+				.unwrap()
+				.starts_with(metadata["issuer"].as_str().unwrap())
+		);
+		assert!(
+			metadata["token_endpoint"]
+				.as_str()
+				.unwrap()
+				.starts_with(metadata["issuer"].as_str().unwrap())
+		);
+		assert!(
+			metadata["registration_endpoint"]
+				.as_str()
+				.unwrap()
+				.starts_with(metadata["issuer"].as_str().unwrap())
+		);
 	}
 
 	#[test]

--- a/examples/mcp-authentication/config.yaml
+++ b/examples/mcp-authentication/config.yaml
@@ -309,9 +309,11 @@ binds:
             #         resourceDocumentation: http://localhost:3000/authentik/docs
             #         resourcePolicyUri: http://localhost:3000/authentik/policies
             # Example configuration for Microsoft Entra ID (Azure AD):
-            # Note the pathPrefix match on the authorization-server path: the gateway serves
-            # /authorize, /token, and /client-registration endpoints beneath it to adapt
+            # The gateway serves /authorize, /token, and /client-registration endpoints
+            # under both the well-known AS metadata path and the issuer path to adapt
             # Entra (strip the RFC 8707 `resource` param, short-circuit DCR).
+            # Note: use pathPrefix on /entra/mcp to also match the issuer-path endpoints
+            # (e.g. /entra/mcp/authorize) advertised in AS metadata for RFC 8414 compliance.
             # - backends:
             #   - mcp:
             #       targets:
@@ -322,7 +324,7 @@ binds:
             #           cmd: npx
             #   matches:
             #   - path:
-            #       exact: /entra/mcp
+            #       pathPrefix: /entra/mcp
             #   - path:
             #       exact: /.well-known/oauth-protected-resource/entra/mcp
             #   - path:


### PR DESCRIPTION
## Description

Fixes #3080

The Entra AS metadata bridging advertises `authorization_endpoint`, `token_endpoint`, and `registration_endpoint` under the full well-known URL path (e.g. `/.well-known/oauth-authorization-server/entra/mcp/authorize`), while the `issuer` field uses the resource path (`/entra/mcp`). This inconsistency causes strict MCP clients (e.g. GitHub Copilot CLI with typescript-sdk >= 2026-07-28) to fail RFC 8414 §3.3 issuer validation.

## Changes

- Use the issuer (resource path) instead of the full well-known URL when constructing Entra endpoint URLs in AS metadata
- Update route matching in `handle_mcp_request` to handle both well-known and issuer-path endpoints for `/authorize` and `/token`
- Add test `entra_metadata_endpoints_match_issuer_path` to verify endpoint/issuer path consistency
- Update example config to use `pathPrefix` for `/entra/mcp` to match new endpoints

## Testing

- All existing tests pass
- New test verifies RFC 8414 compliance for Entra metadata

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
