### PR TITLE
messages: accept tool_reference and unknown tool_result parts

### DIFF
--- a/crates/llm/src/conversion/bedrock.rs
+++ b/crates/llm/src/conversion/bedrock.rs
@@ -1732,8 +1732,16 @@ pub mod from_messages {
 											None
 										}
 									},
+									messages::ToolResultContentPart::ToolReference {
+										tool_name,
+										cache_control,
+									} => {
+										has_cache_control |= cache_control.is_some();
+										Some(bedrock::ToolResultContentBlock::Text(tool_name))
+									},
 									messages::ToolResultContentPart::Document { .. }
-									| messages::ToolResultContentPart::SearchResult { .. } => None,
+									| messages::ToolResultContentPart::SearchResult { .. }
+									| messages::ToolResultContentPart::Unknown => None,
 								})
 								.collect(),
 						};

--- a/crates/llm/src/conversion/completions.rs
+++ b/crates/llm/src/conversion/completions.rs
@@ -841,6 +841,10 @@ pub mod from_messages {
 													text,
 													cache_control,
 													..
+												}
+												| ToolResultContentPart::ToolReference {
+													tool_name: text,
+													cache_control,
 												} => tool_parts.push(completions::RequestToolMessageContentPart::Text(
 													completions::RequestMessageContentPartText {
 														text,
@@ -854,6 +858,7 @@ pub mod from_messages {
 														trailing_cache_control = trailing_cache_control.or(cache_control);
 													}
 												},
+												ToolResultContentPart::Unknown => {},
 											}
 										}
 										if let Some(cache_control) = trailing_cache_control {

--- a/crates/llm/src/conversion/responses.rs
+++ b/crates/llm/src/conversion/responses.rs
@@ -676,24 +676,17 @@ pub mod from_messages {
 				let mut text_values = Vec::new();
 				let has_cache_control = cache_control.is_some();
 				for part in parts {
-					match part {
+					let (text, citations, cache_control) = match part {
 						messages::ToolResultContentPart::Text {
 							text,
 							citations,
 							cache_control,
-						} => {
-							reject_option(
-								&citations,
-								"messages tool_result citations cannot be represented by responses",
-							)?;
-							let mut value = json!({
-								"type": "input_text",
-								"text": &text,
-							});
-							add_prompt_cache_breakpoint(&mut value, cache_control);
-							text_parts.push(text);
-							text_values.push(value);
-						},
+						} => (text, citations, cache_control),
+						messages::ToolResultContentPart::ToolReference {
+							tool_name,
+							cache_control,
+						} => (tool_name, None, cache_control),
+						messages::ToolResultContentPart::Unknown => continue,
 						messages::ToolResultContentPart::Image { .. }
 						| messages::ToolResultContentPart::Document { .. }
 						| messages::ToolResultContentPart::SearchResult { .. } => {
@@ -701,7 +694,18 @@ pub mod from_messages {
 								"messages non-text tool_result content cannot be represented by responses",
 							);
 						},
-					}
+					};
+					reject_option(
+						&citations,
+						"messages tool_result citations cannot be represented by responses",
+					)?;
+					let mut value = json!({
+						"type": "input_text",
+						"text": &text,
+					});
+					add_prompt_cache_breakpoint(&mut value, cache_control);
+					text_parts.push(text);
+					text_values.push(value);
 				}
 				if let Some(cache_control) = cache_control {
 					if let Some(last) = text_values.last_mut() {

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -178,6 +178,11 @@ mod requests {
 		("gpt_adaptive_thinking_with_tools", &[COMPLETIONS]),
 		("reasoning_replay", &[BEDROCK]),
 		("tool_history_without_tools", &[BEDROCK]),
+		("tool_reference", &[COMPLETIONS, BEDROCK, RESPONSES]),
+		(
+			"tool_result_unknown_part",
+			&[COMPLETIONS, BEDROCK, RESPONSES],
+		),
 		("responses_agent_subset", &[RESPONSES]),
 	];
 	const RESPONSES_REQUESTS: &[(&str, &[&str])] = &[

--- a/crates/llm/src/tests/requests/messages/tool_reference.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/tool_reference.bedrock.snap
@@ -1,0 +1,155 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/tool_reference.json
+info:
+  model: claude-sonnet-4-6
+  max_tokens: 1024
+  tools:
+    - name: ToolSearch
+      description: Find and load deferred tool schemas.
+      input_schema:
+        type: object
+        properties:
+          query:
+            type: string
+        required:
+          - query
+    - name: mcp__example__list_widgets
+      description: Lists widgets.
+      input_schema:
+        type: object
+        properties: {}
+      defer_loading: true
+  messages:
+    - role: user
+      content:
+        - type: text
+          text: List the widgets.
+    - role: assistant
+      content:
+        - type: tool_use
+          id: toolu_01AAAA
+          name: ToolSearch
+          input:
+            query: widgets
+    - role: user
+      content:
+        - type: tool_result
+          tool_use_id: toolu_01AAAA
+          content:
+            - type: tool_reference
+              tool_name: mcp__example__list_widgets
+              cache_control:
+                type: ephemeral
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "text": "List the widgets."
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "toolUse": {
+              "toolUseId": "toolu_01AAAA",
+              "name": "ToolSearch",
+              "input": {
+                "query": "widgets"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "toolResult": {
+              "toolUseId": "toolu_01AAAA",
+              "content": [
+                {
+                  "text": "mcp__example__list_widgets"
+                }
+              ],
+              "status": null
+            }
+          },
+          {
+            "cachePoint": {
+              "type": "default"
+            }
+          }
+        ]
+      }
+    ],
+    "inferenceConfig": {
+      "maxTokens": 1024
+    },
+    "toolConfig": {
+      "tools": [
+        {
+          "toolSpec": {
+            "name": "ToolSearch",
+            "description": "Find and load deferred tool schemas.",
+            "inputSchema": {
+              "json": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "toolSpec": {
+            "name": "mcp__example__list_widgets",
+            "description": "Lists widgets.",
+            "inputSchema": {
+              "json": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-sonnet-4-6",
+    "provider": "bedrock",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "List the widgets."
+      },
+      {
+        "role": "assistant",
+        "content": ""
+      },
+      {
+        "role": "user",
+        "content": ""
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/messages/tool_reference.completions.snap
+++ b/crates/llm/src/tests/requests/messages/tool_reference.completions.snap
@@ -1,0 +1,140 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/tool_reference.json
+info:
+  model: claude-sonnet-4-6
+  max_tokens: 1024
+  tools:
+    - name: ToolSearch
+      description: Find and load deferred tool schemas.
+      input_schema:
+        type: object
+        properties:
+          query:
+            type: string
+        required:
+          - query
+    - name: mcp__example__list_widgets
+      description: Lists widgets.
+      input_schema:
+        type: object
+        properties: {}
+      defer_loading: true
+  messages:
+    - role: user
+      content:
+        - type: text
+          text: List the widgets.
+    - role: assistant
+      content:
+        - type: tool_use
+          id: toolu_01AAAA
+          name: ToolSearch
+          input:
+            query: widgets
+    - role: user
+      content:
+        - type: tool_result
+          tool_use_id: toolu_01AAAA
+          content:
+            - type: tool_reference
+              tool_name: mcp__example__list_widgets
+              cache_control:
+                type: ephemeral
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "List the widgets."
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "type": "function",
+            "id": "toolu_01AAAA",
+            "function": {
+              "name": "ToolSearch",
+              "arguments": "{\"query\":\"widgets\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "content": [
+          {
+            "type": "text",
+            "text": "mcp__example__list_widgets"
+          }
+        ],
+        "tool_call_id": "toolu_01AAAA"
+      }
+    ],
+    "model": "claude-sonnet-4-6",
+    "max_completion_tokens": 1024,
+    "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "ToolSearch",
+          "description": "Find and load deferred tool schemas.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "query"
+            ]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "mcp__example__list_widgets",
+          "description": "Lists widgets.",
+          "parameters": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    ]
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-sonnet-4-6",
+    "provider": "openai",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "List the widgets."
+      },
+      {
+        "role": "assistant",
+        "content": ""
+      },
+      {
+        "role": "user",
+        "content": ""
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/messages/tool_reference.json
+++ b/crates/llm/src/tests/requests/messages/tool_reference.json
@@ -1,0 +1,72 @@
+{
+  "model": "claude-sonnet-4-6",
+  "max_tokens": 1024,
+  "tools": [
+    {
+      "name": "ToolSearch",
+      "description": "Find and load deferred tool schemas.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "mcp__example__list_widgets",
+      "description": "Lists widgets.",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "defer_loading": true
+    }
+  ],
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "List the widgets."
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01AAAA",
+          "name": "ToolSearch",
+          "input": {
+            "query": "widgets"
+          }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01AAAA",
+          "content": [
+            {
+              "type": "tool_reference",
+              "tool_name": "mcp__example__list_widgets",
+              "cache_control": {
+                "type": "ephemeral"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/llm/src/tests/requests/messages/tool_reference.responses.snap
+++ b/crates/llm/src/tests/requests/messages/tool_reference.responses.snap
@@ -1,0 +1,136 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/tool_reference.json
+info:
+  model: claude-sonnet-4-6
+  max_tokens: 1024
+  tools:
+    - name: ToolSearch
+      description: Find and load deferred tool schemas.
+      input_schema:
+        type: object
+        properties:
+          query:
+            type: string
+        required:
+          - query
+    - name: mcp__example__list_widgets
+      description: Lists widgets.
+      input_schema:
+        type: object
+        properties: {}
+      defer_loading: true
+  messages:
+    - role: user
+      content:
+        - type: text
+          text: List the widgets.
+    - role: assistant
+      content:
+        - type: tool_use
+          id: toolu_01AAAA
+          name: ToolSearch
+          input:
+            query: widgets
+    - role: user
+      content:
+        - type: tool_result
+          tool_use_id: toolu_01AAAA
+          content:
+            - type: tool_reference
+              tool_name: mcp__example__list_widgets
+              cache_control:
+                type: ephemeral
+---
+{
+  "request": {
+    "input": [
+      {
+        "type": "message",
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "List the widgets."
+          }
+        ]
+      },
+      {
+        "type": "function_call",
+        "id": "toolu_01AAAA",
+        "call_id": "toolu_01AAAA",
+        "name": "ToolSearch",
+        "arguments": "{\"query\":\"widgets\"}",
+        "status": "completed"
+      },
+      {
+        "type": "function_call_output",
+        "call_id": "toolu_01AAAA",
+        "output": [
+          {
+            "type": "input_text",
+            "text": "mcp__example__list_widgets",
+            "prompt_cache_breakpoint": {
+              "mode": "explicit"
+            }
+          }
+        ],
+        "status": "completed"
+      }
+    ],
+    "model": "claude-sonnet-4-6",
+    "max_output_tokens": 1024,
+    "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "name": "ToolSearch",
+        "description": "Find and load deferred tool schemas.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      },
+      {
+        "type": "function",
+        "name": "mcp__example__list_widgets",
+        "description": "Lists widgets.",
+        "parameters": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    ]
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-sonnet-4-6",
+    "provider": "responses",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "List the widgets."
+      },
+      {
+        "role": "assistant",
+        "content": ""
+      },
+      {
+        "role": "user",
+        "content": ""
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/messages/tool_result_unknown_part.bedrock.snap
+++ b/crates/llm/src/tests/requests/messages/tool_result_unknown_part.bedrock.snap
@@ -1,0 +1,150 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/tool_result_unknown_part.json
+info:
+  model: claude-sonnet-4-6
+  max_tokens: 1024
+  tools:
+    - name: ToolSearch
+      description: Find and load deferred tool schemas.
+      input_schema:
+        type: object
+        properties:
+          query:
+            type: string
+        required:
+          - query
+    - name: mcp__example__list_widgets
+      description: Lists widgets.
+      input_schema:
+        type: object
+        properties: {}
+      defer_loading: true
+  messages:
+    - role: user
+      content:
+        - type: text
+          text: List the widgets.
+    - role: assistant
+      content:
+        - type: tool_use
+          id: toolu_01AAAA
+          name: ToolSearch
+          input:
+            query: widgets
+    - role: user
+      content:
+        - type: tool_result
+          tool_use_id: toolu_01AAAA
+          content:
+            - type: text
+              text: 3 widgets found
+            - type: future_block
+              foo: 1
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "text": "List the widgets."
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "toolUse": {
+              "toolUseId": "toolu_01AAAA",
+              "name": "ToolSearch",
+              "input": {
+                "query": "widgets"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "toolResult": {
+              "toolUseId": "toolu_01AAAA",
+              "content": [
+                {
+                  "text": "3 widgets found"
+                }
+              ],
+              "status": null
+            }
+          }
+        ]
+      }
+    ],
+    "inferenceConfig": {
+      "maxTokens": 1024
+    },
+    "toolConfig": {
+      "tools": [
+        {
+          "toolSpec": {
+            "name": "ToolSearch",
+            "description": "Find and load deferred tool schemas.",
+            "inputSchema": {
+              "json": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "toolSpec": {
+            "name": "mcp__example__list_widgets",
+            "description": "Lists widgets.",
+            "inputSchema": {
+              "json": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-sonnet-4-6",
+    "provider": "bedrock",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "List the widgets."
+      },
+      {
+        "role": "assistant",
+        "content": ""
+      },
+      {
+        "role": "user",
+        "content": ""
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/messages/tool_result_unknown_part.completions.snap
+++ b/crates/llm/src/tests/requests/messages/tool_result_unknown_part.completions.snap
@@ -1,0 +1,140 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/tool_result_unknown_part.json
+info:
+  model: claude-sonnet-4-6
+  max_tokens: 1024
+  tools:
+    - name: ToolSearch
+      description: Find and load deferred tool schemas.
+      input_schema:
+        type: object
+        properties:
+          query:
+            type: string
+        required:
+          - query
+    - name: mcp__example__list_widgets
+      description: Lists widgets.
+      input_schema:
+        type: object
+        properties: {}
+      defer_loading: true
+  messages:
+    - role: user
+      content:
+        - type: text
+          text: List the widgets.
+    - role: assistant
+      content:
+        - type: tool_use
+          id: toolu_01AAAA
+          name: ToolSearch
+          input:
+            query: widgets
+    - role: user
+      content:
+        - type: tool_result
+          tool_use_id: toolu_01AAAA
+          content:
+            - type: text
+              text: 3 widgets found
+            - type: future_block
+              foo: 1
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "List the widgets."
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "tool_calls": [
+          {
+            "type": "function",
+            "id": "toolu_01AAAA",
+            "function": {
+              "name": "ToolSearch",
+              "arguments": "{\"query\":\"widgets\"}"
+            }
+          }
+        ]
+      },
+      {
+        "role": "tool",
+        "content": [
+          {
+            "type": "text",
+            "text": "3 widgets found"
+          }
+        ],
+        "tool_call_id": "toolu_01AAAA"
+      }
+    ],
+    "model": "claude-sonnet-4-6",
+    "max_completion_tokens": 1024,
+    "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "ToolSearch",
+          "description": "Find and load deferred tool schemas.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "query"
+            ]
+          }
+        }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "mcp__example__list_widgets",
+          "description": "Lists widgets.",
+          "parameters": {
+            "type": "object",
+            "properties": {}
+          }
+        }
+      }
+    ]
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-sonnet-4-6",
+    "provider": "openai",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "List the widgets."
+      },
+      {
+        "role": "assistant",
+        "content": ""
+      },
+      {
+        "role": "user",
+        "content": ""
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/messages/tool_result_unknown_part.json
+++ b/crates/llm/src/tests/requests/messages/tool_result_unknown_part.json
@@ -1,0 +1,73 @@
+{
+  "model": "claude-sonnet-4-6",
+  "max_tokens": 1024,
+  "tools": [
+    {
+      "name": "ToolSearch",
+      "description": "Find and load deferred tool schemas.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "mcp__example__list_widgets",
+      "description": "Lists widgets.",
+      "input_schema": {
+        "type": "object",
+        "properties": {}
+      },
+      "defer_loading": true
+    }
+  ],
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "text",
+          "text": "List the widgets."
+        }
+      ]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01AAAA",
+          "name": "ToolSearch",
+          "input": {
+            "query": "widgets"
+          }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01AAAA",
+          "content": [
+            {
+              "type": "text",
+              "text": "3 widgets found"
+            },
+            {
+              "type": "future_block",
+              "foo": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/llm/src/tests/requests/messages/tool_result_unknown_part.responses.snap
+++ b/crates/llm/src/tests/requests/messages/tool_result_unknown_part.responses.snap
@@ -1,0 +1,128 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/messages/tool_result_unknown_part.json
+info:
+  model: claude-sonnet-4-6
+  max_tokens: 1024
+  tools:
+    - name: ToolSearch
+      description: Find and load deferred tool schemas.
+      input_schema:
+        type: object
+        properties:
+          query:
+            type: string
+        required:
+          - query
+    - name: mcp__example__list_widgets
+      description: Lists widgets.
+      input_schema:
+        type: object
+        properties: {}
+      defer_loading: true
+  messages:
+    - role: user
+      content:
+        - type: text
+          text: List the widgets.
+    - role: assistant
+      content:
+        - type: tool_use
+          id: toolu_01AAAA
+          name: ToolSearch
+          input:
+            query: widgets
+    - role: user
+      content:
+        - type: tool_result
+          tool_use_id: toolu_01AAAA
+          content:
+            - type: text
+              text: 3 widgets found
+            - type: future_block
+              foo: 1
+---
+{
+  "request": {
+    "input": [
+      {
+        "type": "message",
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "List the widgets."
+          }
+        ]
+      },
+      {
+        "type": "function_call",
+        "id": "toolu_01AAAA",
+        "call_id": "toolu_01AAAA",
+        "name": "ToolSearch",
+        "arguments": "{\"query\":\"widgets\"}",
+        "status": "completed"
+      },
+      {
+        "type": "function_call_output",
+        "call_id": "toolu_01AAAA",
+        "output": "3 widgets found",
+        "status": "completed"
+      }
+    ],
+    "model": "claude-sonnet-4-6",
+    "max_output_tokens": 1024,
+    "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "name": "ToolSearch",
+        "description": "Find and load deferred tool schemas.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "query"
+          ]
+        }
+      },
+      {
+        "type": "function",
+        "name": "mcp__example__list_widgets",
+        "description": "Lists widgets.",
+        "parameters": {
+          "type": "object",
+          "properties": {}
+        }
+      }
+    ]
+  },
+  "parsed": {
+    "input_format": "Messages",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "claude-sonnet-4-6",
+    "provider": "responses",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "List the widgets."
+      },
+      {
+        "role": "assistant",
+        "content": ""
+      },
+      {
+        "role": "user",
+        "content": ""
+      }
+    ]
+  }
+}

