### PR TITLE
fix: honor graceful drain deadline

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,6 +54,9 @@ chrono.workspace = true
 [build-dependencies]
 rustc_version.workspace = true
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
 [lints.rust]
 # This rule makes code more confusing
 mismatched_lifetime_syntaxes = "allow"

--- a/crates/core/src/drain.rs
+++ b/crates/core/src/drain.rs
@@ -21,7 +21,8 @@ pub fn new() -> (DrainTrigger, DrainWatcher) {
 /// * drain: while holding onto this, the future is marked as active, which will block the server from shutting down.
 ///   Additionally, it can be watched (with drain.signaled()) to see when to start a graceful shutdown.
 /// * force_shutdown: when this is triggered, the future must forcefully shutdown any ongoing work ASAP.
-///   This means the graceful drain exceeded the hard deadline, and all work must terminate now.
+///   This happens for immediate shutdown and when graceful drain reaches its hard deadline. It is also
+///   broadcast after a graceful drain completes, when no watched work should remain.
 ///   This is only required for spawned() tasks; otherwise, the future is dropped entirely, canceling all work.
 pub async fn run_with_drain<F, O>(
 	component: String,
@@ -35,14 +36,26 @@ pub async fn run_with_drain<F, O>(
 {
 	let (sub_drain_signal, sub_drain) = new();
 	let (trigger_force_shutdown, force_shutdown) = watch::channel(());
-	let trigger_force_shutdown_cpy = trigger_force_shutdown.clone();
 	// Stop accepting once we drain.
 	// We will then allow connections up to `deadline` to terminate on their own.
 	// After that, they will be forcefully terminated.
 	let fut = make_future(sub_drain, force_shutdown).in_current_span();
+	tokio::pin!(fut);
+
+	// A future that exits before draining indicates that the accept loop failed. Preserve
+	// the immediate shutdown behavior for that case. Once a drain is already ready, it
+	// takes precedence so the graceful drain remains authoritative.
+	let drain = tokio::select! {
+		biased;
+		res = drain.wait_for_drain() => res,
+		_ = &mut fut => {
+			let _ = trigger_force_shutdown.send(());
+			return;
+		},
+	};
+
 	let watch = async move {
-		let res = drain.wait_for_drain().await;
-		if res.mode() == DrainMode::Graceful {
+		if drain.mode() == DrainMode::Graceful {
 			info!(
 				component,
 				"drain started, waiting {:?}-{:?} for any connections to complete", min_delay, deadline
@@ -71,20 +84,21 @@ pub async fn run_with_drain<F, O>(
 		} else {
 			debug!(component, "terminating");
 		}
-		// Trigger force shutdown. In theory, this is only needed in the timeout case. However,
-		// it doesn't hurt to always trigger it.
+		// Notify force-shutdown observers after watched work drains or the deadline
+		// expires. The latter terminates any connections that are still running.
 		let _ = trigger_force_shutdown.send(());
 
 		info!(component, "shutdown complete");
 	};
+	tokio::pin!(watch);
+
+	// The accept future can finish after it stops accepting while spawned connections
+	// still hold upgraded drain watchers. Keep polling it during shutdown, but if it
+	// finishes, continue waiting for the watcher to drain or reach its deadline.
 	tokio::select! {
-		_ = fut => {
-			// Trigger force shutdown. This probably is redundant and the future will not complete
-			// until all tasks are done. But just to be sure send it, in case the future is watching this
-			// but not holding any drain blockers.
-			let _ = trigger_force_shutdown_cpy.send(());
-		},
-		_ = watch => {}
+		biased;
+		_ = &mut watch => {},
+		_ = &mut fut => watch.await,
 	}
 }
 

--- a/crates/core/src/drain.rs
+++ b/crates/core/src/drain.rs
@@ -337,11 +337,80 @@ mod test {
 	use std::sync::atomic::{AtomicUsize, Ordering};
 	use std::task;
 	use std::task::Poll;
+	use std::time::Duration;
 
 	use pin_project_lite::pin_project;
+	use tokio::sync::oneshot;
+	use tokio::task::JoinHandle;
 
 	use crate::drain;
 	use crate::drain::DrainMode::Graceful;
+	use crate::drain::DrainTrigger;
+
+	#[derive(Debug, PartialEq)]
+	enum ConnectionExit {
+		Completed,
+		Forced,
+	}
+
+	struct RunBindHarness {
+		drain: DrainTrigger,
+		connection_complete: oneshot::Sender<()>,
+		connection_exit: oneshot::Receiver<ConnectionExit>,
+		started: oneshot::Receiver<()>,
+		run: JoinHandle<()>,
+	}
+
+	fn run_bind_harness(deadline: Duration, min_delay: Duration) -> RunBindHarness {
+		let (drain, watcher) = drain::new();
+		let (connection_complete, connection_complete_rx) = oneshot::channel();
+		let (connection_exit_tx, connection_exit) = oneshot::channel();
+		let (started_tx, started) = oneshot::channel();
+
+		let run = tokio::spawn(drain::run_with_drain(
+			"test bind".to_string(),
+			watcher,
+			deadline,
+			min_delay,
+			move |drain: drain::DrainWatcher, mut force_shutdown: tokio::sync::watch::Receiver<()>| async move {
+				// Model run_bind: spawned connections hold upgraded drain watchers after
+				// the accept future stops accepting and returns.
+				let drain_watch = drain.clone();
+				let (mut upgrader, weak) = drain.into_weak();
+				let connection_drain = upgrader.upgrade(weak);
+				tokio::spawn(async move {
+					let exit = tokio::select! {
+						_ = connection_complete_rx => ConnectionExit::Completed,
+						_ = force_shutdown.changed() => ConnectionExit::Forced,
+					};
+					drop(connection_drain);
+					let _ = connection_exit_tx.send(exit);
+				});
+				let _ = started_tx.send(());
+
+				let drain = drain_watch.wait_for_drain().await;
+				assert_eq!(drain.mode(), Graceful);
+				upgrader.disable();
+				drop(drain);
+			},
+		));
+
+		RunBindHarness {
+			drain,
+			connection_complete,
+			connection_exit,
+			started,
+			run,
+		}
+	}
+
+	async fn start_graceful_drain(drain: DrainTrigger) -> JoinHandle<()> {
+		let task = tokio::spawn(drain.start_drain_and_wait(Graceful));
+		for _ in 0..3 {
+			tokio::task::yield_now().await;
+		}
+		task
+	}
 
 	pin_project! {
 			#[derive(Debug)]
@@ -369,6 +438,85 @@ mod test {
 				Poll::Pending => Poll::Pending,
 			}
 		}
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn run_with_drain_forces_connections_at_deadline() {
+		let deadline = Duration::from_secs(5);
+		let RunBindHarness {
+			drain,
+			connection_complete,
+			mut connection_exit,
+			started,
+			run,
+		} = run_bind_harness(deadline, Duration::ZERO);
+		started.await.unwrap();
+		let draining = start_graceful_drain(drain).await;
+
+		tokio::time::advance(deadline - Duration::from_millis(1)).await;
+		assert!(matches!(
+			connection_exit.try_recv(),
+			Err(oneshot::error::TryRecvError::Empty)
+		));
+		assert!(!run.is_finished());
+
+		tokio::time::advance(Duration::from_millis(1)).await;
+		assert_eq!(connection_exit.await.unwrap(), ConnectionExit::Forced);
+		run.await.unwrap();
+		draining.await.unwrap();
+		drop(connection_complete);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn run_with_drain_finishes_when_connections_complete_early() {
+		let deadline = Duration::from_secs(5);
+		let RunBindHarness {
+			drain,
+			connection_complete,
+			mut connection_exit,
+			started,
+			run,
+		} = run_bind_harness(deadline, Duration::ZERO);
+		started.await.unwrap();
+		let draining = start_graceful_drain(drain).await;
+
+		tokio::time::advance(Duration::from_secs(2)).await;
+		assert!(matches!(
+			connection_exit.try_recv(),
+			Err(oneshot::error::TryRecvError::Empty)
+		));
+		connection_complete.send(()).unwrap();
+
+		assert_eq!(connection_exit.await.unwrap(), ConnectionExit::Completed);
+		run.await.unwrap();
+		draining.await.unwrap();
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn run_with_drain_keeps_connections_alive_after_min_delay() {
+		let min_delay = Duration::from_secs(3);
+		let RunBindHarness {
+			drain,
+			connection_complete,
+			mut connection_exit,
+			started,
+			run,
+		} = run_bind_harness(Duration::from_secs(5), min_delay);
+		started.await.unwrap();
+		let draining = start_graceful_drain(drain).await;
+
+		tokio::time::advance(min_delay).await;
+		tokio::task::yield_now().await;
+		assert!(matches!(
+			connection_exit.try_recv(),
+			Err(oneshot::error::TryRecvError::Empty)
+		));
+		assert!(!run.is_finished());
+		connection_complete.send(()).unwrap();
+		assert_eq!(connection_exit.await.unwrap(), ConnectionExit::Completed);
+
+		run.await.unwrap();
+		draining.await.unwrap();
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
`run_bind` returns while spawned connections remain active, causing `run_with_drain` to kill requests immediately after SIGTERM. Shutdown now drains until connections finish or the configured deadline expires. By default, requests drain for up to 5 seconds, or `TERMINATION_GRACE_PERIOD_SECONDS - 5`, as documented.

- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
