### PR TITLE
fix(proxy): make remote rate-limit denials actionable

### DIFF
--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use http_body_util::BodyExt;
+
 use super::*;
 use crate::cel;
 use crate::http::jwt;
@@ -667,6 +669,51 @@ fn apply_over_limit_response_returns_429() {
 	let direct = err.into_response_with_grpc(false);
 	assert_eq!(direct.status(), StatusCode::TOO_MANY_REQUESTS);
 	assert_eq!(direct.headers().get("retry-after").unwrap(), "60");
+}
+
+#[tokio::test]
+async fn apply_over_limit_without_body_returns_actionable_json_and_retry_after() {
+	use ::http::StatusCode;
+
+	use crate::http::tests_common::request_for_uri;
+
+	let mut req = request_for_uri("http://example.com/test");
+	let response = proto::RateLimitResponse {
+		overall_code: proto::rate_limit_response::Code::OverLimit as i32,
+		statuses: vec![proto::rate_limit_response::DescriptorStatus {
+			code: proto::rate_limit_response::Code::OverLimit as i32,
+			current_limit: Some(proto::rate_limit_response::RateLimit {
+				name: "hourly".to_string(),
+				requests_per_unit: 60,
+				unit: proto::rate_limit_response::rate_limit::Unit::Hour as i32,
+			}),
+			limit_remaining: 0,
+			duration_until_reset: Some(prost_types::Duration {
+				seconds: 2712,
+				nanos: 0,
+			}),
+			quota: None,
+		}],
+		response_headers_to_add: vec![],
+		request_headers_to_add: vec![],
+		raw_body: vec![],
+		dynamic_metadata: None,
+		quota: None,
+	};
+
+	let err = RemoteRateLimit::apply(&mut req, response).unwrap_err();
+	let direct = err.into_response_with_grpc(false);
+	assert_eq!(direct.status(), StatusCode::TOO_MANY_REQUESTS);
+	assert_eq!(direct.headers().get("retry-after").unwrap(), "2712");
+	assert_eq!(
+		direct.headers().get("content-type").unwrap(),
+		"application/json"
+	);
+	let body = direct.into_body().collect().await.unwrap().to_bytes();
+	let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	assert_eq!(body["error"]["message"], "rate limit exceeded");
+	assert_eq!(body["error"]["type"], "rate_limit_error");
+	assert_eq!(body["error"]["code"], "rate_limit_exceeded");
 }
 
 #[test]

--- a/crates/agentgateway/src/http/remoteratelimit_tests.rs
+++ b/crates/agentgateway/src/http/remoteratelimit_tests.rs
@@ -694,7 +694,11 @@ async fn apply_over_limit_without_body_returns_actionable_json_and_retry_after()
 			}),
 			quota: None,
 		}],
-		response_headers_to_add: vec![],
+		response_headers_to_add: vec![proto::HeaderValue {
+			key: "content-length".to_string(),
+			value: "0".to_string(),
+			raw_value: vec![],
+		}],
 		request_headers_to_add: vec![],
 		raw_body: vec![],
 		dynamic_metadata: None,
@@ -709,6 +713,7 @@ async fn apply_over_limit_without_body_returns_actionable_json_and_retry_after()
 		direct.headers().get("content-type").unwrap(),
 		"application/json"
 	);
+	assert!(direct.headers().get("content-length").is_none());
 	let body = direct.into_body().collect().await.unwrap().to_bytes();
 	let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
 	assert_eq!(body["error"]["message"], "rate limit exceeded");

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -439,13 +439,39 @@ impl ProxyError {
 			ProxyError::SubstrateIngressFailed(status, _) => status,
 			ProxyError::RateLimitExceeded { .. } => StatusCode::TOO_MANY_REQUESTS,
 			ProxyError::RemoteRateLimitExceeded {
+				status,
 				response_headers,
-				raw_body,
+				mut raw_body,
 				..
 			} => {
+				let retry_after = status.map(|status| status.reset_seconds);
+				let body_missing = raw_body.is_empty();
 				let mut rb = ::http::Response::builder().status(StatusCode::TOO_MANY_REQUESTS);
 				if let Some(hm) = rb.headers_mut() {
 					*hm = *response_headers;
+					if body_missing {
+						hm.insert(
+							hyper::header::CONTENT_TYPE,
+							HeaderValue::from_static("application/json"),
+						);
+					}
+					if !hm.contains_key(hyper::header::RETRY_AFTER)
+						&& let Some(retry_after) = retry_after
+						&& let Ok(value) = HeaderValue::try_from(retry_after.to_string())
+					{
+						hm.insert(hyper::header::RETRY_AFTER, value);
+					}
+				}
+				if body_missing {
+					raw_body = serde_json::json!({
+						"error": {
+							"message": "rate limit exceeded",
+							"type": "rate_limit_error",
+							"code": "rate_limit_exceeded",
+						}
+					})
+					.to_string()
+					.into_bytes();
 				}
 				return rb
 					.body(http::Body::from(raw_body))

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -450,6 +450,7 @@ impl ProxyError {
 				if let Some(hm) = rb.headers_mut() {
 					*hm = *response_headers;
 					if body_missing {
+						hm.remove(hyper::header::CONTENT_LENGTH);
 						hm.insert(
 							hyper::header::CONTENT_TYPE,
 							HeaderValue::from_static("application/json"),


### PR DESCRIPTION
## What does this PR do?

Remote rate-limit denials now remain client-actionable when the rate-limit service omits optional fields:

- Preserve an explicit `Retry-After` response header, or derive it from the most-constrained descriptor reset window when absent.
- Return a structured JSON error envelope with `Content-Type: application/json` when the service returns an empty body.
- Preserve non-empty denial bodies and all existing response headers.

## Why?

SDKs commonly rely on `Retry-After` for backoff and otherwise degrade an empty 429 response to an unhelpful generic error.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p agentgateway remoteratelimit::tests --lib` (34 passed)
- `cargo clippy -p agentgateway --all-targets -- -D warnings`
- `gitleaks protect --staged`
- `git diff --check`
- Full `cargo test -p agentgateway --lib`: 2027 passed; five unrelated MCP access-log tests currently panic at `crates/core/src/telemetry.rs:751` while unwrapping a missing global telemetry value.

Fixes #3329

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.