### PR TITLE
proxy: keep serving open connections during drain

### DIFF
--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -302,6 +302,31 @@ pub fn parse_config(
 		.unwrap_or_default();
 	let termination_max_deadline =
 		parse_duration("CONNECTION_TERMINATION_DEADLINE")?.or(raw.connection_termination_deadline);
+	let termination_max_deadline = match termination_max_deadline {
+		Some(period) => period,
+		None => match parse::<u64>("TERMINATION_GRACE_PERIOD_SECONDS")? {
+			// We want our drain period to be less than Kubernetes, so we can use the last few seconds
+			// to abruptly terminate anything remaining before Kubernetes SIGKILLs us.
+			// We could just take the SIGKILL, but it is even more abrupt (TCP RST vs RST_STREAM/TLS close, etc)
+			// Note: we do this in code instead of in configuration so that we can use downward API to expose this variable
+			// if it is added to Kubernetes (https://github.com/kubernetes/kubernetes/pull/125746).
+			Some(secs) => Duration::from_secs(cmp::max(
+				if secs > 10 {
+					secs - 5
+				} else {
+					// If the grace period is really low give less buffer
+					secs - 1
+				},
+				1,
+			)),
+			None => Duration::from_secs(5),
+		},
+	};
+	if termination_min_deadline > termination_max_deadline {
+		anyhow::bail!(
+			"connectionMinTerminationDeadline ({termination_min_deadline:?}) must not exceed connectionTerminationDeadline ({termination_max_deadline:?})"
+		);
+	}
 	let tracing_env = resolve_tracing_env_overrides().ctx("invalid tracing environment overrides")?;
 
 	let mut otlp_headers = raw
@@ -423,26 +448,7 @@ pub fn parse_config(
 		backend: raw.backend,
 		admin_runtime_handle: None,
 		budget_policy: Arc::new(crate::http::budget::BudgetPolicy::default()),
-		termination_max_deadline: match termination_max_deadline {
-				Some(period) => period,
-				None => match parse::<u64>("TERMINATION_GRACE_PERIOD_SECONDS")? {
-				// We want our drain period to be less than Kubernetes, so we can use the last few seconds
-				// to abruptly terminate anything remaining before Kubernetes SIGKILLs us.
-				// We could just take the SIGKILL, but it is even more abrupt (TCP RST vs RST_STREAM/TLS close, etc)
-				// Note: we do this in code instead of in configuration so that we can use downward API to expose this variable
-				// if it is added to Kubernetes (https://github.com/kubernetes/kubernetes/pull/125746).
-				Some(secs) => Duration::from_secs(cmp::max(
-					if secs > 10 {
-						secs - 5
-					} else {
-						// If the grace period is really low give less buffer
-						secs - 1
-					},
-					1,
-				)),
-				None => Duration::from_secs(5),
-			},
-		},
+		termination_max_deadline,
 		tracing: raw
 			.tracing
 			.clone()
@@ -1250,6 +1256,51 @@ config:
 			Some(&"legacy".to_string())
 		);
 		assert_eq!(tracing.protocol, trc::Protocol::Grpc);
+	}
+
+	#[test]
+	fn min_termination_deadline_must_not_exceed_max() {
+		let _env_lock = lock_env();
+
+		let err = parse_config(
+			r#"
+config:
+  connectionMinTerminationDeadline: 10s
+  connectionTerminationDeadline: 5s
+"#
+			.to_string(),
+			None,
+		)
+		.expect_err("min above max should fail");
+
+		assert!(
+			err
+				.to_string()
+				.contains("must not exceed connectionTerminationDeadline"),
+			"unexpected error: {err}"
+		);
+	}
+
+	#[test]
+	fn min_termination_deadline_must_not_exceed_derived_max() {
+		let _env_lock = lock_env();
+
+		let err = parse_config(
+			r#"
+config:
+  connectionMinTerminationDeadline: 10s
+"#
+			.to_string(),
+			None,
+		)
+		.expect_err("min above the default 5s max should fail");
+
+		assert!(
+			err
+				.to_string()
+				.contains("must not exceed connectionTerminationDeadline"),
+			"unexpected error: {err}"
+		);
 	}
 
 	#[test]

