### PR TITLE
fix(llm): keep tool calls intact when a prompt guard masks a message

### DIFF
--- a/crates/agentgateway/src/llm/policy/mod.rs
+++ b/crates/agentgateway/src/llm/policy/mod.rs
@@ -1506,6 +1506,7 @@ impl Policy {
 			.transpose()?;
 		let context = webhook::EvaluationContext::new(original, llm_request.as_ref());
 		let messages = req.get_messages();
+		let sent_roles: Vec<String> = messages.iter().map(|m| m.role.to_string()).collect();
 		let headers = Self::get_webhook_forward_headers(http_headers, &webhook.forward_header_matches);
 		let whr = match webhook::send_request(client, webhook, context, &headers, messages).await {
 			Ok(whr) => whr,
@@ -1534,11 +1535,12 @@ impl Policy {
 				}),
 			));
 		}
-		Self::webhook_request_outcome(whr.action)
+		Self::webhook_request_outcome(whr.action, &sent_roles)
 	}
 
 	fn webhook_request_outcome(
 		action: RequestAction,
+		original_roles: &[String],
 	) -> anyhow::Result<(GuardrailOutcome<RequestGuardMutation>, Option<GuardDetail>)> {
 		match action {
 			RequestAction::Mask(mask) => {
@@ -1549,6 +1551,18 @@ impl Policy {
 				let MaskActionBody::PromptMessages(body) = mask.body else {
 					anyhow::bail!("invalid webhook response");
 				};
+				if body.messages.len() != original_roles.len() {
+					anyhow::bail!(
+						"webhook mask returned {} messages, expected {}",
+						body.messages.len(),
+						original_roles.len()
+					);
+				}
+				for (i, (returned, role)) in body.messages.iter().zip(original_roles).enumerate() {
+					if returned.role.as_str() != role.as_str() {
+						anyhow::bail!("webhook mask changed message role at index {i}");
+					}
+				}
 				Ok((
 					GuardrailOutcome::Masked(RequestGuardMutation::Messages(body.messages)),
 					Some(GuardDetail {

--- a/crates/agentgateway/src/llm/policy/tests.rs
+++ b/crates/agentgateway/src/llm/policy/tests.rs
@@ -342,11 +342,14 @@ fn moderation_flagged_records_guardrail_info() {
 fn webhook_reject_records_guardrail_info() {
 	use crate::llm::policy::webhook::{RejectAction, RequestAction};
 
-	let (outcome, detail) = Policy::webhook_request_outcome(RequestAction::Reject(RejectAction {
-		body: "blocked".to_string(),
-		status_code: 403,
-		reason: Some("policy violation".to_string()),
-	}))
+	let (outcome, detail) = Policy::webhook_request_outcome(
+		RequestAction::Reject(RejectAction {
+			body: "blocked".to_string(),
+			status_code: 403,
+			reason: Some("policy violation".to_string()),
+		}),
+		&[],
+	)
 	.unwrap();
 	assert!(matches!(outcome, GuardrailOutcome::Rejected(_)));
 	assert_eq!(
@@ -3849,4 +3852,85 @@ fn test_zero_width_pattern_is_a_noop() {
 			"messages": [{"role": "user", "content": "hello world"}]
 		})
 	);
+}
+
+#[test]
+fn webhook_mask_rejects_message_count_mismatch() {
+	use crate::llm::policy::webhook::{MaskAction, MaskActionBody, PromptMessages, RequestAction};
+	let original = ["system".to_string(), "user".to_string()];
+	let body = MaskActionBody::PromptMessages(
+		serde_json::from_value::<PromptMessages>(serde_json::json!({
+			"messages": [{"role": "system", "content": "masked"}]
+		}))
+		.unwrap(),
+	);
+	let err = Policy::webhook_request_outcome(
+		RequestAction::Mask(MaskAction { body, reason: None }),
+		&original,
+	)
+	.err()
+	.unwrap();
+	assert!(err.to_string().contains("expected 2"), "{err}");
+}
+
+#[test]
+fn webhook_mask_rejects_role_change() {
+	use crate::llm::policy::webhook::{MaskAction, MaskActionBody, PromptMessages, RequestAction};
+	let original = ["system".to_string(), "user".to_string()];
+	let body = MaskActionBody::PromptMessages(
+		serde_json::from_value::<PromptMessages>(serde_json::json!({
+			"messages": [
+				{"role": "system", "content": "masked"},
+				{"role": "assistant", "content": "masked"}
+			]
+		}))
+		.unwrap(),
+	);
+	let err = Policy::webhook_request_outcome(
+		RequestAction::Mask(MaskAction { body, reason: None }),
+		&original,
+	)
+	.err()
+	.unwrap();
+	assert!(err.to_string().contains("role at index 1"), "{err}");
+}
+
+#[test]
+fn webhook_mask_rejects_wrong_body_variant() {
+	use crate::llm::policy::webhook::{MaskAction, MaskActionBody, RequestAction, ResponseChoices};
+	let original = ["user".to_string()];
+	let body = MaskActionBody::ResponseChoices(
+		serde_json::from_value::<ResponseChoices>(serde_json::json!({ "choices": [] })).unwrap(),
+	);
+	let err = Policy::webhook_request_outcome(
+		RequestAction::Mask(MaskAction { body, reason: None }),
+		&original,
+	)
+	.err()
+	.unwrap();
+	assert!(
+		err.to_string().contains("invalid webhook response"),
+		"{err}"
+	);
+}
+
+#[test]
+fn webhook_mask_accepts_matching_shape() {
+	use crate::llm::policy::webhook::{MaskAction, MaskActionBody, PromptMessages, RequestAction};
+	let original = ["system".to_string(), "user".to_string()];
+	let body = MaskActionBody::PromptMessages(
+		serde_json::from_value::<PromptMessages>(serde_json::json!({
+			"messages": [
+				{"role": "system", "content": "masked"},
+				{"role": "user", "content": "masked"}
+			]
+		}))
+		.unwrap(),
+	);
+	let (outcome, _) = Policy::webhook_request_outcome(
+		RequestAction::Mask(MaskAction { body, reason: None }),
+		&original,
+	)
+	.unwrap();
+	assert!(matches!(outcome, GuardrailOutcome::Masked(_)));
 }

--- a/crates/llm/src/types/completions.rs
+++ b/crates/llm/src/types/completions.rs
@@ -476,7 +476,9 @@ impl super::RequestType for Request {
 	}
 
 	fn set_messages(&mut self, messages: Vec<SimpleChatCompletionMessage>) {
-		self.messages = messages.into_iter().map(convert_message).collect();
+		for (existing, incoming) in self.messages.iter_mut().zip(messages) {
+			set_request_message_text(existing, incoming.content.as_str());
+		}
 	}
 
 	fn visit_text_mut(&mut self, f: &mut dyn FnMut(ContentScope, &mut String)) {
@@ -1373,5 +1375,90 @@ mod tests {
 		});
 
 		assert!(llm_response.output_messages.is_none());
+	}
+}
+
+#[cfg(test)]
+mod repro_3331 {
+	use super::*;
+	use crate::types::RequestType;
+
+	// Reproduction for agentgateway#3331: a promptGuard webhook masking content in ONE
+	// message must not strip tool-call structure from the OTHER messages in the same request.
+	#[test]
+	fn repro_3331_completions_preserves_tool_structure() {
+		let json = r#"{"model":"m","messages":[
+			{"role":"system","content":"You help Alex Smith."},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"get_schema","arguments":"{}"}}]},
+			{"role":"tool","content":"{\"ok\":true}","tool_call_id":"call_1","name":"get_schema"}
+		]}"#;
+		let mut req: Request = serde_json::from_str(json).unwrap();
+		let mut view = req.get_messages();
+		view[0].content = strng::new("You help <REDACTED>.");
+		req.set_messages(view);
+		assert_eq!(req.messages[0].message_text(), Some("You help <REDACTED>."));
+		assert_eq!(
+			req.messages[1].tool_calls.as_ref().map(|t| t.len()),
+			Some(1),
+			"assistant tool_calls must survive a mask on an unrelated message"
+		);
+		assert!(
+			req.messages[1].content.is_none(),
+			"tool-only assistant content must stay absent, not become an empty string"
+		);
+		assert_eq!(
+			req.messages[2].tool_call_id.as_deref(),
+			Some("call_1"),
+			"tool_call_id must survive a mask on an unrelated message"
+		);
+		assert_eq!(
+			req.messages[2].name.as_deref(),
+			Some("get_schema"),
+			"tool message name must survive a mask on an unrelated message"
+		);
+	}
+}
+
+fn set_request_message_text(msg: &mut RequestMessage, text: &str) {
+	match &mut msg.content {
+		None => {},
+		Some(Content::Text(existing)) => {
+			if existing.as_str() != text {
+				*existing = text.to_string();
+			}
+		},
+		Some(Content::Array(parts)) => {
+			let joined = parts
+				.iter()
+				.filter_map(|p| p.text.as_deref())
+				.collect::<Vec<_>>()
+				.join(" ");
+			if joined.as_str() != text {
+				set_content_parts_text(parts, text);
+			}
+		},
+	}
+}
+
+fn set_content_parts_text(parts: &mut Vec<ContentPart>, text: &str) {
+	let mut replaced = false;
+	parts.retain_mut(|p| {
+		if p.text.is_some() {
+			let keep = !replaced && !text.is_empty();
+			replaced = true;
+			if keep {
+				p.text = Some(text.to_string());
+			}
+			keep
+		} else {
+			true
+		}
+	});
+	if !replaced && !text.is_empty() {
+		parts.push(ContentPart {
+			r#type: "text".to_string(),
+			text: Some(text.to_string()),
+			rest: Default::default(),
+		});
 	}
 }

