### PR TITLE
feat(llm): translate Responses to Messages and Chat Completions to Responses

### DIFF
--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -336,6 +336,8 @@ const CHAT_TRANSLATIONS: &[ChatTranslation] = {
 		// Completions
 		chat(InputFormat::Completions, ChatFormat::AnthropicMessages),
 		chat(InputFormat::Completions, ChatFormat::BedrockConverse),
+		// Composed through Messages, so it comes after the direct conversions.
+		chat(InputFormat::Completions, ChatFormat::OpenAIResponses),
 		// Messages
 		chat(InputFormat::Messages, ChatFormat::OpenAICompletions),
 		chat(InputFormat::Messages, ChatFormat::OpenAIResponses),
@@ -343,7 +345,8 @@ const CHAT_TRANSLATIONS: &[ChatTranslation] = {
 		// Responses
 		chat(InputFormat::Responses, ChatFormat::OpenAICompletions),
 		chat(InputFormat::Responses, ChatFormat::BedrockConverse),
-		// Missing: Responses -> Messages
+		// Composed through Completions, so it comes after the direct conversions.
+		chat(InputFormat::Responses, ChatFormat::AnthropicMessages),
 	]
 };
 
@@ -383,8 +386,11 @@ fn render_openai_responses(
 			serde_json::to_vec(&req).map_err(AIError::RequestMarshal)
 		},
 		types::ChatRequest::Messages(req) => conversion::responses::from_messages::translate(&req),
