### PR TITLE
fix: fall back to Host header for HTTP/2 requests missing :authority

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "google-cloud-auth",
+ "h2",
  "hashbrown 0.17.1",
  "headers",
  "headers-accept",

--- a/crates/agentgateway/Cargo.toml
+++ b/crates/agentgateway/Cargo.toml
@@ -207,6 +207,7 @@ tokio = { workspace = true }
 protos = { workspace = true, features = ["spiffe-test-server"] }
 assert_matches.workspace = true
 divan.workspace = true
+h2.workspace = true
 insta.workspace = true
 rstest.workspace = true
 tempfile.workspace = true

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -3711,6 +3711,51 @@ mod tests {
 	use crate::{http, llm};
 
 	#[test]
+	fn normalize_uri_falls_back_to_host_header_for_http2_without_authority() {
+		// Some minimal gRPC clients, and AWS ALB's synthetic gRPC health-check probe, send HTTP/2
+		// requests that omit the :authority pseudo-header and rely on a plain Host header instead
+		// (RFC 7540 8.1.2.3 permits this). Before this fix, normalize_uri only handled that
+		// fallback for HTTP/1.x, so req.uri().authority() stayed None and callers like
+		// crate::http::get_host() rejected the request as InvalidRequest before route selection.
+		let mut req = ::http::Request::builder()
+			.method(Method::GET)
+			.version(::http::Version::HTTP_2)
+			.uri("/v1/embeddings")
+			.header(::http::header::HOST, "ember.internal")
+			.body(http::Body::empty())
+			.unwrap();
+
+		super::normalize_uri(None, &mut req).unwrap();
+
+		assert_eq!(
+			req.uri().authority().map(|a| a.as_str()),
+			Some("ember.internal")
+		);
+		assert_eq!(crate::http::get_host(&req).unwrap(), "ember.internal");
+	}
+
+	#[test]
+	fn normalize_uri_leaves_http2_authority_untouched_when_already_present() {
+		// The common case: an h2-conformant client sets :authority, which the http/h2 crates
+		// already populate into req.uri().authority() before normalize_uri ever runs. Make sure
+		// extending the HTTP/2 fallback doesn't disturb that.
+		let mut req = ::http::Request::builder()
+			.method(Method::GET)
+			.version(::http::Version::HTTP_2)
+			.uri("https://from-authority.internal/v1/embeddings")
+			.header(::http::header::HOST, "from-host-header.internal")
+			.body(http::Body::empty())
+			.unwrap();
+
+		super::normalize_uri(None, &mut req).unwrap();
+
+		assert_eq!(
+			req.uri().authority().map(|a| a.as_str()),
+			Some("from-authority.internal")
+		);
+	}
+
+	#[test]
 	fn configured_request_headers_are_marked_sensitive_at_ingress() {
 		let mut request = ::http::Request::builder()
 			.uri("https://example.com")
@@ -4392,11 +4437,15 @@ fn get_upgrade_type(headers: &HeaderMap) -> Option<HeaderValue> {
 	}
 }
 
-// The http library will not put the authority into req.uri().authority for HTTP/1. Normalize so
-// the rest of the code doesn't need to worry about it
+// The http library will not put the authority into req.uri().authority for HTTP/1, and an HTTP/2
+// request that omits the :authority pseudo-header in favor of a plain Host header (permitted by
+// RFC 7540 8.1.2.3, and sent by some minimal gRPC clients and AWS ALB's gRPC health-check probe)
+// hits the same gap. Normalize so the rest of the code doesn't need to worry about it.
 fn normalize_uri(tls: Option<&TLSConnectionInfo>, req: &mut Request) -> anyhow::Result<()> {
 	debug!("request before normalization: {req:?}");
-	if let ::http::Version::HTTP_10 | ::http::Version::HTTP_11 = req.version() {
+	if let ::http::Version::HTTP_10 | ::http::Version::HTTP_11 | ::http::Version::HTTP_2 =
+		req.version()
+	{
 		let host = req.headers_mut().remove(http::header::HOST);
 		if req.uri().authority().is_none() {
 			let mut parts = std::mem::take(req.uri_mut()).into_parts();

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -3711,51 +3711,6 @@ mod tests {
 	use crate::{http, llm};
 
 	#[test]
-	fn normalize_uri_falls_back_to_host_header_for_http2_without_authority() {
-		// Some minimal gRPC clients, and AWS ALB's synthetic gRPC health-check probe, send HTTP/2
-		// requests that omit the :authority pseudo-header and rely on a plain Host header instead
-		// (RFC 7540 8.1.2.3 permits this). Before this fix, normalize_uri only handled that
-		// fallback for HTTP/1.x, so req.uri().authority() stayed None and callers like
-		// crate::http::get_host() rejected the request as InvalidRequest before route selection.
-		let mut req = ::http::Request::builder()
-			.method(Method::GET)
-			.version(::http::Version::HTTP_2)
-			.uri("/v1/embeddings")
-			.header(::http::header::HOST, "ember.internal")
-			.body(http::Body::empty())
-			.unwrap();
-
-		super::normalize_uri(None, &mut req).unwrap();
-
-		assert_eq!(
-			req.uri().authority().map(|a| a.as_str()),
-			Some("ember.internal")
-		);
-		assert_eq!(crate::http::get_host(&req).unwrap(), "ember.internal");
-	}
-
-	#[test]
-	fn normalize_uri_leaves_http2_authority_untouched_when_already_present() {
-		// The common case: an h2-conformant client sets :authority, which the http/h2 crates
-		// already populate into req.uri().authority() before normalize_uri ever runs. Make sure
-		// extending the HTTP/2 fallback doesn't disturb that.
-		let mut req = ::http::Request::builder()
-			.method(Method::GET)
-			.version(::http::Version::HTTP_2)
-			.uri("https://from-authority.internal/v1/embeddings")
-			.header(::http::header::HOST, "from-host-header.internal")
-			.body(http::Body::empty())
-			.unwrap();
-
-		super::normalize_uri(None, &mut req).unwrap();
-
-		assert_eq!(
-			req.uri().authority().map(|a| a.as_str()),
-			Some("from-authority.internal")
-		);
-	}
-
-	#[test]
 	fn configured_request_headers_are_marked_sensitive_at_ingress() {
 		let mut request = ::http::Request::builder()
 			.uri("https://example.com")
@@ -4437,34 +4392,28 @@ fn get_upgrade_type(headers: &HeaderMap) -> Option<HeaderValue> {
 	}
 }
 
-// The http library will not put the authority into req.uri().authority for HTTP/1, and an HTTP/2
-// request that omits the :authority pseudo-header in favor of a plain Host header (permitted by
-// RFC 7540 8.1.2.3, and sent by some minimal gRPC clients and AWS ALB's gRPC health-check probe)
-// hits the same gap. Normalize so the rest of the code doesn't need to worry about it.
+// Normalize the Host header into the URI authority so the rest of the code doesn't need to care
+// whether the client supplied Host or :authority.
 fn normalize_uri(tls: Option<&TLSConnectionInfo>, req: &mut Request) -> anyhow::Result<()> {
 	debug!("request before normalization: {req:?}");
-	if let ::http::Version::HTTP_10 | ::http::Version::HTTP_11 | ::http::Version::HTTP_2 =
-		req.version()
+	let host = req.headers_mut().remove(http::header::HOST);
+	if req.uri().authority().is_none()
+		&& let Some(host) = host
 	{
-		let host = req.headers_mut().remove(http::header::HOST);
-		if req.uri().authority().is_none() {
-			let mut parts = std::mem::take(req.uri_mut()).into_parts();
-			let host = host
-				// TODO(https://github.com/hyperium/http/pull/811) actually make this shared
-				.and_then(|h| Authority::try_from(h.as_bytes()).ok())
-				.ok_or_else(|| anyhow::anyhow!("no authority or host"))?;
+		let mut parts = std::mem::take(req.uri_mut()).into_parts();
+		// TODO(https://github.com/hyperium/http/pull/811) actually make this shared
+		let host = Authority::try_from(host.as_bytes())?;
 
-			parts.authority = Some(host);
-			if parts.path_and_query.is_some() {
-				// TODO: or always do this?
-				if tls.is_some() {
-					parts.scheme = Some(Scheme::HTTPS);
-				} else {
-					parts.scheme = Some(Scheme::HTTP);
-				}
+		parts.authority = Some(host);
+		if parts.path_and_query.is_some() && parts.scheme.is_none() {
+			// TODO: or always do this?
+			if tls.is_some() {
+				parts.scheme = Some(Scheme::HTTPS);
+			} else {
+				parts.scheme = Some(Scheme::HTTP);
 			}
-			*req.uri_mut() = Uri::from_parts(parts)?
 		}
+		*req.uri_mut() = Uri::from_parts(parts)?
 	}
 	debug!("request after normalization: {req:?}");
 	Ok(())

--- a/crates/agentgateway/tests/tests/basic.rs
+++ b/crates/agentgateway/tests/tests/basic.rs
@@ -398,6 +398,32 @@ async fn basic_http2() {
 	assert_eq!(read_body(res.into_body()).await.version, Version::HTTP_2);
 }
 
+#[tokio::test]
+async fn http2_host_header_without_authority() {
+	let mock = simple_mock().await;
+	let t = setup_proxy_test("{}")
+		.unwrap()
+		.with_backend(*mock.address())
+		.with_bind(simple_bind())
+		.with_route(basic_route(*mock.address()));
+	let (mut client, connection) = h2::client::handshake(t.serve(BIND_KEY)).await.unwrap();
+	let connection = tokio::spawn(connection);
+
+	// h2 encodes an HTTP/1.x-version request on an HTTP/2 connection without
+	// :authority, preserving the regular Host header instead.
+	let request = ::http::Request::builder()
+		.method(Method::GET)
+		.uri("/")
+		.version(Version::HTTP_11)
+		.header(header::HOST, "lo")
+		.body(())
+		.unwrap();
+	let (response, _) = client.send_request(request, true).unwrap();
+	assert_eq!(response.await.unwrap().status(), 200);
+
+	connection.abort();
+}
+
 async fn grpc_trailer_backend(status: &'static str) -> std::net::SocketAddr {
 	let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
 	let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
- [ ] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.

*(Leaving that box unchecked and disclosing here instead: I used AI assistance to investigate the root cause and draft this fix, tests, and description — see the earlier disclosure on the issue. I've reviewed and understand the change below.)*

## Summary

Fixes #3322. A `protocol: HTTP` Gateway listener never reached route selection for a genuine prior-knowledge HTTP/2 (cleartext h2c) request that omits the `:authority` pseudo-header in favor of a plain `Host` header — permitted by RFC 7540 §8.1.2.3, and done by some minimal gRPC clients and by AWS ALB's synthetic gRPC health-check probe.

## Root cause

`normalize_uri()` in `crates/agentgateway/src/proxy/httpproxy.rs` only migrated the `Host` header into `req.uri().authority()` for `HTTP_10`/`HTTP_11`:

```rust
if let ::http::Version::HTTP_10 | ::http::Version::HTTP_11 = req.version() {
    let host = req.headers_mut().remove(http::header::HOST);
    if req.uri().authority().is_none() {
        // ... migrate Host header into the URI authority
    }
}
```

For HTTP/2 it was a no-op — reasonable for the common case, since `h2`/`hyper` already populate the URI authority from `:authority` before this function runs. But when a client omits `:authority` and only sends `Host`, `req.uri().authority()` stays `None`. `get_host()` in `crates/agentgateway/src/http/mod.rs` has no fallback of its own:

```rust
pub fn get_host(req: &Request) -> Result<&str, ProxyError> {
    let host = req.uri().host().ok_or(ProxyError::InvalidRequest)?;
    Ok(host)
}
```

So it returns `Err(ProxyError::InvalidRequest)`, and `proxy_internal` returns early via `get_host(&req)...?` — before `best_match_http()` or the `"selected listener"` debug line is ever reached. That matches the reported symptom exactly: the request is parsed and normalized, but no listener is ever selected.

Checked `BindProtocol::auto`, `detect_misdirected`, `best_match_tls`/`best_match_http` — none of these are implicated; the transport-level h2c-vs-HTTP/1.1 detection and TLS-listener matching are unrelated to this gap. Also confirmed `normalize_uri`/`get_host` are unchanged between `v1.3.1` (where this was first hit) and current `main`, so this isn't something an upgrade alone would fix.

## Fix

Extend the version match to also cover `HTTP_2`. The existing `req.uri().authority().is_none()` guard already protects the common case where `:authority` is set — this only does anything in the gap case where it's absent and a `Host` header is present instead.

## Testing

Two new unit tests alongside `normalize_uri`'s existing test module:
- `normalize_uri_falls_back_to_host_header_for_http2_without_authority` — reproduces the bug (HTTP/2, no `:authority`, only `Host`). Confirmed this fails without the fix.
- `normalize_uri_leaves_http2_authority_untouched_when_already_present` — guards the common case, using a deliberately conflicting `Host` header to prove `:authority` wins when already set.

Ran against current `main`:
- `cargo test -p agentgateway --lib proxy::httpproxy::` — 26/26 pass
- `cargo test -p agentgateway --lib http::` — 713/713 pass
- `cargo fmt -- --check` — clean
- `cargo clippy -p agentgateway --lib --tests` — clean

I have **not** replicated this against a live ALB/Gateway API deployment — the two tests above construct the `::http::Request` directly (a hand-built HTTP/2 request with no `:authority`), which proves the logic is correct for that input shape, but doesn't independently verify that a real `h2c` connection without `:authority` reaches `normalize_uri` in exactly this shape. Flagging that gap rather than overstating confidence.

## Out of scope

`get_host_with_port()` (same file, right below `get_host`) has the same shape — `req.uri().authority()` with no `Host`-header fallback — but wasn't on the failing path traced here, so I left it untouched. Happy to extend this PR to cover it too if that's wanted.
