### PR TITLE
fix(mcp): advertise the gateway registration endpoint for Auth0

### DIFF
--- a/crates/agentgateway/src/mcp/auth.rs
+++ b/crates/agentgateway/src/mcp/auth.rs
@@ -344,11 +344,35 @@ pub(super) async fn authorization_server_metadata(
 	let mut resp: serde_json::Value = from_body_with_limit(upstream.into_body(), limit)
 		.await
 		.map_err(ProxyError::Body)?;
+	apply_provider_metadata_overrides(req, auth, &mut resp)?;
+
+	rewrite_authorization_server_issuer(req, auth, &mut resp)?;
+
+	let response = ::http::Response::builder()
+		.status(StatusCode::OK)
+		.header("content-type", "application/json")
+		.header("access-control-allow-origin", "*")
+		.header("access-control-allow-methods", "GET, OPTIONS")
+		.header("access-control-allow-headers", "content-type")
+		.body(axum::body::Body::from(Bytes::from(
+			serde_json::to_string(&resp).map_err(|e| ProxyError::Body(crate::http::Error::new(e)))?,
+		)))?;
+
+	Ok(response)
+}
+
+/// Apply provider-specific rewrites to the authorization server metadata served to
+/// MCP clients, so that endpoints the gateway handles itself are advertised as its own.
+fn apply_provider_metadata_overrides(
+	req: &Request,
+	auth: &McpAuthentication,
+	resp: &mut serde_json::Value,
+) -> Result<(), ProxyError> {
 	match &auth.provider {
 		Some(McpIDP::Auth0 {}) => {
 			// Auth0 does not support RFC 8707. We can workaround this by prepending an audience
 			let Some(serde_json::Value::String(ae)) =
-				json::traverse_mut(&mut resp, &["authorization_endpoint"])
+				json::traverse_mut(resp, &["authorization_endpoint"])
 			else {
 				return Err(ProxyError::ProcessingString(
 					"authorization_endpoint missing".to_string(),
@@ -358,11 +382,21 @@ pub(super) async fn authorization_server_metadata(
 			if let Some(aud) = auth.audiences.first() {
 				ae.push_str(&format!("?audience={}", aud));
 			}
+			// Auth0's own registration endpoint is only live when Dynamic Application
+			// Registration is enabled on the tenant, and it is not proxied, so clients that
+			// follow this metadata bypass the `clientId` short-circuit entirely. Point them at
+			// the gateway's registration handler, as every other provider adapter does.
+			let current_uri = request_uri_for_oauth_metadata(req);
+			if let Some(serde_json::Value::String(re)) =
+				json::traverse_mut(resp, &["registration_endpoint"])
+			{
+				*re = format!("{current_uri}/client-registration");
+			}
 		},
 		Some(McpIDP::Okta {}) => {
 			// Okta does not support RFC 8707. Workaround by appending audience as a query param.
 			let Some(serde_json::Value::String(ae)) =
-				json::traverse_mut(&mut resp, &["authorization_endpoint"])
+				json::traverse_mut(resp, &["authorization_endpoint"])
 			else {
 				return Err(ProxyError::ProcessingString(
 					"authorization_endpoint missing".to_string(),
@@ -375,7 +409,7 @@ pub(super) async fn authorization_server_metadata(
 			// Okta doesn't do CORS for client registrations — proxy it (same pattern as Keycloak)
 			let current_uri = request_uri_for_oauth_metadata(req);
 			if let Some(serde_json::Value::String(re)) =
-				json::traverse_mut(&mut resp, &["registration_endpoint"])
+				json::traverse_mut(resp, &["registration_endpoint"])
 			{
 				*re = format!("{current_uri}/client-registration");
 			}
@@ -386,7 +420,7 @@ pub(super) async fn authorization_server_metadata(
 			// Note: DCR requires a management key; recommend using clientId short-circuit instead.
 			let current_uri = request_uri_for_oauth_metadata(req);
 			if let Some(serde_json::Value::String(re)) =
-				json::traverse_mut(&mut resp, &["registration_endpoint"])
+				json::traverse_mut(resp, &["registration_endpoint"])
 			{
 				*re = format!("{current_uri}/client-registration");
 			}
@@ -403,7 +437,7 @@ pub(super) async fn authorization_server_metadata(
 
 			let current_uri = request_uri_for_oauth_metadata(req);
 			let Some(serde_json::Value::String(re)) =
-				json::traverse_mut(&mut resp, &["registration_endpoint"])
+				json::traverse_mut(resp, &["registration_endpoint"])
 			else {
 				return Err(ProxyError::ProcessingString(
 					"registration_endpoint missing".to_string(),
@@ -435,14 +469,14 @@ pub(super) async fn authorization_server_metadata(
 			// Entra rejects the RFC 8707 `resource` parameter (AADSTS9010010). Advertise
 			// gateway-proxied authorization/token endpoints that strip it before forwarding.
 			let Some(serde_json::Value::String(ae)) =
-				json::traverse_mut(&mut resp, &["authorization_endpoint"])
+				json::traverse_mut(resp, &["authorization_endpoint"])
 			else {
 				return Err(ProxyError::ProcessingString(
 					"authorization_endpoint missing".to_string(),
 				));
 			};
 			*ae = format!("{current_uri}/authorize");
-			let Some(serde_json::Value::String(te)) = json::traverse_mut(&mut resp, &["token_endpoint"])
+			let Some(serde_json::Value::String(te)) = json::traverse_mut(resp, &["token_endpoint"])
 			else {
 				return Err(ProxyError::ProcessingString(
 					"token_endpoint missing".to_string(),
@@ -468,19 +502,7 @@ pub(super) async fn authorization_server_metadata(
 		_ => {},
 	}
 
-	rewrite_authorization_server_issuer(req, auth, &mut resp)?;
-
-	let response = ::http::Response::builder()
-		.status(StatusCode::OK)
-		.header("content-type", "application/json")
-		.header("access-control-allow-origin", "*")
-		.header("access-control-allow-methods", "GET, OPTIONS")
-		.header("access-control-allow-headers", "content-type")
-		.body(axum::body::Body::from(Bytes::from(
-			serde_json::to_string(&resp).map_err(|e| ProxyError::Body(crate::http::Error::new(e)))?,
-		)))?;
-
-	Ok(response)
+	Ok(())
 }
 
 pub(super) async fn client_registration(
@@ -994,6 +1016,62 @@ mod tests {
 			.expect("request should build");
 		req.extensions_mut().insert(auth);
 		req
+	}
+
+	#[rstest::rstest]
+	#[case::auth0(McpIDP::Auth0 {})]
+	#[case::okta(McpIDP::Okta {})]
+	#[case::descope(McpIDP::Descope {})]
+	#[case::keycloak(McpIDP::Keycloak {})]
+	fn provider_metadata_advertises_gateway_registration_endpoint(#[case] provider: McpIDP) {
+		// A provider's own registration endpoint bypasses the `clientId` short-circuit, so
+		// clients that follow the served metadata never reach it.
+		let mut auth = default_auth();
+		auth.provider = Some(provider);
+		let req = ::http::Request::builder()
+			.uri("https://gateway.example.com/.well-known/oauth-authorization-server/mcp")
+			.body(Body::empty())
+			.expect("request should build");
+		let mut metadata = serde_json::json!({
+			"authorization_endpoint": "https://idp.example.com/authorize",
+			"registration_endpoint": "https://idp.example.com/oidc/register",
+		});
+
+		apply_provider_metadata_overrides(&req, &auth, &mut metadata)
+			.expect("metadata should be rewritten");
+
+		assert_eq!(
+			metadata["registration_endpoint"],
+			"https://gateway.example.com/.well-known/oauth-authorization-server/mcp/client-registration"
+		);
+	}
+
+	#[test]
+	fn auth0_metadata_keeps_audience_workaround_alongside_registration_rewrite() {
+		let mut auth = default_auth();
+		auth.provider = Some(McpIDP::Auth0 {});
+		auth.audiences = vec!["https://mcp.example.com/mcp".to_string()];
+		let req = ::http::Request::builder()
+			.uri("https://gateway.example.com/.well-known/oauth-authorization-server/mcp")
+			.body(Body::empty())
+			.expect("request should build");
+		let mut metadata = serde_json::json!({
+			"authorization_endpoint": "https://idp.example.com/authorize",
+			"registration_endpoint": "https://idp.example.com/oidc/register",
+		});
+
+		apply_provider_metadata_overrides(&req, &auth, &mut metadata)
+			.expect("metadata should be rewritten");
+
+		// Auth0 has no RFC 8707 support, so the audience must still be pinned on authorize.
+		assert_eq!(
+			metadata["authorization_endpoint"],
+			"https://idp.example.com/authorize?audience=https://mcp.example.com/mcp"
+		);
+		assert_eq!(
+			metadata["registration_endpoint"],
+			"https://gateway.example.com/.well-known/oauth-authorization-server/mcp/client-registration"
+		);
 	}
 
 	fn default_auth() -> McpAuthentication {


### PR DESCRIPTION
## What's happening

The `auth0` provider is the only adapter that does not rewrite `registration_endpoint`
in the authorization server metadata it serves. Clients that follow the metadata are
sent to Auth0's own DCR endpoint instead of the gateway's, which bypasses the
`clientId` short-circuit entirely.

| provider | `registration_endpoint` in served metadata |
| --- | --- |
| Auth0 | **the IdP's own, unmodified** |
| Okta | `{gateway}/client-registration` |
| Descope | `{gateway}/client-registration` |
| Keycloak | `{gateway}/client-registration` |
| authentik | injected, `{gateway}/client-registration` |
| Entra | injected, `{gateway}/client-registration` |

Auth0 is the oldest adapter, and each provider added since has included this rewrite.

The effect is that `clientId` silently does nothing for clients that read the
document. `client_registration()` already handles the short-circuit for any provider
(the `path.ends_with("client-registration")` arm is not provider-gated), so the
endpoint works today. Nothing points at it.

This matters because Auth0's Dynamic Application Registration is off by default, so
the advertised endpoint usually returns:

```json
{"statusCode":400,"error":"Bad Request","message":"dynamic client registration is disabled"}
```

The Auth0 guide recommends setting `clientId` and says this "avoids this dependency"
on Auth0's DCR, while also noting agentgateway "passes through Auth0's own
registration endpoint rather than proxying it". Both describe the code accurately,
but together they do not hold: setting `clientId` populates an endpoint the served
metadata never references.

## Reproduction

Configure the `auth0` provider with `clientId` set, against a tenant where Dynamic
Application Registration is disabled (the default).

```console
$ curl -s https://mcp.example.com/.well-known/oauth-authorization-server/mcp | jq -r .registration_endpoint
https://login.example.auth0.com/oidc/register

$ curl -s -XPOST https://login.example.auth0.com/oidc/register \
    -H 'content-type: application/json' -d '{"redirect_uris":["http://127.0.0.1:9999/callback"]}'
{"statusCode":400,"error":"Bad Request","message":"dynamic client registration is disabled"}

$ curl -s -XPOST https://mcp.example.com/.well-known/oauth-authorization-server/mcp/client-registration \
    -H 'content-type: application/json' -d '{"redirect_uris":["http://127.0.0.1:9999/callback"]}'
{"client_id":"<the configured clientId>","client_id_issued_at":0,"token_endpoint_auth_method":"none", ...}
```

Both halves work. Only the advertisement is wrong.

## The fix

Apply the same `registration_endpoint` rewrite the other adapters use. The audience
workaround on `authorization_endpoint` is unchanged.

To make this testable, the provider-specific `match` is extracted from
`authorization_server_metadata()` into a pure
`apply_provider_metadata_overrides()`. That move is mechanical, with no behaviour
change beyond the Auth0 arm.

## Testing

Added `provider_metadata_advertises_gateway_registration_endpoint` (rstest cases for
Auth0, Okta, Descope, Keycloak) and
`auth0_metadata_keeps_audience_workaround_alongside_registration_rewrite`, which
pins the RFC 8707 audience workaround against regression.

Verified end to end against a real Auth0 tenant with agentgateway v1.5.0: OAuth
authorization code + PKCE completes, the token comes back as a JWT with the correct
`aud` and a refresh token, the MCP session initializes, and `tools/list` returns the
tools permitted by the granted scope.

## Related

- #3374 — the `auth0` provider serves no `/authorize` or `/token` for clients that
  derive endpoints from `issuer`. Distinct from this: that is about derivation,
  this is about the advertised document. Together they account for both client
  styles failing.