-		_ => Err(AIError::UnsupportedConversion(strng::literal!(
-			"expected responses request"
+		types::ChatRequest::Completions(req) => {
+			conversion::responses::from_completions::translate(&req, ctx.catalog)
+		},
+		types::ChatRequest::Gemini(_) => Err(AIError::UnsupportedConversion(strng::literal!(
+			"gemini to responses"
 		))),
 	}
 }
@@ -412,9 +418,9 @@ fn render_anthropic_messages(
 			conversion::messages::from_completions::translate(&req, catalog)
 		},
 		types::ChatRequest::Messages(req) => serde_json::to_vec(&req).map_err(AIError::RequestMarshal),
-		types::ChatRequest::Responses(_) => Err(AIError::UnsupportedConversion(strng::literal!(
-			"responses to messages"
-		))),
+		types::ChatRequest::Responses(req) => {
+			conversion::messages::from_responses::translate(&req, catalog)
+		},
 		types::ChatRequest::Gemini(_) => Err(AIError::UnsupportedConversion(strng::literal!(
 			"gemini to messages"
 		))),
@@ -553,6 +559,9 @@ impl ChatTranslation {
 			ChatFormat::OpenAIResponses => match self.input {
 				InputFormat::Responses => AIProvider::parse_response::<types::responses::Response>(bytes),
 				InputFormat::Messages => conversion::responses::from_messages::translate_response(bytes),
+				InputFormat::Completions => {
+					conversion::responses::from_completions::translate_response(bytes)
+				},
 				_ => Err(AIError::UnsupportedConversion(strng::format!(
 					"from {:?} to {:?}",
 					self.output,
@@ -563,6 +572,9 @@ impl ChatTranslation {
 				InputFormat::Messages => AIProvider::parse_response::<types::messages::Response>(bytes),
 				InputFormat::Completions => {
 					conversion::messages::from_completions::translate_response(bytes)
+				},
+				InputFormat::Responses => {
+					conversion::messages::from_responses::translate_response(bytes, ctx.model)
 				},
 				_ => Err(AIError::UnsupportedConversion(strng::format!(
 					"from {:?} to {:?}",
@@ -648,6 +660,14 @@ impl ChatTranslation {
 						ctx.log_content,
 					)
 				}),
+				InputFormat::Completions => resp.map(|b| {
+					conversion::responses::from_completions::translate_stream(
+						b,
+						ctx.buffer_limit,
+						ctx.logger,
+						ctx.log_content,
+					)
+				}),
 				_ => resp,
 			},
 
@@ -657,6 +677,14 @@ impl ChatTranslation {
 				}),
 				InputFormat::Completions => resp.map(|b| {
 					conversion::messages::from_completions::translate_stream(
+						b,
+						ctx.buffer_limit,
+						ctx.logger,
+						ctx.log_content,
+					)
+				}),
+				InputFormat::Responses => resp.map(|b| {
+					conversion::messages::from_responses::translate_stream(
 						b,
 						ctx.buffer_limit,
 						ctx.logger,
@@ -777,7 +805,7 @@ impl ChatTranslation {
 
 			ChatFormat::OpenAIResponses => match format {
 				ChatErrorFormat::OpenAI => match self.input {
-					InputFormat::Responses => Ok(bytes.clone()),
+					InputFormat::Responses | InputFormat::Completions => Ok(bytes.clone()),
 					InputFormat::Messages => {
 						conversion::responses::from_messages::translate_error(bytes, status)
 					},
@@ -792,10 +820,11 @@ impl ChatTranslation {
 					InputFormat::Completions => {
 						conversion::messages::from_completions::translate_error(bytes)
 					},
+					InputFormat::Responses => conversion::messages::from_responses::translate_error(bytes),
 					_ => unsupported(),
 				},
 				ChatErrorFormat::OpenAI => match self.input {
-					InputFormat::Messages => Ok(bytes.clone()),
+					InputFormat::Messages | InputFormat::Responses => Ok(bytes.clone()),
 					_ => unsupported(),
 				},
 				_ => unsupported(),

--- a/crates/llm/src/conversion/messages.rs
+++ b/crates/llm/src/conversion/messages.rs
@@ -262,9 +262,16 @@ pub mod from_completions {
 		catalog: crate::model_catalog::Catalog<'_>,
 	) -> Result<Vec<u8>, AIError> {
 		let typed = json::convert::<_, completions::Request>(req).map_err(AIError::RequestMarshal)?;
-		let model_id = typed.model.clone().unwrap_or_default();
-		let xlated = translate_internal(typed, model_id, catalog);
-		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
+		serde_json::to_vec(&translate_typed(typed, catalog)).map_err(AIError::RequestMarshal)
+	}
+
+	/// The Messages request for an already typed Chat Completions request.
+	pub(crate) fn translate_typed(
+		req: completions::Request,
+		catalog: crate::model_catalog::Catalog<'_>,
+	) -> messages::Request {
+		let model_id = req.model.clone().unwrap_or_default();
+		translate_internal(req, model_id, catalog)
 	}
 
 	fn translate_internal(
@@ -525,7 +532,9 @@ pub mod from_completions {
 		Ok(Box::new(passthrough))
 	}
 
-	fn translate_response_internal(resp: messages::MessagesResponse) -> completions::Response {
+	pub(crate) fn translate_response_internal(
+		resp: messages::MessagesResponse,
+	) -> completions::Response {
 		// Convert Anthropic content blocks to OpenAI message content
 		let mut tool_calls: Vec<completions::MessageToolCalls> = Vec::new();
 		let mut content = None;
@@ -1041,6 +1050,63 @@ impl StreamingToolCalls {
 				finish_reason,
 			}]
 		})
+	}
+}
+
+/// A Responses client on a Messages provider, by way of the Chat Completions converters: the
+/// request goes Responses to Chat Completions to Messages, and the response and stream come back
+/// the same way. What Chat Completions has no place for, such as the provider's built-in tools, is
+/// lost here as it is on those two paths.
+pub mod from_responses {
+	use axum_core::body::Body;
+	use bytes::Bytes;
+
+	use crate::conversion::openai_compat;
+	use crate::types::ResponseType;
+	use crate::types::messages::typed as messages;
+	use crate::{
+		AIError, LogContentFields, StreamingUsageGuard, json, logged_response_parsing, types,
+	};
+
+	pub fn translate(
+		req: &types::responses::Request,
+		catalog: crate::model_catalog::Catalog<'_>,
+	) -> Result<Vec<u8>, AIError> {
+		let completions = openai_compat::from_responses::translate_request(req)?;
+		let request = super::from_completions::translate_typed(completions, catalog);
+		serde_json::to_vec(&request).map_err(AIError::RequestMarshal)
+	}
+
+	pub fn translate_response(bytes: &Bytes, model: &str) -> Result<Box<dyn ResponseType>, AIError> {
+		let resp = serde_json::from_slice::<messages::MessagesResponse>(bytes)
+			.map_err(logged_response_parsing(bytes))?;
+		let completions = super::from_completions::translate_response_internal(resp);
+		let response = openai_compat::to_responses::translate_response_internal(completions, model);
+		let passthrough = json::convert::<_, types::responses::Response>(&response)
+			.map_err(AIError::ResponseParsing)?;
+		Ok(Box::new(passthrough))
+	}
+
+	/// The Messages stage sees the provider's usage and content, so it takes the guard and the
+	/// content flags; the Responses stage only re-frames the events.
+	pub fn translate_stream(
+		b: Body,
+		buffer_limit: usize,
+		log: StreamingUsageGuard,
+		log_content: LogContentFields,
+	) -> Body {
+		let completions = super::from_completions::translate_stream(b, buffer_limit, log, log_content);
+		openai_compat::to_responses::translate_stream(
+			completions,
+			buffer_limit,
+			StreamingUsageGuard::default(),
+			LogContentFields::default(),
+		)
+	}
+
+	/// A Responses client reads the OpenAI error shape the Chat Completions stage produces.
+	pub fn translate_error(bytes: &Bytes) -> Result<Bytes, AIError> {
+		super::from_completions::translate_error(bytes)
 	}
 }
 

--- a/crates/llm/src/conversion/openai_compat.rs
+++ b/crates/llm/src/conversion/openai_compat.rs
@@ -491,7 +491,10 @@ pub mod to_responses {
 		Ok(Box::new(passthrough))
 	}
 
-	fn translate_response_internal(resp: completions::Response, model: &str) -> responses::Response {
+	pub(crate) fn translate_response_internal(
+		resp: completions::Response,
+		model: &str,
+	) -> responses::Response {
 		let response_id = format!("resp_{:016x}", rand::rng().random::<u64>());
 		let response_builder = types::responses::ResponseBuilder::new(response_id, model.to_string());
 

--- a/crates/llm/src/conversion/responses.rs
+++ b/crates/llm/src/conversion/responses.rs
@@ -161,7 +161,9 @@ pub mod from_messages {
 		serde_json::to_vec(&xlated).map_err(AIError::RequestMarshal)
 	}
 
-	fn translate_internal(req: messages::Request) -> Result<types::responses::Request, AIError> {
+	pub(crate) fn translate_internal(
+		req: messages::Request,
+	) -> Result<types::responses::Request, AIError> {
 		let messages::Request {
 			messages,
 			system,
@@ -734,7 +736,7 @@ pub mod from_messages {
 		Ok(Box::new(anthropic))
 	}
 
-	fn translate_response_internal(
+	pub(crate) fn translate_response_internal(
 		resp: responses::Response,
 	) -> Result<messages::MessagesResponse, AIError> {
 		if resp.error.is_some() || matches!(resp.status, responses::Status::Failed) {
@@ -1675,5 +1677,59 @@ pub mod from_messages {
 
 	fn unsupported<T>(reason: &'static str) -> Result<T, AIError> {
 		Err(AIError::UnsupportedConversion(strng::new(reason)))
+	}
+}
+
+/// A Chat Completions client on a Responses provider, by way of the Messages converters: the
+/// request goes Chat Completions to Messages to Responses, and the response and stream come back
+/// the same way. Fields the Messages format has no place for, such as `n`, `logprobs` and
+/// `response_format`, are lost here as they are on those two paths.
+pub mod from_completions {
+	use axum_core::body::Body;
+	use bytes::Bytes;
+
+	use crate::types::ResponseType;
+	use crate::types::completions::typed as completions;
+	use crate::types::responses::typed as responses;
+	use crate::{
+		AIError, LogContentFields, StreamingUsageGuard, conversion, json, logged_response_parsing,
+		types,
+	};
+
+	pub fn translate(
+		req: &types::completions::Request,
+		catalog: crate::model_catalog::Catalog<'_>,
+	) -> Result<Vec<u8>, AIError> {
+		let typed = json::convert::<_, completions::Request>(req).map_err(AIError::RequestMarshal)?;
+		let request = conversion::messages::from_completions::translate_typed(typed, catalog);
+		let request = super::from_messages::translate_internal(request)?;
+		serde_json::to_vec(&request).map_err(AIError::RequestMarshal)
+	}
+
+	pub fn translate_response(bytes: &Bytes) -> Result<Box<dyn ResponseType>, AIError> {
+		let resp = serde_json::from_slice::<responses::Response>(bytes)
+			.map_err(logged_response_parsing(bytes))?;
+		let response = super::from_messages::translate_response_internal(resp)?;
+		let response = conversion::messages::from_completions::translate_response_internal(response);
+		let passthrough = json::convert::<_, types::completions::Response>(&response)
+			.map_err(AIError::ResponseParsing)?;
+		Ok(Box::new(passthrough))
+	}
+
+	/// The Responses stage sees the provider's usage and content, so it takes the guard and the
+	/// content flags; the Chat Completions stage only re-frames the events.
+	pub fn translate_stream(
+		b: Body,
+		buffer_limit: usize,
+		log: StreamingUsageGuard,
+		log_content: LogContentFields,
+	) -> Body {
+		let events = super::from_messages::translate_stream(b, buffer_limit, log, log_content);
+		conversion::messages::from_completions::translate_stream(
+			events,
+			buffer_limit,
+			StreamingUsageGuard::default(),
+			LogContentFields::default(),
+		)
 	}
 }

--- a/crates/llm/src/golden_tests.rs
+++ b/crates/llm/src/golden_tests.rs
@@ -137,12 +137,12 @@ mod requests {
 	}
 
 	const COMPLETION_REQUESTS: &[(&str, &[&str])] = &[
-		("basic", &[ANTHROPIC, BEDROCK, VERTEX_GEMINI]),
+		("basic", &[ANTHROPIC, BEDROCK, VERTEX_GEMINI, RESPONSES]),
 		("prompt-cache-breakpoint", &[ANTHROPIC, BEDROCK]),
 		("full", &[ANTHROPIC, BEDROCK]),
-		("tool-call", &[ANTHROPIC, BEDROCK, VERTEX_GEMINI]),
+		("tool-call", &[ANTHROPIC, BEDROCK, VERTEX_GEMINI, RESPONSES]),
 		("parallel-tool-call", &[BEDROCK, VERTEX_GEMINI]),
-		("reasoning", &[ANTHROPIC, BEDROCK, VERTEX_GEMINI]),
+		("reasoning", &[ANTHROPIC, BEDROCK, VERTEX_GEMINI, RESPONSES]),
 		("reasoning-adaptive", &[ANTHROPIC, BEDROCK]),
 		("reasoning_max", &[ANTHROPIC, VERTEX_GEMINI]),
 		("reasoning_replay", &[BEDROCK]),
@@ -181,10 +181,10 @@ mod requests {
 		("responses_agent_subset", &[RESPONSES]),
 	];
 	const RESPONSES_REQUESTS: &[(&str, &[&str])] = &[
-		("basic", &[BEDROCK, GEMINI]),
-		("instructions", &[BEDROCK, GEMINI]),
+		("basic", &[BEDROCK, GEMINI, ANTHROPIC]),
+		("instructions", &[BEDROCK, GEMINI, ANTHROPIC]),
 		("input-list", &[BEDROCK, GEMINI]),
-		("parallel-tool-call", &[BEDROCK, GEMINI]),
+		("parallel-tool-call", &[BEDROCK, GEMINI, ANTHROPIC]),
 		("structured-output", &[BEDROCK]),
 		("input-media", &[BEDROCK]),
 		("cache_control", &[BEDROCK, GEMINI]),
@@ -260,6 +260,9 @@ mod requests {
 					VERTEX_GEMINI => test_request(VERTEX_GEMINI, &path, |i| {
 						conversion::vertex_gemini::from_completions::translate(i, Some("gemini-2.5-pro"))
 					}),
+					RESPONSES => test_request(RESPONSES, &path, |i| {
+						conversion::responses::from_completions::translate(i, Some(&catalog))
+					}),
 					other => panic!("unsupported provider in COMPLETION_REQUESTS: {other}"),
 				}
 			}
@@ -323,6 +326,9 @@ mod requests {
 					}),
 					GEMINI => test_request(GEMINI, &path, |i| {
 						conversion::openai_compat::from_responses::translate(i)
+					}),
+					ANTHROPIC => test_request(ANTHROPIC, &path, |i| {
+						conversion::messages::from_responses::translate(i, None)
 					}),
 					other => panic!("unsupported provider in RESPONSES_REQUESTS: {other}"),
 				}
@@ -772,6 +778,7 @@ mod responses {
 	const MESSAGES_TO_MESSAGES: &str = "messages-messages";
 	const MESSAGES_TO_COMPLETIONS: &str = "messages-completions";
 	const MESSAGES_TO_DETECT: &str = "messages-detect";
+	const MESSAGES_TO_RESPONSES: &str = "messages-responses";
 	const BEDROCK_TO_COMPLETIONS: &str = "bedrock-completions";
 	const BEDROCK_TO_MESSAGES: &str = "bedrock-messages";
 	const BEDROCK_TO_RESPONSES: &str = "bedrock-responses";
@@ -779,6 +786,7 @@ mod responses {
 	const RESPONSES_TO_RESPONSES: &str = "responses-responses";
 	const RESPONSES_TO_DETECT: &str = "responses-detect";
 	const RESPONSES_TO_MESSAGES: &str = "responses-messages";
+	const RESPONSES_TO_COMPLETIONS: &str = "responses-completions";
 	const VERTEX_GEMINI_TO_COMPLETIONS: &str = "vertex-gemini-completions";
 
 	const ALL_BEDROCK: &[&str] = &[
@@ -801,6 +809,7 @@ mod responses {
 		MESSAGES_TO_MESSAGES,
 		MESSAGES_TO_COMPLETIONS,
 		MESSAGES_TO_DETECT,
+		MESSAGES_TO_RESPONSES,
 	];
 	const ANTHROPIC_RESPONSES: &[(&str, &[&str])] = &[
 		("basic", ALL_ANTHROPIC),
@@ -842,10 +851,14 @@ mod responses {
 				RESPONSES_TO_RESPONSES,
 				RESPONSES_TO_DETECT,
 				RESPONSES_TO_MESSAGES,
+				RESPONSES_TO_COMPLETIONS,
 			],
 		),
-		("tool", &[RESPONSES_TO_MESSAGES]),
-		("reasoning", &[RESPONSES_TO_MESSAGES]),
+		("tool", &[RESPONSES_TO_MESSAGES, RESPONSES_TO_COMPLETIONS]),
+		(
+			"reasoning",
+			&[RESPONSES_TO_MESSAGES, RESPONSES_TO_COMPLETIONS],
+		),
 		("custom-tool", &[RESPONSES_TO_RESPONSES]),
 		("truncated_tool_call", &[RESPONSES_TO_RESPONSES]),
 	];
@@ -910,7 +923,14 @@ mod responses {
 	];
 	const VERTEX_GEMINI_STREAM_RESPONSES: &[&str] = &["stream_tool"];
 	const RESPONSES_STREAM_RESPONSES: &[(&str, &[&str])] = &[
-		("stream", &[RESPONSES_TO_RESPONSES, RESPONSES_TO_DETECT]),
+		(
+			"stream",
+			&[
+				RESPONSES_TO_RESPONSES,
+				RESPONSES_TO_DETECT,
+				RESPONSES_TO_COMPLETIONS,
+			],
+		),
 		("stream-custom-tool", &[RESPONSES_TO_RESPONSES]),
 		(
 			"stream-image",
@@ -949,6 +969,9 @@ mod responses {
 					}),
 					MESSAGES_TO_COMPLETIONS => test_response(provider, &path, |i| {
 						conversion::messages::from_completions::translate_response(&i)
+					}),
+					MESSAGES_TO_RESPONSES => test_response(provider, &path, |i| {
+						conversion::messages::from_responses::translate_response(&i, "input-model")
 					}),
 					MESSAGES_TO_DETECT => test_response(provider, &path, |bytes| {
 						Ok(Box::new(
@@ -1004,6 +1027,9 @@ mod responses {
 					}),
 					RESPONSES_TO_MESSAGES => test_response(provider, &path, |i| {
 						conversion::responses::from_messages::translate_response(&i)
+					}),
+					RESPONSES_TO_COMPLETIONS => test_response(provider, &path, |i| {
+						conversion::responses::from_completions::translate_response(&i)
 					}),
 					other => panic!("unsupported provider in RESPONSES_RESPONSES: {other}"),
 				}
@@ -1230,6 +1256,14 @@ mod responses {
 							LOG_CONTENT,
 						)
 					}),
+					MESSAGES_TO_RESPONSES => response.map(|body| {
+						conversion::messages::from_responses::translate_stream(
+							body,
+							BUFFER_LIMIT,
+							reporter,
+							LOG_CONTENT,
+						)
+					}),
 					MESSAGES_TO_DETECT => types::detect::passthrough_stream(reporter, response),
 					_ => unreachable!(),
 				})
@@ -1289,6 +1323,14 @@ mod responses {
 				test_streaming(provider, &path, |response, reporter| match *provider {
 					RESPONSES_TO_RESPONSES => response.map(|body| {
 						conversion::responses::passthrough_stream(body, BUFFER_LIMIT, reporter, LOG_CONTENT)
+					}),
+					RESPONSES_TO_COMPLETIONS => response.map(|body| {
+						conversion::responses::from_completions::translate_stream(
+							body,
+							BUFFER_LIMIT,
+							reporter,
+							LOG_CONTENT,
+						)
 					}),
 					RESPONSES_TO_DETECT => types::detect::passthrough_stream(reporter, response),
 					_ => unreachable!(),

--- a/crates/llm/src/tests/requests/completions/basic.responses.snap
+++ b/crates/llm/src/tests/requests/completions/basic.responses.snap
@@ -1,0 +1,49 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/completions/basic.json
+info:
+  model: replaceme
+  messages:
+    - role: system
+      content: You are a helpful assistant.
+    - role: user
+      content: What is the name of the LLM provider?
+---
+{
+  "request": {
+    "input": [
+      {
+        "type": "message",
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "What is the name of the LLM provider?"
+          }
+        ]
+      }
+    ],
+    "model": "replaceme",
+    "max_output_tokens": 4096,
+    "stream": false,
+    "instructions": "You are a helpful assistant."
+  },
+  "parsed": {
+    "input_format": "Completions",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "replaceme",
+    "provider": "responses",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "system",
+        "content": "You are a helpful assistant."
+      },
+      {
+        "role": "user",
+        "content": "What is the name of the LLM provider?"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/completions/reasoning.responses.snap
+++ b/crates/llm/src/tests/requests/completions/reasoning.responses.snap
@@ -1,0 +1,46 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/completions/reasoning.json
+info:
+  model: gpt-3.5-turbo
+  messages:
+    - role: user
+      content: How is the current weather in Columbus?
+  reasoning_effort: medium
+---
+{
+  "request": {
+    "input": [
+      {
+        "type": "message",
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "How is the current weather in Columbus?"
+          }
+        ]
+      }
+    ],
+    "model": "gpt-3.5-turbo",
+    "max_output_tokens": 4096,
+    "stream": false,
+    "reasoning": {
+      "effort": "high"
+    }
+  },
+  "parsed": {
+    "input_format": "Completions",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gpt-3.5-turbo",
+    "provider": "responses",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "user",
+        "content": "How is the current weather in Columbus?"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/completions/tool-call.responses.snap
+++ b/crates/llm/src/tests/requests/completions/tool-call.responses.snap
@@ -1,0 +1,103 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/completions/tool-call.json
+info:
+  model: gpt-3.5-turbo
+  messages:
+    - role: user
+      content: How is the current weather in Columbus?
+    - role: assistant
+      content: ~
+      tool_calls:
+        - id: call_iMGPsr4Xx1u0G5sOzFsTCbQU
+          type: function
+          function:
+            name: get_weather
+            arguments: "{\"format\":\"celsius\",\"location\":\"Columbus, OH\"}"
+        - id: call_5rQmXtLpZ9wKvNbJhGyDsFcE
+          type: function
+          function:
+            name: get_time
+            arguments: ""
+    - role: tool
+      tool_call_id: call_iMGPsr4Xx1u0G5sOzFsTCbQU
+      name: get_weather
+      content: "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    - role: tool
+      tool_call_id: call_5rQmXtLpZ9wKvNbJhGyDsFcE
+      name: get_time
+      content: "{ \"time\": \"2026-08-12T12:00:00Z\" }"
+---
+{
+  "request": {
+    "input": [
+      {
+        "type": "message",
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "How is the current weather in Columbus?"
+          }
+        ]
+      },
+      {
+        "type": "function_call",
+        "id": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
+        "call_id": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
+        "name": "get_weather",
+        "arguments": "{\"format\":\"celsius\",\"location\":\"Columbus, OH\"}",
+        "status": "completed"
+      },
+      {
+        "type": "function_call",
+        "id": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+        "call_id": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+        "name": "get_time",
+        "arguments": "{}",
+        "status": "completed"
+      },
+      {
+        "type": "function_call_output",
+        "call_id": "call_iMGPsr4Xx1u0G5sOzFsTCbQU",
+        "output": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }",
+        "status": "completed"
+      },
+      {
+        "type": "function_call_output",
+        "call_id": "call_5rQmXtLpZ9wKvNbJhGyDsFcE",
+        "output": "{ \"time\": \"2026-08-12T12:00:00Z\" }",
+        "status": "completed"
+      }
+    ],
+    "model": "gpt-3.5-turbo",
+    "max_output_tokens": 4096,
+    "stream": false
+  },
+  "parsed": {
+    "input_format": "Completions",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gpt-3.5-turbo",
+    "provider": "responses",
+    "streaming": false,
+    "params": {},
+    "prompt": [
+      {
+        "role": "user",
+        "content": "How is the current weather in Columbus?"
+      },
+      {
+        "role": "assistant",
+        "content": ""
+      },
+      {
+        "role": "tool",
+        "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+      },
+      {
+        "role": "tool",
+        "content": "{ \"time\": \"2026-08-12T12:00:00Z\" }"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/responses/basic.anthropic.snap
+++ b/crates/llm/src/tests/requests/responses/basic.anthropic.snap
@@ -1,0 +1,41 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/responses/basic.json
+info:
+  model: gpt-4o
+  max_output_tokens: 1024
+  input: "Hello, world"
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Hello, world"
+          }
+        ]
+      }
+    ],
+    "model": "gpt-4o",
+    "max_tokens": 1024
+  },
+  "parsed": {
+    "input_format": "Responses",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gpt-4o",
+    "provider": "anthropic",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "Hello, world"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/responses/instructions.anthropic.snap
+++ b/crates/llm/src/tests/requests/responses/instructions.anthropic.snap
@@ -1,0 +1,47 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/responses/instructions.json
+info:
+  model: gpt-4o
+  max_output_tokens: 1024
+  instructions: Always use the get_weather tool for weather questions.
+  input: What is the weather like in San Francisco?
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "What is the weather like in San Francisco?"
+          }
+        ]
+      }
+    ],
+    "system": "Always use the get_weather tool for weather questions.",
+    "model": "gpt-4o",
+    "max_tokens": 1024
+  },
+  "parsed": {
+    "input_format": "Responses",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gpt-4o",
+    "provider": "anthropic",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "system",
+        "content": "Always use the get_weather tool for weather questions."
+      },
+      {
+        "role": "user",
+        "content": "What is the weather like in San Francisco?"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/requests/responses/parallel-tool-call.anthropic.snap
+++ b/crates/llm/src/tests/requests/responses/parallel-tool-call.anthropic.snap
@@ -1,0 +1,101 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/requests/responses/parallel-tool-call.json
+info:
+  model: gpt-4o
+  max_output_tokens: 1024
+  input:
+    - type: message
+      role: user
+      content:
+        - type: input_text
+          text: How is the weather in Columbus and New York?
+    - type: function_call
+      call_id: call_1
+      name: get_weather
+      arguments: "{\"location\":\"Columbus, OH\"}"
+    - type: function_call
+      call_id: call_2
+      name: get_weather
+      arguments: "{\"location\":\"New York, NY\"}"
+    - type: function_call_output
+      call_id: call_1
+      output: "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+    - type: function_call_output
+      call_id: call_2
+      output: "{ \"temperature\": 22, \"condition\": \"Sunny\" }"
+---
+{
+  "request": {
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "How is the weather in Columbus and New York?"
+          }
+        ]
+      },
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "get_weather",
+            "input": {
+              "location": "Columbus, OH"
+            }
+          },
+          {
+            "type": "tool_use",
+            "id": "call_2",
+            "name": "get_weather",
+            "input": {
+              "location": "New York, NY"
+            }
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "call_1",
+            "content": "{ \"temperature\": 15, \"condition\": \"Cloudy\" }"
+          }
+        ]
+      },
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "tool_result",
+            "tool_use_id": "call_2",
+            "content": "{ \"temperature\": 22, \"condition\": \"Sunny\" }"
+          }
+        ]
+      }
+    ],
+    "model": "gpt-4o",
+    "max_tokens": 1024
+  },
+  "parsed": {
+    "input_format": "Responses",
+    "cache_convention": "InputIncludesCache",
+    "request_model": "gpt-4o",
+    "provider": "anthropic",
+    "streaming": false,
+    "params": {
+      "max_tokens": 1024
+    },
+    "prompt": [
+      {
+        "role": "user",
+        "content": "How is the weather in Columbus and New York?"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/response/anthropic/basic.messages-responses.snap
+++ b/crates/llm/src/tests/response/anthropic/basic.messages-responses.snap
@@ -1,0 +1,66 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/basic.json
+info:
+  id: msg_012JYtNYb8sv6Hb67TcGT7xW
+  type: message
+  role: assistant
+  model: claude-haiku-4-5-20251001
+  content:
+    - type: text
+      text: Hi there! How are you doing today? Is there anything I can help you with?
+  stop_reason: end_turn
+  stop_sequence: ~
+  usage:
+    input_tokens: 15
+    cache_creation_input_tokens: 13
+    cache_read_input_tokens: 12
+    output_tokens: 21
+    service_tier: standard
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "completed",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": null,
+            "text": "Hi there! How are you doing today? Is there anything I can help you with?"
+          }
+        ],
+        "id": "[id]",
+        "role": "assistant",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 15,
+      "output_tokens": 21,
+      "input_tokens_details": {
+        "cached_tokens": 12,
+        "cache_write_tokens": 13
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 36
+    },
+    "created_at": "[date]",
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 15,
+    "output_tokens": 21,
+    "total_tokens": 36,
+    "reasoning_tokens": 0,
+    "cache_creation_input_tokens": 13,
+    "cached_input_tokens": 12,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/llm/src/tests/response/anthropic/multiple_text_blocks.messages-responses.snap
+++ b/crates/llm/src/tests/response/anthropic/multiple_text_blocks.messages-responses.snap
@@ -1,0 +1,73 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/multiple_text_blocks.json
+info:
+  id: msg_012JYtNYb8sv6Hb67TcGT7xW
+  type: message
+  role: assistant
+  model: claude-haiku-4-5-20251001
+  content:
+    - type: text
+      text: "The sky is "
+    - type: text
+      text: blue during the day
+      citations:
+        - type: char_location
+          cited_text: the sky appears blue
+          document_index: 0
+          document_title: Sky Facts
+          start_char_index: 0
+          end_char_index: 20
+    - type: text
+      text: "."
+  stop_reason: end_turn
+  stop_sequence: ~
+  usage:
+    input_tokens: 15
+    output_tokens: 21
+    service_tier: standard
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "completed",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": null,
+            "text": "The sky is blue during the day."
+          }
+        ],
+        "id": "[id]",
+        "role": "assistant",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 15,
+      "output_tokens": 21,
+      "input_tokens_details": {
+        "cached_tokens": 0
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 36
+    },
+    "created_at": "[date]",
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 15,
+    "output_tokens": 21,
+    "total_tokens": 36,
+    "reasoning_tokens": 0,
+    "cached_input_tokens": 0,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/llm/src/tests/response/anthropic/stream_basic.messages-responses-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_basic.messages-responses-streaming.snap
@@ -1,0 +1,51 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/stream_basic.json
+---
+event: event
+data: {"type":"response.created","sequence_number":1,"response":{"created_at":123,"id":"","model":"claude-haiku-4-5-20251001","object":"response","output":[],"status":"in_progress"}}
+
+event: event
+data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"in_progress"}}
+
+event: event
+data: {"type":"response.content_part.added","sequence_number":3,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":null,"text":""}}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"","output_index":0,"content_index":0,"delta":"Hi there! How are"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"","output_index":0,"content_index":0,"delta":" you doing today?"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"","output_index":0,"content_index":0,"delta":" Is"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"","output_index":0,"content_index":0,"delta":" there anything I can help"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"","output_index":0,"content_index":0,"delta":" you with?"}
+
+event: event
+data: {"type":"response.content_part.done","sequence_number":9,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":null,"text":""}}
+
+event: event
+data: {"type":"response.output_item.done","sequence_number":10,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"completed"}}
+
+event: event
+data: {"type":"response.completed","sequence_number":11,"response":{"created_at":123,"id":"","model":"claude-haiku-4-5-20251001","object":"response","output":[],"status":"completed","usage":{"input_tokens":15,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":36}}}
+
+
+
+{
+  "input_tokens": 15,
+  "output_tokens": 21,
+  "total_tokens": 36,
+  "cache_creation_input_tokens": 0,
+  "cached_input_tokens": 0,
+  "service_tier": "standard",
+  "provider_model": "claude-haiku-4-5-20251001",
+  "completion": [
+    "Hi there! How are you doing today? Is there anything I can help you with?"
+  ]
+}

--- a/crates/llm/src/tests/response/anthropic/stream_thinking.messages-responses-streaming.snap
+++ b/crates/llm/src/tests/response/anthropic/stream_thinking.messages-responses-streaming.snap
@@ -1,0 +1,48 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/stream_thinking.json
+---
+event: event
+data: {"type":"response.created","sequence_number":1,"response":{"created_at":123,"id":"","model":"claude-opus-4-6","object":"response","output":[],"status":"in_progress"}}
+
+event: event
+data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"in_progress"}}
+
+event: event
+data: {"type":"response.content_part.added","sequence_number":3,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":null,"text":""}}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"","output_index":0,"content_index":0,"delta":"I don't have access to real"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"","output_index":0,"content_index":0,"delta":"\" in your browser\n\nIs there something"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"","output_index":0,"content_index":0,"delta":" specific about San Francisco's climate patterns"}
+
+event: event
+data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"","output_index":0,"content_index":0,"delta":" you'd like to know more about?"}
+
+event: event
+data: {"type":"response.content_part.done","sequence_number":8,"item_id":"","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":null,"text":""}}
+
+event: event
+data: {"type":"response.output_item.done","sequence_number":9,"output_index":0,"item":{"type":"message","content":[],"id":"","role":"assistant","status":"completed"}}
+
+event: event
+data: {"type":"response.completed","sequence_number":10,"response":{"created_at":123,"id":"","model":"claude-opus-4-6","object":"response","output":[],"status":"completed","usage":{"input_tokens":47,"input_tokens_details":{"cached_tokens":0,"cache_write_tokens":0},"output_tokens":264,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":311}}}
+
+
+
+{
+  "input_tokens": 47,
+  "output_tokens": 264,
+  "total_tokens": 311,
+  "cache_creation_input_tokens": 0,
+  "cached_input_tokens": 0,
+  "service_tier": "standard",
+  "provider_model": "claude-opus-4-6",
+  "completion": [
+    "I don't have access to real\" in your browser\n\nIs there something specific about San Francisco's climate patterns you'd like to know more about?"
+  ]
+}

--- a/crates/llm/src/tests/response/anthropic/thinking.messages-responses.snap
+++ b/crates/llm/src/tests/response/anthropic/thinking.messages-responses.snap
@@ -1,0 +1,72 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/thinking.json
+info:
+  id: msg_01BE9GBzjs95TqdG8FeUanUn
+  type: message
+  role: assistant
+  model: claude-opus-4-6
+  content:
+    - type: thinking
+      thinking: The user is asking me about the current weather in San Francisco
+      signature: Es8DCkYI
+    - type: text
+      text: "I don't have access to real-time weather data"
+  stop_reason: end_turn
+  stop_sequence: ~
+  usage:
+    input_tokens: 47
+    cache_creation_input_tokens: 1
+    cache_read_input_tokens: 2
+    cache_creation:
+      ephemeral_5m_input_tokens: 0
+      ephemeral_1h_input_tokens: 0
+    output_tokens: 251
+    service_tier: standard
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "completed",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": null,
+            "text": "I don't have access to real-time weather data"
+          }
+        ],
+        "id": "[id]",
+        "role": "assistant",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 47,
+      "output_tokens": 251,
+      "input_tokens_details": {
+        "cached_tokens": 2,
+        "cache_write_tokens": 1
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 298
+    },
+    "created_at": "[date]",
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 47,
+    "output_tokens": 251,
+    "total_tokens": 298,
+    "reasoning_tokens": 0,
+    "cache_creation_input_tokens": 1,
+    "cached_input_tokens": 2,
+    "provider_model": "input-model"
+  }
+}

--- a/crates/llm/src/tests/response/anthropic/tool.messages-responses.snap
+++ b/crates/llm/src/tests/response/anthropic/tool.messages-responses.snap
@@ -1,0 +1,96 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/anthropic/tool.json
+info:
+  id: msg_01Aq9w938a90dw8q
+  type: message
+  model: claude-opus-4-6
+  stop_reason: tool_use
+  role: assistant
+  content:
+    - type: text
+      text: "<thinking>I need to call the get_weather function, and the user wants SF, which is likely San Francisco, CA.</thinking>"
+    - type: tool_use
+      id: toolu_01A09q90qw90lq917835lq9
+      name: get_weather
+      input:
+        location: "San Francisco, CA"
+        unit: celsius
+  usage:
+    input_tokens: 558
+    cache_creation_input_tokens: 1
+    cache_read_input_tokens: 2
+    output_tokens: 48
+    service_tier: standard
+---
+{
+  "response": {
+    "id": "[id]",
+    "status": "completed",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "annotations": [],
+            "logprobs": null,
+            "text": "<thinking>I need to call the get_weather function, and the user wants SF, which is likely San Francisco, CA.</thinking>"
+          }
+        ],
+        "id": "[id]",
+        "role": "assistant",
+        "status": "completed"
+      },
+      {
+        "type": "function_call",
+        "arguments": "{\"location\":\"San Francisco, CA\",\"unit\":\"celsius\"}",
+        "call_id": "toolu_01A09q90qw90lq917835lq9",
+        "name": "get_weather",
+        "id": "[id]",
+        "status": "completed"
+      }
+    ],
+    "model": "input-model",
+    "usage": {
+      "input_tokens": 558,
+      "output_tokens": 48,
+      "input_tokens_details": {
+        "cached_tokens": 2,
+        "cache_write_tokens": 1
+      },
+      "output_tokens_details": {
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 606
+    },
+    "created_at": "[date]",
+    "object": "response"
+  },
+  "parsed": {
+    "input_tokens": 558,
+    "output_tokens": 48,
+    "total_tokens": 606,
+    "reasoning_tokens": 0,
+    "cache_creation_input_tokens": 1,
+    "cached_input_tokens": 2,
+    "provider_model": "input-model",
+    "output_messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_call",
+            "id": "toolu_01A09q90qw90lq917835lq9",
+            "name": "get_weather",
+            "arguments": {
+              "location": "San Francisco, CA",
+              "unit": "celsius"
+            }
+          }
+        ],
+        "finish_reason": "completed"
+      }
+    ]
+  }
+}