--- a/crates/llm/src/types/messages.rs
+++ b/crates/llm/src/types/messages.rs
@@ -300,25 +300,17 @@ impl RequestType for Request {
 	}
 
 	fn set_messages(&mut self, messages: Vec<SimpleChatCompletionMessage>) {
-		let (system_prompts, message_prompts): (Vec<_>, Vec<_>) = messages
-			.into_iter()
-			.partition(|m| m.role.as_str() == "system");
-
-		self.system = if system_prompts.is_empty() {
-			None
-		} else {
-			Some(TextBlock::Array(
-				system_prompts
-					.into_iter()
-					.map(|p| TextPart::Text {
-						r#type: "text".to_string(),
-						text: p.content.to_string(),
-						rest: Default::default(),
-					})
-					.collect(),
-			))
-		};
-		self.messages = message_prompts.into_iter().map(Into::into).collect();
+		let mut iter = messages.into_iter();
+		if self.system.as_ref().is_some_and(system_block_has_text) {
+			if let Some(system_msg) = iter.next() {
+				if let Some(system) = self.system.as_mut() {
+					set_textblock_text(system, system_msg.content.as_str());
+				}
+			}
+		}
+		for (existing, incoming) in self.messages.iter_mut().zip(iter) {
+			set_anthropic_content(existing, incoming.content.as_str());
+		}
 	}
 
 	fn visit_text_mut(&mut self, f: &mut dyn FnMut(ContentScope, &mut String)) {
@@ -1583,5 +1575,137 @@ mod tests {
 			tool_calls[0].arguments,
 			serde_json::json!({"location":"San Francisco"})
 		);
+	}
+}
+
+#[cfg(test)]
+mod repro_3331 {
+	use super::*;
+	use crate::types::RequestType;
+
+	// Reproduction for agentgateway#3331 (Anthropic Messages): masking one text message must not
+	// destroy tool_use/tool_result blocks or system cache_control elsewhere in the request.
+	#[test]
+	fn repro_3331_anthropic_preserves_tool_blocks() {
+		let json = r#"{"model":"m","max_tokens":10,
+			"system":[{"type":"text","text":"sys","cache_control":{"type":"ephemeral"}}],
+			"messages":[
+				{"role":"assistant","content":[{"type":"tool_use","id":"tu_1","name":"lookup","input":{"q":1}}]},
+				{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_1","content":"42"}]},
+				{"role":"user","content":[{"type":"text","text":"about Alex Smith"}]}
+			]}"#;
+		let mut req: Request = serde_json::from_str(json).unwrap();
+		let mut view = req.get_messages();
+		let last = view.len() - 1;
+		view[last].content = strng::new("about <REDACTED>");
+		req.set_messages(view);
+		let s = serde_json::to_string(&req).unwrap();
+		assert!(s.contains("tool_use"), "tool_use block must survive: {s}");
+		assert!(
+			s.contains("tu_1"),
+			"tool_use id / tool_use_id must survive: {s}"
+		);
+		assert!(
+			s.contains("tool_result"),
+			"tool_result block must survive: {s}"
+		);
+		assert!(
+			s.contains("cache_control"),
+			"system cache_control must survive: {s}"
+		);
+	}
+}
+
+fn system_block_has_text(block: &TextBlock) -> bool {
+	match block {
+		TextBlock::Text(text) => !text.is_empty(),
+		TextBlock::Array(parts) => parts
+			.iter()
+			.any(|p| p.text().is_some_and(|t| !t.is_empty())),
+	}
+}
+
+fn set_textblock_text(block: &mut TextBlock, text: &str) {
+	match block {
+		TextBlock::Text(existing) => {
+			if existing.as_str() != text {
+				*existing = text.to_string();
+			}
+		},
+		TextBlock::Array(parts) => {
+			let joined = parts
+				.iter()
+				.filter_map(TextPart::text)
+				.collect::<Vec<_>>()
+				.join("\n");
+			if joined.as_str() != text {
+				set_textparts_text(parts, text);
+			}
+		},
+	}
+}
+
+fn set_textparts_text(parts: &mut Vec<TextPart>, text: &str) {
+	let mut replaced = false;
+	parts.retain_mut(|p| match p {
+		TextPart::Text { text: existing, .. } => {
+			let keep = !replaced && !text.is_empty();
+			replaced = true;
+			if keep {
+				*existing = text.to_string();
+			}
+			keep
+		},
+		TextPart::Unknown(_) => true,
+	});
+	if !replaced && !text.is_empty() {
+		parts.push(TextPart::Text {
+			r#type: "text".to_string(),
+			text: text.to_string(),
+			rest: Default::default(),
+		});
+	}
+}
+
+fn set_anthropic_content(msg: &mut RequestMessage, text: &str) {
+	match &mut msg.content {
+		None => {},
+		Some(ContentBlock::Text(existing)) => {
+			if existing.as_str() != text {
+				*existing = text.to_string();
+			}
+		},
+		Some(ContentBlock::Array(parts)) => {
+			let joined = parts
+				.iter()
+				.filter_map(ContentPart::text)
+				.collect::<Vec<_>>()
+				.join(" ");
+			if joined.as_str() != text {
+				set_contentparts_text(parts, text);
+			}
+		},
+	}
+}
+
+fn set_contentparts_text(parts: &mut Vec<ContentPart>, text: &str) {
+	let mut replaced = false;
+	parts.retain_mut(|p| match p {
+		ContentPart::Text { text: existing, .. } => {
+			let keep = !replaced && !text.is_empty();
+			replaced = true;
+			if keep {
+				*existing = text.to_string();
+			}
+			keep
+		},
+		ContentPart::Unknown(_) => true,
+	});
+	if !replaced && !text.is_empty() {
+		parts.push(ContentPart::Text {
+			r#type: "text".to_string(),
+			text: text.to_string(),
+			rest: Default::default(),
+		});
 	}
 }

