### PR TITLE
feat: convert chat json_schema aliases to Anthropic and Gemini

### DIFF
--- a/crates/llm/src/conversion/chat_extensions.rs
+++ b/crates/llm/src/conversion/chat_extensions.rs
@@ -1,0 +1,42 @@
+use std::borrow::Cow;
+
+use agent_core::strng;
+use serde_json::{Value, json};
+
+use crate::AIError;
+use crate::types::completions::Request;
+
+pub(crate) fn response_format(req: &Request) -> Result<Option<Cow<'_, Value>>, AIError> {
+	let standard = req.rest.get("response_format").filter(|v| !v.is_null());
+	let Some(alias) = req.rest.get("json_schema").filter(|v| !v.is_null()) else {
+		return Ok(standard.map(Cow::Borrowed));
+	};
+	if !alias.is_object() {
+		return Err(invalid("json_schema must be an object"));
+	}
+	let schema = alias.get("schema").unwrap_or(alias);
+	if !schema.is_object() {
+		return Err(invalid("json_schema.schema must be an object"));
+	}
+	let wrapped = alias.get("schema").is_some();
+	let format = json!({
+		"type": "json_schema",
+		"json_schema": {
+			"name": if wrapped { alias.get("name").cloned().unwrap_or(json!("response")) } else { json!("response") },
+			"strict": if wrapped { alias.get("strict").cloned().unwrap_or(json!(true)) } else { json!(true) },
+			"schema": schema,
+		}
+	});
+	if let Some(standard) = standard
+		&& standard != &format
+	{
+		return Err(invalid(
+			"json_schema and response_format must agree; supply only one",
+		));
+	}
+	Ok(Some(Cow::Owned(format)))
+}
+
+pub(crate) fn invalid(message: &'static str) -> AIError {
+	AIError::UnsupportedConversion(strng::new(message))
+}