--- a/crates/llm/src/tests/response/responses/basic.responses-completions.snap
+++ b/crates/llm/src/tests/response/responses/basic.responses-completions.snap
@@ -1,0 +1,92 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/responses/basic.json
+info:
+  id: resp_0fd43e1b46691ead0069a89a2144808199a06ce29faf5798da
+  object: response
+  created_at: 1772657185
+  status: completed
+  background: false
+  billing:
+    payer: developer
+  completed_at: 1772657185
+  error: ~
+  frequency_penalty: 0
+  incomplete_details: ~
+  instructions: ~
+  max_output_tokens: 1024
+  max_tool_calls: ~
+  model: gpt-4o-2024-08-06
+  output:
+    - id: msg_0fd43e1b46691ead0069a89a21ea1c8199ae1962065e1d3995
+      type: message
+      status: completed
+      content:
+        - type: output_text
+          annotations: []
+          logprobs: []
+          text: Hello! How can I assist you today?
+      role: assistant
+  parallel_tool_calls: true
+  presence_penalty: 0
+  previous_response_id: ~
+  prompt_cache_key: ~
+  prompt_cache_retention: ~
+  reasoning:
+    effort: ~
+    summary: ~
+  safety_identifier: ~
+  service_tier: default
+  store: true
+  temperature: 1
+  text:
+    format:
+      type: text
+    verbosity: medium
+  tool_choice: auto
+  tools: []
+  top_logprobs: 0
+  top_p: 1
+  truncation: disabled
+  usage:
+    input_tokens: 10
+    input_tokens_details:
+      cached_tokens: 0
+    output_tokens: 10
+    output_tokens_details:
+      reasoning_tokens: 0
+    total_tokens: 20
+  user: ~
+  metadata: {}
+---
+{
+  "response": {
+    "model": "gpt-4o-2024-08-06",
+    "service_tier": "default",
+    "usage": {
+      "prompt_tokens": 10,
+      "completion_tokens": 10,
+      "total_tokens": 20
+    },
+    "choices": [
+      {
+        "message": {
+          "content": "Hello! How can I assist you today?",
+          "role": "assistant"
+        },
+        "index": 0,
+        "finish_reason": "stop"
+      }
+    ],
+    "id": "[id]",
+    "created": "[date]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 10,
+    "output_tokens": 10,
+    "total_tokens": 20,
+    "service_tier": "default",
+    "provider_model": "gpt-4o-2024-08-06"
+  }
+}