--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -322,11 +322,14 @@ pub fn parse_config(
 			None => Duration::from_secs(5),
 		},
 	};
-	if termination_min_deadline > termination_max_deadline {
-		anyhow::bail!(
-			"connectionMinTerminationDeadline ({termination_min_deadline:?}) must not exceed connectionTerminationDeadline ({termination_max_deadline:?})"
+	let termination_min_deadline = if termination_min_deadline > termination_max_deadline {
+		warn!(
+			"connectionMinTerminationDeadline ({termination_min_deadline:?}) exceeds connectionTerminationDeadline ({termination_max_deadline:?}); using the maximum for both"
 		);
-	}
+		termination_max_deadline
+	} else {
+		termination_min_deadline
+	};
 	let tracing_env = resolve_tracing_env_overrides().ctx("invalid tracing environment overrides")?;
 
 	let mut otlp_headers = raw
@@ -1259,10 +1262,10 @@ config:
 	}
 
 	#[test]
-	fn min_termination_deadline_must_not_exceed_max() {
+	fn min_termination_deadline_clamps_to_max() {
 		let _env_lock = lock_env();
 
-		let err = parse_config(
+		let config = parse_config(
 			r#"
 config:
   connectionMinTerminationDeadline: 10s
@@ -1271,21 +1274,17 @@ config:
 			.to_string(),
 			None,
 		)
-		.expect_err("min above max should fail");
+		.unwrap();
 
-		assert!(
-			err
-				.to_string()
-				.contains("must not exceed connectionTerminationDeadline"),
-			"unexpected error: {err}"
-		);
+		assert_eq!(config.termination_max_deadline, Duration::from_secs(5));
+		assert_eq!(config.termination_min_deadline, Duration::from_secs(5));
 	}
 
 	#[test]
-	fn min_termination_deadline_must_not_exceed_derived_max() {
+	fn min_termination_deadline_clamps_to_derived_max() {
 		let _env_lock = lock_env();
 
-		let err = parse_config(
+		let config = parse_config(
 			r#"
 config:
   connectionMinTerminationDeadline: 10s
@@ -1293,14 +1292,10 @@ config:
 			.to_string(),
 			None,
 		)
-		.expect_err("min above the default 5s max should fail");
+		.unwrap();
 
-		assert!(
-			err
-				.to_string()
-				.contains("must not exceed connectionTerminationDeadline"),
-			"unexpected error: {err}"
-		);
+		assert_eq!(config.termination_max_deadline, Duration::from_secs(5));
+		assert_eq!(config.termination_min_deadline, Duration::from_secs(5));
 	}
 
 	#[test]

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -303,8 +303,6 @@ impl Gateway {
 			// However, we don't want to block from our listen() loop, or we would never finish.
 			// Having a weak reference allows us to listen() forever without blocking, but create blockers for accepted connections.
 			let (mut upgrader, weak) = drain.into_weak();
-			let (inner_trigger, inner_drain) = drain::new();
-			drop(inner_drain);
 			let admission = pi.admission.bind(&name);
 			let connection_shed = pi
 				.metrics
@@ -390,52 +388,32 @@ impl Gateway {
 				}
 			};
 			upgrader.disable();
-			// Now we are draining. We need to immediately start draining the inner requests
-			// Wait for Min_duration complete AND inner join complete
-			let mode = drain_mode.mode(); // TODO: handle mode differently?
 			drop(drain_mode);
-			let drained_for_minimum = async move {
-				tokio::join!(
-					inner_trigger.start_drain_and_wait(mode),
-					tokio::time::sleep(min_deadline)
-				);
-			};
-			tokio::pin!(drained_for_minimum);
-			// We still need to accept new connections during this time though, so race them
+			// Keep accepting while the drain runs. Connections accepted from here on are not tracked, so
+			// they are at risk of a forced close. This future never completes on its own: run_with_drain
+			// drops it once every tracked connection has finished or the deadline passes.
 			backoff = BACKOFF_INITIAL;
 			loop {
-				tokio::select! {
-					res = listener.accept() => match res {
-						Ok((stream, _peer)) => {
-							backoff = BACKOFF_INITIAL;
-							handle_stream(stream, &upgrader);
+				match listener.accept().await {
+					Ok((stream, _peer)) => {
+						backoff = BACKOFF_INITIAL;
+						handle_stream(stream, &upgrader);
+					},
+					Err(e) => {
+						if is_accept_error_permanent(&e) {
+							error!(bind=?name, "fatal accept error during drain, stopping listener: {e}");
+							std::future::pending::<()>().await;
 						}
-						Err(e) => {
-							if is_accept_error_permanent(&e) {
-								error!(bind=?name, "fatal accept error during drain, stopping listener: {e}");
-								return;
-							}
-							if is_accept_error_per_connection(&e) {
-								debug!(bind=?name, "per-connection accept error during drain: {e}");
-								continue;
-							}
-							warn!(bind=?name, "accept error during drain: {e}");
-							let jittered = Duration::from_millis(
-								rand::rng().random_range(0..=backoff.as_millis() as u64)
-							);
-							tokio::select! {
-								_ = tokio::time::sleep(jittered) => {},
-								_ = &mut drained_for_minimum => { return; }
-							}
-							backoff = (backoff * 2).min(BACKOFF_MAX);
+						if is_accept_error_per_connection(&e) {
+							debug!(bind=?name, "per-connection accept error during drain: {e}");
 							continue;
 						}
+						warn!(bind=?name, "accept error during drain: {e}");
+						let jittered =
+							Duration::from_millis(rand::rng().random_range(0..=backoff.as_millis() as u64));
+						tokio::time::sleep(jittered).await;
+						backoff = (backoff * 2).min(BACKOFF_MAX);
 					},
-					_ = &mut drained_for_minimum => {
-						// We are done! exit.
-						// This will stop accepting new connections
-						return;
-					}
 				}
 			}
 		};

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -292,10 +292,10 @@ impl Gateway {
 		// Therefor, we should have a minimum drain time and a maximum drain time.
 		// No matter what, we will continue accepting connections for <min time>. Any new connections will
 		// be "discouraged" via disabling keepalive.
-		// After that, we will continue processing connections as long as there are any remaining open.
-		// This handles gracefully serving any long-running requests.
-		// New connections may still be made during this time which we will attempt to serve, though they
-		// are at increased risk of early termination.
+		// After that, we close the listener and stop accepting new connections. A refused connection can be
+		// retried transparently; a request cut mid-flight cannot.
+		// Existing connections keep serving until they close or the maximum drain time passes, whichever
+		// comes first. This handles gracefully serving any long-running requests.
 		let accept = |drain: DrainWatcher, force_shutdown: watch::Receiver<()>| async move {
 			// We will need to be able to watch for drains, so take a copy
 			let drain_watch = drain.clone();
@@ -387,35 +387,12 @@ impl Gateway {
 					}
 				}
 			};
+			drop(listener);
 			upgrader.disable();
 			drop(drain_mode);
-			// Keep accepting while the drain runs. Connections accepted from here on are not tracked, so
-			// they are at risk of a forced close. This future never completes on its own: run_with_drain
-			// drops it once every tracked connection has finished or the deadline passes.
-			backoff = BACKOFF_INITIAL;
-			loop {
-				match listener.accept().await {
-					Ok((stream, _peer)) => {
-						backoff = BACKOFF_INITIAL;
-						handle_stream(stream, &upgrader);
-					},
-					Err(e) => {
-						if is_accept_error_permanent(&e) {
-							error!(bind=?name, "fatal accept error during drain, stopping listener: {e}");
-							std::future::pending::<()>().await;
-						}
-						if is_accept_error_per_connection(&e) {
-							debug!(bind=?name, "per-connection accept error during drain: {e}");
-							continue;
-						}
-						warn!(bind=?name, "accept error during drain: {e}");
-						let jittered =
-							Duration::from_millis(rand::rng().random_range(0..=backoff.as_millis() as u64));
-						tokio::time::sleep(jittered).await;
-						backoff = (backoff * 2).min(BACKOFF_MAX);
-					},
-				}
-			}
+			// Returning here would force-close every spawned connection. Park instead, so run_with_drain
+			// decides when to stop: once every tracked connection has finished or the deadline passes.
+			std::future::pending::<()>().await;
 		};
 
 		drain::run_with_drain(component, drain, max_deadline, min_deadline, accept).await;

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -1399,6 +1399,23 @@ impl TestBind {
 		addr
 	}
 
+	/// Only listeners started with `serve_gateway_listener` release their drain handle; other serve_*
+	/// helpers hold one for the life of the test, so a drain after them never completes.
+	pub async fn start_drain(self) {
+		let Self {
+			_drain_tx: drain_tx,
+			drain_rx,
+			..
+		} = self;
+		drop(drain_rx);
+		tokio::time::timeout(
+			std::time::Duration::from_secs(30),
+			drain_tx.start_drain_and_wait(drain::DrainMode::Graceful),
+		)
+		.await
+		.expect("drain did not complete; something still holds a DrainWatcher")
+	}
+
 	pub async fn serve_gateway_listener(&self, bind_name: BindKey) -> SocketAddr {
 		let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
 		listener.set_nonblocking(true).unwrap();

--- a/crates/agentgateway/tests/tests/drain.rs
+++ b/crates/agentgateway/tests/tests/drain.rs
@@ -1,0 +1,185 @@
+use std::net::SocketAddr;
+use std::time::Instant;
+
+use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::HttpConnector;
+use hyper_util::rt::{TokioExecutor, TokioTimer};
+use tokio::sync::mpsc;
+
+use crate::common::prelude::*;
+
+const BODY: &[u8] = b"hello";
+
+async fn holding_backend(hold: Duration) -> (SocketAddr, mpsc::UnboundedReceiver<()>) {
+	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let addr = listener.local_addr().unwrap();
+	let (in_flight, in_flight_rx) = mpsc::unbounded_channel();
+	tokio::spawn(async move {
+		loop {
+			let (stream, _) = listener.accept().await.unwrap();
+			let in_flight = in_flight.clone();
+			tokio::spawn(async move {
+				let service = service_fn(move |_req: http::Request<hyper::body::Incoming>| {
+					let in_flight = in_flight.clone();
+					async move {
+						let _ = in_flight.send(());
+						tokio::time::sleep(hold).await;
+						Ok::<_, Infallible>(http::Response::new(Body::from(BODY)))
+					}
+				});
+				let _ = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
+					.serve_connection(TokioIo::new(stream), service)
+					.await;
+			});
+		}
+	});
+	(addr, in_flight_rx)
+}
+
+async fn gateway(
+	min_deadline: &str,
+	max_deadline: &str,
+	backend: SocketAddr,
+) -> (TestBind, SocketAddr) {
+	let cfg = json!({
+		"config": {
+			"connectionMinTerminationDeadline": min_deadline,
+			"connectionTerminationDeadline": max_deadline,
+		}
+	});
+	let test = setup_proxy_test(&cfg.to_string())
+		.unwrap()
+		.with_backend(backend)
+		.with_bind(simple_bind())
+		.with_route(basic_route(backend));
+	let addr = test.serve_gateway_listener(BIND_KEY).await;
+	(test, addr)
+}
+
+fn http1_client() -> Client<HttpConnector, Body> {
+	Client::builder(TokioExecutor::new())
+		.timer(TokioTimer::new())
+		.build_http()
+}
+
+fn http2_client() -> Client<HttpConnector, Body> {
+	Client::builder(TokioExecutor::new())
+		.timer(TokioTimer::new())
+		.http2_only(true)
+		.build_http()
+}
+
+async fn get(
+	client: Client<HttpConnector, Body>,
+	addr: SocketAddr,
+) -> Result<Response, agentgateway::http::Error> {
+	let url = format!("http://127.0.0.1:{}/", addr.port());
+	RequestBuilder::new(Method::GET, &url).send(client).await
+}
+
+async fn assert_full_response(resp: Response) -> HeaderMap {
+	assert_eq!(resp.status(), StatusCode::OK);
+	let headers = resp.headers().clone();
+	let body = resp.into_body().collect().await.unwrap().to_bytes();
+	assert_eq!(body.as_ref(), BODY);
+	headers
+}
+
+#[tokio::test]
+async fn drain_waits_for_in_flight_request() {
+	let (backend, mut in_flight) = holding_backend(Duration::from_secs(1)).await;
+	let (test, addr) = gateway("0s", "30s", backend).await;
+
+	let request = tokio::spawn(get(http1_client(), addr));
+	in_flight.recv().await.unwrap();
+	let drained = tokio::spawn(test.start_drain());
+
+	let headers = assert_full_response(request.await.unwrap().unwrap()).await;
+	assert_eq!(headers[header::CONNECTION], "close");
+	tokio::time::timeout(Duration::from_secs(1), drained)
+		.await
+		.expect("drain must finish right after the last connection closes")
+		.unwrap();
+}
+
+#[tokio::test]
+async fn drain_waits_for_in_flight_http2_request() {
+	let (backend, mut in_flight) = holding_backend(Duration::from_secs(1)).await;
+	let (test, addr) = gateway("0s", "30s", backend).await;
+
+	let request = tokio::spawn(get(http2_client(), addr));
+	in_flight.recv().await.unwrap();
+	let drained = tokio::spawn(test.start_drain());
+
+	assert_full_response(request.await.unwrap().unwrap()).await;
+	tokio::time::timeout(Duration::from_secs(1), drained)
+		.await
+		.expect("drain must finish right after the last connection closes")
+		.unwrap();
+}
+
+#[tokio::test]
+async fn drain_cuts_request_past_deadline() {
+	let (backend, mut in_flight) = holding_backend(Duration::from_secs(10)).await;
+	let (test, addr) = gateway("0s", "500ms", backend).await;
+
+	let request = tokio::spawn(get(http1_client(), addr));
+	in_flight.recv().await.unwrap();
+	let start = Instant::now();
+	let drained = tokio::spawn(test.start_drain());
+
+	let err = request.await.unwrap().expect_err("request must be cut");
+	assert!(
+		format!("{err:?}").contains("IncompleteMessage"),
+		"expected a mid-response cut, got {err:?}"
+	);
+	tokio::time::timeout(Duration::from_secs(2), drained)
+		.await
+		.expect("drain must finish at the deadline")
+		.unwrap();
+	let elapsed = start.elapsed();
+	assert!(
+		elapsed >= Duration::from_millis(500),
+		"drain ended before the deadline: {elapsed:?}"
+	);
+}
+
+#[tokio::test]
+async fn drain_serves_new_connections_during_minimum() {
+	let (backend, _in_flight) = holding_backend(Duration::ZERO).await;
+	let (test, addr) = gateway("1s", "30s", backend).await;
+
+	let start = Instant::now();
+	let drained = tokio::spawn(test.start_drain());
+	tokio::time::sleep(Duration::from_millis(200)).await;
+
+	assert_full_response(get(http1_client(), addr).await.unwrap()).await;
+	tokio::time::timeout(Duration::from_secs(2), drained)
+		.await
+		.expect("drain must finish once the minimum passes")
+		.unwrap();
+	let elapsed = start.elapsed();
+	assert!(
+		elapsed >= Duration::from_secs(1),
+		"drain ended before the minimum: {elapsed:?}"
+	);
+}
+
+#[tokio::test]
+async fn drain_deadline_includes_minimum() {
+	let (backend, mut in_flight) = holding_backend(Duration::from_secs(10)).await;
+	let (test, addr) = gateway("300ms", "500ms", backend).await;
+
+	let request = tokio::spawn(get(http1_client(), addr));
+	in_flight.recv().await.unwrap();
+	let start = Instant::now();
+	let drained = tokio::spawn(test.start_drain());
+
+	request.await.unwrap().expect_err("request must be cut");
+	drained.await.unwrap();
+	let elapsed = start.elapsed();
+	assert!(
+		elapsed >= Duration::from_millis(500) && elapsed < Duration::from_millis(800),
+		"drain must end at the maximum, not minimum + maximum: {elapsed:?}"
+	);
+}

--- a/crates/agentgateway/tests/tests/drain.rs
+++ b/crates/agentgateway/tests/tests/drain.rs
@@ -183,3 +183,25 @@ async fn drain_deadline_includes_minimum() {
 		"drain must end at the maximum, not minimum + maximum: {elapsed:?}"
 	);
 }
+
+#[tokio::test]
+async fn drain_refuses_new_connections_after_minimum() {
+	let (backend, mut in_flight) = holding_backend(Duration::from_secs(2)).await;
+	let (test, addr) = gateway("300ms", "30s", backend).await;
+
+	let request = tokio::spawn(get(http1_client(), addr));
+	in_flight.recv().await.unwrap();
+	let drained = tokio::spawn(test.start_drain());
+	tokio::time::sleep(Duration::from_millis(600)).await;
+
+	get(http1_client(), addr)
+		.await
+		.expect_err("new connections must be refused once the minimum passes");
+
+	let headers = assert_full_response(request.await.unwrap().unwrap()).await;
+	assert_eq!(headers[header::CONNECTION], "close");
+	tokio::time::timeout(Duration::from_secs(1), drained)
+		.await
+		.expect("drain must finish right after the last connection closes")
+		.unwrap();
+}

--- a/crates/agentgateway/tests/tests/mod.rs
+++ b/crates/agentgateway/tests/tests/mod.rs
@@ -8,6 +8,7 @@ mod connect;
 mod cors;
 mod dfp;
 mod direct_response;
+mod drain;
 mod hbone;
 mod llm;
 mod llm_providers;

--- a/crates/core/src/drain.rs
+++ b/crates/core/src/drain.rs
@@ -51,13 +51,13 @@ pub async fn run_with_drain<F, O>(
 			// the deadline.
 			// If this feature is implemented, we can instead join!() the min_delay and `start_drain_and_wait`.
 			tokio::time::sleep(min_delay).await;
+			let remaining = deadline.saturating_sub(min_delay);
 			info!(
 				component,
-				"minimum drain completed, waiting, not accepting new connections and waiting {:?} for any connections to complete",
-				deadline
+				"minimum drain completed, waiting {:?} for any connections to complete", remaining
 			);
 			let res = tokio::time::timeout(
-				deadline,
+				remaining,
 				sub_drain_signal.start_drain_and_wait(DrainMode::Graceful),
 			)
 			.await;

--- a/crates/core/src/drain.rs
+++ b/crates/core/src/drain.rs
@@ -48,16 +48,18 @@ pub async fn run_with_drain<F, O>(
 				"drain started, waiting {:?}-{:?} for any connections to complete", min_delay, deadline
 			);
 			// Due to https://github.com/hyperium/hyper/issues/3961, we are forced to not start the drain until after
-			// the deadline.
+			// the minimum delay.
 			// If this feature is implemented, we can instead join!() the min_delay and `start_drain_and_wait`.
-			tokio::time::sleep(min_delay).await;
-			let remaining = deadline.saturating_sub(min_delay);
+			let start = tokio::time::Instant::now();
+			let deadline = start + deadline;
+			tokio::time::sleep_until((start + min_delay).min(deadline)).await;
 			info!(
 				component,
-				"minimum drain completed, waiting {:?} for any connections to complete", remaining
+				"minimum drain completed, no longer accepting new connections, waiting {:?} for any connections to complete",
+				deadline.saturating_duration_since(tokio::time::Instant::now())
 			);
-			let res = tokio::time::timeout(
-				remaining,
+			let res = tokio::time::timeout_at(
+				deadline,
 				sub_drain_signal.start_drain_and_wait(DrainMode::Graceful),
 			)
 			.await;


### PR DESCRIPTION
On SIGTERM the gateway force-closes every open connection about 2 ms later with the default settings, so a request in flight ends as a bare EOF with no status code. The accept loop in `run_bind` creates an inner drain channel and drops its only watcher on the next line, so the join that should wait for open connections returns as soon as the minimum deadline passes. That completes the accept future, which fires the force shutdown that every connection task selects on. The wrapper's own deadline arm never gets to run.

The inner channel is gone. Once the minimum passes, the accept loop closes the listener and parks. `run_with_drain` drops it once the outer drain reports every connection closed or the deadline passes. New connections are refused after the minimum: a refused connection can be retried, a request cut mid-flight cannot. Requests on existing connections keep going, and those connections already carry `connection: close` or a GOAWAY.

Letting the deadline arm run showed a second problem: `run_with_drain` slept the minimum and then waited the full maximum, so the window was `min + max`. The maximum is derived from the Kubernetes grace period minus 5 s and is meant as the total. With the Helm defaults (min 10 s, grace 60 s) the drain would run 65 s and the pod would be SIGKILLed first. The wrapper now computes one absolute deadline at drain start and sleeps and times out against it. A minimum above the maximum is clamped to the maximum, so a short `terminationGracePeriodSeconds` with the default minimum still starts. The effective values show in the config the gateway prints at startup.

Note I'm no Rust (nor agent gateway) expert but this feels like the sensible thing to do and solves a real issue for us.

I tested this with one request in flight and SIGTERM sent 0.5 s after it started:

| min | max | backend hold | before | after |
|---|---|---|---|---|
| 0s | 5s (defaults) | 3s | cut at +2 ms | 200 |
| 0s | 5s (defaults) | 20s | cut at +2 ms | cut at +5 s, with the "drain duration expired" warning |
| 3s | 60s | 20s | cut at +6 s | 200 |
| 10s | 55s (Helm defaults) | 3s | cut at +20 s | 200, exit at +10 s |
| 5s | 1s | 20s | cut at +6 s | clamped to 1s/1s, cut at +1 s |
| idle | 60s | none | exit in ~20 ms | exit in ~20 ms |

Before the fix the cut lands at `min + min(min, max)`, so raising the maximum alone changes nothing.

## Call-stack diff

```diff
  Bound::wait_termination                       crates/agentgateway/src/app.rs
  └─ drain_tx.start_drain_and_wait
     └─ run_with_drain                          crates/core/src/drain.rs
-       ├─ watch: sleep(min)
-       │  └─ timeout(max, sub_drain.start_drain_and_wait)
+       ├─ watch: sleep_until(start + min)
+       │  └─ timeout_at(start + max, sub_drain.start_drain_and_wait)
        └─ fut: run_bind accept loop            crates/agentgateway/src/proxy/gateway.rs
           ├─ accept until drain                # unchanged
           ├─ upgrader.disable()                # unchanged
-          └─ select!(accept, join!(inner_trigger.start_drain_and_wait, sleep(min)))
-             └─ returns at 2*min; fut done; force_shutdown fires
+          ├─ drop(listener)
+          └─ pending() until dropped by run_with_drain
```

Unchanged: the outer drain, the connection tasks, and the accept loop's error handling.

- **Tests.** Six integration tests drive `run_bind` on a real listener through a new `TestBind::start_drain` helper. Three fail on `main`: in-flight request over HTTP/1.1 and HTTP/2, and the forced cut at the deadline. The others pin new connections during the minimum, refusal after the minimum, and the total window.
- **Left alone.** TCP passthrough holds the drain watcher but never watches it, so a TCP bind with a live connection now runs to the deadline and is forced closed rather than cut at once. HBONE binds drop their `force_shutdown` sender at creation and are still cut at drain start. Both are pre-existing; happy to follow up on either.
- **AI assistance.** I found the bug tracing a dropped request in production and used an AI assistant to help read the drain code, write the tests, and run the measurements. I have reviewed and understand every line.

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