--- a/crates/llm/src/conversion/chat_extensions_tests.rs
+++ b/crates/llm/src/conversion/chat_extensions_tests.rs
@@ -1,0 +1,118 @@
+use serde_json::{Value, json};
+
+use crate::conversion::{messages, vertex_gemini};
+use crate::model_catalog::{TestCatalog, tags};
+use crate::types::completions::Request;
+
+fn request(fields: Value) -> Request {
+	let mut value = json!({"model": "gemini-2.5-pro", "messages": [{"role": "user", "content": "Hello"}], "max_tokens": 6400});
+	value
+		.as_object_mut()
+		.unwrap()
+		.extend(fields.as_object().unwrap().clone());
+	serde_json::from_value(value).unwrap()
+}
+
+fn messages_body(req: &Request) -> Result<Value, crate::AIError> {
+	let bytes = messages::from_completions::translate(req, None)?;
+	Ok(serde_json::from_slice(&bytes).unwrap())
+}
+
+fn gemini_body(req: &Request) -> Result<Value, crate::AIError> {
+	let bytes = vertex_gemini::from_completions::translate(req, None)?;
+	Ok(serde_json::from_slice(&bytes).unwrap())
+}
+
+#[test]
+fn bare_schema_matches_wrapped_schema_on_both_providers() {
+	let schema =
+		json!({"type": "object", "properties": {"value": {"type": "string"}}, "required": ["value"]});
+	let bare = request(json!({"json_schema": schema}));
+	let wrapped = request(json!({"json_schema": {"name": "response", "schema": schema}}));
+	assert_eq!(
+		messages_body(&bare).unwrap(),
+		messages_body(&wrapped).unwrap()
+	);
+	assert_eq!(gemini_body(&bare).unwrap(), gemini_body(&wrapped).unwrap());
+}
+
+#[test]
+fn conflicting_schema_fields_are_rejected_by_both_providers() {
+	let req =
+		request(json!({"json_schema": {"type": "object"}, "response_format": {"type": "json_object"}}));
+	assert!(
+		messages_body(&req)
+			.unwrap_err()
+			.to_string()
+			.contains("must agree")
+	);
+	assert!(
+		gemini_body(&req)
+			.unwrap_err()
+			.to_string()
+			.contains("must agree")
+	);
+}
+
+#[test]
+fn identical_schema_fields_are_accepted() {
+	let alias = json!({"name": "person", "strict": true, "schema": {"type": "object"}});
+	let req = request(
+		json!({"json_schema": alias, "response_format": {"type": "json_schema", "json_schema": alias}}),
+	);
+	assert!(messages_body(&req).is_ok());
+	assert!(gemini_body(&req).is_ok());
+}
+
+#[rstest::rstest]
+#[case(json!("invalid"))]
+#[case(json!({"schema": []}))]
+fn invalid_schemas_are_rejected(#[case] schema: Value) {
+	let req = request(json!({"json_schema": schema}));
+	assert!(messages_body(&req).is_err());
+	assert!(gemini_body(&req).is_err());
+}
+
+#[test]
+fn adaptive_messages_use_standard_reasoning_effort() {
+	let catalog = TestCatalog::new([("adaptive-model", &[tags::ADAPTIVE_THINKING][..])]);
+	let req = request(json!({"model": "adaptive-model", "reasoning_effort": "high"}));
+	let bytes = messages::from_completions::translate(&req, Some(&catalog)).unwrap();
+	let body: Value = serde_json::from_slice(&bytes).unwrap();
+	assert_eq!(body["thinking"]["type"], "adaptive");
+	assert_eq!(body["output_config"]["effort"], "high");
+}
+
+#[test]
+fn gemini_three_uses_standard_reasoning_effort() {
+	let req = request(json!({"model": "gemini-3.1-pro", "reasoning_effort": "high"}));
+	assert_eq!(
+		gemini_body(&req).unwrap()["generationConfig"]["thinkingConfig"],
+		json!({"thinkingLevel": "high", "includeThoughts": true})
+	);
+}
+
+#[test]
+fn nonstandard_reasoning_does_not_override_standard_effort() {
+	let standard = request(json!({"reasoning_effort": "low"}));
+	let extended = request(json!({
+			"reasoning_effort": "low",
+			"reasoning": {"effort": "high", "max_tokens": 2048, "exclude": true}
+	}));
+	assert_eq!(
+		messages_body(&standard).unwrap(),
+		messages_body(&extended).unwrap()
+	);
+	assert_eq!(
+		gemini_body(&standard).unwrap(),
+		gemini_body(&extended).unwrap()
+	);
+}
+
+#[test]
+fn passthrough_serialization_preserves_schema_and_standard_effort() {
+	let fields = json!({"reasoning_effort": "high", "json_schema": {"type": "object"}});
+	let wire = serde_json::to_value(request(fields.clone())).unwrap();
+	assert_eq!(wire["reasoning_effort"], fields["reasoning_effort"]);
+	assert_eq!(wire["json_schema"], fields["json_schema"]);
+}

--- a/crates/llm/src/conversion/messages.rs
+++ b/crates/llm/src/conversion/messages.rs
@@ -261,7 +261,12 @@ pub mod from_completions {
 		req: &types::completions::Request,
 		catalog: crate::model_catalog::Catalog<'_>,
 	) -> Result<Vec<u8>, AIError> {
-		let typed = json::convert::<_, completions::Request>(req).map_err(AIError::RequestMarshal)?;
+		let mut typed =
+			json::convert::<_, completions::Request>(req).map_err(AIError::RequestMarshal)?;
+		if let Some(format) = super::super::chat_extensions::response_format(req)? {
+			typed.response_format =
+				Some(serde_json::from_value(format.into_owned()).map_err(AIError::RequestParsing)?);
+		}
 		let model_id = typed.model.clone().unwrap_or_default();
 		let xlated = translate_internal(typed, model_id, catalog);
 		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)

--- a/crates/llm/src/conversion/mod.rs
+++ b/crates/llm/src/conversion/mod.rs
@@ -1,4 +1,5 @@
 pub mod bedrock;
+pub mod chat_extensions;
 pub mod completions;
 pub mod gemini;
 pub mod messages;
@@ -6,6 +7,9 @@ pub mod openai_compat;
 pub mod responses;
 pub mod vertex;
 pub mod vertex_gemini;
+
+#[cfg(test)]
+mod chat_extensions_tests;
 
 /// Translate an OpenAI `tool_calls[].function.arguments` string into an Anthropic
 /// `tool_use.input` value.

