### PR TITLE
feat(a2a): support custom agent card path for non-standard agents

### DIFF
--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -13629,7 +13629,10 @@ func (x *BackendPolicySpec_Ai) GetRoutes() map[string]BackendPolicySpec_Ai_Route
 }
 
 type BackendPolicySpec_A2A struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Custom path suffix for agent card requests (e.g., "/agent.json").
+	// Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.
+	AgentCardPath string `protobuf:"bytes,1,opt,name=agent_card_path,json=agentCardPath,proto3" json:"agent_card_path,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -13662,6 +13665,13 @@ func (x *BackendPolicySpec_A2A) ProtoReflect() protoreflect.Message {
 // Deprecated: Use BackendPolicySpec_A2A.ProtoReflect.Descriptor instead.
 func (*BackendPolicySpec_A2A) Descriptor() ([]byte, []int) {
 	return file_resource_proto_rawDescGZIP(), []int{58, 1}
+}
+
+func (x *BackendPolicySpec_A2A) GetAgentCardPath() string {
+	if x != nil {
+		return x.AgentCardPath
+	}
+	return ""
 }
 
 type BackendPolicySpec_InferenceRouting struct {
@@ -18784,7 +18794,7 @@ const file_resource_proto_rawDesc = "" +
 	"\vPolicyPhase\x12\t\n" +
 	"\x05ROUTE\x10\x00\x12\v\n" +
 	"\aGATEWAY\x10\x01B\x06\n" +
-	"\x04kind\"\xa4i\n" +
+	"\x04kind\"\xcci\n" +
 	"\x11BackendPolicySpec\x12D\n" +
 	"\x03a2a\x18\x01 \x01(\v20.agentgateway.dev.resource.BackendPolicySpec.A2aH\x00R\x03a2a\x12l\n" +
 	"\x11inference_routing\x18\x02 \x01(\v2=.agentgateway.dev.resource.BackendPolicySpec.InferenceRoutingH\x00R\x10inferenceRouting\x12Z\n" +
@@ -18987,8 +18997,9 @@ const file_resource_proto_rawDesc = "" +
 	"\x06RERANK\x10\n" +
 	"\x12\x14\n" +
 	"\x10GENERATE_CONTENT\x10\v\x12\x17\n" +
-	"\x13GEMINI_COUNT_TOKENS\x10\f\x1a\x05\n" +
-	"\x03A2a\x1a\x92\x02\n" +
+	"\x13GEMINI_COUNT_TOKENS\x10\f\x1a-\n" +
+	"\x03A2a\x12&\n" +
+	"\x0fagent_card_path\x18\x01 \x01(\tR\ragentCardPath\x1a\x92\x02\n" +
 	"\x10InferenceRouting\x12T\n" +
 	"\x0fendpoint_picker\x18\x01 \x01(\v2+.agentgateway.dev.resource.BackendReferenceR\x0eendpointPicker\x12l\n" +
 	"\ffailure_mode\x18\x02 \x01(\x0e2I.agentgateway.dev.resource.BackendPolicySpec.InferenceRouting.FailureModeR\vfailureMode\":\n" +

--- a/controller/pkg/agentgateway/plugins/a2a_plugin.go
+++ b/controller/pkg/agentgateway/plugins/a2a_plugin.go
@@ -18,6 +18,9 @@ import (
 const (
 	legacyA2aProtocol = "kgateway.dev/a2a"
 	a2aProtocol       = "agentgateway.dev/a2a"
+
+	// Service annotation for custom agent card path (e.g., "/agent.json").
+	a2aAgentCardPathAnnotation = "agentgateway.dev/a2a-agent-card-path"
 )
 
 // NewA2APlugin creates a new A2A policy plugin
@@ -57,6 +60,13 @@ func translatePoliciesForService(krtctx krt.HandlerContext, svc *corev1.Service,
 		if port.AppProtocol != nil && (*port.AppProtocol == a2aProtocol || *port.AppProtocol == legacyA2aProtocol) {
 			logger.Debug("found A2A service", "service", svc.Name, "namespace", svc.Namespace, "port", port.Port)
 			hostname := fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, clusterDomain)
+
+			// Read custom agent card path from annotation
+			var agentCardPath string
+			if svc.Annotations != nil {
+				agentCardPath = svc.Annotations[a2aAgentCardPathAnnotation]
+			}
+
 			policy := &api.Policy{
 				Key: fmt.Sprintf("a2a/%s/%s/%d", svc.Namespace, svc.Name, port.Port),
 				// TODO: this is awkward since its doesn't include a Kind..
@@ -69,7 +79,9 @@ func translatePoliciesForService(krtctx krt.HandlerContext, svc *corev1.Service,
 				Kind: &api.Policy_Backend{
 					Backend: &api.BackendPolicySpec{
 						Kind: &api.BackendPolicySpec_A2A_{
-							A2A: &api.BackendPolicySpec_A2A{},
+							A2A: &api.BackendPolicySpec_A2A{
+								AgentCardPath: agentCardPath,
+							},
 						},
 					},
 				},

--- a/crates/agentgateway/src/a2a/mod.rs
+++ b/crates/agentgateway/src/a2a/mod.rs
@@ -8,56 +8,73 @@ use crate::http::{Body, BodyInspection, Response, filters};
 use crate::json;
 use crate::types::agent::A2aPolicy;
 
-pub async fn apply_to_request(_: &A2aPolicy, req: &mut Request<Body>) -> RequestType {
-	// Possible options are POST a JSON-RPC message or GET /.well-known/agent.json
+pub async fn apply_to_request(pol: &A2aPolicy, req: &mut Request<Body>) -> RequestType {
+	// Possible options are POST a JSON-RPC message or GET agent card
 	// For agent card, we will process only on the response
-	classify_request(req).await
+	classify_request(pol, req).await
 }
 
-async fn classify_request(req: &mut Request<Body>) -> RequestType {
-	// Possible options are POST a JSON-RPC message or GET /.well-known/agent.json
+async fn classify_request(pol: &A2aPolicy, req: &mut Request<Body>) -> RequestType {
+	// Possible options are POST a JSON-RPC message or GET agent card
 	// For agent card, we will process only on the response
-	match (req.method(), req.uri().path()) {
+	let agent_card_suffix: Option<String> = match (req.method(), req.uri().path()) {
+		// Standard agent card paths:
 		// agent-card.json: v0.3.0+
-		// agent.json: older versions
-		(m, path)
-			if m == http::Method::GET
-				&& (path.ends_with("/.well-known/agent.json")
-					|| path.ends_with("/.well-known/agent-card.json")) =>
-		{
-			// In case of rewrite, use the original so we know where to send them back to
-			let uri = req
-				.extensions()
-				.get::<filters::OriginalUrl>()
-				.map(|u| u.0.clone())
-				.unwrap_or_else(|| req.uri().clone());
-			let uri = crate::http::x_headers::apply_forwarded_scheme(uri, req.headers());
-			// Also record the (possibly rewritten) backend path so we can compute
-			// relative interface URLs on the response side.
-			let backend_path = req.uri().path().to_string();
-			let rewrite = req
-				.extensions()
-				.get::<filters::AppliedUrlRewrite>()
-				.cloned();
-			RequestType::AgentCard(uri, backend_path, rewrite)
+		(m, path) if m == http::Method::GET && path.ends_with("/.well-known/agent-card.json") => {
+			Some("/.well-known/agent-card.json".to_string())
 		},
-		(m, _) if m == http::Method::POST => {
-			let method = match crate::http::classify_content_type(req.headers()) {
-				crate::http::WellKnownContentTypes::Json => match inspect_method(req).await {
-					Ok(method) => method,
-					Err(e) => {
-						warn!("failed to read a2a request: {e}");
-						Strng::from("unknown")
-					},
-				},
-				_ => {
-					warn!("unknown content type from A2A");
+		// agent.json: older versions
+		(m, path) if m == http::Method::GET && path.ends_with("/.well-known/agent.json") => {
+			Some("/.well-known/agent.json".to_string())
+		},
+		// Custom agent card path
+		(m, path) if m == http::Method::GET => {
+			if let Some(custom_path) = &pol.agent_card_path {
+				if path.ends_with(custom_path.as_str()) {
+					Some(custom_path.to_string())
+				} else {
+					None
+				}
+			} else {
+				None
+			}
+		},
+		_ => None,
+	};
+
+	if let Some(suffix) = agent_card_suffix {
+		// In case of rewrite, use the original so we know where to send them back to
+		let uri = req
+			.extensions()
+			.get::<filters::OriginalUrl>()
+			.map(|u| u.0.clone())
+			.unwrap_or_else(|| req.uri().clone());
+		let uri = crate::http::x_headers::apply_forwarded_scheme(uri, req.headers());
+		// Also record the (possibly rewritten) backend path so we can compute
+		// relative interface URLs on the response side.
+		let backend_path = req.uri().path().to_string();
+		let rewrite = req
+			.extensions()
+			.get::<filters::AppliedUrlRewrite>()
+			.cloned();
+		RequestType::AgentCard(uri, backend_path, rewrite, suffix)
+	} else if req.method() == http::Method::POST {
+		let method = match crate::http::classify_content_type(req.headers()) {
+			crate::http::WellKnownContentTypes::Json => match inspect_method(req).await {
+				Ok(method) => method,
+				Err(e) => {
+					warn!("failed to read a2a request: {e}");
 					Strng::from("unknown")
 				},
-			};
-			RequestType::Call(method)
-		},
-		_ => RequestType::Unknown,
+			},
+			_ => {
+				warn!("unknown content type from A2A");
+				Strng::from("unknown")
+			},
+		};
+		RequestType::Call(method)
+	} else {
+		RequestType::Unknown
 	}
 }
 
@@ -65,7 +82,17 @@ async fn classify_request(req: &mut Request<Body>) -> RequestType {
 pub enum RequestType {
 	#[default]
 	Unknown,
-	AgentCard(http::Uri, String, Option<filters::AppliedUrlRewrite>),
+	/// Agent card request with:
+	/// - The original (gateway-facing) URI
+	/// - The backend request path
+	/// - The applied URL rewrite (if any)
+	/// - The agent card path suffix (for stripping when computing base URL)
+	AgentCard(
+		http::Uri,
+		String,
+		Option<filters::AppliedUrlRewrite>,
+		String,
+	),
 	Call(Strng),
 }
 
@@ -163,7 +190,7 @@ pub async fn apply_to_response(
 		return Ok(None);
 	};
 	match a2a_type {
-		RequestType::AgentCard(uri, backend_path, rewrite) => {
+		RequestType::AgentCard(uri, backend_path, rewrite, agent_card_suffix) => {
 			// For agent card, we need to mutate the request to insert the proper URL to reach it
 			// through the gateway.
 			let buffer_limit = crate::http::response_buffer_limit(resp);
@@ -171,13 +198,13 @@ pub async fn apply_to_response(
 			let Ok(mut agent_card) = json::from_body_with_limit::<Value>(body, buffer_limit).await else {
 				anyhow::bail!("agent card invalid JSON");
 			};
-			let gateway_base = build_agent_path(uri);
+			let gateway_base = build_agent_path(uri, &agent_card_suffix);
 
 			// Compute the backend agent base by stripping the agent-card suffix from the
 			// (possibly rewritten) backend request path. This lets us compute the *relative*
 			// part of interface URLs so they are anchored at the gateway path instead of
 			// being naively appended.
-			let backend_agent_path = strip_agent_card_suffix(&backend_path);
+			let backend_agent_path = strip_agent_card_suffix(&backend_path, &agent_card_suffix);
 
 			if let Some(interfaces) = agent_card.get_mut("supportedInterfaces") {
 				// A2A v1.0: rewrite url inside each AgentInterface entry.
@@ -257,16 +284,20 @@ async fn inspect_method(req: &mut Request<Body>) -> anyhow::Result<Strng> {
 	Ok(json::inspect_body::<JsonRpcMethod>(req).await?.method)
 }
 
-fn build_agent_path(uri: Uri) -> String {
+fn build_agent_path(uri: Uri, agent_card_suffix: &str) -> String {
 	// Keep the original URL the found the agent at, but strip the agent card suffix.
 	// Note: this won't work in the case they are hosting their agent in other locations.
-	let path = strip_agent_card_suffix(uri.path());
+	let path = strip_agent_card_suffix(uri.path(), agent_card_suffix);
 	uri.to_string().replace(uri.path(), path)
 }
 
-/// Strip the agent-card well-known suffix from a path, returning the base path
-/// where the agent is hosted.
-fn strip_agent_card_suffix(path: &str) -> &str {
+/// Strip the agent-card suffix from a path, returning the base path.
+fn strip_agent_card_suffix<'a>(path: &'a str, agent_card_suffix: &str) -> &'a str {
+	// Try the provided suffix first
+	if let Some(stripped) = path.strip_suffix(agent_card_suffix) {
+		return stripped;
+	}
+	// Fall back to standard suffixes
 	let path = path.strip_suffix("/.well-known/agent.json").unwrap_or(path);
 	path
 		.strip_suffix("/.well-known/agent-card.json")

--- a/crates/agentgateway/src/a2a/tests.rs
+++ b/crates/agentgateway/src/a2a/tests.rs
@@ -15,42 +15,61 @@ fn test_build_agent_path() {
 		// Test stripping /.well-known/agent.json
 		(
 			"https://example.com/.well-known/agent.json",
+			"/.well-known/agent.json",
 			"https://example.com",
 		),
 		(
 			"https://example.com/api/.well-known/agent.json",
+			"/.well-known/agent.json",
 			"https://example.com/api",
 		),
 		(
 			"http://localhost:8080/service/.well-known/agent.json",
+			"/.well-known/agent.json",
 			"http://localhost:8080/service",
 		),
 		// Test stripping /.well-known/agent-card.json
 		(
 			"https://example.com/.well-known/agent-card.json",
+			"/.well-known/agent-card.json",
 			"https://example.com",
 		),
 		(
 			"https://example.com/api/.well-known/agent-card.json",
+			"/.well-known/agent-card.json",
 			"https://example.com/api",
 		),
 		(
 			"http://localhost:8080/service/.well-known/agent-card.json",
+			"/.well-known/agent-card.json",
 			"http://localhost:8080/service",
 		),
 		(
 			"https://example.com:443/.well-known/agent.json",
+			"/.well-known/agent.json",
 			"https://example.com:443",
 		),
 		(
 			"http://example.com:80/.well-known/agent-card.json",
+			"/.well-known/agent-card.json",
 			"http://example.com:80",
+		),
+		// Test stripping custom agent card paths (issue #3018)
+		(
+			"https://solutions.com/api/ai/config/agents/agent-orchestrator/agent.json",
+			"/agent.json",
+			"https://solutions.com/api/ai/config/agents/agent-orchestrator",
+		),
+		(
+			"https://elasticsearch.com/s/_ops/api/agent_builder/a2a/test_v1.json",
+			"/test_v1.json",
+			"https://elasticsearch.com/s/_ops/api/agent_builder/a2a",
 		),
 	];
 
-	for (input_url, expected_output) in test_cases {
+	for (input_url, suffix, expected_output) in test_cases {
 		let uri: Uri = input_url.parse().expect("Failed to parse URI");
-		let result = build_agent_path(uri);
+		let result = build_agent_path(uri, suffix);
 		assert_eq!(result, expected_output, "Failed for input: {input_url}");
 	}
 }
@@ -71,7 +90,10 @@ async fn test_classify_request_extracts_method_and_preserves_body() {
 		.body(http::Body::from(body.clone()))
 		.unwrap();
 
-	let ty = classify_request(&mut req).await;
+	let pol = A2aPolicy {
+		agent_card_path: None,
+	};
+	let ty = classify_request(&pol, &mut req).await;
 
 	match ty {
 		RequestType::Call(method) => assert_eq!(method.as_str(), "tasks/send"),
@@ -94,10 +116,13 @@ async fn test_classify_request_uses_original_url_for_agent_card() {
 		.extensions_mut()
 		.insert(crate::http::filters::OriginalUrl(original.clone()));
 
-	let ty = classify_request(&mut req).await;
+	let pol = A2aPolicy {
+		agent_card_path: None,
+	};
+	let ty = classify_request(&pol, &mut req).await;
 
 	match ty {
-		RequestType::AgentCard(uri, _, _) => assert_eq!(uri, original),
+		RequestType::AgentCard(uri, _, _, _) => assert_eq!(uri, original),
 		other => panic!("expected agent card request, got {other:?}"),
 	}
 }
@@ -116,10 +141,13 @@ async fn test_classify_request_uses_original_url_for_agent_card_with_subpath() {
 		.extensions_mut()
 		.insert(crate::http::filters::OriginalUrl(original.clone()));
 
-	let ty = classify_request(&mut req).await;
+	let pol = A2aPolicy {
+		agent_card_path: None,
+	};
+	let ty = classify_request(&pol, &mut req).await;
 
 	match ty {
-		RequestType::AgentCard(uri, _, _) => assert_eq!(uri, original),
+		RequestType::AgentCard(uri, _, _, _) => assert_eq!(uri, original),
 		other => panic!("expected agent card request, got {other:?}"),
 	}
 }
@@ -139,10 +167,13 @@ async fn test_classify_request_uses_x_forwarded_proto_for_agent_card() {
 		.extensions_mut()
 		.insert(crate::http::filters::OriginalUrl(original));
 
-	let ty = classify_request(&mut req).await;
+	let pol = A2aPolicy {
+		agent_card_path: None,
+	};
+	let ty = classify_request(&pol, &mut req).await;
 
 	match ty {
-		RequestType::AgentCard(uri, _, _) => {
+		RequestType::AgentCard(uri, _, _, _) => {
 			assert_eq!(
 				uri,
 				"https://example.com/api/.well-known/agent-card.json"
@@ -163,7 +194,10 @@ async fn test_classify_request_returns_unknown_method_on_invalid_json() {
 		.body(http::Body::from("{\"jsonrpc\":\"2.0\""))
 		.unwrap();
 
-	let ty = classify_request(&mut req).await;
+	let pol = A2aPolicy {
+		agent_card_path: None,
+	};
+	let ty = classify_request(&pol, &mut req).await;
 
 	match ty {
 		RequestType::Call(method) => assert_eq!(method.as_str(), "unknown"),
@@ -185,13 +219,16 @@ async fn test_apply_to_response_rewrites_agent_card_url() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"https://example.com/api/.well-known/agent-card.json"
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -220,13 +257,16 @@ async fn test_apply_to_response_rewrites_v1_agent_card_single_interface() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"https://example.com/api/.well-known/agent-card.json"
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -259,13 +299,16 @@ async fn test_apply_to_response_rewrites_v1_agent_card_multiple_interfaces() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"https://example.com/api/.well-known/agent-card.json"
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -301,13 +344,16 @@ async fn test_apply_to_response_rewrites_v1_agent_card_root_path() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"https://example.com/.well-known/agent-card.json"
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -340,13 +386,16 @@ async fn test_apply_to_response_skips_interface_without_url() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"https://example.com/api/.well-known/agent-card.json"
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -373,13 +422,16 @@ async fn test_apply_to_response_errors_when_neither_url_field_present() {
 		.unwrap();
 
 	let result = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"https://example.com/.well-known/agent-card.json"
 				.parse()
 				.unwrap(),
 			"/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -412,7 +464,9 @@ async fn test_apply_to_response_records_success_call_telemetry() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("tasks/send")),
 		&mut resp,
 	)
@@ -447,7 +501,9 @@ async fn test_apply_to_response_records_error_call_telemetry() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("tasks/send")),
 		&mut resp,
 	)
@@ -477,7 +533,9 @@ async fn test_apply_to_response_records_unknown_size_json_call_telemetry() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("tasks/send")),
 		&mut resp,
 	)
@@ -501,7 +559,9 @@ async fn test_apply_to_response_records_unknown_call_telemetry() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("tasks/send")),
 		&mut resp,
 	)
@@ -524,7 +584,9 @@ async fn test_apply_to_response_skips_invalid_json_call_telemetry() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("tasks/send")),
 		&mut resp,
 	)
@@ -549,7 +611,9 @@ async fn test_apply_to_response_skips_non_json_call_telemetry() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("tasks/send")),
 		&mut resp,
 	)
@@ -575,7 +639,9 @@ async fn test_apply_to_response_skips_partial_call_telemetry() {
 	resp.extensions_mut().insert(BufferLimit::new(4));
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("tasks/send")),
 		&mut resp,
 	)
@@ -610,7 +676,9 @@ async fn test_apply_to_response_rewrites_url_with_path_rewrite() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			// Original (gateway) URL where the client requested the agent card.
 			"http://localhost:4001/a2a/tick/.well-known/agent-card.json"
@@ -620,6 +688,7 @@ async fn test_apply_to_response_rewrites_url_with_path_rewrite() {
 			// /a2a/tick -> /a2a/tock before sending to the backend.
 			"/a2a/tock/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -655,13 +724,16 @@ async fn test_apply_to_response_preserves_subpath_with_path_rewrite() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"http://localhost:4001/a2a/tick/.well-known/agent-card.json"
 				.parse()
 				.unwrap(),
 			"/a2a/tock/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -698,13 +770,16 @@ async fn test_apply_to_response_avoids_partial_path_segment_match() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"http://gateway/public/weather/.well-known/agent-card.json"
 				.parse()
 				.unwrap(),
 			"/internal/weather/.well-known/agent-card.json".to_string(),
 			None,
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -746,7 +821,9 @@ async fn test_apply_to_response_uses_prefix_rewrite_context() {
 		.unwrap();
 
 	apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::AgentCard(
 			"http://gateway.example/gw/svc/agent/.well-known/agent-card.json"
 				.parse()
@@ -756,6 +833,7 @@ async fn test_apply_to_response_uses_prefix_rewrite_context() {
 				path: Some(crate::types::agent::PathRedirect::Prefix("/".into())),
 				path_match: crate::types::agent::PathMatch::PathPrefix("/gw".into()),
 			}),
+			"/.well-known/agent-card.json".to_string(),
 		),
 		&mut resp,
 	)
@@ -808,7 +886,9 @@ async fn test_apply_to_response_records_v1_nested_task_telemetry() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("SendMessage")),
 		&mut resp,
 	)
@@ -823,6 +903,197 @@ async fn test_apply_to_response_records_v1_nested_task_telemetry() {
 		Some("completed")
 	);
 	assert_eq!(info.context_id.as_ref().map(|s| s.as_str()), Some("ctx"));
+}
+
+// Test cases for issue #3018: non-standard agent card paths
+// These tests verify the behavior when agent card is at non-standard paths
+
+#[tokio::test]
+async fn test_classify_request_non_standard_agent_card_path_with_custom_config() {
+	// Regression test for issue #3018: non-standard agents that host agent card
+	// at a custom path should be recognized when agent_card_path is configured.
+	//
+	// Example: https://solutions.com/api/ai/config/agents/agent-orchestrator/agent.json
+	let original: Uri = "https://example.com/api/ai/config/agents/agent-orchestrator/agent.json"
+		.parse()
+		.unwrap();
+	let mut req = ::http::Request::builder()
+		.method(Method::GET)
+		.uri("http://backend.internal/api/ai/config/agents/agent-orchestrator/agent.json")
+		.body(http::Body::empty())
+		.unwrap();
+	req
+		.extensions_mut()
+		.insert(crate::http::filters::OriginalUrl(original.clone()));
+
+	// Configure custom agent card path
+	let pol = A2aPolicy {
+		agent_card_path: Some(agent_core::strng::Strng::from("/agent.json")),
+	};
+	let ty = classify_request(&pol, &mut req).await;
+
+	// With custom path configured, this should now return AgentCard
+	match ty {
+		RequestType::AgentCard(uri, _, _, suffix) => {
+			assert_eq!(uri, original);
+			assert_eq!(suffix, "/agent.json");
+		},
+		other => {
+			panic!("expected agent card request for non-standard path with custom config, got {other:?}")
+		},
+	}
+}
+
+#[tokio::test]
+async fn test_classify_request_non_standard_agent_card_path_elasticsearch_style() {
+	// Regression test for issue #3018: Elasticsearch-style non-standard agent card paths
+	//
+	// Example: https://elasticsearch.com/s/_ops/api/agent_builder/a2a/test_v1.json
+	let original: Uri = "https://example.com/s/_ops/api/agent_builder/a2a/test_v1.json"
+		.parse()
+		.unwrap();
+	let mut req = ::http::Request::builder()
+		.method(Method::GET)
+		.uri("http://backend.internal/s/_ops/api/agent_builder/a2a/test_v1.json")
+		.body(http::Body::empty())
+		.unwrap();
+	req
+		.extensions_mut()
+		.insert(crate::http::filters::OriginalUrl(original.clone()));
+
+	// Configure custom agent card path for Elasticsearch-style
+	let pol = A2aPolicy {
+		agent_card_path: Some(agent_core::strng::Strng::from("/test_v1.json")),
+	};
+	let ty = classify_request(&pol, &mut req).await;
+
+	// With custom path configured, this should now return AgentCard
+	match ty {
+		RequestType::AgentCard(uri, _, _, suffix) => {
+			assert_eq!(uri, original);
+			assert_eq!(suffix, "/test_v1.json");
+		},
+		other => {
+			panic!("expected agent card request for custom JSON path with custom config, got {other:?}")
+		},
+	}
+}
+
+#[tokio::test]
+async fn test_classify_request_without_custom_config_still_works_for_standard_paths() {
+	// Verify that standard paths still work without custom configuration
+	let original: Uri = "https://example.com/.well-known/agent-card.json"
+		.parse()
+		.unwrap();
+	let mut req = ::http::Request::builder()
+		.method(Method::GET)
+		.uri("http://backend.internal/.well-known/agent-card.json")
+		.body(http::Body::empty())
+		.unwrap();
+	req
+		.extensions_mut()
+		.insert(crate::http::filters::OriginalUrl(original.clone()));
+
+	// No custom path configured
+	let pol = A2aPolicy {
+		agent_card_path: None,
+	};
+	let ty = classify_request(&pol, &mut req).await;
+
+	match ty {
+		RequestType::AgentCard(uri, _, _, suffix) => {
+			assert_eq!(uri, original);
+			assert_eq!(suffix, "/.well-known/agent-card.json");
+		},
+		other => panic!("expected agent card request for standard path, got {other:?}"),
+	}
+}
+
+#[tokio::test]
+async fn test_apply_to_response_non_standard_agent_card_url_rewrite() {
+	// Regression test for issue #3018: URL rewrite should work for non-standard agent cards
+	// This test verifies that when a non-standard agent card is recognized,
+	// the URL rewriting works correctly.
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			serde_json::to_vec(&json!({
+				"name": "Elasticsearch Agent",
+				"url": "https://elasticsearch.com/s/_ops/api/agent_builder/a2a/_test_v1",
+			}))
+			.unwrap(),
+		))
+		.unwrap();
+
+	// This simulates a non-standard agent card path being recognized with custom suffix
+	let result = apply_to_response(
+		Some(&A2aPolicy {
+			agent_card_path: Some(agent_core::strng::Strng::from("/_test_v1.json")),
+		}),
+		RequestType::AgentCard(
+			"https://gateway.example.com/a2a/_test_v1.json"
+				.parse()
+				.unwrap(),
+			"/s/_ops/api/agent_builder/a2a/_test_v1.json".to_string(),
+			None,
+			"/_test_v1.json".to_string(), // Custom suffix
+		),
+		&mut resp,
+	)
+	.await;
+
+	// If the agent card is recognized, URL rewriting should work
+	assert!(result.is_ok());
+	let body = http::read_resp_body(resp).await.unwrap();
+	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	// The URL should be rewritten to the gateway path (with suffix stripped)
+	assert_eq!(json["url"], "https://gateway.example.com/a2a");
+}
+
+#[tokio::test]
+async fn test_apply_to_response_non_standard_agent_card_with_supported_interfaces() {
+	// Regression test for issue #3018: URL rewrite for non-standard agent cards
+	// with supportedInterfaces (A2A v1.0 format)
+	let mut resp = ::http::Response::builder()
+		.header(header::CONTENT_TYPE, "application/json")
+		.body(http::Body::from(
+			serde_json::to_vec(&json!({
+				"name": "Solutions Agent",
+				"supportedInterfaces": [
+					// Interface URL shares common path with the agent card path
+					{ "protocolBinding": "JSONRPC", "url": "https://solutions.com/api/ai/config/agents/agent-orchestrator/a2a/" }
+				],
+			}))
+			.unwrap(),
+		))
+		.unwrap();
+
+	let result = apply_to_response(
+		Some(&A2aPolicy {
+			agent_card_path: Some(agent_core::strng::Strng::from("/agent.json")),
+		}),
+		RequestType::AgentCard(
+			"https://gateway.example.com/a2a/agents/agent-orchestrator/agent.json"
+				.parse()
+				.unwrap(),
+			"/api/ai/config/agents/agent-orchestrator/agent.json".to_string(),
+			None,
+			"/agent.json".to_string(), // Custom suffix
+		),
+		&mut resp,
+	)
+	.await;
+
+	assert!(result.is_ok());
+	let body = http::read_resp_body(resp).await.unwrap();
+	let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+	// The interface URL should be rewritten to the gateway path
+	// The common prefix /api/ai/config/agents/agent-orchestrator is stripped,
+	// leaving /a2a/ which is appended to the gateway base
+	assert_eq!(
+		json["supportedInterfaces"][0]["url"],
+		"https://gateway.example.com/a2a/agents/agent-orchestrator/a2a/"
+	);
 }
 
 #[tokio::test]
@@ -846,7 +1117,9 @@ async fn test_apply_to_response_records_v1_nested_message_telemetry() {
 		.unwrap();
 
 	let info = apply_to_response(
-		Some(&A2aPolicy {}),
+		Some(&A2aPolicy {
+			agent_card_path: None,
+		}),
 		RequestType::Call(Strng::from("SendMessage")),
 		&mut resp,
 	)

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -447,7 +447,7 @@ async fn apply_backend_policies(
 		}
 		if matches!(
 			a2a_type,
-			a2a::RequestType::Call(_) | a2a::RequestType::AgentCard(_, _, _)
+			a2a::RequestType::Call(_) | a2a::RequestType::AgentCard(..)
 		) {
 			log.add(|l| {
 				l.backend_protocol = Some(cel::BackendProtocol::a2a);

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -2844,8 +2844,14 @@ impl BackendTrafficPolicy {
 	}
 }
 
+/// A2A policy configuration for agent-to-agent communication.
 #[apply(schema!)]
-pub struct A2aPolicy {}
+pub struct A2aPolicy {
+	/// Custom path suffix for agent card requests (e.g., "/agent.json").
+	/// Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.
+	#[serde(skip_serializing_if = "is_default")]
+	pub agent_card_path: Option<Strng>,
+}
 
 #[apply(schema!)]
 pub struct Authorization(pub Arc<RuleSet>);

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2273,7 +2273,14 @@ fn backend_policy_from_proto(
 ) -> Result<BackendTrafficPolicy, ProtoError> {
 	use crate::types::proto::agent::backend_policy_spec as bps;
 	Ok(match &spec.kind {
-		Some(bps::Kind::A2a(_)) => BackendTrafficPolicy::A2a(A2aPolicy {}),
+		Some(bps::Kind::A2a(a2a)) => {
+			let agent_card_path = if a2a.agent_card_path.is_empty() {
+				None
+			} else {
+				Some(agent_core::strng::Strng::from(a2a.agent_card_path.clone()))
+			};
+			BackendTrafficPolicy::A2a(A2aPolicy { agent_card_path })
+		},
 		Some(bps::Kind::InferenceRouting(ir)) => {
 			let failure_mode = match bps::inference_routing::FailureMode::try_from(ir.failure_mode)? {
 				bps::inference_routing::FailureMode::Unknown

--- a/crates/protos/proto/resource.proto
+++ b/crates/protos/proto/resource.proto
@@ -1537,7 +1537,11 @@ message BackendPolicySpec {
     // If empty or no route matches, the implementation defaults to COMPLETIONS behavior.
     map<string, RouteType> routes = 7;
   }
-  message A2a {}
+  message A2a {
+    // Custom path suffix for agent card requests (e.g., "/agent.json").
+    // Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.
+    string agent_card_path = 1;
+  }
   message InferenceRouting {
     enum FailureMode {
       UNKNOWN = 0;

--- a/schema/config.json
+++ b/schema/config.json
@@ -4909,7 +4909,17 @@
       "additionalProperties": false
     },
     "A2aPolicy": {
+      "description": "A2A policy configuration for agent-to-agent communication.",
       "type": "object",
+      "properties": {
+        "agentCardPath": {
+          "description": "Custom path suffix for agent card requests (e.g., \"/agent.json\").\nSupplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
       "additionalProperties": false
     },
     "Policy": {

--- a/schema/config.md
+++ b/schema/config.md
@@ -533,6 +533,7 @@
 |`binds[].listeners[].routes[].policies.mcpAuthentication.clientId`|string|OAuth client ID advertised to MCP clients when needed.|
 |`binds[].listeners[].routes[].policies.mcpAuthentication.clientSecret`|string|OAuth client secret injected into proxied token requests for confidential clients.<br>Currently used by the `entra` provider, whose Web-platform app registrations require a<br>client secret at the token endpoint.|
 |`binds[].listeners[].routes[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`binds[].listeners[].routes[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`binds[].listeners[].routes[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`binds[].listeners[].routes[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -7089,6 +7090,7 @@
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`binds[].listeners[].routes[].backends[].ai.policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`binds[].listeners[].routes[].backends[].ai.policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`binds[].listeners[].routes[].backends[].ai.policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -10488,6 +10490,7 @@
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -13850,6 +13853,7 @@
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`binds[].listeners[].routes[].backends[].policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`binds[].listeners[].routes[].backends[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`binds[].listeners[].routes[].backends[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`binds[].listeners[].routes[].backends[].policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -19421,6 +19425,7 @@
 |`policies[].policy.mcpAuthentication.clientId`|string|OAuth client ID advertised to MCP clients when needed.|
 |`policies[].policy.mcpAuthentication.clientSecret`|string|OAuth client secret injected into proxied token requests for confidential clients.<br>Currently used by the `entra` provider, whose Web-platform app registrations require a<br>client secret at the token endpoint.|
 |`policies[].policy.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`policies[].policy.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`policies[].policy.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`policies[].policy.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`policies[].policy.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -25977,6 +25982,7 @@
 |`backends[].ai.policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`backends[].ai.policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`backends[].ai.policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`backends[].ai.policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`backends[].ai.policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`backends[].ai.policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`backends[].ai.policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -29376,6 +29382,7 @@
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`backends[].ai.groups[].providers[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`backends[].ai.groups[].providers[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`backends[].ai.groups[].providers[].policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -32736,6 +32743,7 @@
 |`backends[].policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`backends[].policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`backends[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`backends[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`backends[].policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`backends[].policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`backends[].policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -35184,6 +35192,7 @@
 |`routeGroups[].routes[].policies.mcpAuthentication.clientId`|string|OAuth client ID advertised to MCP clients when needed.|
 |`routeGroups[].routes[].policies.mcpAuthentication.clientSecret`|string|OAuth client secret injected into proxied token requests for confidential clients.<br>Currently used by the `entra` provider, whose Web-platform app registrations require a<br>client secret at the token endpoint.|
 |`routeGroups[].routes[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`routeGroups[].routes[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`routeGroups[].routes[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routeGroups[].routes[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`routeGroups[].routes[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -41740,6 +41749,7 @@
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`routeGroups[].routes[].backends[].ai.policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`routeGroups[].routes[].backends[].ai.policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`routeGroups[].routes[].backends[].ai.policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`routeGroups[].routes[].backends[].ai.policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -45139,6 +45149,7 @@
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`routeGroups[].routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -48501,6 +48512,7 @@
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`routeGroups[].routes[].backends[].policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`routeGroups[].routes[].backends[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`routeGroups[].routes[].backends[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`routeGroups[].routes[].backends[].policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`routeGroups[].routes[].backends[].policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -53597,6 +53609,7 @@
 |`routes[].policies.mcpAuthentication.clientId`|string|OAuth client ID advertised to MCP clients when needed.|
 |`routes[].policies.mcpAuthentication.clientSecret`|string|OAuth client secret injected into proxied token requests for confidential clients.<br>Currently used by the `entra` provider, whose Web-platform app registrations require a<br>client secret at the token endpoint.|
 |`routes[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`routes[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`routes[].policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`routes[].policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`routes[].policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|
@@ -60153,6 +60166,7 @@
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`routes[].backends[].ai.policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`routes[].backends[].ai.policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`routes[].backends[].ai.policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`routes[].backends[].ai.policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`routes[].backends[].ai.policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`routes[].backends[].ai.policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -63552,6 +63566,7 @@
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`routes[].backends[].ai.groups[].providers[].policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`routes[].backends[].ai.groups[].providers[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`routes[].backends[].ai.groups[].providers[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`routes[].backends[].ai.groups[].providers[].policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -66914,6 +66929,7 @@
 |`routes[].backends[].policies.mcpGuardrails.processors[].kind`|enum|Possible values: `remote`.|
 |`routes[].backends[].policies.mcpGuardrails.processors[].methods`|object|Allowlist: only methods listed here run through this processor, at the<br>configured phase. Keys may be exact (`tools/call`), prefix (`tools/*`),<br>or suffix (`*/list`) wildcards, or `*` for all methods. Methods matching<br>no key bypass this processor; see [`phase::resolve`] for match precedence.|
 |`routes[].backends[].policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`routes[].backends[].policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`routes[].backends[].policies.inferenceRouting`|object|Route requests through an endpoint picker before forwarding to this backend.|
 |`routes[].backends[].policies.inferenceRouting.endpointPicker`|object|Endpoint picker backend that selects the destination endpoint.<br>Exactly one of service, host, or backend may be set.|
 |`routes[].backends[].policies.inferenceRouting.endpointPicker.service`|object|Service reference. Service must be defined in the top level services list.|
@@ -77081,6 +77097,7 @@
 |`mcp.policies.mcpAuthentication.clientId`|string|OAuth client ID advertised to MCP clients when needed.|
 |`mcp.policies.mcpAuthentication.clientSecret`|string|OAuth client secret injected into proxied token requests for confidential clients.<br>Currently used by the `entra` provider, whose Web-platform app registrations require a<br>client secret at the token endpoint.|
 |`mcp.policies.a2a`|object|Mark this traffic as A2A to enable A2A processing and telemetry.|
+|`mcp.policies.a2a.agentCardPath`|string|Custom path suffix for agent card requests (e.g., "/agent.json").<br>Supplements standard paths: /.well-known/agent.json and /.well-known/agent-card.json.|
 |`mcp.policies.ai`|object|Mark this as LLM traffic to enable LLM processing.|
 |`mcp.policies.ai.promptGuard`|object|Prompt and response guardrails to apply to LLM traffic.|
 |`mcp.policies.ai.promptGuard.streaming`|enum|Apply prompt guards to streaming responses and realtime websocket messages.<br>Possible values: `Disabled`, `Enabled`.|


### PR DESCRIPTION
## Summary

Add support for A2A agents that host their agent card at non-standard paths (not `/.well-known/agent.json` or `/.well-known/agent-card.json`).

Fixes #3018

## Changes

- Add `agent_card_path` field to `A2aPolicy` (Rust) and proto
- Update `classify_request` to match custom paths
- Update `strip_agent_card_suffix` to handle custom suffixes
- Update Go controller to read annotation from Service
- Add unit tests for non-standard agent card paths

## Usage

```yaml
apiVersion: v1
kind: Service
metadata:
  name: my-agent
  annotations:
    agentgateway.dev/a2a-agent-card-path: "/api/agents/my-agent/agent.json"
spec:
  ports:
    - port: 8080
      appProtocol: agentgateway.dev/a2a
```

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.