### PR TITLE
Adding new Example to deploy agentgateway standalone on render.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .venv
 .env
 .env.*
+!.env.example
 *.local
 var/
 controller/_output

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,9 @@ span more than one agentgateway traffic type.
   authorize OpenAI and Anthropic traffic with NetBird Agent Network before
   routing it through a private agentgateway listener. Includes Kubernetes and
   standalone Docker Compose deployments.
+* [render-deploy](render-deploy/README.md): deploy standalone agentgateway on
+  Render with a public HTTPS URL, a persistent `/config` disk, and a Blueprint
+  (`render.yaml`).
 
 ### MCP
 

--- a/examples/render-deploy/.env.example
+++ b/examples/render-deploy/.env.example
@@ -1,0 +1,14 @@
+# Set these in the Render Environment tab. Never commit real values.
+
+PORT=4000
+UI_USER=admin
+UI_PASSWORD=
+
+OPENAI_API_KEY=
+GITHUB_PERSONAL_ACCESS_TOKEN=
+
+# Virtual LLM keys live in /config/config.yaml (or the UI), not in git.
+# Placeholders only — rotate anything that was ever pasted into a screenshot.
+# sk-lab-admin-...
+# sk-lab-demo-...
+# sk-lab-limited-...

--- a/examples/render-deploy/.env.example
+++ b/examples/render-deploy/.env.example
@@ -1,16 +1,14 @@
 # Set these in the Render Environment tab. Never commit real values.
-# First boot writes them into /config/config.yaml as $OPENAI_API_KEY and
-# $GITHUB_PERSONAL_ACCESS_TOKEN (plus placeholder virtual keys).
+# Only UI_PASSWORD is required. Add models and MCP in the UI after login.
 
 PORT=4000
 UI_USER=admin
 UI_PASSWORD=
 
+# Optional. Set these in the dashboard if a model or MCP target you add
+# in the UI references them as $OPENAI_API_KEY / $ANTHROPIC_API_KEY /
+# $GITHUB_PERSONAL_ACCESS_TOKEN / $DATABASE_URL.
 OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
 GITHUB_PERSONAL_ACCESS_TOKEN=
-
-# Virtual LLM keys live in /config/config.yaml (or the UI), not in git.
-# Placeholders only — rotate anything that was ever pasted into a screenshot.
-# sk-lab-admin-...
-# sk-lab-demo-...
-# sk-lab-limited-...
+# DATABASE_URL=  # Render Postgres, if you switch config.database.url

--- a/examples/render-deploy/.env.example
+++ b/examples/render-deploy/.env.example
@@ -1,4 +1,6 @@
 # Set these in the Render Environment tab. Never commit real values.
+# First boot writes them into /config/config.yaml as $OPENAI_API_KEY and
+# $GITHUB_PERSONAL_ACCESS_TOKEN (plus placeholder virtual keys).
 
 PORT=4000
 UI_USER=admin

--- a/examples/render-deploy/Dockerfile
+++ b/examples/render-deploy/Dockerfile
@@ -4,7 +4,8 @@
 # The published image has no shell (ENTRYPOINT=/app/agentgateway). Empty
 # /config auto-gen serves /ui/ with no auth. This image writes
 # /config/.htpasswd from UI_USER / UI_PASSWORD on every start, seeds
-# config.yaml on first boot, then execs the gateway.
+# config.yaml (UI basicAuth, OpenAI wildcard, virtual keys, GitHub MCP)
+# on first boot, then execs the gateway.
 #
 # Pin: https://agentgateway.dev/docs/standalone/latest/setup/install/docker/
 #

--- a/examples/render-deploy/Dockerfile
+++ b/examples/render-deploy/Dockerfile
@@ -1,0 +1,28 @@
+# Wrapper around the official image so Render can persist /config and
+# protect /ui/ with HTTP basic auth.
+#
+# The published image has no shell (ENTRYPOINT=/app/agentgateway). Empty
+# /config auto-gen serves /ui/ with no auth. This image writes
+# /config/.htpasswd from UI_USER / UI_PASSWORD on every start, seeds
+# config.yaml on first boot, then execs the gateway.
+#
+# Pin: https://agentgateway.dev/docs/standalone/latest/setup/install/docker/
+#
+# The published image USER is 65532. Render disks are typically
+# root-owned, so first boot cannot write /config unless we run as root.
+
+ARG AGENTGATEWAY_VERSION=v1.5.0
+
+FROM cr.agentgateway.dev/agentgateway:${AGENTGATEWAY_VERSION} AS agw
+
+FROM debian:trixie-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openssl ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=agw /app/agentgateway /app/agentgateway
+COPY entrypoint.sh /entrypoint
+RUN chmod +x /entrypoint \
+ && /app/agentgateway --version
+USER 0
+EXPOSE 4000
+ENTRYPOINT ["/entrypoint"]

--- a/examples/render-deploy/Dockerfile
+++ b/examples/render-deploy/Dockerfile
@@ -8,8 +8,9 @@
 #
 # Pin: https://agentgateway.dev/docs/standalone/latest/setup/install/docker/
 #
-# The published image USER is 65532. Render disks are typically
-# root-owned, so first boot cannot write /config unless we run as root.
+# The published image USER is 65532. Render disks are typically root-owned,
+# so this image starts as root to claim /config, then the entrypoint chowns
+# the disk and drops to 65532 via setpriv before exec'ing the gateway.
 
 ARG AGENTGATEWAY_VERSION=v1.5.0
 
@@ -17,12 +18,14 @@ FROM cr.agentgateway.dev/agentgateway:${AGENTGATEWAY_VERSION} AS agw
 
 FROM debian:trixie-slim
 RUN apt-get update \
