### PR TITLE
fix(telemetry): zero-pad the sub-second part of log timestamps

### DIFF
--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -879,6 +879,9 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
+	use std::thread;
+	use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 	use super::*;
 
 	#[test]
@@ -906,6 +909,25 @@ mod tests {
 		write_json_log(&mut buf, "info", "test", &kv).expect("log should serialize");
 
 		assert_eq!(json_field_value(&buf, "ordinary_float"), "123.456");
+	}
+
+	#[test]
+	fn json_log_time_keeps_leading_zeros_in_fraction() {
+		// The timestamp is read from the clock inside the writer, so the test cannot
+		// choose it. The fraction only lost its leading zeros below 100000 µs (e.g.
+		// ".4101Z" for 4101 µs), so sleep until the next second boundary to sample
+		// inside that window instead of whatever instant the test happens to run at.
+		let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+		thread::sleep(Duration::from_nanos(u64::from(
+			1_000_000_000 - now.subsec_nanos(),
+		)));
+		let mut buf = String::new();
+
+		write_json_log(&mut buf, "info", "test", &[]).expect("log should serialize");
+
+		let time = json_field_value(&buf, "time").trim_matches('"');
+		// "2025-07-16T18:32:01.000000Z".len(): a six-digit fraction, never shorter
+		assert_eq!(time.len(), 27, "{time}");
 	}
 
 	fn json_field_value<'a>(json: &'a str, field: &str) -> &'a str {

--- a/crates/core/src/telemetry.rs
+++ b/crates/core/src/telemetry.rs
@@ -879,9 +879,6 @@ pub mod testing {
 
 #[cfg(test)]
 mod tests {
-	use std::thread;
-	use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
 	use super::*;
 
 	#[test]
@@ -909,25 +906,6 @@ mod tests {
 		write_json_log(&mut buf, "info", "test", &kv).expect("log should serialize");
 
 		assert_eq!(json_field_value(&buf, "ordinary_float"), "123.456");
-	}
-
-	#[test]
-	fn json_log_time_keeps_leading_zeros_in_fraction() {
-		// The timestamp is read from the clock inside the writer, so the test cannot
-		// choose it. The fraction only lost its leading zeros below 100000 µs (e.g.
-		// ".4101Z" for 4101 µs), so sleep until the next second boundary to sample
-		// inside that window instead of whatever instant the test happens to run at.
-		let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-		thread::sleep(Duration::from_nanos(u64::from(
-			1_000_000_000 - now.subsec_nanos(),
-		)));
-		let mut buf = String::new();
-
-		write_json_log(&mut buf, "info", "test", &[]).expect("log should serialize");
-
-		let time = json_field_value(&buf, "time").trim_matches('"');
-		// "2025-07-16T18:32:01.000000Z".len(): a six-digit fraction, never shorter
-		assert_eq!(time.len(), 27, "{time}");
 	}
 
 	fn json_field_value<'a>(json: &'a str, field: &str) -> &'a str {

--- a/crates/core/src/telemetry/date.rs
+++ b/crates/core/src/telemetry/date.rs
@@ -23,6 +23,8 @@ pub(crate) fn write(dst: &mut String) {
 		let micros = nanos / 1000;
 		let mut buf = itoa::Buffer::new();
 		let s = buf.format(micros);
+		// Zero-pad to six digits so 3270 renders as "003270", not "3270"
+		dst.push_str(&"000000"[s.len()..]);
 		dst.push_str(s);
 		// Finish off with a Z
 		dst.push('Z');

--- a/crates/core/src/telemetry/date.rs
+++ b/crates/core/src/telemetry/date.rs
@@ -12,8 +12,11 @@ pub fn build() -> String {
 	w
 }
 pub(crate) fn write(dst: &mut String) {
+	write_at(dst, SystemTime::now());
+}
+
+fn write_at(dst: &mut String, now: SystemTime) {
 	CACHED.with(|cache| {
-		let now = SystemTime::now();
 		cache.borrow_mut().check(&now);
 		// Push the base
 		dst.push_str(cache.borrow().buffer());
@@ -96,5 +99,30 @@ impl fmt::Write for CachedDate {
 		self.bytes[self.pos..self.pos + len].copy_from_slice(s.as_bytes());
 		self.pos += len;
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn timestamp_fraction_has_six_digits() {
+		let base = UNIX_EPOCH + Duration::from_secs(1_750_000_000);
+		// The cache normally starts at the current time; seed it for this fixed timestamp.
+		CACHED.with(|cache| cache.borrow_mut().update(&base));
+
+		for (micros, expected) in [
+			(0, "000000"),
+			(1, "000001"),
+			(3270, "003270"),
+			(99_999, "099999"),
+			(100_000, "100000"),
+			(999_999, "999999"),
+		] {
+			let mut buf = String::new();
+			write_at(&mut buf, base + Duration::from_micros(micros));
+			assert_eq!(buf, format!("2025-06-15T15:06:40.{expected}Z"));
+		}
 	}
 }


### PR DESCRIPTION
This PR fixes #3369 
It adds leading zeros to the timestamp when the sub-second fraction is less than 100000 micro seconds.
AI assistance was used to write the test.

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