--- a/crates/llm/src/types/responses.rs
+++ b/crates/llm/src/types/responses.rs
@@ -586,22 +586,37 @@ impl RequestType for Request {
 		messages
 	}
 
-	fn set_messages(&mut self, mut messages: Vec<SimpleChatCompletionMessage>) {
+	fn set_messages(&mut self, messages: Vec<SimpleChatCompletionMessage>) {
+		let mut iter = messages.into_iter();
 		if self.instructions.is_some() {
-			self.instructions = messages
-				.first()
-				.filter(|message| matches!(message.role.as_str(), "developer" | "system"))
-				.map(|message| message.content.to_string());
-			if self.instructions.is_some() {
-				messages.remove(0);
+			if let Some(system_msg) = iter.next() {
+				if let Some(instructions) = self.instructions.as_mut() {
+					if instructions.as_str() != system_msg.content.as_str() {
+						*instructions = system_msg.content.to_string();
+					}
+				}
 			}
 		}
-		self.input = RequestInput::Items(
-			messages
-				.into_iter()
-				.map(RawInputItem::from_simple_message)
-				.collect(),
-		);
+		match &mut self.input {
+			RequestInput::Text(text) => {
+				if let Some(msg) = iter.next() {
+					if text.as_str() != msg.content.as_str() {
+						*text = msg.content.to_string();
+					}
+				}
+			},
+			RequestInput::Items(items) => {
+				for item in items.iter_mut() {
+					if let Some(existing) = item.as_simple_message() {
+						if let Some(msg) = iter.next() {
+							if existing.content.as_str() != msg.content.as_str() {
+								item.set_message_text(msg.content.as_str());
+							}
+						}
+					}
+				}
+			},
+		}
 	}
 
 	fn visit_text_mut(&mut self, f: &mut dyn FnMut(ContentScope, &mut String)) {
@@ -1054,11 +1069,7 @@ mod tests {
 		};
 		assert_eq!(input.len(), 2);
 		assert_eq!(input[0].0["role"], "system");
-		assert_eq!(input[0].0["content"][0]["type"], "input_text");
-		assert_eq!(
-			input[0].0["content"][0]["text"],
-			"masked input system message"
-		);
+		assert_eq!(input[0].0["content"], "masked input system message");
 		assert_eq!(input[1].0["role"], "user");
 	}
 
@@ -1109,5 +1120,76 @@ mod tests {
 		let llm_response = response.to_llm_response(crate::LogContentFields::default());
 
 		assert!(llm_response.output_messages.is_none());
+	}
+}
+
+#[cfg(test)]
+mod repro_3331 {
+	use super::*;
+	use crate::types::RequestType;
+
+	// Reproduction for agentgateway#3331 (OpenAI Responses): masking a message must not drop
+	// sibling function_call / function_call_output items from the request input.
+	#[test]
+	fn repro_3331_responses_preserves_function_items() {
+		let json = r#"{"model":"m","input":[
+			{"role":"user","content":[{"type":"input_text","text":"look up Alex Smith"}]},
+			{"type":"function_call","call_id":"fc_1","name":"lookup","arguments":"{\"q\":1}","id":"item_1"},
+			{"type":"function_call_output","call_id":"fc_1","output":"42","id":"item_2"}
+		]}"#;
+		let mut req: Request = serde_json::from_str(json).unwrap();
+		let mut view = req.get_messages();
+		view[0].content = strng::new("look up <REDACTED>");
+		req.set_messages(view);
+		let s = serde_json::to_string(&req).unwrap();
+		assert!(
+			s.contains("\"function_call\""),
+			"function_call item must survive: {s}"
+		);
+		assert!(
+			s.contains("function_call_output"),
+			"function_call_output item must survive: {s}"
+		);
+		assert!(s.contains("fc_1"), "call_id must survive: {s}");
+	}
+}
+
+impl RawInputItem {
+	fn set_message_text(&mut self, text: &str) {
+		let Some(content) = self.0.get_mut("content") else {
+			return;
+		};
+		match content {
+			Value::String(existing) => {
+				if existing.as_str() != text {
+					*existing = text.to_string();
+				}
+			},
+			Value::Array(parts) => {
+				let mut replaced = false;
+				parts.retain_mut(|p| {
+					let is_text = p
+						.get("type")
+						.and_then(|t| t.as_str())
+						.is_some_and(|t| t == "input_text" || t == "output_text");
+					if is_text {
+						let keep = !replaced && !text.is_empty();
+						replaced = true;
+						if keep {
+							if let Some(obj) = p.as_object_mut() {
+								obj.insert("text".to_string(), Value::String(text.to_string()));
+							}
+						}
+						keep
+					} else {
+						true
+					}
+				});
+				if !replaced && !text.is_empty() {
+					parts.push(serde_json::json!({"type": "input_text", "text": text}));
+				}
+			},
+			_ => {},
+		}
 	}
 }


### PR DESCRIPTION
Fixes #3331.

Thanks @logeshs92 for the clear report and for tracking down the Completions root cause — made this easy to pin down.

Short version: when a promptGuard webhook masks one message, the write-back was rebuilding every message from the plain `{role, content}` the webhook sees. That view has no tool info, so it quietly wiped `tool_calls` / `tool_call_id` off *all* the other messages too — enough to break any tool-calling chat the moment a guard touched something unrelated. Same issue in all three formats: Completions, Anthropic Messages, and OpenAI Responses.

The fix treats the webhook output as "here's new text," not "here's the new request." It updates the text on the existing messages in place and leaves everything else alone — tool calls, IDs, cache control, all of it. Untouched messages stay exactly as they were. And before anything changes, it checks the webhook returned the same messages in the same roles; if not, it errors out and the request is left untouched. No schema changes, nothing touched on the response side.

Tests: per-format tests that fail on main and pass with this, plus checks that bad webhook responses (wrong count, changed role) error out instead of mangling the request. `cargo test -p agent-llm` is green — 375 passed.

I used AI assistance on the code and tests, then reviewed and own the result.

- [x] Description, docs, and comments are written by a human, not an LLM (per the Code of Conduct).