--- a/crates/llm/src/tests/response/responses/reasoning.responses-completions.snap
+++ b/crates/llm/src/tests/response/responses/reasoning.responses-completions.snap
@@ -1,0 +1,103 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/responses/reasoning.json
+info:
+  id: resp_0fd43e1b46691ead0069a89a2144808199a06ce29faf5798da
+  object: response
+  created_at: 1772657185
+  status: completed
+  background: false
+  billing:
+    payer: developer
+  completed_at: 1772657185
+  error: ~
+  frequency_penalty: 0
+  incomplete_details: ~
+  instructions: ~
+  max_output_tokens: 1024
+  max_tool_calls: ~
+  model: qwen3-8b
+  output:
+    - id: rs_0fd43e1b46691ead0069a89a21ea1c8199ae1962065e1d3995
+      type: reasoning
+      summary: []
+      content:
+        - type: reasoning_text
+          text: The user asked for a short greeting. Keep it simple.
+      encrypted_content: ~
+      status: ~
+    - id: msg_0fd43e1b46691ead0069a89a21ea1c8199ae1962065e1d3995
+      type: message
+      status: completed
+      content:
+        - type: output_text
+          annotations: []
+          logprobs: []
+          text: Hello! How can I assist you today?
+      role: assistant
+  parallel_tool_calls: true
+  presence_penalty: 0
+  previous_response_id: ~
+  prompt_cache_key: ~
+  prompt_cache_retention: ~
+  reasoning:
+    effort: ~
+    summary: ~
+  safety_identifier: ~
+  service_tier: default
+  store: true
+  temperature: 1
+  text:
+    format:
+      type: text
+  tool_choice: none
+  tools: []
+  top_logprobs: ~
+  top_p: 1
+  truncation: disabled
+  usage:
+    input_tokens: 18
+    input_tokens_details:
+      cached_tokens: 0
+      input_tokens_per_turn: []
+      cached_tokens_per_turn: []
+    output_tokens: 5
+    output_tokens_details:
+      reasoning_tokens: 8
+      tool_output_tokens: 0
+      output_tokens_per_turn: []
+      tool_output_tokens_per_turn: []
+    total_tokens: 23
+  user: ~
+---
+{
+  "response": {
+    "model": "qwen3-8b",
+    "service_tier": "default",
+    "usage": {
+      "prompt_tokens": 18,
+      "completion_tokens": 5,
+      "total_tokens": 23
+    },
+    "choices": [
+      {
+        "message": {
+          "content": "Hello! How can I assist you today?",
+          "role": "assistant"
+        },
+        "index": 0,
+        "finish_reason": "stop"
+      }
+    ],
+    "id": "[id]",
+    "created": "[date]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 18,
+    "output_tokens": 5,
+    "total_tokens": 23,
+    "service_tier": "default",
+    "provider_model": "qwen3-8b"
+  }
+}

