### PR TITLE
 substrate: emit ate.actor.uid and ate.router.route.duration

### DIFF
--- a/crates/agentgateway/src/http/substrate/ateattr.rs
+++ b/crates/agentgateway/src/http/substrate/ateattr.rs
@@ -9,6 +9,7 @@ use std::fmt::{Display, Formatter};
 /// The atespace-scoped addressable name, mirroring `k8s.pod.name`. Upstream has deliberately no
 /// `ate.actor.id`: it is ambiguous once an actor has both a name and a uid.
 pub(crate) const ATE_ACTOR_NAME: &str = "ate.actor.name";
+pub(crate) const ATE_ACTOR_UID: &str = "ate.actor.uid";
 pub(crate) const ATE_ATESPACE: &str = "ate.atespace";
 pub(crate) const ATE_ROUTER_RESUME: &str = "ate.router.resume";
 
@@ -60,6 +61,7 @@ mod tests {
 		assert_eq!(super::ATE_ROUTER_RESUME, "ate.router.resume");
 		assert_eq!(super::ATE_ATESPACE, "ate.atespace");
 		assert_eq!(super::ATE_ACTOR_NAME, "ate.actor.name");
+		assert_eq!(super::ATE_ACTOR_UID, "ate.actor.uid");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/http/substrate/ateattr.rs
+++ b/crates/agentgateway/src/http/substrate/ateattr.rs
@@ -6,6 +6,9 @@
 
 use std::fmt::{Display, Formatter};
 
+/// The atespace-scoped addressable name, mirroring `k8s.pod.name`. Upstream has deliberately no
+/// `ate.actor.id`: it is ambiguous once an actor has both a name and a uid.
+pub(crate) const ATE_ACTOR_NAME: &str = "ate.actor.name";
 pub(crate) const ATE_ATESPACE: &str = "ate.atespace";
 pub(crate) const ATE_ROUTER_RESUME: &str = "ate.router.resume";
 
@@ -56,6 +59,7 @@ mod tests {
 		assert_eq!(ResumeDisposition::Joined.as_str(), "joined");
 		assert_eq!(super::ATE_ROUTER_RESUME, "ate.router.resume");
 		assert_eq!(super::ATE_ATESPACE, "ate.atespace");
+		assert_eq!(super::ATE_ACTOR_NAME, "ate.actor.name");
 	}
 
 	#[test]

--- a/crates/agentgateway/src/http/substrate/ateattr.rs
+++ b/crates/agentgateway/src/http/substrate/ateattr.rs
@@ -12,6 +12,7 @@ pub(crate) const ATE_ACTOR_NAME: &str = "ate.actor.name";
 pub(crate) const ATE_ACTOR_UID: &str = "ate.actor.uid";
 pub(crate) const ATE_ATESPACE: &str = "ate.atespace";
 pub(crate) const ATE_ROUTER_RESUME: &str = "ate.router.resume";
+pub(crate) const ATE_ROUTER_ROUTE_DURATION: &str = "ate.router.route.duration";
 
 /// Whether this request experienced a cold actor activation.
 ///
@@ -62,6 +63,10 @@ mod tests {
 		assert_eq!(super::ATE_ATESPACE, "ate.atespace");
 		assert_eq!(super::ATE_ACTOR_NAME, "ate.actor.name");
 		assert_eq!(super::ATE_ACTOR_UID, "ate.actor.uid");
+		assert_eq!(
+			super::ATE_ROUTER_ROUTE_DURATION,
+			"ate.router.route.duration"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/http/substrate/egress.rs
+++ b/crates/agentgateway/src/http/substrate/egress.rs
@@ -113,7 +113,7 @@ impl SubstrateEgress {
 			atespace: identity.atespace,
 			name: identity.actor_name,
 		};
-		log.ate_actor_id = Some(actor.name.clone());
+		log.ate_actor_name = Some(actor.name.clone());
 		log.ate_atespace = Some(actor.atespace.clone());
 		let channel = self
 			.target

--- a/crates/agentgateway/src/http/substrate/egress.rs
+++ b/crates/agentgateway/src/http/substrate/egress.rs
@@ -114,6 +114,7 @@ impl SubstrateEgress {
 			name: identity.actor_name,
 		};
 		log.ate_actor_name = Some(actor.name.clone());
+		log.ate_actor_uid = Some(identity.actor_uid.clone());
 		log.ate_atespace = Some(actor.atespace.clone());
 		let channel = self
 			.target

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -92,6 +92,7 @@ struct CachedAssignment {
 	expires_at: Instant,
 	generation: u64,
 	resumed: bool,
+	uid: Option<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -272,7 +273,7 @@ impl SubstrateIngress {
 		&self,
 		client: &PolicyClient,
 		actor: &ActorRef,
-	) -> Result<(SocketAddr, bool), ResumeError> {
+	) -> Result<(SocketAddr, bool, Option<String>), ResumeError> {
 		let budget = self.request_parking.budget();
 		let deadline = tokio::time::Instant::now() + budget;
 		let result = async {
@@ -310,6 +311,10 @@ impl SubstrateIngress {
 								"ResumeActor response did not include an actor".to_owned(),
 							)
 						})?;
+						let uid = actor
+							.metadata
+							.map(|metadata| metadata.uid)
+							.filter(|uid| !uid.is_empty());
 						let assignment = actor
 							.status
 							.and_then(|status| status.worker_assignment)
@@ -327,7 +332,11 @@ impl SubstrateIngress {
 									assignment.worker_pod_ip
 								))
 							})?;
-						return Ok((SocketAddr::new(ip, self.connect_target_port.get()), resumed));
+						return Ok((
+							SocketAddr::new(ip, self.connect_target_port.get()),
+							resumed,
+							uid,
+						));
 					},
 					Ok(Err(status)) if self.retryable_while_parked(status.code()) => {
 						let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
@@ -418,11 +427,12 @@ impl SubstrateIngress {
 					let result = self
 						.resume_actor(client, &actor)
 						.await
-						.map(|(target, resumed)| CachedAssignment {
+						.map(|(target, resumed, uid)| CachedAssignment {
 							target,
 							expires_at: Instant::now() + self.cache_ttl,
 							generation: self.cache.next_generation.fetch_add(1, Ordering::Relaxed),
 							resumed,
+							uid,
 						});
 					let _ = guard.insert(result.clone());
 					match &result {
@@ -460,6 +470,15 @@ impl SubstrateRequestState {
 
 	pub(crate) fn resume_disposition(&self) -> ResumeDisposition {
 		*self.resume.lock().unwrap()
+	}
+
+	pub(crate) fn actor_uid(&self) -> Option<String> {
+		self
+			.current
+			.lock()
+			.unwrap()
+			.as_ref()
+			.and_then(|current| current.uid.clone())
 	}
 
 	/// Policy events describe a single resolution attempt; this describes the request. A

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -152,6 +152,7 @@ pub(crate) struct SubstrateRequestState {
 	client: PolicyClient,
 	current: Arc<Mutex<Option<CachedAssignment>>>,
 	resume: Arc<Mutex<ResumeDisposition>>,
+	route_duration: Arc<Mutex<Duration>>,
 }
 
 fn default_cache_ttl() -> Duration {
@@ -481,11 +482,20 @@ impl SubstrateRequestState {
 			.and_then(|current| current.uid.clone())
 	}
 
+	pub(crate) fn route_duration(&self) -> Duration {
+		*self.route_duration.lock().unwrap()
+	}
+
 	/// Policy events describe a single resolution attempt; this describes the request. A
 	/// stale-assignment retry can therefore log `triggered` while its last event says `none`.
 	fn record_resume(&self, observed: ResumeDisposition) {
 		let mut resume = self.resume.lock().unwrap();
 		*resume = (*resume).max(observed);
+	}
+
+	fn record_route_duration(&self, observed: Duration) {
+		let mut duration = self.route_duration.lock().unwrap();
+		*duration = duration.saturating_add(observed);
 	}
 
 	pub(crate) async fn resolve_target(&self) -> Result<Target, crate::proxy::ProxyResponse> {
@@ -506,7 +516,10 @@ impl SubstrateRequestState {
 			);
 			return Ok(Target::Address(current.target));
 		}
-		match self.ingress.resolve(&self.client, self.actor.clone()).await {
+		let started = tokio::time::Instant::now();
+		let resolution = self.ingress.resolve(&self.client, self.actor.clone()).await;
+		self.record_route_duration(started.elapsed());
+		match resolution {
 			Ok(Resolved {
 				assignment,
 				source,
@@ -672,6 +685,7 @@ impl RequestPolicyTrait for SubstrateIngress {
 			client: client.clone(),
 			current: Arc::new(Mutex::new(None)),
 			resume: Arc::new(Mutex::new(ResumeDisposition::None)),
+			route_duration: Arc::new(Mutex::new(Duration::ZERO)),
 		});
 		Ok(PolicyResponse::default())
 	}

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -635,7 +635,7 @@ impl RequestPolicyTrait for SubstrateIngress {
 			atespace: atespace.to_owned(),
 			name: name.to_owned(),
 		};
-		log.ate_actor_id = Some(actor.name.clone());
+		log.ate_actor_name = Some(actor.name.clone());
 		log.ate_atespace = Some(actor.atespace.clone());
 		// Ordinary atunnel ingress uses this header to select the actor port and
 		// strips it before forwarding. Raw CONNECT carries the port in its

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2307,9 +2307,11 @@ async fn make_backend_call(
 	{
 		let resume = state.resume_disposition().as_str();
 		let actor_uid = state.actor_uid();
+		let route_duration = state.route_duration();
 		log.add(|l| {
 			l.ate_router_resume = Some(resume);
 			l.ate_actor_uid = actor_uid;
+			l.ate_router_route_duration = Some(route_duration);
 		});
 	}
 	substrate_selection?;

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2306,7 +2306,11 @@ async fn make_backend_call(
 		.get::<http::substrate::SubstrateRequestState>()
 	{
 		let resume = state.resume_disposition().as_str();
-		log.add(|l| l.ate_router_resume = Some(resume));
+		let actor_uid = state.actor_uid();
+		log.add(|l| {
+			l.ate_router_resume = Some(resume);
+			l.ate_actor_uid = actor_uid;
+		});
 	}
 	substrate_selection?;
 

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1115,6 +1115,7 @@ impl RequestLog {
 			ate_actor_uid: None,
 			ate_atespace: None,
 			ate_router_resume: None,
+			ate_router_route_duration: None,
 			request_handle: None,
 			request_snapshot: None,
 			response_snapshot: None,
@@ -1294,6 +1295,7 @@ pub struct RequestLog {
 	pub ate_actor_uid: Option<String>,
 	pub ate_atespace: Option<String>,
 	pub ate_router_resume: Option<&'static str>,
+	pub ate_router_route_duration: Option<Duration>,
 
 	pub request_handle: Option<ActiveHandle>,
 	pub request_snapshot: Option<Arc<cel::RequestSnapshot>>,
@@ -1512,6 +1514,9 @@ impl Drop for DropOnLog {
 			}
 
 			let dur = format!("{}ms", duration.as_millis());
+			let route_duration = log
+				.ate_router_route_duration
+				.map(|duration| duration.as_secs_f64());
 			let grpc = log.grpc_status.load();
 
 			let input_tokens = llm_response.as_ref().and_then(|l| l.input_tokens);
@@ -1715,6 +1720,10 @@ impl Drop for DropOnLog {
 				(ateattr::ATE_ACTOR_UID, log.ate_actor_uid.display()),
 				(ateattr::ATE_ATESPACE, log.ate_atespace.display()),
 				(ateattr::ATE_ROUTER_RESUME, log.ate_router_resume.display()),
+				(
+					ateattr::ATE_ROUTER_ROUTE_DURATION,
+					route_duration.map(Into::into),
+				),
 				// OpenTelemetry Gen AI Semantic Conventions v1.40.0
 				(
 					"gen_ai.operation.name",

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1111,7 +1111,7 @@ impl RequestLog {
 			a2a_method: None,
 			a2a_response: None,
 			inference_pool: None,
-			ate_actor_id: None,
+			ate_actor_name: None,
 			ate_atespace: None,
 			ate_router_resume: None,
 			request_handle: None,
@@ -1289,7 +1289,7 @@ pub struct RequestLog {
 
 	pub inference_pool: Option<SocketAddr>,
 
-	pub ate_actor_id: Option<String>,
+	pub ate_actor_name: Option<String>,
 	pub ate_atespace: Option<String>,
 	pub ate_router_resume: Option<&'static str>,
 
@@ -1709,7 +1709,7 @@ impl Drop for DropOnLog {
 					"inferencepool.selected_endpoint",
 					log.inference_pool.display(),
 				),
-				("ate.actor.id", log.ate_actor_id.display()),
+				(ateattr::ATE_ACTOR_NAME, log.ate_actor_name.display()),
 				(ateattr::ATE_ATESPACE, log.ate_atespace.display()),
 				(ateattr::ATE_ROUTER_RESUME, log.ate_router_resume.display()),
 				// OpenTelemetry Gen AI Semantic Conventions v1.40.0

--- a/crates/agentgateway/src/telemetry/log.rs
+++ b/crates/agentgateway/src/telemetry/log.rs
@@ -1112,6 +1112,7 @@ impl RequestLog {
 			a2a_response: None,
 			inference_pool: None,
 			ate_actor_name: None,
+			ate_actor_uid: None,
 			ate_atespace: None,
 			ate_router_resume: None,
 			request_handle: None,
@@ -1290,6 +1291,7 @@ pub struct RequestLog {
 	pub inference_pool: Option<SocketAddr>,
 
 	pub ate_actor_name: Option<String>,
+	pub ate_actor_uid: Option<String>,
 	pub ate_atespace: Option<String>,
 	pub ate_router_resume: Option<&'static str>,
 
@@ -1710,6 +1712,7 @@ impl Drop for DropOnLog {
 					log.inference_pool.display(),
 				),
 				(ateattr::ATE_ACTOR_NAME, log.ate_actor_name.display()),
+				(ateattr::ATE_ACTOR_UID, log.ate_actor_uid.display()),
 				(ateattr::ATE_ATESPACE, log.ate_atespace.display()),
 				(ateattr::ATE_ROUTER_RESUME, log.ate_router_resume.display()),
 				// OpenTelemetry Gen AI Semantic Conventions v1.40.0

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -7,11 +7,14 @@ use tokio::sync::Notify;
 
 use crate::common::prelude::*;
 
+const ACTOR_UID: &str = "6f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f";
+
 #[derive(Clone)]
 struct IngressHandler {
 	pod_ip: String,
 	calls: Arc<AtomicUsize>,
 	resumed: bool,
+	uid: &'static str,
 }
 
 #[derive(Clone)]
@@ -60,13 +63,16 @@ impl ateapimock::Handler for IngressHandler {
 		self.calls.fetch_add(1, Ordering::Relaxed);
 		Ok(ResumeActorResponse {
 			actor: Some(Actor {
+				metadata: Some(ResourceMetadata {
+					uid: self.uid.to_owned(),
+					..Default::default()
+				}),
 				status: Some(ActorStatus {
 					state: 0,
 					worker_assignment: Some(protos::ateapi::WorkerAssignment {
 						worker_pod_ip: self.pod_ip.clone(),
 					}),
 				}),
-				..Default::default()
 			}),
 			resumed: self.resumed,
 		})
@@ -91,6 +97,7 @@ struct SelectiveParkingHandler {
 	release: Arc<Notify>,
 	calls: Arc<AtomicUsize>,
 	resumed: bool,
+	uid: &'static str,
 }
 
 #[async_trait::async_trait]
@@ -107,13 +114,16 @@ impl ateapimock::Handler for SelectiveParkingHandler {
 		}
 		Ok(ResumeActorResponse {
 			actor: Some(Actor {
+				metadata: Some(ResourceMetadata {
+					uid: self.uid.to_owned(),
+					..Default::default()
+				}),
 				status: Some(ActorStatus {
 					state: 0,
 					worker_assignment: Some(protos::ateapi::WorkerAssignment {
 						worker_pod_ip: self.pod_ip.clone(),
 					}),
 				}),
-				..Default::default()
 			}),
 			resumed: self.resumed,
 		})
@@ -165,6 +175,7 @@ async fn actor_ingress_resolves_the_dynamic_backend() {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
 			resumed: true,
+			uid: ACTOR_UID,
 		}
 	})
 	.spawn()
@@ -326,6 +337,7 @@ async fn actor_ingress_keeps_cached_actor_available_when_parking_is_full() {
 			release: release.clone(),
 			calls: calls.clone(),
 			resumed: true,
+			uid: ACTOR_UID,
 		}
 	})
 	.spawn()
@@ -389,6 +401,12 @@ async fn assert_logged_resume(path: &str, want: &str) {
 	.unwrap();
 }
 
+async fn find_request_log(path: &str) -> Value {
+	agent_core::telemetry::testing::eventually_find(&[("scope", "request"), ("http.path", path)])
+		.await
+		.unwrap()
+}
+
 fn actor_url(actor: &str, path: &str) -> String {
 	format!("http://{actor}.demo.actors.resources.substrate.ate.dev{path}")
 }
@@ -426,6 +444,7 @@ async fn actor_ingress_reports_a_triggered_resume_as_a_cold_start() {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
 			resumed: true,
+			uid: ACTOR_UID,
 		}
 	})
 	.spawn()
@@ -471,6 +490,7 @@ async fn actor_ingress_reports_no_resume_when_the_actor_is_already_running() {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
 			resumed: false,
+			uid: ACTOR_UID,
 		}
 	})
 	.spawn()
@@ -501,6 +521,7 @@ async fn actor_ingress_reports_no_resume_for_a_cache_hit_after_a_cold_start() {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
 			resumed: true,
+			uid: ACTOR_UID,
 		}
 	})
 	.spawn()
@@ -527,6 +548,120 @@ async fn actor_ingress_reports_no_resume_for_a_cache_hit_after_a_cold_start() {
 }
 
 #[tokio::test]
+async fn actor_ingress_logs_the_actor_uid_on_a_cold_start() {
+	const PATH: &str = "/actor-uid-cold";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || IngressHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+			resumed: true,
+			uid: ACTOR_UID,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let response = send_request(
+		gateway.serve_http(BIND_KEY),
+		Method::GET,
+		&actor_url("my-actor", PATH),
+	)
+	.await;
+	assert_eq!(response.status(), StatusCode::OK);
+	assert_eq!(calls.load(Ordering::Relaxed), 1);
+
+	let log = find_request_log(PATH).await;
+	assert_eq!(log["ate.actor.uid"].as_str(), Some(ACTOR_UID), "{log:#?}");
+}
+
+#[tokio::test]
+async fn actor_ingress_logs_the_actor_uid_from_the_assignment_cache() {
+	const COLD_PATH: &str = "/actor-uid-cache-cold";
+	const WARM_PATH: &str = "/actor-uid-cache-warm";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || IngressHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+			resumed: true,
+			uid: ACTOR_UID,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	for path in [COLD_PATH, WARM_PATH] {
+		let response = send_request(
+			gateway.serve_http(BIND_KEY),
+			Method::GET,
+			&actor_url("my-actor", path),
+		)
+		.await;
+		assert_eq!(response.status(), StatusCode::OK);
+	}
+
+	assert_eq!(
+		calls.load(Ordering::Relaxed),
+		1,
+		"the second request must be served from the assignment cache"
+	);
+	for path in [COLD_PATH, WARM_PATH] {
+		let log = find_request_log(path).await;
+		assert_eq!(
+			log["ate.actor.uid"].as_str(),
+			Some(ACTOR_UID),
+			"{path}: {log:#?}"
+		);
+	}
+}
+
+#[tokio::test]
+async fn actor_ingress_logs_actor_identity_under_the_upstream_spellings() {
+	const PATH: &str = "/actor-identity-spelling";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || IngressHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+			resumed: true,
+			uid: ACTOR_UID,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let response = send_request(
+		gateway.serve_http(BIND_KEY),
+		Method::GET,
+		&actor_url("my-actor", PATH),
+	)
+	.await;
+	assert_eq!(response.status(), StatusCode::OK);
+
+	let log = find_request_log(PATH).await;
+	assert_eq!(log["ate.actor.name"].as_str(), Some("my-actor"), "{log:#?}");
+	assert_eq!(log["ate.actor.uid"].as_str(), Some(ACTOR_UID), "{log:#?}");
+	assert_eq!(log["ate.atespace"].as_str(), Some("demo"), "{log:#?}");
+	assert!(
+		log.get("ate.actor.id").is_none(),
+		"ate.actor.id was renamed to ate.actor.name: {log:#?}"
+	);
+}
+
+#[tokio::test]
 async fn actor_ingress_reports_a_joined_resume_for_a_follower_on_an_in_flight_resume() {
 	const LEADER_PATH: &str = "/resume-join-leader";
 	const FOLLOWER_PATH: &str = "/resume-join-follower";
@@ -546,6 +681,7 @@ async fn actor_ingress_reports_a_joined_resume_for_a_follower_on_an_in_flight_re
 			release: release.clone(),
 			calls: calls.clone(),
 			resumed: true,
+			uid: ACTOR_UID,
 		}
 	})
 	.spawn()
@@ -639,6 +775,7 @@ async fn actor_ingress_uses_the_original_connect_authority() {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
 			resumed: true,
+			uid: ACTOR_UID,
 		}
 	})
 	.spawn()
@@ -753,6 +890,7 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 			pod_ip: pod_ip.clone(),
 			calls: calls.clone(),
 			resumed: true,
+			uid: ACTOR_UID,
 		}
 	})
 	.spawn()

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -401,6 +401,17 @@ async fn assert_logged_resume(path: &str, want: &str) {
 	.unwrap();
 }
 
+fn logged_route_duration(log: &Value) -> f64 {
+	let duration = &log["ate.router.route.duration"];
+	assert!(
+		duration.as_str().is_none(),
+		"the route duration must be a number, not a formatted string: {log:#?}"
+	);
+	duration
+		.as_f64()
+		.unwrap_or_else(|| panic!("no numeric ate.router.route.duration: {log:#?}"))
+}
+
 async fn find_request_log(path: &str) -> Value {
 	agent_core::telemetry::testing::eventually_find(&[("scope", "request"), ("http.path", path)])
 		.await
@@ -714,6 +725,231 @@ async fn actor_ingress_reports_a_joined_resume_for_a_follower_on_an_in_flight_re
 
 	assert_logged_resume(LEADER_PATH, "triggered").await;
 	assert_logged_resume(FOLLOWER_PATH, "joined").await;
+}
+
+#[tokio::test]
+async fn actor_ingress_reports_the_activation_time_for_a_triggered_resume() {
+	const PATH: &str = "/route-duration-triggered";
+	const GATE: Duration = Duration::from_millis(300);
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let entered = Arc::new(Notify::new());
+	let release = Arc::new(Notify::new());
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let entered = entered.clone();
+		let release = release.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || SelectiveParkingHandler {
+			pod_ip: pod_ip.clone(),
+			parked_actor: "my-actor".to_string(),
+			entered: entered.clone(),
+			release: release.clone(),
+			calls: calls.clone(),
+			resumed: true,
+			uid: ACTOR_UID,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let request = tokio::spawn({
+		let io = gateway.serve_http(BIND_KEY);
+		let url = actor_url("my-actor", PATH);
+		async move { send_request(io, Method::GET, &url).await }
+	});
+	entered.notified().await;
+	tokio::time::sleep(GATE).await;
+	release.notify_one();
+	assert_eq!(request.await.unwrap().status(), StatusCode::OK);
+
+	assert_logged_resume(PATH, "triggered").await;
+	let log = find_request_log(PATH).await;
+	let duration = logged_route_duration(&log);
+	assert!(
+		duration >= 0.25,
+		"a resume gated for {GATE:?} must report at least that long, got {duration}: {log:#?}"
+	);
+}
+
+#[tokio::test]
+async fn actor_ingress_reports_a_followers_own_wait_rather_than_the_leaders() {
+	const LEADER_PATH: &str = "/route-duration-leader";
+	const FOLLOWER_PATH: &str = "/route-duration-follower";
+	const LEAD: Duration = Duration::from_millis(300);
+	const FOLLOWER_WAIT: Duration = Duration::from_millis(200);
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let entered = Arc::new(Notify::new());
+	let release = Arc::new(Notify::new());
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let entered = entered.clone();
+		let release = release.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || SelectiveParkingHandler {
+			pod_ip: pod_ip.clone(),
+			parked_actor: "my-actor".to_string(),
+			entered: entered.clone(),
+			release: release.clone(),
+			calls: calls.clone(),
+			resumed: true,
+			uid: ACTOR_UID,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let leader = tokio::spawn({
+		let io = gateway.serve_http(BIND_KEY);
+		let url = actor_url("my-actor", LEADER_PATH);
+		async move { send_request(io, Method::GET, &url).await }
+	});
+	// The leader is inside ResumeActor. It stays there for LEAD before the follower is even sent,
+	// so the two requests cannot have waited the same amount of time.
+	entered.notified().await;
+	tokio::time::sleep(LEAD).await;
+	let follower = tokio::spawn({
+		let io = gateway.serve_http(BIND_KEY);
+		let url = actor_url("my-actor", FOLLOWER_PATH);
+		async move { send_request(io, Method::GET, &url).await }
+	});
+	tokio::time::sleep(FOLLOWER_WAIT).await;
+	release.notify_one();
+
+	assert_eq!(leader.await.unwrap().status(), StatusCode::OK);
+	assert_eq!(follower.await.unwrap().status(), StatusCode::OK);
+	assert_eq!(
+		calls.load(Ordering::Relaxed),
+		1,
+		"the follower must have joined the leader's resume, not started its own"
+	);
+	assert_logged_resume(LEADER_PATH, "triggered").await;
+	assert_logged_resume(FOLLOWER_PATH, "joined").await;
+
+	let leader_log = find_request_log(LEADER_PATH).await;
+	let follower_log = find_request_log(FOLLOWER_PATH).await;
+	let leader_duration = logged_route_duration(&leader_log);
+	let follower_duration = logged_route_duration(&follower_log);
+	assert!(
+		leader_duration >= 0.45,
+		"the leader waited {LEAD:?} + {FOLLOWER_WAIT:?}, got {leader_duration}: {leader_log:#?}"
+	);
+	assert!(
+		follower_duration >= 0.15,
+		"the follower parked on the guard for {FOLLOWER_WAIT:?}, got {follower_duration}: {follower_log:#?}"
+	);
+	assert!(
+		leader_duration - follower_duration > 0.15,
+		"a follower must report its own wait, not the leader's cached number: \
+		 leader={leader_duration} follower={follower_duration}"
+	);
+}
+
+#[tokio::test]
+async fn actor_ingress_reports_a_near_zero_duration_for_a_cache_hit() {
+	const COLD_PATH: &str = "/route-duration-cache-cold";
+	const WARM_PATH: &str = "/route-duration-cache-warm";
+	const GATE: Duration = Duration::from_millis(300);
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let entered = Arc::new(Notify::new());
+	let release = Arc::new(Notify::new());
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let entered = entered.clone();
+		let release = release.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || SelectiveParkingHandler {
+			pod_ip: pod_ip.clone(),
+			parked_actor: "my-actor".to_string(),
+			entered: entered.clone(),
+			release: release.clone(),
+			calls: calls.clone(),
+			resumed: true,
+			uid: ACTOR_UID,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let cold = tokio::spawn({
+		let io = gateway.serve_http(BIND_KEY);
+		let url = actor_url("my-actor", COLD_PATH);
+		async move { send_request(io, Method::GET, &url).await }
+	});
+	entered.notified().await;
+	tokio::time::sleep(GATE).await;
+	release.notify_one();
+	assert_eq!(cold.await.unwrap().status(), StatusCode::OK);
+
+	let warm = send_request(
+		gateway.serve_http(BIND_KEY),
+		Method::GET,
+		&actor_url("my-actor", WARM_PATH),
+	)
+	.await;
+	assert_eq!(warm.status(), StatusCode::OK);
+	assert_eq!(
+		calls.load(Ordering::Relaxed),
+		1,
+		"the second request must be served from the assignment cache"
+	);
+
+	let cold_log = find_request_log(COLD_PATH).await;
+	let warm_log = find_request_log(WARM_PATH).await;
+	let cold_duration = logged_route_duration(&cold_log);
+	let warm_duration = logged_route_duration(&warm_log);
+	assert!(
+		warm_duration < 0.05,
+		"a cache hit resolves without ateapi, got {warm_duration}: {warm_log:#?}"
+	);
+	assert!(
+		cold_duration - warm_duration > 0.15,
+		"a cache hit must not inherit the cold start's duration: \
+		 cold={cold_duration} warm={warm_duration}"
+	);
+}
+
+#[tokio::test]
+async fn actor_ingress_emits_the_route_duration_as_a_number_of_seconds() {
+	const PATH: &str = "/route-duration-number";
+	let actor = simple_mock().await;
+	let calls = Arc::new(AtomicUsize::new(0));
+	let api = ateapimock::AteApiMock::new({
+		let calls = calls.clone();
+		let pod_ip = actor.address().ip().to_string();
+		move || IngressHandler {
+			pod_ip: pod_ip.clone(),
+			calls: calls.clone(),
+			resumed: true,
+			uid: ACTOR_UID,
+		}
+	})
+	.spawn()
+	.await;
+	let gateway = resume_disposition_gateway(api.address, actor.address().port()).await;
+
+	let response = send_request(
+		gateway.serve_http(BIND_KEY),
+		Method::GET,
+		&actor_url("my-actor", PATH),
+	)
+	.await;
+	assert_eq!(response.status(), StatusCode::OK);
+
+	let log = find_request_log(PATH).await;
+	assert!(
+		log["ate.router.route.duration"].is_number(),
+		"a latency panel queries this arithmetically: {log:#?}"
+	);
+	assert!(
+		log["duration"].as_str().is_some(),
+		"the sibling `duration` is the formatted style this key must not copy: {log:#?}"
+	);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Follow-up to #3289.

### Changes

`ate.actor.uid`: the record only had the actor name, so you could only join it to substrate's actor lifecycle logs on (atespace, name). Reuse a name and you silently merge two different actors in a per-agent panel.

`ate.router.route.duration`: we logged whether a route was cold but not how long it took, so there was no way to get an activation p95 or an SLO ratio.

Measured per request rather than per resume, so a follower waiting on someone else's resume reports its own wait instead of the leader's. Read it split by `ate.router.resume`: `triggered` is activation time, `none` is a warm route, and averaging those together doesn't mean anything.

Name matches upstream's `atenet.router.route.duration`, which measures the same thing. Didn't use `ate.router.resume.duration` because it's also emitted on the warm path where no resume happened, so that name would be frequently confusing.

Note that: `ate.actor.id` is now `ate.actor.name` It always had the name, never an id. This now follows upstream's registry.

### Egress doesn't work yet

I added the uid there too, but `authorize_connect` builds a `RequestLog` and drops it without ever emitting.
Fixing it means deciding whether adenied `CONNECT` should produce an access log line, which feels like a follow-up PR. Happy to take guidance on the approach.

+ Still missing for full parity with upstream `ate.template.*` (our trimmed proto has no`ActorTemplate`) and `ate.router.outcome`.

[x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
