### PR TITLE
fix(llm): strip Gemini thought signatures on non-Gemini egress

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -351,7 +351,7 @@ fn render_openai_completions(
 	req: types::ChatRequest,
 	ctx: &ChatRequestContext<'_>,
 ) -> Result<Vec<u8>, AIError> {
-	match req {
+	let body = match req {
 		types::ChatRequest::Completions(mut req) => {
 			apply_openai_moderation(&mut req.moderation, ctx)?;
 			serde_json::to_vec(&req).map_err(AIError::RequestMarshal)
@@ -370,14 +370,15 @@ fn render_openai_completions(
 		types::ChatRequest::Gemini(_) => Err(AIError::UnsupportedConversion(strng::literal!(
 			"gemini to completions"
 		))),
-	}
+	}?;
+	conversion::strip_vertex_thought_signatures(body)
 }
 
 fn render_openai_responses(
 	req: types::ChatRequest,
 	ctx: &ChatRequestContext<'_>,
 ) -> Result<Vec<u8>, AIError> {
-	match req {
+	let body = match req {
 		types::ChatRequest::Responses(mut req) => {
 			apply_openai_moderation(&mut req.moderation, ctx)?;
 			serde_json::to_vec(&req).map_err(AIError::RequestMarshal)
@@ -386,7 +387,8 @@ fn render_openai_responses(
 		_ => Err(AIError::UnsupportedConversion(strng::literal!(
 			"expected responses request"
 		))),
-	}
+	}?;
+	conversion::strip_vertex_thought_signatures(body)
 }
 
 fn apply_openai_moderation(
@@ -480,7 +482,7 @@ fn render_bedrock_converse(
 		})
 	};
 	Ok(RenderedChatRequest {
-		body: bedrock.body,
+		body: conversion::strip_vertex_thought_signatures(bedrock.body)?,
 		provider_state,
 	})
 }
@@ -514,8 +516,11 @@ impl ChatTranslation {
 			ChatFormat::OpenAIResponses => render_openai_responses(req, ctx),
 			ChatFormat::AnthropicMessages if matches!(ctx.provider, AIProvider::Vertex(_)) => {
 				vertex::prepare_anthropic_message_body(render_anthropic_messages(req, ctx.catalog)?)
+					.and_then(conversion::strip_vertex_thought_signatures)
 			},
-			ChatFormat::AnthropicMessages => render_anthropic_messages(req, ctx.catalog),
+			ChatFormat::AnthropicMessages => {
+				conversion::strip_vertex_thought_signatures(render_anthropic_messages(req, ctx.catalog)?)
+			},
 			ChatFormat::BedrockConverse => return render_bedrock_converse(req, ctx),
 			ChatFormat::VertexGemini => {
 				return Ok(RenderedChatRequest {

--- a/crates/agentgateway/src/llm/tests.rs
+++ b/crates/agentgateway/src/llm/tests.rs
@@ -125,6 +125,47 @@ fn gemini_inbound_to_non_gemini_upstream_is_unsupported() {
 }
 
 #[test]
+fn non_gemini_completions_egress_strips_vertex_thought_signature() {
+	let provider = AIProvider::OpenAI(openai::Provider {
+		model: None,
+		moderation: None,
+	});
+	let translation = provider
+		.chat_translation(InputFormat::Completions, Some("gpt-5"), None)
+		.expect("OpenAI completions translation");
+	let req: types::completions::Request = serde_json::from_value(json!({
+		"model": "gpt-5",
+		"messages": [
+			{
+				"role": "assistant",
+				"content": null,
+				"tool_calls": [{
+					"id": "call-1__thought__signature",
+					"type": "function",
+					"function": {"name": "lookup", "arguments": "{}"}
+				}]
+			},
+			{"role": "tool", "tool_call_id": "call-1__thought__signature", "content": "ok"}
+		]
+	}))
+	.unwrap();
+	let rendered = translation
+		.render_request(
+			types::ChatRequest::Completions(req),
+			&ChatRequestContext {
+				catalog: None,
+				provider: &provider,
+				headers: &HeaderMap::new(),
+				prompt_caching: None,
+			},
+		)
+		.expect("render");
+	let out: Value = serde_json::from_slice(&rendered.body).expect("valid body");
+	assert_eq!(out["messages"][0]["tool_calls"][0]["id"], "call-1");
+	assert_eq!(out["messages"][1]["tool_call_id"], "call-1");
+}
+
+#[test]
 fn custom_provider_generate_content_advertises_the_native_chat_format() {
 	let provider = custom_provider(custom::ProviderFormat::GenerateContent);
 

--- a/crates/llm/src/conversion/mod.rs
+++ b/crates/llm/src/conversion/mod.rs
@@ -47,19 +47,14 @@ fn strip_thought_signature_fields(value: &mut serde_json::Value) {
 		return;
 	};
 
-	let item_type = object
-		.get("type")
-		.and_then(serde_json::Value::as_str)
-		.map(str::to_owned);
-	if (item_type.as_deref() == Some("function") && object.contains_key("function"))
-		|| item_type.as_deref() == Some("tool_use")
-	{
+	let item_type = object.get("type").and_then(serde_json::Value::as_str);
+	let is_function_call = item_type == Some("function") && object.contains_key("function");
+	let is_tool_use = item_type == Some("tool_use");
+	let is_responses_call = matches!(item_type, Some("function_call" | "function_call_output"));
+	if is_function_call || is_tool_use {
 		strip_string_field(object, "id");
 	}
-	if matches!(
-		item_type.as_deref(),
-		Some("function_call" | "function_call_output")
-	) {
+	if is_responses_call {
 		strip_string_field(object, "call_id");
 	}
 	if object.get("role").and_then(serde_json::Value::as_str) == Some("tool") {
@@ -131,7 +126,12 @@ mod tests {
 						"function": {"name": "lookup", "arguments": "{}"}
 					}]
 				},
-				{"role": "tool", "tool_call_id": "call-1__thought__signature"}
+				{
+					"role": "tool",
+					"tool_call_id": "call-1__thought__signature",
+					"tool_use_id": "call-2__thought__signature",
+					"toolUseId": "call-3__thought__signature"
+				}
 			],
 			"input": [
 				{"type": "function_call", "call_id": "call-1__thought__signature"},
@@ -145,6 +145,8 @@ mod tests {
 		let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
 		assert_eq!(body["messages"][0]["tool_calls"][0]["id"], "call-1");
 		assert_eq!(body["messages"][1]["tool_call_id"], "call-1");
+		assert_eq!(body["messages"][1]["tool_use_id"], "call-2");
+		assert_eq!(body["messages"][1]["toolUseId"], "call-3");
 		assert_eq!(body["input"][0]["call_id"], "call-1");
 		assert_eq!(body["input"][1]["call_id"], "call-1");
 		assert_eq!(body["content"][0]["id"], "call-1");

--- a/crates/llm/src/conversion/mod.rs
+++ b/crates/llm/src/conversion/mod.rs
@@ -7,6 +7,8 @@ pub mod responses;
 pub mod vertex;
 pub mod vertex_gemini;
 
+use crate::AIError;
+
 /// Translate an OpenAI `tool_calls[].function.arguments` string into an Anthropic
 /// `tool_use.input` value.
 ///
@@ -23,6 +25,68 @@ pub(crate) fn tool_arguments_to_input(arguments: &str) -> serde_json::Value {
 		.unwrap_or_else(|_| serde_json::Value::String(arguments.to_string()))
 }
 
+/// Remove the internal Vertex Gemini thought-signature suffix from tool-call identifiers before
+/// a request is sent to another provider. Native Gemini requests must keep the suffix so the
+/// provider can recover the signature, while OpenAI-compatible, Anthropic, and Bedrock wire
+/// formats have no such convention and may reject the resulting overlong identifier.
+pub fn strip_vertex_thought_signatures(mut body: Vec<u8>) -> Result<Vec<u8>, AIError> {
+	let mut value: serde_json::Value =
+		serde_json::from_slice(&body).map_err(AIError::RequestMarshal)?;
+	strip_thought_signature_fields(&mut value);
+	body = serde_json::to_vec(&value).map_err(AIError::RequestMarshal)?;
+	Ok(body)
+}
+
+fn strip_thought_signature_fields(value: &mut serde_json::Value) {
+	let serde_json::Value::Object(object) = value else {
+		if let serde_json::Value::Array(values) = value {
+			for value in values {
+				strip_thought_signature_fields(value);
+			}
+		}
+		return;
+	};
+
+	let item_type = object
+		.get("type")
+		.and_then(serde_json::Value::as_str)
+		.map(str::to_owned);
+	if (item_type.as_deref() == Some("function") && object.contains_key("function"))
+		|| item_type.as_deref() == Some("tool_use")
+	{
+		strip_string_field(object, "id");
+	}
+	if matches!(
+		item_type.as_deref(),
+		Some("function_call" | "function_call_output")
+	) {
+		strip_string_field(object, "call_id");
+	}
+	if object.get("role").and_then(serde_json::Value::as_str) == Some("tool") {
+		strip_string_field(object, "tool_call_id");
+	}
+	if let Some(serde_json::Value::Array(tool_calls)) = object.get_mut("tool_calls") {
+		for tool_call in tool_calls {
+			if let serde_json::Value::Object(tool_call) = tool_call {
+				strip_string_field(tool_call, "id");
+			}
+		}
+	}
+	strip_string_field(object, "tool_use_id");
+	strip_string_field(object, "toolUseId");
+
+	for value in object.values_mut() {
+		strip_thought_signature_fields(value);
+	}
+}
+
+fn strip_string_field(object: &mut serde_json::Map<String, serde_json::Value>, field: &str) {
+	let Some(value) = object.get(field).and_then(serde_json::Value::as_str) else {
+		return;
+	};
+	let stripped = vertex_gemini::strip_thought_signature(value).to_owned();
+	object.insert(field.to_string(), serde_json::Value::String(stripped));
+}
 #[cfg(test)]
 mod rerank_tests;
 
@@ -30,7 +94,7 @@ mod rerank_tests;
 mod tests {
 	use serde_json::json;
 
-	use super::tool_arguments_to_input;
+	use super::{strip_vertex_thought_signatures, tool_arguments_to_input};
 
 	#[test]
 	fn empty_arguments_become_an_empty_object() {
@@ -54,5 +118,36 @@ mod tests {
 			json!("{\"location\": \"Par")
 		);
 		assert_eq!(tool_arguments_to_input("  "), json!("  "));
+	}
+
+	#[test]
+	fn strips_vertex_thought_signatures_only_from_tool_identifiers() {
+		let body = serde_json::to_vec(&json!({
+			"messages": [
+				{
+					"role": "assistant",
+					"tool_calls": [{
+						"id": "call-1__thought__signature",
+						"function": {"name": "lookup", "arguments": "{}"}
+					}]
+				},
+				{"role": "tool", "tool_call_id": "call-1__thought__signature"}
+			],
+			"input": [
+				{"type": "function_call", "call_id": "call-1__thought__signature"},
+				{"type": "function_call_output", "call_id": "call-1__thought__signature"}
+			],
+			"content": [{"type": "tool_use", "id": "call-1__thought__signature"}],
+			"metadata": {"id": "call-1__thought__signature"}
+		}))
+		.unwrap();
+		let body = strip_vertex_thought_signatures(body).unwrap();
+		let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+		assert_eq!(body["messages"][0]["tool_calls"][0]["id"], "call-1");
+		assert_eq!(body["messages"][1]["tool_call_id"], "call-1");
+		assert_eq!(body["input"][0]["call_id"], "call-1");
+		assert_eq!(body["input"][1]["call_id"], "call-1");
+		assert_eq!(body["content"][0]["id"], "call-1");
+		assert_eq!(body["metadata"]["id"], "call-1__thought__signature");
 	}
 }

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -22,6 +22,10 @@ fn split_tool_call_id(raw: &str) -> (&str, Option<&str>) {
 	}
 }
 
+pub(crate) fn strip_thought_signature(raw: &str) -> &str {
+	split_tool_call_id(raw).0
+}
+
 /// Embed an optional thoughtSignature into a tool_call id for the client to echo back. A call with
 /// no signature keeps a plain id (no trailing separator), matching faithful passthrough.
 fn join_tool_call_id(base: String, signature: Option<&str>) -> String {


### PR DESCRIPTION
## Summary

Vertex Gemini encodes `thoughtSignature` values into OpenAI-compatible tool-call IDs so clients can echo them on the next native Gemini turn. When that history is replayed to a different provider, the internal suffix can make the ID exceed provider limits (for example, OpenAI's 64-character limit).

This change strips the internal `__thought__` suffix only while rendering requests for non-Gemini provider formats:

- OpenAI Chat Completions and Responses
- Anthropic Messages
- Bedrock Converse

Native Gemini rendering remains unchanged, so Gemini 3 signature round-trips continue to preserve the signature. The sanitizer only rewrites recognized tool identifier fields and leaves unrelated IDs untouched.

Part of #3342.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p agent-llm --lib` (373 passed)
- `cargo test -p agentgateway llm::tests --lib` (92 passed)
- `cargo clippy -p agent-llm -p agentgateway --all-targets`
- `git diff --check`
- gitleaks scan over the contribution commit

Added focused regressions for identifier sanitization and the OpenAI egress path.