--- a/crates/llm/src/tests/response/responses/stream.responses-completions-streaming.snap
+++ b/crates/llm/src/tests/response/responses/stream.responses-completions-streaming.snap
@@ -1,0 +1,45 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/responses/stream.json
+---
+data: {"id":"","choices":[{"index":0,"delta":{"content":"Hello","role":"assistant"}}],"created":123,"model":"gpt-4.1-mini","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+
+data: {"id":"","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":"call_xxx","type":"function","function":{"name":"get_weather"}}]}}],"created":123,"model":"gpt-4.1-mini","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+
+data: {"id":"","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"{\"loc"}}]}}],"created":123,"model":"gpt-4.1-mini","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+
+data: {"id":"","choices":[{"index":0,"delta":{"content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":"ation\":\"San Francisco\"}"}}]}}],"created":123,"model":"gpt-4.1-mini","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
+
+data: {"id":"","choices":[{"index":0,"delta":{"content":null},"finish_reason":"tool_calls"}],"created":123,"model":"gpt-4.1-mini","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":12,"completion_tokens":8,"total_tokens":20}}
+
+data: [DONE]
+
+
+
+{
+  "input_tokens": 12,
+  "output_tokens": 8,
+  "total_tokens": 20,
+  "reasoning_tokens": 0,
+  "cached_input_tokens": 0,
+  "provider_model": "gpt-4.1-mini",
+  "completion": [
+    "Hello"
+  ],
+  "output_messages": [
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "tool_call",
+          "id": "call_xxx",
+          "name": "get_weather",
+          "arguments": {
+            "location": "San Francisco"
+          }
+        }
+      ],
+      "finish_reason": "tool_use"
+    }
+  ]
+}

