### PR TITLE
Fix rate-limit denial headers and add Retry-After

### DIFF
--- a/crates/agentgateway/src/http/remoteratelimit.rs
+++ b/crates/agentgateway/src/http/remoteratelimit.rs
@@ -483,7 +483,7 @@ impl RemoteRateLimit {
 		if overall_code != (proto::rate_limit_response::Code::Ok as i32) {
 			let mut hm = HeaderMap::new();
 			process_headers(&mut hm, response_headers_to_add);
-			process_ratelimit_status_headers(&mut hm, &statuses);
+			process_ratelimit_status_headers(&mut hm, &statuses, true);
 			return Err(ProxyError::RemoteRateLimitExceeded {
 				status: ratelimit_status(&statuses),
 				raw_body,
@@ -495,7 +495,7 @@ impl RemoteRateLimit {
 		// Surface the standard x-ratelimit-* headers on allowed responses so clients can self-throttle.
 		let mut hm = HeaderMap::new();
 		process_headers(&mut hm, response_headers_to_add);
-		process_ratelimit_status_headers(&mut hm, &statuses);
+		process_ratelimit_status_headers(&mut hm, &statuses, false);
 		if !hm.is_empty() {
 			res.response_headers = Some(hm);
 		}
@@ -618,6 +618,7 @@ fn ratelimit_status(
 fn process_ratelimit_status_headers(
 	hm: &mut HeaderMap,
 	statuses: &[proto::rate_limit_response::DescriptorStatus],
+	denied: bool,
 ) {
 	if let Some(status) = ratelimit_status(statuses) {
 		http::x_headers::set_ratelimit_headers(
@@ -626,6 +627,20 @@ fn process_ratelimit_status_headers(
 			status.remaining,
 			status.reset_seconds,
 		);
+	}
+	// Only denials need Retry-After; allowed responses still get advisory quota headers.
+	// Like Envoy, derive the longest denied reset separately: current_limit may be
+	// absent, and advisory x-ratelimit headers may describe a different descriptor.
+	if denied
+		&& let Some(reset) = statuses
+			.iter()
+			.filter(|s| s.code == proto::rate_limit_response::Code::OverLimit as i32)
+			.filter_map(|s| s.duration_until_reset.as_ref())
+			.map(|d| (d.seconds.max(0) as u64 + u64::from(d.nanos > 0)).max(1))
+			.max()
+	{
+		hm.entry(::http::header::RETRY_AFTER)
+			.or_insert(reset.into());
 	}
 }
 

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -276,12 +276,12 @@ async fn apply_request_policies(
 
 	rp.llm_request_policies.local_rate_limit = pol
 		.local_rate_limit
-		.apply_selected("local rate limit", c, l, req, rp.headers())
+		.apply_selected("local rate limit", c, l, req, &mut rp.rate_limit_headers)
 		.await?;
 
 	rp.llm_request_policies.remote_rate_limit = pol
 		.remote_rate_limit
-		.apply_selected("remote rate limit", c, l, req, rp.headers())
+		.apply_selected("remote rate limit", c, l, req, &mut rp.rate_limit_headers)
 		.await?;
 
 	rp.buffer = pol.buffer.apply("buffer", c, l, req, rp.headers()).await?;
@@ -2834,7 +2834,7 @@ async fn make_backend_call(
 								policy_client.clone(),
 								&mut req,
 								&llm_request,
-								&mut response_policies.response_headers,
+								&mut response_policies.rate_limit_headers,
 							)
 							.assert_size::<{ 3 * 1024 }>(),
 						)
@@ -4569,6 +4569,8 @@ struct ResponsePolicies {
 	backend_transformation: ResponsePolicy<Transformation>,
 	gateway_transformation: ResponsePolicy<Transformation>,
 	response_headers: HeaderMap,
+	// Headers from allowed rate-limit checks, skipped when a later check denies.
+	rate_limit_headers: HeaderMap,
 	ext_proc: Option<ExtProcRequest>,
 	gateway_ext_proc: Option<ExtProcRequest>,
 	// Populated by the standard request-policy flow after conditional rate-limit policies are
@@ -4600,6 +4602,13 @@ impl ResponsePolicies {
 		l: &mut RequestLog,
 		is_upstream_response: bool,
 	) -> Result<(), ProxyResponse> {
+		// A denying policy already supplied its own rate-limit headers. Otherwise,
+		// include the allowed checks' headers even on direct responses. Apply these
+		// before response policies so explicit header modifiers can still override them.
+		if resp.extensions().get::<super::RateLimitDenied>().is_none() {
+			merge_in_headers(Some(self.rate_limit_headers.clone()), resp.headers_mut());
+		}
+
 		let rh = &mut self.response_headers;
 
 		self

--- a/crates/agentgateway/src/proxy/mod.rs
+++ b/crates/agentgateway/src/proxy/mod.rs
@@ -169,6 +169,10 @@ impl Display for ProxyResponseReason {
 	}
 }
 
+/// Marks responses whose rate-limit headers come from a denying policy.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RateLimitDenied;
+
 #[derive(thiserror::Error, Debug)]
 pub enum ProxyError {
 	#[error("bind not found")]
@@ -451,7 +455,9 @@ impl ProxyError {
 				raw_body,
 				..
 			} => {
-				let mut rb = ::http::Response::builder().status(StatusCode::TOO_MANY_REQUESTS);
+				let mut rb = ::http::Response::builder()
+					.status(StatusCode::TOO_MANY_REQUESTS)
+					.extension(RateLimitDenied);
 				if let Some(hm) = rb.headers_mut() {
 					*hm = *response_headers;
 				}
@@ -503,6 +509,12 @@ impl ProxyError {
 		};
 		let grpc_status = is_grpc_request.then(|| proxy_error_to_grpc_status(&self, code));
 		let mut rb = ::http::Response::builder().status(code);
+		if matches!(
+			&self,
+			ProxyError::RateLimitExceeded { .. } | ProxyError::MCP(mcp::Error::RateLimited { .. })
+		) {
+			rb = rb.extension(RateLimitDenied);
+		}
 
 		// Apply per-error headers
 		if let ProxyError::RateLimitExceeded {
@@ -513,6 +525,7 @@ impl ProxyError {
 			&& let Some(hm) = rb.headers_mut()
 		{
 			http::x_headers::set_ratelimit_headers(hm, limit, remaining, reset_seconds);
+			hm.insert(::http::header::RETRY_AFTER, reset_seconds.max(1).into());
 		}
 		if let ProxyError::MCP(mcp::Error::RateLimited { headers, .. }) = &self
 			&& let Some(hm) = rb.headers_mut()

--- a/crates/agentgateway/tests/tests/auth.rs
+++ b/crates/agentgateway/tests/tests/auth.rs
@@ -359,8 +359,11 @@ async fn network_http_ext_authz_denies_tcp_connection() {
 	assert_eq!(authz.received_requests().await.unwrap().len(), 1);
 }
 
+#[rstest::rstest]
+#[case::upstream(false)]
+#[case::direct_response(true)]
 #[tokio::test]
-async fn local_ratelimit() {
+async fn local_ratelimit(#[case] direct_response: bool) {
 	let (_mock, mut bind, io) = basic_setup().await;
 	bind
 		.attach_route_policy(json!({
@@ -372,8 +375,17 @@ async fn local_ratelimit() {
 		}))
 		.await;
 
+	if direct_response {
+		bind
+			.attach_route_policy(json!({
+				"directResponse": {"status": 200, "body": "hello"}
+			}))
+			.await;
+	}
+
 	let res = send_request(io.clone(), Method::GET, "http://lo").await;
 	assert_eq!(res.status(), 200);
+	assert!(res.headers().get(header::RETRY_AFTER).is_none());
 	// Allowed responses advertise the current limit so clients can self-throttle.
 	assert_eq!(res.hdr("x-ratelimit-limit"), "1");
 	assert_eq!(res.hdr("x-ratelimit-remaining"), "0");
@@ -384,6 +396,7 @@ async fn local_ratelimit() {
 	// The 429 still carries the limit info.
 	assert_eq!(res.hdr("x-ratelimit-limit"), "1");
 	assert_eq!(res.hdr("x-ratelimit-remaining"), "0");
+	assert_eq!(res.hdr("retry-after"), "1");
 }
 
 #[tokio::test]

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -1212,6 +1212,125 @@ async fn single_upstream_request(mock: &MockServer) -> wiremock::Request {
 	requests.pop().unwrap()
 }
 
+#[rstest::rstest]
+#[case::retry_after(false)]
+#[case::denial_after_allowed_check(true)]
+#[tokio::test]
+async fn llm_remote_ratelimit_response(#[case] check_requests: bool) {
+	use agentgateway::http::remoteratelimit::proto;
+	use proto::rate_limit_response::rate_limit::Unit;
+	use proto::rate_limit_response::{Code, DescriptorStatus, RateLimit};
+
+	struct RateLimitHeaders;
+
+	#[async_trait::async_trait]
+	impl ratelimitmock::Handler for RateLimitHeaders {
+		async fn should_rate_limit(
+			&mut self,
+			request: &proto::RateLimitRequest,
+		) -> Result<proto::RateLimitResponse, tonic::Status> {
+			let statuses: Vec<_> = request
+				.descriptors
+				.iter()
+				.map(|descriptor| {
+					let (code, limit, remaining, reset, unit) = match descriptor.entries[0].key.as_str() {
+						"requests" => (Code::Ok, 60, 56, 12, Unit::Minute),
+						"tokens" => (Code::OverLimit, 100, 0, 38, Unit::Minute),
+						"spend" => (Code::OverLimit, 1000, 0, 2712, Unit::Hour),
+						key => panic!("unexpected descriptor: {key}"),
+					};
+					DescriptorStatus {
+						code: code as i32,
+						current_limit: Some(RateLimit {
+							name: descriptor.entries[0].key.clone(),
+							requests_per_unit: limit,
+							unit: unit as i32,
+						}),
+						limit_remaining: remaining,
+						duration_until_reset: Some(prost_types::Duration {
+							seconds: reset,
+							nanos: 0,
+						}),
+						..Default::default()
+					}
+				})
+				.collect();
+			Ok(proto::RateLimitResponse {
+				overall_code: if statuses.iter().any(|s| s.code == Code::OverLimit as i32) {
+					Code::OverLimit
+				} else {
+					Code::Ok
+				} as i32,
+				statuses,
+				..Default::default()
+			})
+		}
+	}
+
+	let rate_limit = ratelimitmock::RateLimitMock::new(|| RateLimitHeaders)
+		.spawn()
+		.await;
+	let mock = body_mock(llm_body!("response/completions/basic.json")).await;
+	let (mock, mut bind, io) = setup_llm_mock(
+		mock,
+		AIProvider::OpenAI(openai::Provider {
+			model: None,
+			moderation: None,
+		}),
+		false,
+		"{}",
+	);
+	let mut descriptors = vec![
+		json!({"entries": [{"key": "tokens", "value": "\"model\""}], "type": "tokens"}),
+		json!({"entries": [{"key": "spend", "value": "\"user\""}], "type": "tokens"}),
+	];
+	if check_requests {
+		descriptors.insert(
+			0,
+			json!({
+				"entries": [{"key": "requests", "value": "\"user\""}], "type": "requests"
+			}),
+		);
+	}
+	bind
+		.attach_route_policy(json!({
+			"remoteRateLimit": {
+				"domain": "llm",
+				"host": rate_limit.address.to_string(),
+				"descriptors": descriptors,
+			}
+		}))
+		.await;
+
+	let res = send_request_body(
+		io,
+		Method::POST,
+		"http://lo",
+		&completions_request_body(false),
+	)
+	.await;
+	assert!(mock.received_requests().await.unwrap().is_empty());
+	// Envoy's advisory selection keeps the first descriptor on a remaining-count tie.
+	// Retry-After must instead wait for every denied window, and an earlier allowed
+	// request check must not overwrite either set of denial headers.
+	assert_eq!(
+		json!({
+			"status": res.status().as_u16(),
+			"limit": res.hdr("x-ratelimit-limit"),
+			"remaining": res.hdr("x-ratelimit-remaining"),
+			"reset": res.hdr("x-ratelimit-reset"),
+			"retry-after": res.headers().get(header::RETRY_AFTER).map(|v| v.to_str().unwrap()),
+		}),
+		json!({
+			"status": 429,
+			"limit": "100",
+			"remaining": "0",
+			"reset": "38",
+			"retry-after": "2712",
+		})
+	);
+}
+
 async fn assert_llm_remote_rate_limit_cost(
 	response_body: &[u8],
 	request_body: &[u8],


### PR DESCRIPTION
Keep headers from allowed checks separate and skip them when error rendering
marks a rate-limit denial. Preserve advisory headers on direct responses and
allow explicit response policies to override them.

Add Retry-After for local and remote denials, using the longest denied reset
for RLS while preserving service-provided values and Envoy quota selection.

Validated with six rate-limit integration tests, including direct responses,
successful checks followed by denials, and existing CORS coverage.

Fixes #3328
Fixes #3329

Signed-off-by: John Howard <john.howard@solo.io>
