### PR TITLE
fix(mcp): propagate _meta envelope to multi-target resolve requests

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -12,10 +12,11 @@ use itertools::Itertools;
 use rmcp::ErrorData;
 use rmcp::model::{
 	CacheScope, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, DiscoverResult,
-	ExtensionCapabilities, Implementation, JsonRpcNotification, JsonRpcRequest, ListPromptsResult,
-	ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, PaginatedRequestParams,
-	ProtocolVersion, RequestId, ResultType, ServerCapabilities, ServerInfo, ServerJsonRpcMessage,
-	ServerNotification, ServerRequest, ServerResult, SubscriptionFilter,
+	ExtensionCapabilities, Extensions, Implementation, JsonRpcNotification, JsonRpcRequest,
+	ListPromptsResult, ListResourceTemplatesResult, ListResourcesResult, ListToolsResult,
+	PaginatedRequestParams, ProtocolVersion, RequestId, RequestMetaObject, ResultType,
+	ServerCapabilities, ServerInfo, ServerJsonRpcMessage, ServerNotification, ServerRequest,
+	ServerResult, SubscriptionFilter,
 };
 use tracing::{debug, info, warn};
 
@@ -240,15 +241,27 @@ impl ResolveKind {
 		}
 	}
 
-	fn list_request(&self, cursor: Option<String>) -> ClientRequest {
+	fn list_request(
+		&self,
+		cursor: Option<String>,
+		meta: Option<&RequestMetaObject>,
+	) -> ClientRequest {
 		let params = cursor.map(|c| PaginatedRequestParams::default().with_cursor(Some(c)));
+		// Propagate the original client request's `_meta` onto the resolve request so
+		// modern (2026-07-28) upstreams that require the per-request envelope accept it.
+		let mut extensions = Extensions::new();
+		if let Some(m) = meta {
+			extensions.insert(m.clone());
+		}
 		match self {
 			ResolveKind::Tool => ClientRequest::ListToolsRequest(rmcp::model::ListToolsRequest {
 				params,
+				extensions,
 				..Default::default()
 			}),
 			ResolveKind::Prompt => ClientRequest::ListPromptsRequest(rmcp::model::ListPromptsRequest {
 				params,
+				extensions,
 				..Default::default()
 			}),
 		}
@@ -397,9 +410,10 @@ impl Relay {
 		kind: ResolveKind,
 		res: &'b str,
 		ctx: &IncomingRequestContext,
+		meta: Option<&RequestMetaObject>,
 	) -> Result<(Cow<'a, str>, &'b str), UpstreamError> {
 		if self.needs_resolution() {
-			let target = self.resolve_unprefixed(kind, res, ctx).await?;
+			let target = self.resolve_unprefixed(kind, res, ctx, meta).await?;
 			return Ok((Cow::Owned(target.to_string()), res));
 		}
 		let (target, name) = self.parse_resource_name(res)?;
@@ -415,12 +429,13 @@ impl Relay {
 		kind: ResolveKind,
 		name: &str,
 		ctx: &IncomingRequestContext,
+		meta: Option<&RequestMetaObject>,
 	) -> Result<Strng, UpstreamError> {
 		let futs: Vec<_> = self
 			.upstreams
 			.iter_named()
 			.map(|(target, con)| async move {
-				let res = Self::serves_name(target.as_str(), &con, kind, name, ctx).await;
+				let res = Self::serves_name(target.as_str(), &con, kind, name, ctx, meta).await;
 				(target, res)
 			})
 			.collect();
@@ -462,6 +477,7 @@ impl Relay {
 		kind: ResolveKind,
 		name: &str,
 		ctx: &IncomingRequestContext,
+		meta: Option<&RequestMetaObject>,
 	) -> Result<bool, UpstreamError> {
 		// Gateway-generated ids: reusing the client's id here would make the upstream
 		// see it twice (list probe, then the forwarded call) in one session.
@@ -473,7 +489,7 @@ impl Relay {
 			let seq = RESOLVE_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 			let req = JsonRpcRequest::new(
 				RequestId::String(format!("agw-resolve-{seq}").into()),
-				kind.list_request(cursor),
+				kind.list_request(cursor, meta),
 			);
 			let Some(result) =
 				Self::first_response(con.generic_stream(target_name, req, ctx).await?).await?

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -7964,192 +7964,45 @@ async fn mcp_guardrails_mutated_resource_read_reaches_upstream() {
 	assert!(text.contains("Business Intelligence Memo"));
 }
 
-/// Mock upstream that strictly enforces the `2026-07-28` `_meta` envelope:
-/// every non-initialize/non-discover request must carry
-/// `io.modelcontextprotocol/protocolVersion` and
-/// `io.modelcontextprotocol/clientCapabilities` in `params._meta`.
-///
-/// This replicates the behavior of modern Python FastMCP/mcp 2.x upstreams,
-/// which reject requests lacking these keys with `-32602`.
-async fn mock_modern_strict_streamable_http_server(tool_name: &str) -> MockServer {
-	agent_core::telemetry::testing::setup_test_logging();
-	let (tx, rx) = tokio::sync::oneshot::channel();
-	let init_counter = std::sync::Arc::new(tokio::sync::Mutex::new(0_i32));
-	let init_counter_clone = init_counter.clone();
-	let tool_name = tool_name.to_string();
-	let router = axum::Router::new().route(
-		"/mcp",
-		axum::routing::post(move |body: axum::Json<serde_json::Value>| {
-			let init_counter = init_counter_clone.clone();
-			let tool_name = tool_name.clone();
-			async move {
-				let id = body.get("id").cloned().unwrap_or(serde_json::Value::Null);
-				let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
-
-				// Strict _meta validation for modern protocol, matching Python mcp 2.x behavior.
-				// initialize and server/discover are exempt because they set up the session.
-				let requires_meta = !matches!(method, "initialize" | "server/discover");
-				if requires_meta {
-					let meta = body.pointer("/params/_meta");
-					let has_pv = meta
-						.and_then(|m| m.get("io.modelcontextprotocol/protocolVersion"))
-						.is_some();
-					let has_cc = meta
-						.and_then(|m| m.get("io.modelcontextprotocol/clientCapabilities"))
-						.is_some();
-					if !has_pv || !has_cc {
-						return Ok::<_, http::StatusCode>(axum::Json(serde_json::json!({
-							"jsonrpc": "2.0",
-							"id": id,
-							"error": {
-								"code": -32602,
-								"message": "params._meta is missing the required envelope key(s): io.modelcontextprotocol/protocolVersion, io.modelcontextprotocol/clientCapabilities"
-							}
-						})));
-					}
-				}
-
-				let result = match method {
-					"server/discover" => serde_json::json!({
-						"resultType": "complete",
-						"supportedVersions": ["2026-07-28"],
-						"capabilities": {"tools": {}},
-						"serverInfo": {"name": "strict-modern-mock", "version": "0.0.1"}
-					}),
-					"initialize" => {
-						*init_counter.lock().await += 1;
-						serde_json::json!({
-							"protocolVersion": "2026-07-28",
-							"capabilities": {"tools": {}},
-							"serverInfo": {"name": "strict-modern-mock", "version": "0.0.1"}
-						})
-					},
-					"tools/list" => serde_json::json!({
-						"resultType": "complete",
-						"tools": [{
-							"name": tool_name,
-							"description": format!("Mock tool {tool_name}"),
-							"inputSchema": {"type": "object"}
-						}]
-					}),
-					"tools/call" => {
-						let name = body
-							.pointer("/params/name")
-							.and_then(|n| n.as_str())
-							.unwrap_or("");
-						serde_json::json!({
-							"resultType": "complete",
-							"content": [{"type": "text", "text": format!("{name}:ok")}],
-							"isError": false
-						})
-					},
-					_ => {
-						return Ok::<_, http::StatusCode>(axum::Json(serde_json::json!({
-							"jsonrpc": "2.0",
-							"id": id,
-							"error": {"code": -32601, "message": method}
-						})));
-					},
-				};
-				Ok::<_, http::StatusCode>(axum::Json(serde_json::json!({
-					"jsonrpc": "2.0",
-					"id": id,
-					"result": result
-				})))
-			}
-		}),
-	);
-	let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-	let addr = tcp_listener.local_addr().unwrap();
-	tokio::spawn(async move {
-		let _ = axum::serve(tcp_listener, router)
-			.with_graceful_shutdown(async {
-				let _ = rx.await;
-			})
-			.await;
-	});
-	MockServer {
-		addr,
-		init_counter,
-		_cancel: tx,
-	}
-}
-
-/// Reproduces https://github.com/agentgateway/agentgateway/issues/3357
-///
-/// With two or more modern (`2026-07-28`) MCP targets, a client request that
-/// carries the per-request `_meta` envelope gets `-32602` from the gateway's
-/// own internal resolve request — the resolve `tools/list` that the gateway
-/// issues to figure out which target owns a tool does not propagate the
-/// client's `_meta`, so strict modern upstreams reject it.
-///
-/// With a single target the call succeeds (no resolve round-trip needed).
+// Regression for https://github.com/agentgateway/agentgateway/issues/3357.
 #[tokio::test]
 async fn modern_multi_target_resolve_propagates_meta() {
-	let alpha = mock_modern_strict_streamable_http_server("alpha_ping").await;
-	let beta = mock_modern_strict_streamable_http_server("beta_ping").await;
+	let (mock, capture) = mock_mrtr_streamable_http_server().await;
+	let other = mock_modern_streamable_http_server().await;
 	let t = never_prefix_proxy(
-		vec![("alpha", alpha.addr, false), ("beta", beta.addr, false)],
+		vec![("a", mock.addr, false), ("b", other.addr, false)],
 		false,
 	);
 	let io = t.serve_real_listener(strng::new("bind")).await;
-
-	let client = reqwest::Client::new();
-	let url = format!("http://{io}/mcp");
 	let meta = modern_meta();
-
 	let body = serde_json::json!({
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "tools/call",
 		"params": {
-			"name": "alpha_ping",
+			"name": "guarded_echo",
 			"arguments": {},
 			"_meta": meta
 		}
 	});
-	let resp = mcp_json_post(&client, &url, &body)
+	let resp = mcp_json_post(&reqwest::Client::new(), &format!("http://{io}/mcp"), &body)
 		.header("mcp-protocol-version", "2026-07-28")
 		.header("mcp-method", "tools/call")
-		.header("mcp-name", "alpha_ping")
+		.header("mcp-name", "guarded_echo")
 		.send()
 		.await
 		.unwrap();
+	assert_eq!(resp.status(), reqwest::StatusCode::OK);
+	let result = terminal_result(&resp.text().await.unwrap(), 1);
+	assert_eq!(result["content"][0]["text"], "no-elicitation-capability");
 
-	let status = resp.status();
-	let content_type = resp
-		.headers()
-		.get("content-type")
-		.map(|v| v.to_str().unwrap_or("").to_string())
-		.unwrap_or_default();
-	let raw_body = resp.text().await.unwrap();
-
-	// Before the fix, the resolve request fails with -32602 from the upstream
-	// because it lacks _meta. After the fix, the call succeeds with 200.
-	assert_eq!(
-		status,
-		reqwest::StatusCode::OK,
-		"tools/call should succeed with multi-target modern upstreams; got {status}: {raw_body}"
-	);
-
-	// The gateway may return either JSON or SSE depending on the request.
-	// Parse accordingly.
-	let resp_body = if content_type.contains("text/event-stream") {
-		// SSE: find the "data:" line with a JSON-RPC response.
-		raw_body
-			.lines()
-			.find(|line| line.starts_with("data: "))
-			.map(|line| {
-				serde_json::from_str::<serde_json::Value>(line.trim_start_matches("data: ")).unwrap()
-			})
-			.unwrap_or_else(|| panic!("no data: line in SSE response: {raw_body}"))
-	} else {
-		serde_json::from_str(&raw_body).expect("response should be valid JSON")
-	};
-
-	let result_text = resp_body
-		.pointer("/result/content/0/text")
-		.and_then(|v| v.as_str())
-		.unwrap_or("");
-	assert_eq!(result_text, "alpha_ping:ok");
+	// Check the gateway-generated list probe, not just the forwarded tool call.
+	let requests = capture.lock().unwrap();
+	let probe = requests
+		.iter()
+		.find(|r| r["method"] == "tools/list")
+		.unwrap();
+	for (key, value) in meta.as_object().unwrap() {
+		assert_eq!(&probe["params"]["_meta"][key], value, "{key}");
+	}
 }

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -7963,3 +7963,193 @@ async fn mcp_guardrails_mutated_resource_read_reaches_upstream() {
 		.expect("resource should return text");
 	assert!(text.contains("Business Intelligence Memo"));
 }
+
+/// Mock upstream that strictly enforces the `2026-07-28` `_meta` envelope:
+/// every non-initialize/non-discover request must carry
+/// `io.modelcontextprotocol/protocolVersion` and
+/// `io.modelcontextprotocol/clientCapabilities` in `params._meta`.
+///
+/// This replicates the behavior of modern Python FastMCP/mcp 2.x upstreams,
+/// which reject requests lacking these keys with `-32602`.
+async fn mock_modern_strict_streamable_http_server(tool_name: &str) -> MockServer {
+	agent_core::telemetry::testing::setup_test_logging();
+	let (tx, rx) = tokio::sync::oneshot::channel();
+	let init_counter = std::sync::Arc::new(tokio::sync::Mutex::new(0_i32));
+	let init_counter_clone = init_counter.clone();
+	let tool_name = tool_name.to_string();
+	let router = axum::Router::new().route(
+		"/mcp",
+		axum::routing::post(move |body: axum::Json<serde_json::Value>| {
+			let init_counter = init_counter_clone.clone();
+			let tool_name = tool_name.clone();
+			async move {
+				let id = body.get("id").cloned().unwrap_or(serde_json::Value::Null);
+				let method = body.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+				// Strict _meta validation for modern protocol, matching Python mcp 2.x behavior.
+				// initialize and server/discover are exempt because they set up the session.
+				let requires_meta = !matches!(method, "initialize" | "server/discover");
+				if requires_meta {
+					let meta = body.pointer("/params/_meta");
+					let has_pv = meta
+						.and_then(|m| m.get("io.modelcontextprotocol/protocolVersion"))
+						.is_some();
+					let has_cc = meta
+						.and_then(|m| m.get("io.modelcontextprotocol/clientCapabilities"))
+						.is_some();
+					if !has_pv || !has_cc {
+						return Ok::<_, http::StatusCode>(axum::Json(serde_json::json!({
+							"jsonrpc": "2.0",
+							"id": id,
+							"error": {
+								"code": -32602,
+								"message": "params._meta is missing the required envelope key(s): io.modelcontextprotocol/protocolVersion, io.modelcontextprotocol/clientCapabilities"
+							}
+						})));
+					}
+				}
+
+				let result = match method {
+					"server/discover" => serde_json::json!({
+						"resultType": "complete",
+						"supportedVersions": ["2026-07-28"],
+						"capabilities": {"tools": {}},
+						"serverInfo": {"name": "strict-modern-mock", "version": "0.0.1"}
+					}),
+					"initialize" => {
+						*init_counter.lock().await += 1;
+						serde_json::json!({
+							"protocolVersion": "2026-07-28",
+							"capabilities": {"tools": {}},
+							"serverInfo": {"name": "strict-modern-mock", "version": "0.0.1"}
+						})
+					},
+					"tools/list" => serde_json::json!({
+						"resultType": "complete",
+						"tools": [{
+							"name": tool_name,
+							"description": format!("Mock tool {tool_name}"),
+							"inputSchema": {"type": "object"}
+						}]
+					}),
+					"tools/call" => {
+						let name = body
+							.pointer("/params/name")
+							.and_then(|n| n.as_str())
+							.unwrap_or("");
+						serde_json::json!({
+							"resultType": "complete",
+							"content": [{"type": "text", "text": format!("{name}:ok")}],
+							"isError": false
+						})
+					},
+					_ => {
+						return Ok::<_, http::StatusCode>(axum::Json(serde_json::json!({
+							"jsonrpc": "2.0",
+							"id": id,
+							"error": {"code": -32601, "message": method}
+						})));
+					},
+				};
+				Ok::<_, http::StatusCode>(axum::Json(serde_json::json!({
+					"jsonrpc": "2.0",
+					"id": id,
+					"result": result
+				})))
+			}
+		}),
+	);
+	let tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+	let addr = tcp_listener.local_addr().unwrap();
+	tokio::spawn(async move {
+		let _ = axum::serve(tcp_listener, router)
+			.with_graceful_shutdown(async {
+				let _ = rx.await;
+			})
+			.await;
+	});
+	MockServer {
+		addr,
+		init_counter,
+		_cancel: tx,
+	}
+}
+
+/// Reproduces https://github.com/agentgateway/agentgateway/issues/3357
+///
+/// With two or more modern (`2026-07-28`) MCP targets, a client request that
+/// carries the per-request `_meta` envelope gets `-32602` from the gateway's
+/// own internal resolve request — the resolve `tools/list` that the gateway
+/// issues to figure out which target owns a tool does not propagate the
+/// client's `_meta`, so strict modern upstreams reject it.
+///
+/// With a single target the call succeeds (no resolve round-trip needed).
+#[tokio::test]
+async fn modern_multi_target_resolve_propagates_meta() {
+	let alpha = mock_modern_strict_streamable_http_server("alpha_ping").await;
+	let beta = mock_modern_strict_streamable_http_server("beta_ping").await;
+	let t = never_prefix_proxy(
+		vec![("alpha", alpha.addr, false), ("beta", beta.addr, false)],
+		false,
+	);
+	let io = t.serve_real_listener(strng::new("bind")).await;
+
+	let client = reqwest::Client::new();
+	let url = format!("http://{io}/mcp");
+	let meta = modern_meta();
+
+	let body = serde_json::json!({
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/call",
+		"params": {
+			"name": "alpha_ping",
+			"arguments": {},
+			"_meta": meta
+		}
+	});
+	let resp = mcp_json_post(&client, &url, &body)
+		.header("mcp-protocol-version", "2026-07-28")
+		.header("mcp-method", "tools/call")
+		.header("mcp-name", "alpha_ping")
+		.send()
+		.await
+		.unwrap();
+
+	let status = resp.status();
+	let content_type = resp
+		.headers()
+		.get("content-type")
+		.map(|v| v.to_str().unwrap_or("").to_string())
+		.unwrap_or_default();
+	let raw_body = resp.text().await.unwrap();
+
+	// Before the fix, the resolve request fails with -32602 from the upstream
+	// because it lacks _meta. After the fix, the call succeeds with 200.
+	assert_eq!(
+		status,
+		reqwest::StatusCode::OK,
+		"tools/call should succeed with multi-target modern upstreams; got {status}: {raw_body}"
+	);
+
+	// The gateway may return either JSON or SSE depending on the request.
+	// Parse accordingly.
+	let resp_body = if content_type.contains("text/event-stream") {
+		// SSE: find the "data:" line with a JSON-RPC response.
+		raw_body
+			.lines()
+			.find(|line| line.starts_with("data: "))
+			.map(|line| {
+				serde_json::from_str::<serde_json::Value>(line.trim_start_matches("data: ")).unwrap()
+			})
+			.unwrap_or_else(|| panic!("no data: line in SSE response: {raw_body}"))
+	} else {
+		serde_json::from_str(&raw_body).expect("response should be valid JSON")
+	};
+
+	let result_text = resp_body
+		.pointer("/result/content/0/text")
+		.and_then(|v| v.as_str())
+		.unwrap_or("");
+	assert_eq!(result_text, "alpha_ping:ok");
+}

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -16,7 +16,7 @@ use headers::HeaderMapExt;
 use rmcp::model::{
 	ClientInfo, ClientJsonRpcMessage, ClientNotification, ClientRequest, ConstString, GetMeta,
 	Implementation, InitializeRequest, JsonRpcRequest, ProtocolVersion, Reference, RequestId,
-	ServerJsonRpcMessage,
+	RequestMetaObject, ServerJsonRpcMessage,
 };
 use rmcp::transport::common::http_header::{EVENT_STREAM_MIME_TYPE, JSON_MIME_TYPE};
 use sse_stream::{KeepAlive, Sse, SseBody, SseStream};
@@ -189,10 +189,11 @@ impl Session {
 		log: &AsyncLog<mcp::MCPInfo>,
 		cel: &rbac::CelExecWrapper,
 		ctx: &IncomingRequestContext,
+		meta: Option<&RequestMetaObject>,
 	) -> Result<(Cow<'a, str>, &'b str), UpstreamError> {
 		let (service_name, prompt) = self
 			.relay
-			.resolve_resource_name(ResolveKind::Prompt, name, ctx)
+			.resolve_resource_name(ResolveKind::Prompt, name, ctx, meta)
 			.await?;
 		log.non_atomic_mutate(|l| {
 			l.set_prompt(service_name.to_string(), prompt.to_string());
@@ -565,10 +566,15 @@ impl Session {
 					},
 					ClientRequest::CallToolRequest(ctr) => {
 						let name = ctr.params.name.clone();
+						// Propagate the client's `_meta` to the resolve list request so modern
+						// (2026-07-28) upstreams that require the per-request envelope accept it.
+						let resolve_meta = ctr.extensions.get::<RequestMetaObject>().cloned();
+						let resolve_meta_opt = resolve_meta.as_ref().and_then(non_empty_meta);
 						let (service_name, tool) = Box::pin(self.relay.resolve_resource_name(
 							ResolveKind::Tool,
 							&name,
 							&ctx,
+							resolve_meta_opt,
 						))
 						.await?;
 						let call_arguments = ctr.params.arguments.clone();
@@ -600,10 +606,15 @@ impl Session {
 					},
 					ClientRequest::GetPromptRequest(gpr) => {
 						let name = gpr.params.name.clone();
+						// Propagate the client's `_meta` to the resolve list request so modern
+						// (2026-07-28) upstreams that require the per-request envelope accept it.
+						let resolve_meta = gpr.extensions.get::<RequestMetaObject>().cloned();
+						let resolve_meta_opt = resolve_meta.as_ref().and_then(non_empty_meta);
 						let (service_name, prompt) = Box::pin(self.relay.resolve_resource_name(
 							ResolveKind::Prompt,
 							&name,
 							&ctx,
+							resolve_meta_opt,
 						))
 						.await?;
 						log.non_atomic_mutate(|l| {
@@ -696,8 +707,19 @@ impl Session {
 					ClientRequest::CompleteRequest(cr) => match &cr.params.r#ref {
 						Reference::Prompt(prompt) => {
 							let name = prompt.name.clone();
-							let (service_name, prompt_name) =
-								Box::pin(self.authorize_prompt_request(&name, &method, &log, &cel, &ctx)).await?;
+							// Propagate the client's `_meta` to the resolve list request so modern
+							// (2026-07-28) upstreams that require the per-request envelope accept it.
+							let resolve_meta = cr.extensions.get::<RequestMetaObject>().cloned();
+							let resolve_meta_opt = resolve_meta.as_ref().and_then(non_empty_meta);
+							let (service_name, prompt_name) = Box::pin(self.authorize_prompt_request(
+								&name,
+								&method,
+								&log,
+								&cel,
+								&ctx,
+								resolve_meta_opt,
+							))
+							.await?;
 							cr.params.r#ref = Reference::for_prompt(prompt_name.to_string());
 							Box::pin(self.relay.send_single(r, ctx, &service_name, None)).await
 						},
@@ -778,6 +800,19 @@ impl Session {
 		};
 		self.strip_unsupported_client_capabilities(&mut capabilities, ctx);
 		message.get_meta_mut().set_client_capabilities(capabilities);
+	}
+}
+
+/// Return a reference to `meta` if it carries at least one key, or `None` if empty.
+///
+/// Used to avoid propagating an empty `_meta` envelope onto gateway-internal resolve
+/// requests: legacy clients and modern clients with no envelope both yield an empty
+/// `RequestMetaObject`, and forwarding that adds no value.
+fn non_empty_meta(meta: &RequestMetaObject) -> Option<&RequestMetaObject> {
+	if meta.0.0.is_empty() {
+		None
+	} else {
+		Some(meta)
 	}
 }
 

--- a/crates/agentgateway/src/mcp/session.rs
+++ b/crates/agentgateway/src/mcp/session.rs
@@ -568,13 +568,15 @@ impl Session {
 						let name = ctr.params.name.clone();
 						// Propagate the client's `_meta` to the resolve list request so modern
 						// (2026-07-28) upstreams that require the per-request envelope accept it.
-						let resolve_meta = ctr.extensions.get::<RequestMetaObject>().cloned();
-						let resolve_meta_opt = resolve_meta.as_ref().and_then(non_empty_meta);
+						let resolve_meta = ctr
+							.extensions
+							.get::<RequestMetaObject>()
+							.and_then(non_empty_meta);
 						let (service_name, tool) = Box::pin(self.relay.resolve_resource_name(
 							ResolveKind::Tool,
 							&name,
 							&ctx,
-							resolve_meta_opt,
+							resolve_meta,
 						))
 						.await?;
 						let call_arguments = ctr.params.arguments.clone();
@@ -608,13 +610,15 @@ impl Session {
 						let name = gpr.params.name.clone();
 						// Propagate the client's `_meta` to the resolve list request so modern
 						// (2026-07-28) upstreams that require the per-request envelope accept it.
-						let resolve_meta = gpr.extensions.get::<RequestMetaObject>().cloned();
-						let resolve_meta_opt = resolve_meta.as_ref().and_then(non_empty_meta);
+						let resolve_meta = gpr
+							.extensions
+							.get::<RequestMetaObject>()
+							.and_then(non_empty_meta);
 						let (service_name, prompt) = Box::pin(self.relay.resolve_resource_name(
 							ResolveKind::Prompt,
 							&name,
 							&ctx,
-							resolve_meta_opt,
+							resolve_meta,
 						))
 						.await?;
 						log.non_atomic_mutate(|l| {
@@ -709,15 +713,17 @@ impl Session {
 							let name = prompt.name.clone();
 							// Propagate the client's `_meta` to the resolve list request so modern
 							// (2026-07-28) upstreams that require the per-request envelope accept it.
-							let resolve_meta = cr.extensions.get::<RequestMetaObject>().cloned();
-							let resolve_meta_opt = resolve_meta.as_ref().and_then(non_empty_meta);
+							let resolve_meta = cr
+								.extensions
+								.get::<RequestMetaObject>()
+								.and_then(non_empty_meta);
 							let (service_name, prompt_name) = Box::pin(self.authorize_prompt_request(
 								&name,
 								&method,
 								&log,
 								&cel,
 								&ctx,
-								resolve_meta_opt,
+								resolve_meta,
 							))
 							.await?;
 							cr.params.r#ref = Reference::for_prompt(prompt_name.to_string());


### PR DESCRIPTION
## What

Fix `-32602` errors from modern (`2026-07-28`) MCP upstreams when the gateway serves two or more targets.

## Why

With multiple MCP targets, the gateway issues internal `tools/list` probes (`id: agw-resolve-*`) to figure out which target owns a tool. These probes were built with empty extensions, so their serialized body lacked the `_meta` envelope (`protocolVersion`, `clientCapabilities`) that strict modern upstreams require on every request. The upstream rejected them with `-32602`, breaking `tools/call` for modern clients in multi-target setups.

Single-target and legacy (`initialize` + `Mcp-Session-Id`) clients were unaffected.

## How

Propagate the original client request's `RequestMetaObject` through `resolve_resource_name` → `resolve_unprefixed` → `serves_name` → `list_request` so the gateway-internal list probe carries the same `_meta` the client sent. Empty meta is suppressed (`None`) to preserve legacy behavior.

Fixes #3357.

## Test

- Adds `mock_modern_strict_streamable_http_server` that validates the `_meta` envelope on every request (mirrors Python `mcp` 2.x behavior).
- Adds `modern_multi_target_resolve_propagates_meta` regression test — fails before the fix (400 / `-32602`), passes after.
- All existing unit tests continue to pass.

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
