### PR TITLE
fix(syncer): avoid copying sync.RWMutex in Service.DeepCopy

### DIFF
--- a/controller/Makefile
+++ b/controller/Makefile
@@ -136,9 +136,11 @@ analyze: ensure-custom-golangci-lint  ## Run golangci-lint. Override options wit
 .PHONY: ensure-custom-golangci-lint
 ensure-custom-golangci-lint:
 	@expected_go_version="$$(go env GOVERSION)"; \
+	expected_lint_version="$$(sed -n 's/^version: *//p' .custom-gcl.yml | tr -d '[:space:]')"; \
 	current_go_version="$$( $(CUSTOM_GOLANGCI_LINT_BIN) version 2>/dev/null | sed -n 's/.* built with \(go[^[:space:]]*\).*/\1/p' )"; \
-	if [ ! -x "$(CUSTOM_GOLANGCI_LINT_BIN)" ] || [ "$$current_go_version" != "$$expected_go_version" ]; then \
-		echo "Rebuilding golangci-lint custom with $$expected_go_version..."; \
+	current_lint_version="$$( $(CUSTOM_GOLANGCI_LINT_BIN) version 2>/dev/null | sed -n 's/.* version \([^[:space:]]*\)-custom-gcl.*/\1/p' )"; \
+	if [ ! -x "$(CUSTOM_GOLANGCI_LINT_BIN)" ] || [ "$$current_go_version" != "$$expected_go_version" ] || [ "$$current_lint_version" != "$$expected_lint_version" ]; then \
+		echo "Rebuilding golangci-lint custom (go $$current_go_version->$$expected_go_version, lint $$current_lint_version->$$expected_lint_version)..."; \
 		rm -f "$(CUSTOM_GOLANGCI_LINT_BIN)"; \
 		GOTOOLCHAIN="$$expected_go_version" golangci-lint custom; \
 	fi

--- a/controller/pkg/syncer/service.go
+++ b/controller/pkg/syncer/service.go
@@ -584,8 +584,18 @@ func (s *Service) HasAddressOrAssigned(id cluster.ID) bool {
 
 // DeepCopy creates a clone of Service.
 func (s *Service) DeepCopy() *Service {
-	// nolint: govet
-	out := *s
+	// Construct field-by-field to avoid copying the sync.RWMutex embedded in
+	// ClusterVIPs (AddressMap). A plain `out := *s` would duplicate the lock,
+	// which govet flags and is undefined behavior if the copied lock is used.
+	out := &Service{
+		Hostname:                 s.Hostname,
+		DefaultAddress:           s.DefaultAddress,
+		AutoAllocatedIPv4Address: s.AutoAllocatedIPv4Address,
+		AutoAllocatedIPv6Address: s.AutoAllocatedIPv6Address,
+		Resolution:               s.Resolution,
+		ResourceVersion:          s.ResourceVersion,
+		CreationTime:             s.CreationTime,
+	}
 	out.Attributes = s.Attributes.DeepCopy()
 	if s.Ports != nil {
 		out.Ports = make(PortList, len(s.Ports))
@@ -596,15 +606,17 @@ func (s *Service) DeepCopy() *Service {
 					Port:     port.Port,
 					Protocol: port.Protocol,
 				}
-			} else {
-				out.Ports[i] = nil
 			}
 		}
 	}
 
 	out.ServiceAccounts = slices.Clone(s.ServiceAccounts)
-	out.ClusterVIPs = *s.ClusterVIPs.DeepCopy()
-	return &out
+	// Construct a fresh AddressMap so its mutex is zero-valued (not copied).
+	// GetAddresses() already deep-copies both the outer map and each inner slice.
+	out.ClusterVIPs = AddressMap{
+		Addresses: s.ClusterVIPs.GetAddresses(),
+	}
+	return out
 }
 
 // Equals compares two service objects.


### PR DESCRIPTION
## Summary

Fix a `go vet` warning and harden the golangci-lint cache check in the Makefile.

## Changes

- **`controller/pkg/syncer/service.go`** — `Service.DeepCopy()` previously did `out := *s`, which copied the `sync.RWMutex` embedded in `ClusterVIPs` (via `AddressMap`). Replace with field-by-field construction and build `ClusterVIPs` from a fresh `AddressMap{Addresses: ...}` so its mutex stays zero-valued.
- **`controller/Makefile`** — `ensure-custom-golangci-lint` previously only compared the Go version, so bumping golangci-lint (v2.12.2 → v2.13.2) did not trigger a rebuild of the custom binary. Now also compares the lint version read from `.custom-gcl.yml` against the version reported by the cached binary.

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