- && apt-get install -y --no-install-recommends openssl ca-certificates \
+ && apt-get install -y --no-install-recommends apache2-utils ca-certificates \
  && rm -rf /var/lib/apt/lists/*
+# apache2-utils for `htpasswd -B` (bcrypt); setpriv ships in util-linux.
 COPY --from=agw /app/agentgateway /app/agentgateway
 COPY entrypoint.sh /entrypoint
 RUN chmod +x /entrypoint \
  && /app/agentgateway --version
+# Root is only for chowning the mounted disk; the entrypoint drops to 65532.
 USER 0
 EXPOSE 4000
 ENTRYPOINT ["/entrypoint"]

--- a/examples/render-deploy/Dockerfile
+++ b/examples/render-deploy/Dockerfile
@@ -3,9 +3,9 @@
 #
 # The published image has no shell (ENTRYPOINT=/app/agentgateway). Empty
 # /config auto-gen serves /ui/ with no auth. This image writes
-# /config/.htpasswd from UI_USER / UI_PASSWORD on every start, seeds
-# config.yaml (UI basicAuth, OpenAI wildcard, virtual keys, GitHub MCP)
-# on first boot, then execs the gateway.
+# /config/.htpasswd from UI_USER / UI_PASSWORD on every start, seeds a
+# UI-only config.yaml on first boot, then execs the gateway. Add models
+# and MCP in the UI after login.
 #
 # Pin: https://agentgateway.dev/docs/standalone/latest/setup/install/docker/
 #

--- a/examples/render-deploy/README.md
+++ b/examples/render-deploy/README.md
@@ -54,7 +54,7 @@ flowchart LR
 
 | Fact | Value |
 |------|--------|
-| Service | Web Service, Docker, **Starter** |
+| Service | Web Service, Docker, **0.5c-512mb** |
 | URL | `https://<your-service>.onrender.com` — **HTTPS only** |
 | Disk | **`agw-config`** → **`/config`**, 1 GB |
 | UI | `/ui/` basic auth via `UI_USER` + `UI_PASSWORD` |
@@ -109,7 +109,7 @@ Render prompts for `UI_PASSWORD` on first Blueprint create. Pin `PORT=4000`. Gen
 
 ### 3. Disk
 
-The Blueprint already declares **`agw-config`** → **`/config`**, 1 GB. Disks are not available on Render Free — Starter is the floor. Without the volume, config and analytics reset on every deploy.
+The Blueprint already declares **`agw-config`** → **`/config`**, 1 GB. Disks are not available on Render Free — **0.5c-512mb** is the floor (Render still accepts `starter` as an alias). Without the volume, config and analytics reset on every deploy.
 
 ### 4. Deploy
 
@@ -147,7 +147,7 @@ Render publishes **HTTPS :443** to one container port. That port is `4000`. Ther
 | `:4000` on the public hostname | Do not use |
 | `:15000` | No — loopback only |
 
-Starter is enough for a demo. The disk is the persistence story.
+0.5c-512mb is enough for a demo. The disk is the persistence story.
 
 ## Security
 

--- a/examples/render-deploy/README.md
+++ b/examples/render-deploy/README.md
@@ -4,18 +4,18 @@ This example deploys standalone agentgateway on [Render](https://render.com) as 
 
 Render terminates TLS on `:443` and forwards to the container’s `PORT=4000`. Do not publish `:4000` yourself, and do not call the service over `http://`.
 
-**Canonical Blueprint:** [`render.yaml`](./render.yaml) in this folder.
+The Blueprint file is [`render.yaml`](./render.yaml) in this folder. Render looks for `render.yaml` at the **repo root** by default, so you have to point it at this subdirectory:
 
-| How you create it | What to set |
-|-------------------|-------------|
-| Deploy-to-Render button | `path=examples/render-deploy/render.yaml` (Render’s query param is `path`, not `blueprintPath`) |
+| How you create the service | Where to put that path |
+|----------------------------|------------------------|
+| [Deploy to Render](https://render.com/deploy?repo=https://github.com/agentgateway/agentgateway&path=examples/render-deploy/render.yaml) button | Query param `path=examples/render-deploy/render.yaml` |
 | Dashboard → New Blueprint | **Blueprint Path** = `examples/render-deploy/render.yaml` |
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/agentgateway/agentgateway&path=examples/render-deploy/render.yaml)
 
 `dockerfilePath` / `dockerContext` inside the YAML stay relative to the **repo root** (`./examples/render-deploy/Dockerfile`), even though the Blueprint file lives under `examples/render-deploy/`.
 
-The image this service builds is this folder’s [`Dockerfile`](./Dockerfile): a thin wrapper around the official `cr.agentgateway.dev/agentgateway` image. The wrapper writes `/config/.htpasswd` on every start, seeds `config.yaml` (UI basicAuth, OpenAI wildcard, virtual keys, GitHub MCP) on first boot, chowns the disk, then drops to uid 65532 — the gateway itself does not run as root. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
+The image this service builds is this folder’s [`Dockerfile`](./Dockerfile): a thin wrapper around the official `cr.agentgateway.dev/agentgateway` image. The wrapper writes `/config/.htpasswd` on every start, seeds a UI-only `config.yaml` on first boot, chowns the disk, then drops to uid 65532 — the gateway itself does not run as root. Add LLM models and MCP servers in the UI after login. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
 
 ## Architecture
 
@@ -35,17 +35,11 @@ flowchart LR
     Admin["admin :15000 loopback only"]
   end
 
-  subgraph upstreams [Upstreams]
-    OpenAI[OpenAI API]
-    GH["GitHub remote MCP<br/>api.githubcopilot.com/mcp/"]
-  end
-
   Browser -->|HTTPS only| TLS
   App -->|HTTPS only| TLS
   TLS --> GW
   GW -->|"/ui/ + basicAuth"| Browser
-  GW -->|"/v1/* Bearer virtual key"| OpenAI
-  GW -->|"/mcp"| GH
+  GW -->|"/v1/* /mcp after you add them in the UI"| App
   GW --- Disk
   GW -.-> Admin
 ```
@@ -53,12 +47,10 @@ flowchart LR
 | Public path | Who it is for | Auth |
 |-------------|----------------|------|
 | `/ui/` | Operators | HTTP basic (`UI_USER` / `UI_PASSWORD`) |
-| `/v1/*` | Apps, playground, `curl` | `llm.policies.apiKey` **strict** — Bearer virtual key |
-| `/mcp` | MCP clients | GitHub PAT on the upstream target |
+| `/v1/*` | Apps, playground, `curl` | Whatever you configure in **LLM** (none until you add a model) |
+| `/mcp` | MCP clients | Whatever you configure in **MCP** (none until you add a server) |
 
 `ui.policies` does **not** cover `/v1/*`. Do not send the UI password as an LLM Bearer token.
-
-## Example layout
 
 | Fact | Value |
 |------|--------|
@@ -66,44 +58,28 @@ flowchart LR
 | URL | `https://<your-service>.onrender.com` — **HTTPS only** |
 | Disk | **`agw-config`** → **`/config`**, 1 GB |
 | UI | `/ui/` basic auth via `UI_USER` + `UI_PASSWORD` |
-| LLM | OpenAI wildcard `*` on `/v1/*` |
-| MCP | GitHub remote Copilot MCP on `/mcp` (Streamable HTTP) |
+| LLM / MCP | Add in the UI after login |
+| Database | SQLite on the disk. Optional: [Render Postgres](https://render.com/docs/postgresql-creating-connecting) — point `config.database.url` at the connection string in the UI |
 | Admin | `:15000` on `127.0.0.1` — not on the internet |
 
-Virtual API keys (`llm.policies.apiKey` `mode: strict`):
-
-| Key (placeholder) | `metadata.name` | Models | Extra |
-|-------------------|-----------------|--------|-------|
-| `sk-lab-admin-...` | `admin` | any | — |
-| `sk-lab-demo-...` | `demo` | selected models | — |
-| `sk-lab-limited-...` | `limited` | `gpt-4.1-nano` | rolling token budget |
-
-Rotate anything that ever leaked. The strings above are placeholders — they are not live secrets.
-
-Example config (same shape as [`config.example.yaml`](./config.example.yaml)):
+First-boot config (same shape as [`config.example.yaml`](./config.example.yaml)):
 
 ```yaml
-llm:
+config:
+  database:
+    url: sqlite:///config/data.db
+gateways:
+  default:
+    port: 4000
+ui:
+  gateways: [default]
   policies:
-    apiKey:
+    basicAuth:
       mode: strict
-      keys:
-      - key: sk-lab-admin-...
-        metadata: { name: admin }
-      - key: sk-lab-demo-...
-        metadata: { name: demo }
-        allowedModels: [gpt-4.1-nano, gpt-4.1, gpt-4o]
-      - key: sk-lab-limited-...
-        metadata: { name: limited }
-        allowedModels: [gpt-4.1-nano]
-        budgets:
-        - name: tokens
-          limit: { unit: Tokens, amount: 1000 }
-          window: { rolling: 1h }
-          onBudgetExceeded: Block
+      htpasswd:
+        file: /config/.htpasswd
+      realm: agentgateway
 ```
-
-A `GET /v1/models` with no `Authorization` header returns `api key authentication failure: no API Key found`. That is the strict policy working.
 
 ## Environment variables
 
@@ -114,30 +90,22 @@ Set these in the Render **Environment** tab. Never commit real values. See [`.en
 | `PORT` | **Yes** | Must be `4000`. Render proxies `$PORT` (default `10000`); the gateway listens on 4000. |
 | `UI_USER` | No | Basic-auth username. Default `admin`. Letters, digits, `.`, `_`, `@`, `-` only. |
 | `UI_PASSWORD` | **Yes** | Entrypoint writes `/config/.htpasswd` every start. Process exits 1 if unset. |
-| `OPENAI_API_KEY` | For OpenAI | Expanded as `$OPENAI_API_KEY` on the model. |
-| `GITHUB_PERSONAL_ACCESS_TOKEN` | For GitHub MCP | Bearer the gateway sends to `api.githubcopilot.com`. |
+
+Provider keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_PERSONAL_ACCESS_TOKEN`, `DATABASE_URL`) are optional. Add them later if a model or MCP target you create in the UI references `$THAT_VAR`. The Blueprint does not prompt for them: `sync: false` would make Render require a value, and agentgateway exits if `config.yaml` expands a `$VAR` that is unset.
 
 ## How to deploy
 
 ### 1. Create the Render web service
 
-**Button / Blueprint** — prefer this folder’s Blueprint:
+Use the button above, or Dashboard → New Blueprint with **Blueprint Path** `examples/render-deploy/render.yaml`. From a fork, point the Blueprint at that fork.
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/agentgateway/agentgateway&path=examples/render-deploy/render.yaml)
-
-- One-click URL uses `path=examples/render-deploy/render.yaml` (required when the file is not at repo root).
-- Dashboard: **Blueprint Path** = `examples/render-deploy/render.yaml`.
-- File: [`render.yaml`](./render.yaml).
-
-From a fork, create a Blueprint against that repo and set the same Blueprint Path.
-
-**Manual** — New → Web Service → this repo, Docker, `./examples/render-deploy/Dockerfile`, context `./examples/render-deploy`. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
+**Manual** — New → Web Service → this repo, Docker, `./examples/render-deploy/Dockerfile`, context `./examples/render-deploy`. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`.
 
 Pushes to the linked branch auto-deploy when `examples/render-deploy/` changes (`autoDeployTrigger: commit` + `buildFilter`). Other folders in this repo do not rebuild the service. Do not also set `autoDeploy` — Render rejects a Blueprint that includes both.
 
 ### 2. Set the env vars
 
-Render prompts for `sync: false` keys on first Blueprint create. Pin `PORT=4000`. Generate `UI_PASSWORD` in the dashboard. Paste provider tokens there, not into git.
+Render prompts for `UI_PASSWORD` on first Blueprint create. Pin `PORT=4000`. Generate the password in the dashboard.
 
 ### 3. Disk
 
@@ -145,16 +113,16 @@ The Blueprint already declares **`agw-config`** → **`/config`**, 1 GB. Disks a
 
 ### 4. Deploy
 
-First boot writes `.htpasswd` + the lab `config.yaml` (UI basicAuth, OpenAI wildcard, virtual keys, GitHub MCP), chowns `/config` to uid 65532, then execs the gateway as that uid, which watches `/config/config.yaml`. In Render logs you want:
+First boot writes `.htpasswd` + a UI-only `config.yaml`, chowns `/config` to uid 65532, then execs the gateway as that uid. In Render logs you want:
 
-- `entrypoint: seeded /config/config.yaml (llm + mcp + ui basicAuth)` (first boot) or `entrypoint: updated /config/config.yaml (lab=true)` (old UI-only disk)
+- `entrypoint: seeded /config/config.yaml (ui basicAuth)`
 - `state_manager Watching config file: /config/config.yaml`
 - `app serving UI at http://localhost:4000/ui`
 - `proxy::gateway started bind bind="bind/4000"`
 - admin on `127.0.0.1:15000`
 - `==> Your service is live`
 
-If this service was created before the lab seed shipped, click **Manual Deploy**. The disk already has a config file, so a rebuild alone is not enough unless the entrypoint is allowed to merge missing `llm` / `mcp` sections (it will not overwrite models or MCP you added in the UI).
+If an earlier revision of this example wrote lab `llm` / `mcp` placeholders (`$OPENAI_API_KEY`), the entrypoint replaces that file with the UI-only seed so the process can boot. Models you added in the UI are left alone unless they still reference those lab placeholders.
 
 A `http.status=401` on `/ui/` with `basic authentication failure: no basic authentication credentials found` is success. Health checks must **not** `GET /ui/` (401 ≠ healthy). The Blueprint omits `healthCheckPath` so Render uses TCP on `:4000`.
 
@@ -164,53 +132,7 @@ A `http.status=401` on `/ui/` with `basic authentication failure: no basic authe
 https://<your-service>.onrender.com/ui/
 ```
 
-Browser basic-auth prompt: `UI_USER` / `UI_PASSWORD`. Gateway Overview should show LLM, MCP, and Traffic on gateway **default**.
-
-### 6. Confirm OpenAI
-
-The seed already has incoming name `*`, provider OpenAI, API key `$OPENAI_API_KEY`. Set `OPENAI_API_KEY` in the Environment tab (Render restarts the service). **LLM → Models** should show the wildcard; outgoing model stays “Incoming model.” Only use **Add model** if you want a second provider.
-
-### 7. Confirm virtual keys
-
-The seed is already **LLM → Virtual API Keys**, strict mode, three lab keys: `admin` (any), `demo` (selected models), `limited` (`gpt-4.1-nano` + token budget). Use placeholders in docs; paste real secrets only in the dashboard / disk.
-
-### 8. Call chat completions (HTTPS + Bearer)
-
-The playground’s wildcard row needs a **specific model** before Send is enabled. From a client:
-
-```sh
-export HOST=https://<your-service>.onrender.com
-export VKEY='sk-lab-limited-...'   # placeholder — use your lab key
-
-curl -sS "$HOST/v1/chat/completions" \
-  -H "Authorization: Bearer $VKEY" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "gpt-4.1-nano",
-    "messages": [{"role": "user", "content": "Reply with one word: pong"}]
-  }'
-```
-
-A 200 with token usage shows up under **LLM → Logs**.
-
-### 9. Confirm GitHub MCP
-
-The seed already attaches GitHub remote Copilot MCP to the `default` gateway (no second public port):
-
-```yaml
-mcp:
-  gateways: [default]
-  targets:
-  - name: github
-    mcp:
-      host: https://api.githubcopilot.com/mcp/
-    policies:
-      backendAuth:
-        key:
-          value: $GITHUB_PERSONAL_ACCESS_TOKEN
-```
-
-Set `GITHUB_PERSONAL_ACCESS_TOKEN` in the Environment tab. **MCP → Servers** should show `github`, Streamable HTTP, **ready**. Clients use `https://<your-service>.onrender.com/mcp`. Only use **Add server** for extra targets.
+Browser basic-auth prompt: `UI_USER` / `UI_PASSWORD`. Gateway Overview shows Traffic on gateway **default**. Add models under **LLM → Models** and servers under **MCP → Servers**. If a field asks for an env var (`$OPENAI_API_KEY`, `$GITHUB_PERSONAL_ACCESS_TOKEN`, …), set that var in the Render Environment tab first.
 
 ## Ports and limits
 
@@ -219,8 +141,8 @@ Render publishes **HTTPS :443** to one container port. That port is `4000`. Ther
 | Address | Reachable from the internet? |
 |---------|------------------------------|
 | `https://<service>.onrender.com/ui/` | Yes, basic auth |
-| `https://<service>.onrender.com/v1/*` | Yes, virtual API key |
-| `https://<service>.onrender.com/mcp` | Yes, MCP |
+| `https://<service>.onrender.com/v1/*` | Yes, after you add an LLM model |
+| `https://<service>.onrender.com/mcp` | Yes, after you add an MCP server |
 | `http://<service>.onrender.com/...` | Do not use |
 | `:4000` on the public hostname | Do not use |
 | `:15000` | No — loopback only |
@@ -233,17 +155,16 @@ Starter is enough for a demo. The disk is the persistence story.
 
 That is **demo-grade** behind Render TLS. It is not an IdP.
 
-- Rotate `UI_PASSWORD`, `OPENAI_API_KEY`, `GITHUB_PERSONAL_ACCESS_TOKEN`, and every virtual key if this URL is more than a lab.
-- Scope the GitHub PAT. Remote Copilot MCP will do whatever that token can do.
+- Rotate `UI_PASSWORD` and any provider keys if this URL is more than a lab.
 - HTTP basic is not SSO, however strong the hash.
 
 Inline bcrypt in `config.yaml` is a footgun: hashes contain `$`, and agentgateway env-expands `$VARS`. A file-backed htpasswd is read as raw bytes with no expansion, which is why the entrypoint writes one.
 
-`config.yaml` and `.htpasswd` are both created mode `600` and owned by uid 65532, so virtual keys you add to the config are not world-readable inside the container.
+`config.yaml` and `.htpasswd` are both created mode `600` and owned by uid 65532.
 
 ## Verify
 
-HTTPS only. Placeholders, not real secrets.
+HTTPS only.
 
 ```sh
 HOST=https://<your-service>.onrender.com
@@ -255,25 +176,6 @@ curl -sI "$HOST/ui/" | grep -E 'HTTP/|www-authenticate'
 
 curl -sI -u "$UI_USER:$UI_PASSWORD" "$HOST/ui/" | head -5
 # HTTP/2 200
-
-# LLM requires a virtual key
-curl -sS "$HOST/v1/models"
-# api key authentication failure: no API Key found
-
-curl -sS "$HOST/v1/models" -H "Authorization: Bearer sk-lab-admin-..."
-curl -sS "$HOST/v1/chat/completions" \
-  -H "Authorization: Bearer sk-lab-limited-..." \
-  -H 'Content-Type: application/json' \
-  -d '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Reply with one word: pong"}]}'
-# limited is gpt-4.1-nano + token budget — expect 429 budget_exceeded after the window fills
-
-# MCP — GitHub remote (POST)
-curl -sS "$HOST/mcp" \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json, text/event-stream' \
-  -H 'mcp-protocol-version: 2025-06-18' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"howto","version":"1"}}}'
-# look for serverInfo.name: github-mcp-server
 ```
 
-A 401 on `/ui/` without credentials, a 200 with them, a 401 on `/v1/models` without a Bearer key, and an MCP `initialize` that names `github-mcp-server` is the smoke test.
+A 401 on `/ui/` without credentials and a 200 with them is the smoke test. LLM and MCP checks depend on what you added in the UI.

--- a/examples/render-deploy/README.md
+++ b/examples/render-deploy/README.md
@@ -133,7 +133,7 @@ From a fork, create a Blueprint against that repo and set the same Blueprint Pat
 
 **Manual** — New → Web Service → this repo, Docker, `./examples/render-deploy/Dockerfile`, context `./examples/render-deploy`. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
 
-`autoDeploy` is off so pushes to this repository do not redeploy every copy of the button.
+`autoDeployTrigger: off` so pushes to this repository do not redeploy every copy of the button. Do not also set `autoDeploy` — Render rejects a Blueprint that includes both.
 
 ### 2. Set the env vars
 

--- a/examples/render-deploy/README.md
+++ b/examples/render-deploy/README.md
@@ -15,7 +15,7 @@ Render terminates TLS on `:443` and forwards to the container’s `PORT=4000`. D
 
 `dockerfilePath` / `dockerContext` inside the YAML stay relative to the **repo root** (`./examples/render-deploy/Dockerfile`), even though the Blueprint file lives under `examples/render-deploy/`.
 
-The image this service builds is this folder’s [`Dockerfile`](./Dockerfile): a thin wrapper around the official `cr.agentgateway.dev/agentgateway` image. The wrapper writes `/config/.htpasswd` on every start, seeds `config.yaml` on first boot, chowns the disk, then drops to uid 65532 — the gateway itself does not run as root. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
+The image this service builds is this folder’s [`Dockerfile`](./Dockerfile): a thin wrapper around the official `cr.agentgateway.dev/agentgateway` image. The wrapper writes `/config/.htpasswd` on every start, seeds `config.yaml` (UI basicAuth, OpenAI wildcard, virtual keys, GitHub MCP) on first boot, chowns the disk, then drops to uid 65532 — the gateway itself does not run as root. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
 
 ## Architecture
 
@@ -133,7 +133,7 @@ From a fork, create a Blueprint against that repo and set the same Blueprint Pat
 
 **Manual** — New → Web Service → this repo, Docker, `./examples/render-deploy/Dockerfile`, context `./examples/render-deploy`. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
 
-`autoDeployTrigger: off` so pushes to this repository do not redeploy every copy of the button. Do not also set `autoDeploy` — Render rejects a Blueprint that includes both.
+Pushes to the linked branch auto-deploy when `examples/render-deploy/` changes (`autoDeployTrigger: commit` + `buildFilter`). Other folders in this repo do not rebuild the service. Do not also set `autoDeploy` — Render rejects a Blueprint that includes both.
 
 ### 2. Set the env vars
 
@@ -145,13 +145,16 @@ The Blueprint already declares **`agw-config`** → **`/config`**, 1 GB. Disks a
 
 ### 4. Deploy
 
-First boot writes `.htpasswd` + a seed `config.yaml`, chowns `/config` to uid 65532, then execs the gateway as that uid, which watches `/config/config.yaml`. In Render logs you want:
+First boot writes `.htpasswd` + the lab `config.yaml` (UI basicAuth, OpenAI wildcard, virtual keys, GitHub MCP), chowns `/config` to uid 65532, then execs the gateway as that uid, which watches `/config/config.yaml`. In Render logs you want:
 
+- `entrypoint: seeded /config/config.yaml (llm + mcp + ui basicAuth)` (first boot) or `entrypoint: updated /config/config.yaml (lab=true)` (old UI-only disk)
 - `state_manager Watching config file: /config/config.yaml`
 - `app serving UI at http://localhost:4000/ui`
 - `proxy::gateway started bind bind="bind/4000"`
 - admin on `127.0.0.1:15000`
 - `==> Your service is live`
+
+If this service was created before the lab seed shipped, click **Manual Deploy**. The disk already has a config file, so a rebuild alone is not enough unless the entrypoint is allowed to merge missing `llm` / `mcp` sections (it will not overwrite models or MCP you added in the UI).
 
 A `http.status=401` on `/ui/` with `basic authentication failure: no basic authentication credentials found` is success. Health checks must **not** `GET /ui/` (401 ≠ healthy). The Blueprint omits `healthCheckPath` so Render uses TCP on `:4000`.
 
@@ -163,13 +166,13 @@ https://<your-service>.onrender.com/ui/
 
 Browser basic-auth prompt: `UI_USER` / `UI_PASSWORD`. Gateway Overview should show LLM, MCP, and Traffic on gateway **default**.
 
-### 6. Add OpenAI
+### 6. Confirm OpenAI
 
-**LLM → Models → Add model.** Incoming name `*`, provider OpenAI, API key `$OPENAI_API_KEY`. Outgoing model stays “Incoming model.”
+The seed already has incoming name `*`, provider OpenAI, API key `$OPENAI_API_KEY`. Set `OPENAI_API_KEY` in the Environment tab (Render restarts the service). **LLM → Models** should show the wildcard; outgoing model stays “Incoming model.” Only use **Add model** if you want a second provider.
 
-### 7. Add virtual keys
+### 7. Confirm virtual keys
 
-**LLM → Virtual API Keys** (or edit `/config/config.yaml`). Strict mode. Three lab keys: `admin` (any), `demo` (selected models), `limited` (`gpt-4.1-nano` + token budget). Use placeholders in docs; paste real secrets only in the dashboard / disk.
+The seed is already **LLM → Virtual API Keys**, strict mode, three lab keys: `admin` (any), `demo` (selected models), `limited` (`gpt-4.1-nano` + token budget). Use placeholders in docs; paste real secrets only in the dashboard / disk.
 
 ### 8. Call chat completions (HTTPS + Bearer)
 
@@ -190,15 +193,9 @@ curl -sS "$HOST/v1/chat/completions" \
 
 A 200 with token usage shows up under **LLM → Logs**.
 
-### 9. Add GitHub MCP
+### 9. Confirm GitHub MCP
 
-**MCP → Servers → Add server.**
-
-- Name: `github`
-- Type: **Streamable HTTP**
-- Endpoint: `https://api.githubcopilot.com/mcp/`
-
-Attach MCP to the existing `default` gateway (no second public port). Auth is a backend key:
+The seed already attaches GitHub remote Copilot MCP to the `default` gateway (no second public port):
 
 ```yaml
 mcp:
@@ -213,7 +210,7 @@ mcp:
           value: $GITHUB_PERSONAL_ACCESS_TOKEN
 ```
 
-State should go **ready**. Clients use `https://<your-service>.onrender.com/mcp`.
+Set `GITHUB_PERSONAL_ACCESS_TOKEN` in the Environment tab. **MCP → Servers** should show `github`, Streamable HTTP, **ready**. Clients use `https://<your-service>.onrender.com/mcp`. Only use **Add server** for extra targets.
 
 ## Ports and limits
 

--- a/examples/render-deploy/README.md
+++ b/examples/render-deploy/README.md
@@ -15,7 +15,7 @@ Render terminates TLS on `:443` and forwards to the container’s `PORT=4000`. D
 
 `dockerfilePath` / `dockerContext` inside the YAML stay relative to the **repo root** (`./examples/render-deploy/Dockerfile`), even though the Blueprint file lives under `examples/render-deploy/`.
 
-The image this service builds is this folder’s [`Dockerfile`](./Dockerfile): a thin wrapper around the official `cr.agentgateway.dev/agentgateway` image. The wrapper writes `/config/.htpasswd` on every start and seeds `config.yaml` on first boot. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
+The image this service builds is this folder’s [`Dockerfile`](./Dockerfile): a thin wrapper around the official `cr.agentgateway.dev/agentgateway` image. The wrapper writes `/config/.htpasswd` on every start, seeds `config.yaml` on first boot, chowns the disk, then drops to uid 65532 — the gateway itself does not run as root. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
 
 ## Architecture
 
@@ -112,7 +112,7 @@ Set these in the Render **Environment** tab. Never commit real values. See [`.en
 | Variable | Required | Purpose |
 |----------|----------|---------|
 | `PORT` | **Yes** | Must be `4000`. Render proxies `$PORT` (default `10000`); the gateway listens on 4000. |
-| `UI_USER` | No | Basic-auth username. Default `admin`. |
+| `UI_USER` | No | Basic-auth username. Default `admin`. Letters, digits, `.`, `_`, `@`, `-` only. |
 | `UI_PASSWORD` | **Yes** | Entrypoint writes `/config/.htpasswd` every start. Process exits 1 if unset. |
 | `OPENAI_API_KEY` | For OpenAI | Expanded as `$OPENAI_API_KEY` on the model. |
 | `GITHUB_PERSONAL_ACCESS_TOKEN` | For GitHub MCP | Bearer the gateway sends to `api.githubcopilot.com`. |
@@ -145,7 +145,7 @@ The Blueprint already declares **`agw-config`** → **`/config`**, 1 GB. Disks a
 
 ### 4. Deploy
 
-First boot writes `.htpasswd` + a seed `config.yaml`, then the gateway watches `/config/config.yaml`. In Render logs you want:
+First boot writes `.htpasswd` + a seed `config.yaml`, chowns `/config` to uid 65532, then execs the gateway as that uid, which watches `/config/config.yaml`. In Render logs you want:
 
 - `state_manager Watching config file: /config/config.yaml`
 - `app serving UI at http://localhost:4000/ui`
@@ -232,15 +232,17 @@ Starter is enough for a demo. The disk is the persistence story.
 
 ## Security
 
-`ui.policies.basicAuth` `mode: strict` plus file htpasswd (`{SHA}` lines the entrypoint rewrites every start). Unauthenticated `GET /ui/` is **401** and `WWW-Authenticate: Basic realm="agentgateway"`.
+`ui.policies.basicAuth` `mode: strict` plus file htpasswd (`$2y$` bcrypt at cost 10, rewritten every start via `htpasswd -B`). Unauthenticated `GET /ui/` is **401** and `WWW-Authenticate: Basic realm="agentgateway"`.
 
 That is **demo-grade** behind Render TLS. It is not an IdP.
 
 - Rotate `UI_PASSWORD`, `OPENAI_API_KEY`, `GITHUB_PERSONAL_ACCESS_TOKEN`, and every virtual key if this URL is more than a lab.
 - Scope the GitHub PAT. Remote Copilot MCP will do whatever that token can do.
-- `{SHA}` / HTTP basic is not SSO.
+- HTTP basic is not SSO, however strong the hash.
 
-Inline bcrypt in `config.yaml` is a footgun: hashes contain `$`, and agentgateway env-expands `$VARS`. That is why the entrypoint uses a file.
+Inline bcrypt in `config.yaml` is a footgun: hashes contain `$`, and agentgateway env-expands `$VARS`. A file-backed htpasswd is read as raw bytes with no expansion, which is why the entrypoint writes one.
+
+`config.yaml` and `.htpasswd` are both created mode `600` and owned by uid 65532, so virtual keys you add to the config are not world-readable inside the container.
 
 ## Verify
 

--- a/examples/render-deploy/README.md
+++ b/examples/render-deploy/README.md
@@ -1,0 +1,280 @@
+## Render Deploy Example
+
+This example deploys standalone agentgateway on [Render](https://render.com) as a Docker web service with a public **HTTPS** URL.
+
+Render terminates TLS on `:443` and forwards to the container’s `PORT=4000`. Do not publish `:4000` yourself, and do not call the service over `http://`.
+
+**Canonical Blueprint:** [`render.yaml`](./render.yaml) in this folder.
+
+| How you create it | What to set |
+|-------------------|-------------|
+| Deploy-to-Render button | `path=examples/render-deploy/render.yaml` (Render’s query param is `path`, not `blueprintPath`) |
+| Dashboard → New Blueprint | **Blueprint Path** = `examples/render-deploy/render.yaml` |
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/agentgateway/agentgateway&path=examples/render-deploy/render.yaml)
+
+`dockerfilePath` / `dockerContext` inside the YAML stay relative to the **repo root** (`./examples/render-deploy/Dockerfile`), even though the Blueprint file lives under `examples/render-deploy/`.
+
+The image this service builds is this folder’s [`Dockerfile`](./Dockerfile): a thin wrapper around the official `cr.agentgateway.dev/agentgateway` image. The wrapper writes `/config/.htpasswd` on every start and seeds `config.yaml` on first boot. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
+
+## Architecture
+
+Render gives you **one** public port. UI, LLM, and MCP therefore share `gateways.default` on `:4000` and split by path. Admin `:15000` is loopback-only inside the container. Config, htpasswd, and SQLite live on disk **`agw-config`** mounted at **`/config`**.
+
+```mermaid
+flowchart LR
+  subgraph clients [Clients]
+    Browser[Browser]
+    App[App / curl / IDE]
+  end
+
+  subgraph render [Render]
+    TLS["TLS :443"]
+    GW["agentgateway PORT 4000"]
+    Disk[("disk agw-config → /config")]
+    Admin["admin :15000 loopback only"]
+  end
+
+  subgraph upstreams [Upstreams]
+    OpenAI[OpenAI API]
+    GH["GitHub remote MCP<br/>api.githubcopilot.com/mcp/"]
+  end
+
+  Browser -->|HTTPS only| TLS
+  App -->|HTTPS only| TLS
+  TLS --> GW
+  GW -->|"/ui/ + basicAuth"| Browser
+  GW -->|"/v1/* Bearer virtual key"| OpenAI
+  GW -->|"/mcp"| GH
+  GW --- Disk
+  GW -.-> Admin
+```
+
+| Public path | Who it is for | Auth |
+|-------------|----------------|------|
+| `/ui/` | Operators | HTTP basic (`UI_USER` / `UI_PASSWORD`) |
+| `/v1/*` | Apps, playground, `curl` | `llm.policies.apiKey` **strict** — Bearer virtual key |
+| `/mcp` | MCP clients | GitHub PAT on the upstream target |
+
+`ui.policies` does **not** cover `/v1/*`. Do not send the UI password as an LLM Bearer token.
+
+## Example layout
+
+| Fact | Value |
+|------|--------|
+| Service | Web Service, Docker, **Starter** |
+| URL | `https://<your-service>.onrender.com` — **HTTPS only** |
+| Disk | **`agw-config`** → **`/config`**, 1 GB |
+| UI | `/ui/` basic auth via `UI_USER` + `UI_PASSWORD` |
+| LLM | OpenAI wildcard `*` on `/v1/*` |
+| MCP | GitHub remote Copilot MCP on `/mcp` (Streamable HTTP) |
+| Admin | `:15000` on `127.0.0.1` — not on the internet |
+
+Virtual API keys (`llm.policies.apiKey` `mode: strict`):
+
+| Key (placeholder) | `metadata.name` | Models | Extra |
+|-------------------|-----------------|--------|-------|
+| `sk-lab-admin-...` | `admin` | any | — |
+| `sk-lab-demo-...` | `demo` | selected models | — |
+| `sk-lab-limited-...` | `limited` | `gpt-4.1-nano` | rolling token budget |
+
+Rotate anything that ever leaked. The strings above are placeholders — they are not live secrets.
+
+Example config (same shape as [`config.example.yaml`](./config.example.yaml)):
+
+```yaml
+llm:
+  policies:
+    apiKey:
+      mode: strict
+      keys:
+      - key: sk-lab-admin-...
+        metadata: { name: admin }
+      - key: sk-lab-demo-...
+        metadata: { name: demo }
+        allowedModels: [gpt-4.1-nano, gpt-4.1, gpt-4o]
+      - key: sk-lab-limited-...
+        metadata: { name: limited }
+        allowedModels: [gpt-4.1-nano]
+        budgets:
+        - name: tokens
+          limit: { unit: Tokens, amount: 1000 }
+          window: { rolling: 1h }
+          onBudgetExceeded: Block
+```
+
+A `GET /v1/models` with no `Authorization` header returns `api key authentication failure: no API Key found`. That is the strict policy working.
+
+## Environment variables
+
+Set these in the Render **Environment** tab. Never commit real values. See [`.env.example`](./.env.example).
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `PORT` | **Yes** | Must be `4000`. Render proxies `$PORT` (default `10000`); the gateway listens on 4000. |
+| `UI_USER` | No | Basic-auth username. Default `admin`. |
+| `UI_PASSWORD` | **Yes** | Entrypoint writes `/config/.htpasswd` every start. Process exits 1 if unset. |
+| `OPENAI_API_KEY` | For OpenAI | Expanded as `$OPENAI_API_KEY` on the model. |
+| `GITHUB_PERSONAL_ACCESS_TOKEN` | For GitHub MCP | Bearer the gateway sends to `api.githubcopilot.com`. |
+
+## How to deploy
+
+### 1. Create the Render web service
+
+**Button / Blueprint** — prefer this folder’s Blueprint:
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/agentgateway/agentgateway&path=examples/render-deploy/render.yaml)
+
+- One-click URL uses `path=examples/render-deploy/render.yaml` (required when the file is not at repo root).
+- Dashboard: **Blueprint Path** = `examples/render-deploy/render.yaml`.
+- File: [`render.yaml`](./render.yaml).
+
+From a fork, create a Blueprint against that repo and set the same Blueprint Path.
+
+**Manual** — New → Web Service → this repo, Docker, `./examples/render-deploy/Dockerfile`, context `./examples/render-deploy`. Do **not** pick **Existing Image** → `cr.agentgateway.dev/agentgateway:v1.5.0`. Empty `/config` auto-gen serves `/ui/` with **no auth**.
+
+`autoDeploy` is off so pushes to this repository do not redeploy every copy of the button.
+
+### 2. Set the env vars
+
+Render prompts for `sync: false` keys on first Blueprint create. Pin `PORT=4000`. Generate `UI_PASSWORD` in the dashboard. Paste provider tokens there, not into git.
+
+### 3. Disk
+
+The Blueprint already declares **`agw-config`** → **`/config`**, 1 GB. Disks are not available on Render Free — Starter is the floor. Without the volume, config and analytics reset on every deploy.
+
+### 4. Deploy
+
+First boot writes `.htpasswd` + a seed `config.yaml`, then the gateway watches `/config/config.yaml`. In Render logs you want:
+
+- `state_manager Watching config file: /config/config.yaml`
+- `app serving UI at http://localhost:4000/ui`
+- `proxy::gateway started bind bind="bind/4000"`
+- admin on `127.0.0.1:15000`
+- `==> Your service is live`
+
+A `http.status=401` on `/ui/` with `basic authentication failure: no basic authentication credentials found` is success. Health checks must **not** `GET /ui/` (401 ≠ healthy). The Blueprint omits `healthCheckPath` so Render uses TCP on `:4000`.
+
+### 5. Open the UI over HTTPS
+
+```
+https://<your-service>.onrender.com/ui/
+```
+
+Browser basic-auth prompt: `UI_USER` / `UI_PASSWORD`. Gateway Overview should show LLM, MCP, and Traffic on gateway **default**.
+
+### 6. Add OpenAI
+
+**LLM → Models → Add model.** Incoming name `*`, provider OpenAI, API key `$OPENAI_API_KEY`. Outgoing model stays “Incoming model.”
+
+### 7. Add virtual keys
+
+**LLM → Virtual API Keys** (or edit `/config/config.yaml`). Strict mode. Three lab keys: `admin` (any), `demo` (selected models), `limited` (`gpt-4.1-nano` + token budget). Use placeholders in docs; paste real secrets only in the dashboard / disk.
+
+### 8. Call chat completions (HTTPS + Bearer)
+
+The playground’s wildcard row needs a **specific model** before Send is enabled. From a client:
+
+```sh
+export HOST=https://<your-service>.onrender.com
+export VKEY='sk-lab-limited-...'   # placeholder — use your lab key
+
+curl -sS "$HOST/v1/chat/completions" \
+  -H "Authorization: Bearer $VKEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-4.1-nano",
+    "messages": [{"role": "user", "content": "Reply with one word: pong"}]
+  }'
+```
+
+A 200 with token usage shows up under **LLM → Logs**.
+
+### 9. Add GitHub MCP
+
+**MCP → Servers → Add server.**
+
+- Name: `github`
+- Type: **Streamable HTTP**
+- Endpoint: `https://api.githubcopilot.com/mcp/`
+
+Attach MCP to the existing `default` gateway (no second public port). Auth is a backend key:
+
+```yaml
+mcp:
+  gateways: [default]
+  targets:
+  - name: github
+    mcp:
+      host: https://api.githubcopilot.com/mcp/
+    policies:
+      backendAuth:
+        key:
+          value: $GITHUB_PERSONAL_ACCESS_TOKEN
+```
+
+State should go **ready**. Clients use `https://<your-service>.onrender.com/mcp`.
+
+## Ports and limits
+
+Render publishes **HTTPS :443** to one container port. That port is `4000`. There is no public `:4000` URL and no public admin.
+
+| Address | Reachable from the internet? |
+|---------|------------------------------|
+| `https://<service>.onrender.com/ui/` | Yes, basic auth |
+| `https://<service>.onrender.com/v1/*` | Yes, virtual API key |
+| `https://<service>.onrender.com/mcp` | Yes, MCP |
+| `http://<service>.onrender.com/...` | Do not use |
+| `:4000` on the public hostname | Do not use |
+| `:15000` | No — loopback only |
+
+Starter is enough for a demo. The disk is the persistence story.
+
+## Security
+
+`ui.policies.basicAuth` `mode: strict` plus file htpasswd (`{SHA}` lines the entrypoint rewrites every start). Unauthenticated `GET /ui/` is **401** and `WWW-Authenticate: Basic realm="agentgateway"`.
+
+That is **demo-grade** behind Render TLS. It is not an IdP.
+
+- Rotate `UI_PASSWORD`, `OPENAI_API_KEY`, `GITHUB_PERSONAL_ACCESS_TOKEN`, and every virtual key if this URL is more than a lab.
+- Scope the GitHub PAT. Remote Copilot MCP will do whatever that token can do.
+- `{SHA}` / HTTP basic is not SSO.
+
+Inline bcrypt in `config.yaml` is a footgun: hashes contain `$`, and agentgateway env-expands `$VARS`. That is why the entrypoint uses a file.
+
+## Verify
+
+HTTPS only. Placeholders, not real secrets.
+
+```sh
+HOST=https://<your-service>.onrender.com
+
+# UI locked
+curl -sI "$HOST/ui/" | grep -E 'HTTP/|www-authenticate'
+# HTTP/2 401
+# www-authenticate: Basic realm="agentgateway"
+
+curl -sI -u "$UI_USER:$UI_PASSWORD" "$HOST/ui/" | head -5
+# HTTP/2 200
+
+# LLM requires a virtual key
+curl -sS "$HOST/v1/models"
+# api key authentication failure: no API Key found
+
+curl -sS "$HOST/v1/models" -H "Authorization: Bearer sk-lab-admin-..."
+curl -sS "$HOST/v1/chat/completions" \
+  -H "Authorization: Bearer sk-lab-limited-..." \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"gpt-4.1-nano","messages":[{"role":"user","content":"Reply with one word: pong"}]}'
+# limited is gpt-4.1-nano + token budget — expect 429 budget_exceeded after the window fills
+
+# MCP — GitHub remote (POST)
+curl -sS "$HOST/mcp" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H 'mcp-protocol-version: 2025-06-18' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"howto","version":"1"}}}'
+# look for serverInfo.name: github-mcp-server
+```
+
+A 401 on `/ui/` without credentials, a 200 with them, a 401 on `/v1/models` without a Bearer key, and an MCP `initialize` that names `github-mcp-server` is the smoke test.

--- a/examples/render-deploy/config.example.yaml
+++ b/examples/render-deploy/config.example.yaml
@@ -1,7 +1,8 @@
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 #
 # Example shape for a Render deployment — placeholders only.
-# The live service stores the real file on the agw-config disk at /config/config.yaml.
+# The entrypoint seeds this onto the agw-config disk as /config/config.yaml
+# on first boot (and merges llm/mcp if an older UI-only seed is already there).
 # Do not commit real UI passwords, provider keys, or virtual API keys.
 #
 # Render publishes HTTPS :443 → container :4000. Admin :15000 stays loopback.

--- a/examples/render-deploy/config.example.yaml
+++ b/examples/render-deploy/config.example.yaml
@@ -1,9 +1,15 @@
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 #
-# Example shape for a Render deployment — placeholders only.
-# The entrypoint seeds this onto the agw-config disk as /config/config.yaml
-# on first boot (and merges llm/mcp if an older UI-only seed is already there).
-# Do not commit real UI passwords, provider keys, or virtual API keys.
+# What first boot writes to /config/config.yaml on the agw-config disk.
+# Add LLM models and MCP servers in the UI after login — do not put
+# $OPENAI_API_KEY or $GITHUB_PERSONAL_ACCESS_TOKEN here unless those
+# env vars are set (agentgateway exits if a $VAR is missing, and
+# llm.models is required whenever llm is present).
+#
+# SQLite on the disk is the default. To use Render Postgres instead,
+# create a database (https://render.com/docs/postgresql-creating-connecting)
+# and change config.database.url in the UI to the connection string
+# (or $DATABASE_URL once that env var exists).
 #
 # Render publishes HTTPS :443 → container :4000. Admin :15000 stays loopback.
 
@@ -23,49 +29,3 @@ ui:
       htpasswd:
         file: /config/.htpasswd
       realm: agentgateway
-
-llm:
-  gateways: [default]
-  policies:
-    apiKey:
-      mode: strict
-      keys:
-      - key: sk-lab-admin-...
-        metadata:
-          name: admin
-      - key: sk-lab-demo-...
-        metadata:
-          name: demo
-        allowedModels:
-        - gpt-4.1-nano
-        - gpt-4.1
-        - gpt-4o
-      - key: sk-lab-limited-...
-        metadata:
-          name: limited
-        allowedModels:
-        - gpt-4.1-nano
-        budgets:
-        - name: tokens
-          limit:
-            unit: Tokens
-            amount: 1000
-          window:
-            rolling: 1h
-          onBudgetExceeded: Block
-  models:
-  - name: '*'
-    provider: openAI
-    params:
-      apiKey: $OPENAI_API_KEY
-
-mcp:
-  gateways: [default]
-  targets:
-  - name: github
-    mcp:
-      host: https://api.githubcopilot.com/mcp/
-    policies:
-      backendAuth:
-        key:
-          value: $GITHUB_PERSONAL_ACCESS_TOKEN

--- a/examples/render-deploy/config.example.yaml
+++ b/examples/render-deploy/config.example.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+#
+# Example shape for a Render deployment — placeholders only.
+# The live service stores the real file on the agw-config disk at /config/config.yaml.
+# Do not commit real UI passwords, provider keys, or virtual API keys.
+#
+# Render publishes HTTPS :443 → container :4000. Admin :15000 stays loopback.
+
+config:
+  database:
+    url: sqlite:///config/data.db
+
+gateways:
+  default:
+    port: 4000
+
+ui:
+  gateways: [default]
+  policies:
+    basicAuth:
+      mode: strict
+      htpasswd:
+        file: /config/.htpasswd
+      realm: agentgateway
+
+llm:
+  gateways: [default]
+  policies:
+    apiKey:
+      mode: strict
+      keys:
+      - key: sk-lab-admin-...
+        metadata:
+          name: admin
+      - key: sk-lab-demo-...
+        metadata:
+          name: demo
+        allowedModels:
+        - gpt-4.1-nano
+        - gpt-4.1
+        - gpt-4o
+      - key: sk-lab-limited-...
+        metadata:
+          name: limited
+        allowedModels:
+        - gpt-4.1-nano
+        budgets:
+        - name: tokens
+          limit:
+            unit: Tokens
+            amount: 1000
+          window:
+            rolling: 1h
+          onBudgetExceeded: Block
+  models:
+  - name: '*'
+    provider: openAI
+    params:
+      apiKey: $OPENAI_API_KEY
+
+mcp:
+  gateways: [default]
+  targets:
+  - name: github
+    mcp:
+      host: https://api.githubcopilot.com/mcp/
+    policies:
+      backendAuth:
+        key:
+          value: $GITHUB_PERSONAL_ACCESS_TOKEN

--- a/examples/render-deploy/entrypoint.sh
+++ b/examples/render-deploy/entrypoint.sh
@@ -4,6 +4,11 @@
 # dashboard env changes take effect. Inline bcrypt in config.yaml is a
 # footgun: hashes contain $ and agentgateway env-expands $VARS. The htpasswd
 # file is read as raw bytes, so bcrypt is safe there.
+#
+# First boot writes UI basicAuth only. Add models and MCP in the UI after
+# login — do not seed $OPENAI_API_KEY / $GITHUB_PERSONAL_ACCESS_TOKEN.
+# agentgateway exits if config.yaml expands a $VAR that is unset, and
+# llm.models is required whenever an llm section is present.
 set -eu
 
 # Pinned, not configurable: render.yaml mounts the disk at /config and the
@@ -44,64 +49,7 @@ mkdir -p "${CONFIG_DIR}"
 umask 077
 printf '%s\n' "${UI_PASSWORD}" | htpasswd -niB -C 10 "${UI_USER}" > "${HTPASSWD_FILE}"
 
-# Lab seed (same shape as config.example.yaml). First boot writes the whole
-# file. An older UI-only disk gets missing llm/mcp appended; existing
-# operator-set sections are left alone.
-append_lab_llm() {
-  cat <<'EOF'
-llm:
-  gateways: [default]
-  policies:
-    apiKey:
-      mode: strict
-      keys:
-      - key: sk-lab-admin-...
-        metadata:
-          name: admin
-      - key: sk-lab-demo-...
-        metadata:
-          name: demo
-        allowedModels:
-        - gpt-4.1-nano
-        - gpt-4.1
-        - gpt-4o
-      - key: sk-lab-limited-...
-        metadata:
-          name: limited
-        allowedModels:
-        - gpt-4.1-nano
-        budgets:
-        - name: tokens
-          limit:
-            unit: Tokens
-            amount: 1000
-          window:
-            rolling: 1h
-          onBudgetExceeded: Block
-  models:
-  - name: '*'
-    provider: openAI
-    params:
-      apiKey: $OPENAI_API_KEY
-EOF
-}
-
-append_lab_mcp() {
-  cat <<'EOF'
-mcp:
-  gateways: [default]
-  targets:
-  - name: github
-    mcp:
-      host: https://api.githubcopilot.com/mcp/
-    policies:
-      backendAuth:
-        key:
-          value: $GITHUB_PERSONAL_ACCESS_TOKEN
-EOF
-}
-
-if [ ! -f "${CONFIG_FILE}" ]; then
+write_ui_seed() {
   cat > "${CONFIG_FILE}" <<'EOF'
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
 config:
@@ -119,22 +67,18 @@ ui:
         file: /config/.htpasswd
       realm: agentgateway
 EOF
-  append_lab_llm >> "${CONFIG_FILE}"
-  append_lab_mcp >> "${CONFIG_FILE}"
-  echo "entrypoint: seeded ${CONFIG_FILE} (llm + mcp + ui basicAuth)" >&2
-else
-  lab=0
-  if ! grep -Eq '^llm:' "${CONFIG_FILE}"; then
-    append_lab_llm >> "${CONFIG_FILE}"
-    lab=1
-  fi
-  if ! grep -Eq '^mcp:' "${CONFIG_FILE}"; then
-    append_lab_mcp >> "${CONFIG_FILE}"
-    lab=1
-  fi
-  if [ "${lab}" = 1 ]; then
-    echo "entrypoint: updated ${CONFIG_FILE} (lab=true)" >&2
-  fi
+}
+
+if [ ! -f "${CONFIG_FILE}" ]; then
+  write_ui_seed
+  echo "entrypoint: seeded ${CONFIG_FILE} (ui basicAuth)" >&2
+elif grep -q '\$OPENAI_API_KEY\|\$GITHUB_PERSONAL_ACCESS_TOKEN\|sk-lab-admin' "${CONFIG_FILE}" && \
+     [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]; then
+  # Earlier revisions of this example appended lab llm/mcp that expand
+  # unset $VARS and crash the process. Replace that seed with UI-only;
+  # add models and MCP in the UI.
+  write_ui_seed
+  echo "entrypoint: replaced lab llm/mcp seed with UI-only ${CONFIG_FILE}" >&2
 fi
 
 # Root only on first boot to claim the disk; the gateway itself never runs

--- a/examples/render-deploy/entrypoint.sh
+++ b/examples/render-deploy/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Prepare /config, then exec the official agentgateway binary.
+# UI_PASSWORD is required. The file htpasswd is rewritten every start so
+# dashboard env changes take effect. Inline bcrypt in config.yaml is a
+# footgun: hashes contain $ and agentgateway env-expands $VARS.
+set -eu
+
+CONFIG_DIR="${AGW_CONFIG_DIR:-/config}"
+CONFIG_FILE="${CONFIG_DIR}/config.yaml"
+HTPASSWD_FILE="${CONFIG_DIR}/.htpasswd"
+BIN="${AGENTGATEWAY_BIN:-/app/agentgateway}"
+
+UI_USER="${UI_USER:-admin}"
+UI_PASSWORD="${UI_PASSWORD:-}"
+
+if [ -z "${UI_PASSWORD}" ]; then
+  echo "entrypoint: UI_PASSWORD is required to protect the UI; set it in the Render dashboard" >&2
+  exit 1
+fi
+
+case "${UI_USER}" in
+  *:*|*[$'\n\r']*)
+    echo "entrypoint: UI_USER must not contain ':' or newlines" >&2
+    exit 1
+    ;;
+esac
+
+mkdir -p "${CONFIG_DIR}"
+
+hash="$(printf '%s' "${UI_PASSWORD}" | openssl dgst -binary -sha1 | openssl enc -base64 -A)"
+printf '%s:{SHA}%s\n' "${UI_USER}" "${hash}" > "${HTPASSWD_FILE}"
+chmod 600 "${HTPASSWD_FILE}"
+
+if [ ! -f "${CONFIG_FILE}" ]; then
+  cat > "${CONFIG_FILE}" <<'EOF'
+# yaml-language-server: $schema=https://agentgateway.dev/schema/config
+config:
+  database:
+    url: sqlite:///config/data.db
+gateways:
+  default:
+    port: 4000
+ui:
+  gateways: [default]
+  policies:
+    basicAuth:
+      mode: strict
+      htpasswd:
+        file: /config/.htpasswd
+      realm: agentgateway
+EOF
+fi
+
+exec "${BIN}" -f "${CONFIG_FILE}"

--- a/examples/render-deploy/entrypoint.sh
+++ b/examples/render-deploy/entrypoint.sh
@@ -1,14 +1,22 @@
 #!/bin/sh
-# Prepare /config, then exec the official agentgateway binary.
+# Prepare /config, then exec the official agentgateway binary as uid 65532.
 # UI_PASSWORD is required. The file htpasswd is rewritten every start so
 # dashboard env changes take effect. Inline bcrypt in config.yaml is a
-# footgun: hashes contain $ and agentgateway env-expands $VARS.
+# footgun: hashes contain $ and agentgateway env-expands $VARS. The htpasswd
+# file is read as raw bytes, so bcrypt is safe there.
 set -eu
 
-CONFIG_DIR="${AGW_CONFIG_DIR:-/config}"
+# Pinned, not configurable: render.yaml mounts the disk at /config and the
+# seeded config.yaml below refers to /config by absolute path.
+CONFIG_DIR="/config"
 CONFIG_FILE="${CONFIG_DIR}/config.yaml"
 HTPASSWD_FILE="${CONFIG_DIR}/.htpasswd"
 BIN="${AGENTGATEWAY_BIN:-/app/agentgateway}"
+
+# The published image's uid. Render disks mount root-owned, so this image
+# starts as root, chowns the disk, then drops to this uid.
+RUN_UID=65532
+RUN_GID=65532
 
 UI_USER="${UI_USER:-admin}"
 UI_PASSWORD="${UI_PASSWORD:-}"
@@ -18,18 +26,23 @@ if [ -z "${UI_PASSWORD}" ]; then
   exit 1
 fi
 
+# $'\n' is a bashism; under dash (debian's /bin/sh) the old bracket
+# expression matched a literal 'n' and rejected the default user "admin".
+# Whitelist instead -- this also excludes ':' and newlines.
 case "${UI_USER}" in
-  *:*|*[$'\n\r']*)
-    echo "entrypoint: UI_USER must not contain ':' or newlines" >&2
+  ''|*[!A-Za-z0-9._@-]*)
+    echo "entrypoint: UI_USER must be non-empty and use only letters, digits, '.', '_', '@' or '-'" >&2
     exit 1
     ;;
 esac
 
 mkdir -p "${CONFIG_DIR}"
 
-hash="$(printf '%s' "${UI_PASSWORD}" | openssl dgst -binary -sha1 | openssl enc -base64 -A)"
-printf '%s:{SHA}%s\n' "${UI_USER}" "${hash}" > "${HTPASSWD_FILE}"
-chmod 600 "${HTPASSWD_FILE}"
+# -B bcrypt, -C 10 cost, -i reads the password from stdin so it never lands
+# in argv. {SHA} would be unsalted SHA-1; the htpasswd-verify fork accepts
+# $2y$ bcrypt. It does not accept $6$, so openssl passwd is not a substitute.
+umask 077
+printf '%s\n' "${UI_PASSWORD}" | htpasswd -niB -C 10 "${UI_USER}" > "${HTPASSWD_FILE}"
 
 if [ ! -f "${CONFIG_FILE}" ]; then
   cat > "${CONFIG_FILE}" <<'EOF'
@@ -49,6 +62,14 @@ ui:
         file: /config/.htpasswd
       realm: agentgateway
 EOF
+fi
+
+# Root only on first boot to claim the disk; the gateway itself never runs
+# as root. Skip both steps if the container was already started non-root.
+if [ "$(id -u)" = "0" ]; then
+  chown -R "${RUN_UID}:${RUN_GID}" "${CONFIG_DIR}"
+  exec setpriv --reuid="${RUN_UID}" --regid="${RUN_GID}" --clear-groups \
+    "${BIN}" -f "${CONFIG_FILE}"
 fi
 
 exec "${BIN}" -f "${CONFIG_FILE}"

--- a/examples/render-deploy/entrypoint.sh
+++ b/examples/render-deploy/entrypoint.sh
@@ -44,6 +44,63 @@ mkdir -p "${CONFIG_DIR}"
 umask 077
 printf '%s\n' "${UI_PASSWORD}" | htpasswd -niB -C 10 "${UI_USER}" > "${HTPASSWD_FILE}"
 
+# Lab seed (same shape as config.example.yaml). First boot writes the whole
+# file. An older UI-only disk gets missing llm/mcp appended; existing
+# operator-set sections are left alone.
+append_lab_llm() {
+  cat <<'EOF'
+llm:
+  gateways: [default]
+  policies:
+    apiKey:
+      mode: strict
+      keys:
+      - key: sk-lab-admin-...
+        metadata:
+          name: admin
+      - key: sk-lab-demo-...
+        metadata:
+          name: demo
+        allowedModels:
+        - gpt-4.1-nano
+        - gpt-4.1
+        - gpt-4o
+      - key: sk-lab-limited-...
+        metadata:
+          name: limited
+        allowedModels:
+        - gpt-4.1-nano
+        budgets:
+        - name: tokens
+          limit:
+            unit: Tokens
+            amount: 1000
+          window:
+            rolling: 1h
+          onBudgetExceeded: Block
+  models:
+  - name: '*'
+    provider: openAI
+    params:
+      apiKey: $OPENAI_API_KEY
+EOF
+}
+
+append_lab_mcp() {
+  cat <<'EOF'
+mcp:
+  gateways: [default]
+  targets:
+  - name: github
+    mcp:
+      host: https://api.githubcopilot.com/mcp/
+    policies:
+      backendAuth:
+        key:
+          value: $GITHUB_PERSONAL_ACCESS_TOKEN
+EOF
+}
+
 if [ ! -f "${CONFIG_FILE}" ]; then
   cat > "${CONFIG_FILE}" <<'EOF'
 # yaml-language-server: $schema=https://agentgateway.dev/schema/config
@@ -62,6 +119,22 @@ ui:
         file: /config/.htpasswd
       realm: agentgateway
 EOF
+  append_lab_llm >> "${CONFIG_FILE}"
+  append_lab_mcp >> "${CONFIG_FILE}"
+  echo "entrypoint: seeded ${CONFIG_FILE} (llm + mcp + ui basicAuth)" >&2
+else
+  lab=0
+  if ! grep -Eq '^llm:' "${CONFIG_FILE}"; then
+    append_lab_llm >> "${CONFIG_FILE}"
+    lab=1
+  fi
+  if ! grep -Eq '^mcp:' "${CONFIG_FILE}"; then
+    append_lab_mcp >> "${CONFIG_FILE}"
+    lab=1
+  fi
+  if [ "${lab}" = 1 ]; then
+    echo "entrypoint: updated ${CONFIG_FILE} (lab=true)" >&2
+  fi
 fi
 
 # Root only on first boot to claim the disk; the gateway itself never runs

--- a/examples/render-deploy/render.yaml
+++ b/examples/render-deploy/render.yaml
@@ -1,11 +1,11 @@
 # Standalone agentgateway — Render Blueprint
-# Canonical Blueprint Path for this example:
-#   examples/render-deploy/render.yaml
+# File: examples/render-deploy/render.yaml
 #
-# Deploy-to-Render button (use `path`, not blueprintPath):
+# Render looks for render.yaml at the repo root by default. This Blueprint
+# lives in a subdirectory, so:
+#   Deploy button:  ?path=examples/render-deploy/render.yaml
+#   Dashboard:      Blueprint Path = examples/render-deploy/render.yaml
 #   https://render.com/deploy?repo=https://github.com/agentgateway/agentgateway&path=examples/render-deploy/render.yaml
-#
-# Dashboard: New Blueprint → Blueprint Path = examples/render-deploy/render.yaml
 #
 # Builds examples/render-deploy/Dockerfile (entrypoint + official image).
 # Do not use runtime: image — that skips the Dockerfile and leaves /ui/
@@ -47,9 +47,6 @@ services:
       # Optional; entrypoint defaults to admin when unset.
       - key: UI_USER
         value: admin
-      - key: OPENAI_API_KEY
-        sync: false
-      - key: ANTHROPIC_API_KEY
-        sync: false
-      - key: GITHUB_PERSONAL_ACCESS_TOKEN
-        sync: false
+      # Provider keys are optional. Do not declare them with sync: false —
+      # Render would prompt as required, and a missing $VAR in config.yaml
+      # crashes the gateway. Add models / MCP in the UI after login.

--- a/examples/render-deploy/render.yaml
+++ b/examples/render-deploy/render.yaml
@@ -21,7 +21,9 @@ services:
     runtime: docker
     plan: starter
     numInstances: 1
-    autoDeploy: false
+    # Replaces the deprecated autoDeploy boolean. Render rejects a Blueprint
+    # that sets both. `off` = manual deploys only (do not rebuild on every
+    # push to this repo).
     autoDeployTrigger: off
     dockerfilePath: ./examples/render-deploy/Dockerfile
     dockerContext: ./examples/render-deploy

--- a/examples/render-deploy/render.yaml
+++ b/examples/render-deploy/render.yaml
@@ -22,9 +22,11 @@ services:
     plan: starter
     numInstances: 1
     # Replaces the deprecated autoDeploy boolean. Render rejects a Blueprint
-    # that sets both. `off` = manual deploys only (do not rebuild on every
-    # push to this repo).
-    autoDeployTrigger: off
+    # that sets both. Rebuild on commits that touch this example only.
+    autoDeployTrigger: commit
+    buildFilter:
+      paths:
+        - examples/render-deploy/**
     dockerfilePath: ./examples/render-deploy/Dockerfile
     dockerContext: ./examples/render-deploy
     # /ui/ is basic-auth protected (401 without creds). TCP-style default

--- a/examples/render-deploy/render.yaml
+++ b/examples/render-deploy/render.yaml
@@ -1,0 +1,51 @@
+# Standalone agentgateway — Render Blueprint
+# Canonical Blueprint Path for this example:
+#   examples/render-deploy/render.yaml
+#
+# Deploy-to-Render button (use `path`, not blueprintPath):
+#   https://render.com/deploy?repo=https://github.com/agentgateway/agentgateway&path=examples/render-deploy/render.yaml
+#
+# Dashboard: New Blueprint → Blueprint Path = examples/render-deploy/render.yaml
+#
+# Builds examples/render-deploy/Dockerfile (entrypoint + official image).
+# Do not use runtime: image — that skips the Dockerfile and leaves /ui/
+# unauthenticated on an empty disk.
+# https://agentgateway.dev/docs/standalone/latest/setup/install/docker/
+#
+# dockerfilePath / dockerContext are relative to the repo root (Render
+# Blueprint spec), even though this file lives under examples/render-deploy/.
+
+services:
+  - type: web
+    name: agentgateway
+    runtime: docker
+    plan: starter
+    numInstances: 1
+    autoDeploy: false
+    autoDeployTrigger: off
+    dockerfilePath: ./examples/render-deploy/Dockerfile
+    dockerContext: ./examples/render-deploy
+    # /ui/ is basic-auth protected (401 without creds). TCP-style default
+    # (omit healthCheckPath) treats a listening :4000 as healthy.
+    disk:
+      name: agw-config
+      mountPath: /config
+      sizeGB: 1
+    envVars:
+      # Render routes public HTTP to $PORT (default 10000). The generated
+      # gateway listens on 4000 — pin PORT so they match.
+      - key: PORT
+        value: "4000"
+      # Required. Render prompts on first Blueprint create.
+      # sync: false is not allowed inside envVarGroups (Render docs).
+      - key: UI_PASSWORD
+        sync: false
+      # Optional; entrypoint defaults to admin when unset.
+      - key: UI_USER
+        value: admin
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: ANTHROPIC_API_KEY
+        sync: false
+      - key: GITHUB_PERSONAL_ACCESS_TOKEN
+        sync: false

--- a/examples/render-deploy/render.yaml
+++ b/examples/render-deploy/render.yaml
@@ -19,7 +19,9 @@ services:
   - type: web
     name: agentgateway
     runtime: docker
-    plan: starter
+    # Render renamed plans; "starter" still resolves. 0.5c-512mb is the
+    # default for a new web service and the smallest plan that can attach a disk.
+    plan: 0.5c-512mb
     numInstances: 1
     # Replaces the deprecated autoDeploy boolean. Render rejects a Blueprint
     # that sets both. Rebuild on commits that touch this example only.


### PR DESCRIPTION
Adding an render.yaml example for anyone to deploy  — standalone agentgateway on Render as a Docker web service.

Render-specific traps:
- Blueprint path is `examples/render-deploy/render.yaml`.


- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.