--- a/crates/llm/src/types/messages.rs
+++ b/crates/llm/src/types/messages.rs
@@ -795,6 +795,14 @@ pub mod typed {
 			#[serde(skip_serializing_if = "Option::is_none")]
 			cache_control: Option<CacheControlEphemeral>,
 		},
+		ToolReference {
+			tool_name: String,
+			#[serde(skip_serializing_if = "Option::is_none")]
+			cache_control: Option<CacheControlEphemeral>,
+		},
+		// Same tolerance as ContentBlock: an unrecognized part must not reject the whole request
+		#[serde(other)]
+		Unknown,
 	}
 
 	#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, Eq)]
@@ -1420,6 +1428,23 @@ pub mod typed {
 mod tests {
 	use super::*;
 	use crate::types::ResponseType;
+
+	#[test]
+	fn tool_result_parts_accept_tool_reference_and_unknown_types() {
+		let parsed: typed::ToolResultContent = serde_json::from_value(serde_json::json!([
+			{"type": "tool_reference", "tool_name": "mcp__example__list_widgets"},
+			{"type": "future_block", "foo": 1}
+		]))
+		.expect("unrecognized tool_result parts must not fail parsing");
+		let typed::ToolResultContent::Array(parts) = parsed else {
+			panic!("expected array content");
+		};
+		assert!(matches!(
+			&parts[0],
+			typed::ToolResultContentPart::ToolReference { tool_name, .. } if tool_name == "mcp__example__list_widgets"
+		));
+		assert!(matches!(parts[1], typed::ToolResultContentPart::Unknown));
+	}
 
 	fn make_typed_response_with_tool_use() -> typed::MessagesResponse {
 		typed::MessagesResponse {


### PR DESCRIPTION
A `/v1/messages` request whose `tool_result.content` array holds a `tool_reference` part (Anthropic `advanced-tool-use-2025-11-20`, emitted by Claude Code's ToolSearch tool) failed typed parsing with a 400: "data did not match any variant of untagged enum ToolResultContent".

`ToolResultContentPart` is internally tagged on `type` with no fallback, so any unrecognized part failed the `Array` arm and the untagged parent rejected the whole request. The sibling `ContentBlock` already tolerates unknown blocks via `#[serde(other)] Unknown`.

- Add `ToolReference { tool_name, cache_control }` and `#[serde(other)] Unknown` variants to `ToolResultContentPart`.
- Converters render a tool reference as its tool name (Bedrock text block, Completions text part, Responses input_text), carrying its cache_control like a text part; the referenced tool definition is already emitted in the tool list. Unknown parts are dropped by all three converters, so a part newer than the build can never fail a request; on Responses that is deliberately more tolerant than its own `ContentBlock::Unknown` arm, which still rejects.
- Golden fixtures cover the Claude Code ToolSearch shape with a cache breakpoint (`tool_reference.json`, across Completions, Bedrock and Responses) and an unknown part alongside text (`tool_result_unknown_part.json`), plus a serde unit test for the unknown-type fallback.

Only the typed request used by the converters was affected; the Anthropic passthrough keeps unknown parts as raw JSON. `#[serde(other)]` rescues unknown `type` values only: a part with no `type`, or a `tool_reference` without `tool_name`, still fails. A tool_result left with no usable parts still serializes as empty content, which Bedrock Converse rejects; that is pre-existing for document-only results and not addressed here. This does not make deferred tools work on Bedrock Converse (#3240).

Fixes #3239

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