--- a/crates/llm/src/conversion/vertex_gemini.rs
+++ b/crates/llm/src/conversion/vertex_gemini.rs
@@ -187,7 +187,7 @@ pub mod from_completions {
 
 		let tools = build_tools(req);
 		let tool_config = build_tool_config(req);
-		let generation_config = build_generation_config(req, &model);
+		let generation_config = build_generation_config(req, &model)?;
 
 		let cached_content = req
 			.rest
@@ -680,7 +680,7 @@ pub mod from_completions {
 	fn build_generation_config(
 		req: &types::completions::Request,
 		model: &str,
-	) -> Option<vg::GenerationConfig> {
+	) -> Result<Option<vg::GenerationConfig>, AIError> {
 		let stop_sequences = match &req.stop {
 			Some(Value::String(s)) => vec![s.clone()],
 			Some(Value::Array(a)) => a
@@ -691,7 +691,7 @@ pub mod from_completions {
 			_ => Vec::new(),
 		};
 
-		let (response_mime_type, response_schema) = response_format(req);
+		let (response_mime_type, response_schema) = response_format(req)?;
 		let thinking_config = thinking_config(req, model);
 
 		let cfg = vg::GenerationConfig {
@@ -715,17 +715,19 @@ pub mod from_completions {
 		};
 
 		if cfg == vg::GenerationConfig::default() {
-			None
+			Ok(None)
 		} else {
-			Some(cfg)
+			Ok(Some(cfg))
 		}
 	}
 
-	fn response_format(req: &types::completions::Request) -> (Option<String>, Option<Value>) {
-		let Some(rf) = req.rest.get("response_format") else {
-			return (None, None);
+	fn response_format(
+		req: &types::completions::Request,
+	) -> Result<(Option<String>, Option<Value>), AIError> {
+		let Some(rf) = crate::conversion::chat_extensions::response_format(req)? else {
+			return Ok((None, None));
 		};
-		match rf.get("type").and_then(Value::as_str) {
+		Ok(match rf.get("type").and_then(Value::as_str) {
 			Some("json_object") => (Some("application/json".into()), None),
 			Some("json_schema") => {
 				// Unwrap OpenAI's {schema, strict, name, description} and normalize the bare schema.
@@ -736,7 +738,7 @@ pub mod from_completions {
 				(Some("application/json".into()), schema)
 			},
 			_ => (None, None),
-		}
+		})
 	}
 
 	// Gemini's responseSchema / functionDeclarations[].parameters accept only a subset of JSON Schema.

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -151,7 +151,8 @@ mod requests {
 		("image-inline", &[VERTEX_GEMINI]),
 		("image-file", &[VERTEX_GEMINI]),
 		("file-inline", &[VERTEX_GEMINI]),
-		("structured-output", &[VERTEX_GEMINI]),
+		("structured-output", &[ANTHROPIC, VERTEX_GEMINI]),
+		("chat-extensions", &[ANTHROPIC, VERTEX_GEMINI]),
 		("multi-turn-tools", &[VERTEX_GEMINI]),
 		// Stands in for `full`, whose remote HTTP image the Gemini path rejects.
 		("generation-config", &[VERTEX_GEMINI]),

--- a/crates/llm/src/tests/requests/completions/chat-extensions.anthropic.snap
+++ b/crates/llm/src/tests/requests/completions/chat-extensions.anthropic.snap
@@ -1,0 +1,104 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/completions/chat-extensions.json
+info:
+  model: gemini-2.5-pro
+  messages:
+    - role: system
+      content: Extract structured person information.
+    - role: user
+      content: "Ada Lovelace, age 36, interests: mathematics."
+  max_tokens: 6400
+  reasoning_effort: high
+  json_schema:
+    name: person
+    strict: true
+    schema:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+          minimum: 0
+        interests:
+          type: array
+          items:
+            type: string
+      required:
+        - name
+        - age
+        - interests
+      additionalProperties: false
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Ada Lovelace, age 36, interests: mathematics."
+          }
+        ]
+      }
+    ],
+    "system": "Extract structured person information.",
+    "model": "gemini-2.5-pro",
+    "max_tokens": 6400,
+    "thinking": {
+      "type": "enabled",
+      "budget_tokens": 4096
+    },
+    "output_config": {
+      "format": {
+        "type": "json_schema",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "age": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "interests": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "name",
+            "age",
+            "interests"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  },
+  "parsed": {
+    "input_format": "Completions",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gemini-2.5-pro",
+    "provider": "anthropic",
+    "streaming": false,
+    "params": {
+      "max_tokens": 6400
+    },
+    "prompt": [
+      {
+        "role": "system",
+        "content": "Extract structured person information."
+      },
+      {
+        "role": "user",
+        "content": "Ada Lovelace, age 36, interests: mathematics."
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/completions/chat-extensions.json
+++ b/crates/llm/src/tests/requests/completions/chat-extensions.json
@@ -1,0 +1,23 @@
+{
+  "model": "gemini-2.5-pro",
+  "messages": [
+    { "role": "system", "content": "Extract structured person information." },
+    { "role": "user", "content": "Ada Lovelace, age 36, interests: mathematics." }
+  ],
+  "max_tokens": 6400,
+  "reasoning_effort": "high",
+  "json_schema": {
+    "name": "person",
+    "strict": true,
+    "schema": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "age": { "type": "integer", "minimum": 0 },
+        "interests": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["name", "age", "interests"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/crates/llm/src/tests/requests/completions/chat-extensions.vertex-gemini.snap
+++ b/crates/llm/src/tests/requests/completions/chat-extensions.vertex-gemini.snap
@@ -1,0 +1,105 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/completions/chat-extensions.json
+info:
+  model: gemini-2.5-pro
+  messages:
+    - role: system
+      content: Extract structured person information.
+    - role: user
+      content: "Ada Lovelace, age 36, interests: mathematics."
+  max_tokens: 6400
+  reasoning_effort: high
+  json_schema:
+    name: person
+    strict: true
+    schema:
+      type: object
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+          minimum: 0
+        interests:
+          type: array
+          items:
+            type: string
+      required:
+        - name
+        - age
+        - interests
+      additionalProperties: false
+---
+{
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "Ada Lovelace, age 36, interests: mathematics."
+          }
+        ]
+      }
+    ],
+    "systemInstruction": {
+      "parts": [
+        {
+          "text": "Extract structured person information."
+        }
+      ]
+    },
+    "generationConfig": {
+      "maxOutputTokens": 6400,
+      "responseMimeType": "application/json",
+      "responseSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "age": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "interests": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "name",
+          "age",
+          "interests"
+        ]
+      },
+      "thinkingConfig": {
+        "thinkingBudget": 4096,
+        "includeThoughts": true
+      }
+    }
+  },
+  "parsed": {
+    "input_format": "Completions",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gemini-2.5-pro",
+    "provider": "vertex",
+    "streaming": false,
+    "params": {
+      "max_tokens": 6400
+    },
+    "prompt": [
+      {
+        "role": "system",
+        "content": "Extract structured person information."
+      },
+      {
+        "role": "user",
+        "content": "Ada Lovelace, age 36, interests: mathematics."
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/completions/structured-output.anthropic.snap
+++ b/crates/llm/src/tests/requests/completions/structured-output.anthropic.snap
@@ -1,0 +1,93 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/completions/structured-output.json
+info:
+  model: gemini-2.5-pro
+  messages:
+    - role: user
+      content: "Extract the person from: Ada Lovelace, age 36."
+  response_format:
+    type: json_schema
+    json_schema:
+      name: person
+      schema:
+        type: object
+        properties:
+          person:
+            $ref: "#/$defs/Person"
+        required:
+          - person
+        $defs:
+          Person:
+            type: object
+            properties:
+              name:
+                type: string
+              age:
+                type: integer
+            required:
+              - name
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Extract the person from: Ada Lovelace, age 36."
+          }
+        ]
+      }
+    ],
+    "model": "gemini-2.5-pro",
+    "max_tokens": 4096,
+    "output_config": {
+      "format": {
+        "type": "json_schema",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "person": {
+              "$ref": "#/$defs/Person"
+            }
+          },
+          "required": [
+            "person"
+          ],
+          "$defs": {
+            "Person": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "age": {
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "name"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "parsed": {
+    "input_format": "Completions",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gemini-2.5-pro",
+    "provider": "anthropic",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Extract the person from: Ada Lovelace, age 36."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Map the top-level `json_schema` alias to structured output in Anthropic Messages and Gemini. Accept bare or wrapped schemas, reject invalid schemas, and reject conflicting `json_schema` and `response_format` values.

Preserve existing `response_format` and `reasoning_effort` conversion.

Includes regression and golden tests. AI assisted the implementation.

- [ ] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.

Fixes #3365.
