### PR TITLE
fix(config): skip shell expansion in YAML comment lines

### DIFF
--- a/crates/agentgateway/src/config.rs
+++ b/crates/agentgateway/src/config.rs
@@ -35,7 +35,7 @@ pub fn parse_config(
 	local_config_source: Option<ConfigSource>,
 ) -> anyhow::Result<Config> {
 	// Shellexpend before parsing it
-	let contents = contents.replace("# yaml-language-server: $schema", "#");
+	let contents = neutralize_env_vars_in_yaml_comments(&contents);
 	let contents = shellexpand::full(&contents)?;
 	let nested: NestedRawConfig = serdes::yamlviajson::from_str(&contents).ctx("invalid config")?;
 	let raw = nested.config.unwrap_or_default();
@@ -733,6 +733,24 @@ pub fn empty_to_none<A: AsRef<str>>(inp: Option<A>) -> Option<A> {
 	}
 	inp
 }
+
+// Escape '$' in full-line YAML comments so 'shellexpand' won't try to resolve environment variables in commented-out lines. 
+pub(crate) fn neutralize_env_vars_in_yaml_comments(input: &str) -> String {
+	let mut result = String::with_capacity(input.len());
+	for line in input.split('\n') {
+		if line.trim().starts_with('#') {
+			result.push_str(&line.replace('$', ""));
+		} else {
+			result.push_str(line);
+		}
+		result.push('\n');
+	}
+	if input.ends_with('\n') {
+		result.pop();
+	}
+	result
+}
+
 // tries to parse the URI so we can fail early
 fn validate_uri(uri_str: Option<String>) -> anyhow::Result<Option<String>> {
 	let Some(uri_str) = uri_str else {
@@ -1620,6 +1638,28 @@ config:
 		assert_eq!(config.network.as_str(), "static-network");
 	}
 
+	#[test]
+	fn ignores_env_vars_in_yaml_comments() {
+		let _env_lock = lock_env();
+		unsafe {
+			env::remove_var("COMMENTED_VAR");
+			env::remove_var("API_KEY");
+		}
+
+		let config = parse_config(
+			r#"
+# network: "${COMMENTED_VAR}"
+# apiKey: $API_KEY
+config:
+  network: "actual-value"
+"#
+			.to_string(),
+			None,
+		)
+		.expect("commented-out environment variables should not cause an error");
+		assert_eq!(config.network.as_str(), "actual-value");
+	}
+	
 	#[test]
 	fn errors_on_unset_environment_variable() {
 		let _env_lock = lock_env();

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -81,8 +81,7 @@ impl NormalizedLocalConfig {
 		gateway_name: ListenerTarget,
 		s: &str,
 	) -> anyhow::Result<NormalizedLocalConfig> {
-		// Avoid shell expanding the comment for schema. Probably there are better ways to do this!
-		let s = s.replace("# yaml-language-server: $schema", "#");
+		let s = crate::config::neutralize_env_vars_in_yaml_comments(s);
 		let s = shellexpand::full(&s)?;
 		let local_config: LocalConfig = serdes::yamlviajson::from_str(&s)?;
 		let mut registration_config = config.clone();


### PR DESCRIPTION
## Summary
Inside `agentgateway` crate, config load runs `shellexpand` on the raw YAML, so a commented-out line like `# CUSTOM_NETWORK_URL: ${CUSTOM_NETWORK_URL}` fails startup if that variable is unset. So, strip `$` from commented-out line `#` before expansion in `parse_config` and local config. 

Fixes [#3359](https://github.com/agentgateway/agentgateway/issues/3359).

## Changes
- Added a new function `neutralize_env_vars_in_yaml_comments` in `agnetgateway/src/config.rs` (rust)
- updated config.rs and types/local.rs with the function call to strip `$` from the commented-out line
- Added the test case to validate the functionality. 

## Usage
```yaml
# Uncomment below to enable custom network:
# network: "${CUSTOM_NETWORK}" 
config:
    network: "default"
```
agentgateway startup won't fail because of commented-out line with environment variable. 

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.