--- a/crates/llm/src/tests/response/responses/tool.responses-completions.snap
+++ b/crates/llm/src/tests/response/responses/tool.responses-completions.snap
@@ -1,0 +1,100 @@
+---
+source: crates/llm/src/golden_tests.rs
+description: src/tests/response/responses/tool.json
+info:
+  id: resp_tool
+  object: response
+  created_at: 123
+  status: completed
+  model: gpt-4.1-mini
+  service_tier: default
+  output:
+    - type: message
+      id: msg_text
+      role: assistant
+      status: completed
+      content:
+        - type: output_text
+          text: I will check that.
+          annotations: []
+    - type: function_call
+      id: fc_1
+      call_id: call_weather
+      name: get_weather
+      arguments: "{\"location\":\"San Francisco\"}"
+      status: completed
+  usage:
+    input_tokens: 30
+    input_tokens_details:
+      cached_tokens: 4
+      cache_write_tokens: 6
+    output_tokens: 5
+    output_tokens_details:
+      reasoning_tokens: 0
+    total_tokens: 35
+---
+{
+  "response": {
+    "model": "gpt-4.1-mini",
+    "service_tier": "default",
+    "usage": {
+      "prompt_tokens": 20,
+      "completion_tokens": 5,
+      "total_tokens": 25,
+      "prompt_tokens_details": {
+        "cached_tokens": 4,
+        "cache_write_tokens": 6
+      },
+      "cache_read_input_tokens": 4,
+      "cache_creation_input_tokens": 6
+    },
+    "choices": [
+      {
+        "message": {
+          "content": "I will check that.",
+          "role": "assistant",
+          "tool_calls": [
+            {
+              "type": "function",
+              "id": "call_weather",
+              "function": {
+                "name": "get_weather",
+                "arguments": "{\"location\":\"San Francisco\"}"
+              }
+            }
+          ]
+        },
+        "index": 0,
+        "finish_reason": "tool_calls"
+      }
+    ],
+    "id": "[id]",
+    "created": "[date]",
+    "object": "chat.completion"
+  },
+  "parsed": {
+    "input_tokens": 20,
+    "output_tokens": 5,
+    "total_tokens": 25,
+    "cache_creation_input_tokens": 6,
+    "cached_input_tokens": 4,
+    "service_tier": "default",
+    "provider_model": "gpt-4.1-mini",
+    "output_messages": [
+      {
+        "role": "assistant",
+        "content": [
+          {
+            "type": "tool_call",
+            "id": "call_weather",
+            "name": "get_weather",
+            "arguments": {
+              "location": "San Francisco"
+            }
+          }
+        ],
+        "finish_reason": "tool_calls"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What this does

Fills the two holes in the chat translation table: a Responses client on a provider that only speaks Messages, and a Chat Completions client on a provider that only speaks Responses. Both are composed from the converters that already exist rather than written a third time. Responses to Messages goes through Chat Completions, and Chat Completions to Responses goes through Messages, for the request, the buffered response, the stream and the error body alike.

## How it works

Each pair is a small module next to its provider format, `messages::from_responses` and `responses::from_completions`, that hands the typed output of one converter to the next. The stream is two stages of the existing SSE translators chained on the body; the stage that reads the provider's bytes takes the usage guard and the content flags, and the other stage only re-frames events. The new entries sit after the direct conversions in the table, so a provider that speaks Chat Completions or Responses natively is never routed through them. Error bodies follow the same route: an Anthropic error reaches a Responses client in the OpenAI shape the Chat Completions stage already produces.

## What is lost

The composed pairs lose exactly what the two paths they are built from lose. Chat Completions has no place for a provider's built-in tools, so a Responses request that declares one reaches a Messages provider without it. Messages has no place for `n`, `logprobs`, `response_format` and the penalty parameters, so a Chat Completions request loses those on a Responses provider. The Responses to Messages converter still skips reasoning output items, so a Chat Completions client on a Responses provider does not get `reasoning_content` from them; that is a limit of the existing pair, not of the composition.

## Testing

Golden cases were added for both pairs from the existing fixtures: three Chat Completions requests to Responses, three Responses requests to Messages, buffered and streamed Messages responses to Responses, and buffered and streamed Responses responses to Chat Completions, sixteen snapshots in all.

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
