### PR TITLE
backend: accept partially invalid backend

### DIFF
--- a/controller/pkg/agentgateway/plugins/ai_policies.go
+++ b/controller/pkg/agentgateway/plugins/ai_policies.go
@@ -14,12 +14,13 @@ import (
 
 func processRequestGuard(ctx PolicyCtx, namespace string, reqs []agentgateway.PromptguardRequest) ([]*api.BackendPolicySpec_Ai_RequestGuard, error) {
 	var res []*api.BackendPolicySpec_Ai_RequestGuard
+	var errs []error
 	for _, req := range reqs {
 		pgReq := &api.BackendPolicySpec_Ai_RequestGuard{}
 		if req.Webhook != nil {
 			wh, err := processWebhook(ctx, namespace, req.Webhook)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
 			}
 			pgReq.Kind = &api.BackendPolicySpec_Ai_RequestGuard_Webhook{
 				Webhook: wh,
@@ -54,7 +55,7 @@ func processRequestGuard(ctx PolicyCtx, namespace string, reqs []agentgateway.Pr
 		res = append(res, pgReq)
 	}
 
-	return res, nil
+	return res, errors.Join(errs...)
 }
 
 func processContentScope(scope agentgateway.ContentScope) api.BackendPolicySpec_Ai_ContentScope {
@@ -74,12 +75,13 @@ func processContentScope(scope agentgateway.ContentScope) api.BackendPolicySpec_
 
 func processResponseGuard(ctx PolicyCtx, namespace string, resps []agentgateway.PromptguardResponse) ([]*api.BackendPolicySpec_Ai_ResponseGuard, error) {
 	var res []*api.BackendPolicySpec_Ai_ResponseGuard
+	var errs []error
 	for _, req := range resps {
 		pgReq := &api.BackendPolicySpec_Ai_ResponseGuard{}
 		if req.Webhook != nil {
 			wh, err := processWebhook(ctx, namespace, req.Webhook)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
 			}
 			pgReq.Kind = &api.BackendPolicySpec_Ai_ResponseGuard_Webhook{
 				Webhook: wh,
@@ -107,7 +109,7 @@ func processResponseGuard(ctx PolicyCtx, namespace string, resps []agentgateway.
 		res = append(res, pgReq)
 	}
 
-	return res, nil
+	return res, errors.Join(errs...)
 }
 
 func processPromptEnrichment(enrichment *agentgateway.AIPromptEnrichment) *api.BackendPolicySpec_Ai_PromptEnrichment {
@@ -137,9 +139,12 @@ func processWebhook(ctx PolicyCtx, namespace string, webhook *agentgateway.Webho
 		return nil, nil
 	}
 
+	var errs []error
 	be, err := BuildBackendRef(ctx, webhook.BackendRef, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build webhook: %v", err)
+		errs = append(errs, fmt.Errorf("failed to build webhook: %v", err))
+		// A nil backend translates to an invalid target, preserving failureMode.
+		be = nil
 	}
 
 	w := &api.BackendPolicySpec_Ai_Webhook{
@@ -148,13 +153,9 @@ func processWebhook(ctx PolicyCtx, namespace string, webhook *agentgateway.Webho
 		Action:      mapRejectAuditAction(webhook.Action),
 	}
 
-	var errs []error
 	w.Headers = castCELMap(webhook.Headers, func(key string, expr agentgateway.CELExpression) {
 		errs = append(errs, fmt.Errorf("webhook header %q is not a valid CEL expression: %s", key, expr))
 	})
-	if err := errors.Join(errs...); err != nil {
-		return nil, err
-	}
 
 	if len(webhook.ForwardHeaderMatches) > 0 {
 		headers := make([]*api.HeaderMatch, 0, len(webhook.ForwardHeaderMatches))
@@ -176,7 +177,7 @@ func processWebhook(ctx PolicyCtx, namespace string, webhook *agentgateway.Webho
 		w.ForwardHeaderMatches = headers
 	}
 
-	return w, nil
+	return w, errors.Join(errs...)
 }
 
 func webhookFailureMode(mode agentgateway.FailureMode) api.BackendPolicySpec_Ai_Webhook_FailureMode {

--- a/controller/pkg/agentgateway/plugins/backend_policies.go
+++ b/controller/pkg/agentgateway/plugins/backend_policies.go
@@ -866,9 +866,8 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 			if err != nil {
 				logger.Error("error parsing request prompt guard", "error", err)
 				errs = append(errs, err)
-			} else {
-				translatedAIPolicy.PromptGuard.Request = r
 			}
+			translatedAIPolicy.PromptGuard.Request = r
 		}
 
 		if aiSpec.PromptGuard.Response != nil {
@@ -876,9 +875,8 @@ func translateBackendAI(ctx PolicyCtx, agwPolicy *agentgateway.AgentgatewayPolic
 			if err != nil {
 				logger.Error("error parsing response prompt guard", "error", err)
 				errs = append(errs, err)
-			} else {
-				translatedAIPolicy.PromptGuard.Response = r
 			}
+			translatedAIPolicy.PromptGuard.Response = r
 		}
 	}
 

--- a/controller/pkg/agentgateway/plugins/jwks_lookup.go
+++ b/controller/pkg/agentgateway/plugins/jwks_lookup.go
@@ -8,7 +8,12 @@ import (
 
 func resolveJWKSInlineForOwner(ctx PolicyCtx, owner jwks.RemoteJwksOwner) (string, error) {
 	if ctx.JWKSLookup == nil {
-		return "", fmt.Errorf("jwks lookup is not configured")
+		return `{"keys":[]}`, fmt.Errorf("jwks lookup is not configured")
 	}
-	return ctx.JWKSLookup.InlineForOwner(ctx.Krt, owner)
+	inline, err := ctx.JWKSLookup.InlineForOwner(ctx.Krt, owner)
+	if err != nil {
+		// Keep authentication installed with no trusted keys while reporting the lookup failure.
+		return `{"keys":[]}`, err
+	}
+	return inline, nil
 }

--- a/controller/pkg/agentgateway/plugins/jwks_translation_test.go
+++ b/controller/pkg/agentgateway/plugins/jwks_translation_test.go
@@ -28,7 +28,7 @@ func longStringPtr(s string) *agentgateway.LongString {
 	return &v
 }
 
-func TestProcessJWTAuthenticationPolicyWhenLookupReturnsErrorOmitsRemoteProviderAndReturnsError(t *testing.T) {
+func TestProcessJWTAuthenticationPolicyWhenLookupReturnsErrorPreservesRemoteProviderAndReturnsError(t *testing.T) {
 	sentinel := errors.New("lookup failed")
 	jwtAuth := &agentgateway.JWTAuthentication{
 		Mode: agentgateway.JWTAuthenticationModeStrict,
@@ -67,8 +67,15 @@ func TestProcessJWTAuthenticationPolicyWhenLookupReturnsErrorOmitsRemoteProvider
 	if jwtSpec == nil {
 		t.Fatal("expected jwt spec")
 	}
-	if got := len(jwtSpec.Providers); got != 0 {
-		t.Fatalf("expected remote provider to be omitted, got %d providers", got)
+	if got := len(jwtSpec.Providers); got != 1 {
+		t.Fatalf("expected remote provider to be preserved, got %d providers", got)
+	}
+	provider := jwtSpec.Providers[0]
+	if provider.GetInline() != `{"keys":[]}` {
+		t.Fatalf("expected empty key set, got %q", provider.GetInline())
+	}
+	if provider.Issuer != jwtAuth.Providers[0].Issuer || len(provider.Audiences) != 1 || provider.Audiences[0] != "aud-a" {
+		t.Fatalf("expected issuer and audiences to be preserved, got %v", provider)
 	}
 	if jwtSpec.Mode != api.TrafficPolicySpec_JWT_STRICT {
 		t.Fatalf("expected strict mode, got %v", jwtSpec.Mode)
@@ -242,7 +249,7 @@ func TestTranslateMCPAuthenticationSpecTranslatesEmptyRequiredClaims(t *testing.
 	}
 }
 
-func TestTranslateMCPAuthenticationSpecWhenLookupReturnsErrorLeavesInlineEmptyAndReturnsError(t *testing.T) {
+func TestTranslateMCPAuthenticationSpecWhenLookupReturnsErrorEmitsEmptyKeySetAndReturnsError(t *testing.T) {
 	sentinel := errors.New("lookup failed")
 	authn := &agentgateway.MCPAuthentication{
 		Issuer:    "issuer.example",
@@ -273,8 +280,8 @@ func TestTranslateMCPAuthenticationSpecWhenLookupReturnsErrorLeavesInlineEmptyAn
 	if spec == nil {
 		t.Fatal("expected spec to still be emitted")
 	}
-	if spec.JwksInline != "" {
-		t.Fatalf("expected jwks inline to be empty, got %q", spec.JwksInline)
+	if spec.JwksInline != `{"keys":[]}` {
+		t.Fatalf("expected empty key set, got %q", spec.JwksInline)
 	}
 	if spec.Issuer != authn.Issuer {
 		t.Fatalf("expected issuer %q, got %q", authn.Issuer, spec.Issuer)

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/ai.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/ai.yaml
@@ -182,6 +182,33 @@ output:
                     hostname: webhook.default.svc.cluster.local
                     namespace: default
                 failureMode: FAIL_OPEN
+            response:
+            - regex:
+                rules:
+                - regex: bad.*
+                - builtin: EMAIL
+                - builtin: CA_SIN
+                - builtin: PHONE_NUMBER
+                - builtin: SSN
+              rejection:
+                body: cmVnZXggcmVqZWN0ZWQgb24gcmVzcG9uc2U=
+            - webhook:
+                action: REJECT_AUDIT_ACTION_REJECT
+            - bedrockGuardrails:
+                action: REJECT_AUDIT_ACTION_REJECT
+                identifier: bedrock-guardrail-identifier
+                region: us-west-2
+                version: DRAFT
+            - googleModelArmor:
+                action: REJECT_AUDIT_ACTION_REJECT
+                inlinePolicies:
+                - auth:
+                    gcp:
+                      idToken:
+                        audience: https://ai-guardrails.example.com
+                location: us-central1
+                projectId: model-armor-project-id
+                templateId: model-armor-template-id
           prompts:
             append:
             - content: hello!

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-auth-missing-persisted-keyset.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-auth-missing-persisted-keyset.yaml
@@ -60,6 +60,7 @@ output:
           audiences:
           - api://test
           issuer: https://sts.windows.net/test-path/
+          jwksInline: '{"keys":[]}'
           mode: STRICT
           resourceMetadata: {}
       key: default/mcp-auth-missing-persisted-keyset:mcp-authentication:default/be

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-auth-resolver-backend-missing.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/mcp-auth-resolver-backend-missing.yaml
@@ -48,6 +48,7 @@ output:
           audiences:
           - api://test
           issuer: https://sts.windows.net/test-path/
+          jwksInline: '{"keys":[]}'
           mode: STRICT
           resourceMetadata: {}
       key: default/mcp-auth-resolver-backend-missing:mcp-authentication:default/be

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/multi-target-ref-backend-policy.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/multi-target-ref-backend-policy.yaml
@@ -155,6 +155,7 @@ output:
           audiences:
           - api://test
           issuer: https://sts.windows.net/test-path/
+          jwksInline: '{"keys":[]}'
           mode: STRICT
           resourceMetadata:
             extra:
@@ -182,6 +183,7 @@ output:
           audiences:
           - api://test
           issuer: https://sts.windows.net/test-path/
+          jwksInline: '{"keys":[]}'
           mode: STRICT
           resourceMetadata:
             extra:
@@ -209,6 +211,7 @@ output:
           audiences:
           - api://test
           issuer: https://sts.windows.net/test-path/
+          jwksInline: '{"keys":[]}'
           mode: STRICT
           resourceMetadata:
             extra:
@@ -236,6 +239,7 @@ output:
           audiences:
           - api://test
           issuer: https://sts.windows.net/test-path/
+          jwksInline: '{"keys":[]}'
           mode: STRICT
           resourceMetadata:
             extra:

--- a/controller/pkg/agentgateway/plugins/testdata/backendpolicy/prompt-guard-invalid-webhooks.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/backendpolicy/prompt-guard-invalid-webhooks.yaml
@@ -1,0 +1,115 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: prompt-guard-invalid-webhooks
+  namespace: default
+spec:
+  targetRefs:
+  - kind: Gateway
+    name: test
+    group: gateway.networking.k8s.io
+  backend:
+    ai:
+      promptGuard:
+        request:
+        - webhook:
+            backendRef:
+              name: guardrails
+              port: 8000
+            headers:
+              x-session-id: "not( valid cel"
+        - regex:
+            matches:
+            - secret
+        - webhook:
+            backendRef:
+              name: missing-guardrails
+              port: 8000
+            failureMode: FailOpen
+        response:
+        - webhook:
+            backendRef:
+              name: guardrails
+              port: 8000
+            headers:
+              x-session-id: "not( valid cel"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: guardrails
+  namespace: default
+spec:
+  ports:
+  - port: 8000
+
+---
+# Output
+output:
+- gateway:
+    Name: test
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        ai:
+          promptGuard:
+            request:
+            - webhook:
+                action: REJECT_AUDIT_ACTION_REJECT
+                backend:
+                  port: 8000
+                  service:
+                    hostname: guardrails.default.svc.cluster.local
+                    namespace: default
+                headers:
+                  x-session-id: not( valid cel
+            - regex:
+                rules:
+                - regex: secret
+            - webhook:
+                action: REJECT_AUDIT_ACTION_REJECT
+                failureMode: FAIL_OPEN
+            response:
+            - webhook:
+                action: REJECT_AUDIT_ACTION_REJECT
+                backend:
+                  port: 8000
+                  service:
+                    hostname: guardrails.default.svc.cluster.local
+                    namespace: default
+                headers:
+                  x-session-id: not( valid cel
+      key: backend/default/prompt-guard-invalid-webhooks:ai:default/test
+      name:
+        kind: AgentgatewayPolicy
+        name: prompt-guard-invalid-webhooks
+        namespace: default
+      target:
+        gateway:
+          name: test
+          namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayPolicy
+  metadata:
+    name: prompt-guard-invalid-webhooks
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: test
+        namespace: default
+      conditions:
+      - lastTransitionTime: fake
+        message: |-
+          webhook header "x-session-id" is not a valid CEL expression: not( valid cel
+          failed to build webhook: unable to find the Service default/missing-guardrails
+          webhook header "x-session-id" is not a valid CEL expression: not( valid cel
+        reason: PartiallyValid
+        status: "True"
+        type: Accepted
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/jwt-mcp-missing-persisted-keyset.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/jwt-mcp-missing-persisted-keyset.yaml
@@ -1,7 +1,19 @@
 apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: test-jwks
+  namespace: default
+spec:
+  static:
+    host: login.test.com
+    port: 443
+  policies:
+    tls: {}
+---
+apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
-  name: jwt-remote-resolver-backend-missing
+  name: jwt-mcp-missing-persisted-keyset
   namespace: default
 spec:
   targetRefs:
@@ -23,6 +35,12 @@ spec:
               kind: AgentgatewayBackend
               group: agentgateway.dev
             jwksPath: test-path/discovery/v2.0/keys
+      mcp:
+        provider: Auth0
+        resourceMetadata:
+          oauthScopesSupported:
+          - read
+
 ---
 # Output
 output:
@@ -31,10 +49,10 @@ output:
     Namespace: default
   resource:
     policy:
-      key: traffic/default/jwt-remote-resolver-backend-missing:jwt:default/test
+      key: traffic/default/jwt-mcp-missing-persisted-keyset:jwt:default/test
       name:
         kind: AgentgatewayPolicy
-        name: jwt-remote-resolver-backend-missing
+        name: jwt-mcp-missing-persisted-keyset
         namespace: default
       target:
         gateway:
@@ -42,6 +60,12 @@ output:
           namespace: default
       traffic:
         jwt:
+          mcp:
+            provider: AUTH0
+            resourceMetadata:
+              extra:
+                oauthScopesSupported:
+                - read
           mode: STRICT
           providers:
           - audiences:
@@ -53,7 +77,7 @@ status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayPolicy
   metadata:
-    name: jwt-remote-resolver-backend-missing
+    name: jwt-mcp-missing-persisted-keyset
     namespace: default
   spec: null
   status:
@@ -65,7 +89,8 @@ status:
         namespace: default
       conditions:
       - lastTransitionTime: fake
-        message: backend default/test-jwks not found, policy default/jwt-remote-resolver-backend-missing
+        message: jwks keyset for "https://login.test.com:443/test-path/discovery/v2.0/keys"
+          isn't available (not yet fetched or fetch failed)
         reason: PartiallyValid
         status: "True"
         type: Accepted

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/jwt-remote-missing-persisted-keyset.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/jwt-remote-missing-persisted-keyset.yaml
@@ -55,6 +55,11 @@ output:
       traffic:
         jwt:
           mode: STRICT
+          providers:
+          - audiences:
+            - api://test
+            inline: '{"keys":[]}'
+            issuer: https://sts.windows.net/test-path/
         phase: GATEWAY
 status:
 - apiVersion: agentgateway.dev/v1alpha1

--- a/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/jwt-remote-url-missing-persisted-keyset.yaml
+++ b/controller/pkg/agentgateway/plugins/testdata/trafficpolicy/jwt-remote-url-missing-persisted-keyset.yaml
@@ -41,6 +41,11 @@ output:
       traffic:
         jwt:
           mode: STRICT
+          providers:
+          - audiences:
+            - api://test
+            inline: '{"keys":[]}'
+            issuer: https://sts.windows.net/test-path/
         phase: GATEWAY
 status:
 - apiVersion: agentgateway.dev/v1alpha1

--- a/controller/pkg/agentgateway/plugins/traffic_plugin.go
+++ b/controller/pkg/agentgateway/plugins/traffic_plugin.go
@@ -786,7 +786,6 @@ func processJWTAuthenticationPolicy(ctx PolicyCtx, jwt *agentgateway.JWTAuthenti
 			inline, err := resolveJWKSInlineForOwner(ctx, owner)
 			if err != nil {
 				errs = append(errs, err)
-				continue
 			}
 			jp.JwksSource = &api.TrafficPolicySpec_JWTProvider_Inline{Inline: inline}
 			p.Providers = append(p.Providers, jp)

--- a/controller/pkg/agentgateway/translator/testdata/backends/ai-auth-secret-missing-authorization.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/ai-auth-secret-missing-authorization.yaml
@@ -22,7 +22,25 @@ data:
   someOtherKey: dGVzdA==
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - name: backend
+            openai:
+              model: gpt-4
+      inlinePolicies:
+      - auth:
+          key: {}
+      key: default/openai-backend
+      name:
+        name: openai-backend
+        namespace: default
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -35,6 +53,6 @@ status:
     - lastTransitionTime: fake
       message: 'failed to translate backend: secret default/secret-without-auth missing
         Authorization value'
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/ai-auth-secret-missing-custom-key.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/ai-auth-secret-missing-custom-key.yaml
@@ -24,7 +24,25 @@ data:
 
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - name: backend
+            openai:
+              model: gpt-4
+      inlinePolicies:
+      - auth:
+          key: {}
+      key: default/openai-backend
+      name:
+        name: openai-backend
+        namespace: default
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -37,6 +55,6 @@ status:
     - lastTransitionTime: fake
       message: 'failed to translate backend: secret default/secret-without-token missing
         apiToken value'
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/ai-auth-secret-ref-not-found.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/ai-auth-secret-ref-not-found.yaml
@@ -14,7 +14,25 @@ spec:
         name: missing-secret
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - name: backend
+            openai:
+              model: gpt-4
+      inlinePolicies:
+      - auth:
+          key: {}
+      key: default/openai-backend
+      name:
+        name: openai-backend
+        namespace: default
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -26,6 +44,6 @@ status:
     conditions:
     - lastTransitionTime: fake
       message: 'failed to translate backend: secret default/missing-secret not found'
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/ai-webhook-backend-ref-not-found.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/ai-webhook-backend-ref-not-found.yaml
@@ -37,7 +37,13 @@ output:
             name: backend
       inlinePolicies:
       - ai:
-          promptGuard: {}
+          promptGuard:
+            request:
+            - webhook:
+                action: REJECT_AUDIT_ACTION_REJECT
+            response:
+            - webhook:
+                action: REJECT_AUDIT_ACTION_REJECT
       key: default/anthropic-backend
       name:
         name: anthropic-backend

--- a/controller/pkg/agentgateway/translator/testdata/backends/ai-webhook-backend-ref-not-found.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/ai-webhook-backend-ref-not-found.yaml
@@ -23,7 +23,25 @@ spec:
               port: 456
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - anthropic:
+              model: claude-4-5-sonnet
+            name: backend
+      inlinePolicies:
+      - ai:
+          promptGuard: {}
+      key: default/anthropic-backend
+      name:
+        name: anthropic-backend
+        namespace: default
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -37,6 +55,6 @@ status:
       message: |-
         failed to translate backend: failed to build webhook: unable to find the Service default/invalid-request-ref
         failed to build webhook: unable to find the Service default/invalid-response-ref
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/health-invalid-cel.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/health-invalid-cel.yaml
@@ -1,0 +1,64 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  namespace: default
+  name: health-invalid-cel
+spec:
+  ai:
+    groups:
+    - providers:
+      - name: provider-a
+        openai: {}
+        host: mock-llm.default.svc.cluster.local
+        port: 4801
+      - name: provider-b
+        openai: {}
+        host: mock-llm.default.svc.cluster.local
+        port: 4802
+  policies:
+    health:
+      unhealthyCondition: "not( valid cel"
+
+---
+# Output
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - hostOverride:
+              host: mock-llm.default.svc.cluster.local
+              port: 4801
+            name: provider-a
+            openai: {}
+          - hostOverride:
+              host: mock-llm.default.svc.cluster.local
+              port: 4802
+            name: provider-b
+            openai: {}
+      inlinePolicies:
+      - health:
+          unhealthyCondition: not( valid cel
+      key: default/health-invalid-cel
+      name:
+        name: health-invalid-cel
+        namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayBackend
+  metadata:
+    name: health-invalid-cel
+    namespace: default
+  spec: null
+  status:
+    conditions:
+    - lastTransitionTime: fake
+      message: 'failed to translate backend: backend health unhealthyCondition is
+        not a valid CEL expression: not( valid cel'
+      reason: PartiallyValid
+      status: "True"
+      type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-authentication-jwks-missing-persisted-keyset.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-authentication-jwks-missing-persisted-keyset.yaml
@@ -31,6 +31,7 @@ output:
     backend:
       inlinePolicies:
       - mcpAuthentication:
+          jwksInline: '{"keys":[]}'
           mode: STRICT
           resourceMetadata: {}
       key: default/mcp-backend

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-authentication-jwks-missing-persisted-keyset.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-authentication-jwks-missing-persisted-keyset.yaml
@@ -23,7 +23,21 @@ spec:
               port: 8080
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - mcpAuthentication:
+          mode: STRICT
+          resourceMetadata: {}
+      key: default/mcp-backend
+      mcp: {}
+      name:
+        name: mcp-backend
+        namespace: default
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -36,6 +50,6 @@ status:
     - lastTransitionTime: fake
       message: 'failed to translate backend: jwks keyset for "http://store-uninitialized.default.svc.cluster.local:8080/"
         isn''t available (not yet fetched or fetch failed)'
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-authentication-jwks-resolver-backend-missing.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-authentication-jwks-resolver-backend-missing.yaml
@@ -22,7 +22,21 @@ spec:
               name: test-jwks
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - mcpAuthentication:
+          mode: STRICT
+          resourceMetadata: {}
+      key: default/mcp-backend
+      mcp: {}
+      name:
+        name: mcp-backend
+        namespace: default
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -35,6 +49,6 @@ status:
     - lastTransitionTime: fake
       message: 'failed to translate backend: backend default/test-jwks not found,
         policy default/inline_policy'
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-authentication-jwks-resolver-backend-missing.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-authentication-jwks-resolver-backend-missing.yaml
@@ -30,6 +30,7 @@ output:
     backend:
       inlinePolicies:
       - mcpAuthentication:
+          jwksInline: '{"keys":[]}'
           mode: STRICT
           resourceMetadata: {}
       key: default/mcp-backend

--- a/controller/pkg/agentgateway/translator/testdata/backends/mcp-static-policy-error.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/mcp-static-policy-error.yaml
@@ -17,7 +17,37 @@ spec:
               name: missing-secret
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      key: default/mcp-static-policy-error
+      mcp:
+        targets:
+        - backend:
+            backend: default/mcp-static-policy-error/target-with-bad-policy
+          name: target-with-bad-policy
+          protocol: SSE
+      name:
+        name: mcp-static-policy-error
+        namespace: default
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - auth:
+          key: {}
+      key: default/mcp-static-policy-error/target-with-bad-policy
+      name:
+        name: mcp-static-policy-error
+        namespace: default
+      static:
+        host: mcp-server.example.com
+        port: 8080
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -29,6 +59,6 @@ status:
     conditions:
     - lastTransitionTime: fake
       message: 'failed to translate backend: secret default/missing-secret not found'
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/oauth-secret-ref-not-found.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/oauth-secret-ref-not-found.yaml
@@ -36,6 +36,26 @@ output:
     Namespace: default
   resource:
     backend:
+      inlinePolicies:
+      - auth:
+          oauthTokenExchange:
+            clientAuth:
+              clientId: gateway
+              clientSecret: ""
+            tokenEndpoint:
+              backend: default/token-endpoint
+      key: default/static-backend
+      name:
+        name: static-backend
+        namespace: default
+      static:
+        host: example.com
+        port: 8888
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
       key: default/token-endpoint
       name:
         name: token-endpoint
@@ -54,8 +74,8 @@ status:
     conditions:
     - lastTransitionTime: fake
       message: 'failed to translate backend: secret default/missing-secret not found'
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend

--- a/controller/pkg/agentgateway/translator/testdata/backends/session-affinity-invalid-cel.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/session-affinity-invalid-cel.yaml
@@ -1,0 +1,64 @@
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  namespace: default
+  name: session-affinity-invalid-cel
+spec:
+  ai:
+    groups:
+    - providers:
+      - name: provider-a
+        openai: {}
+        host: mock-llm.default.svc.cluster.local
+        port: 4801
+      - name: provider-b
+        openai: {}
+        host: mock-llm.default.svc.cluster.local
+        port: 4802
+  policies:
+    sessionAffinity:
+      source: "not( valid cel"
+
+---
+# Output
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      ai:
+        providerGroups:
+        - providers:
+          - hostOverride:
+              host: mock-llm.default.svc.cluster.local
+              port: 4801
+            name: provider-a
+            openai: {}
+          - hostOverride:
+              host: mock-llm.default.svc.cluster.local
+              port: 4802
+            name: provider-b
+            openai: {}
+      inlinePolicies:
+      - sessionAffinity:
+          source: not( valid cel
+      key: default/session-affinity-invalid-cel
+      name:
+        name: session-affinity-invalid-cel
+        namespace: default
+status:
+- apiVersion: agentgateway.dev/v1alpha1
+  kind: AgentgatewayBackend
+  metadata:
+    name: session-affinity-invalid-cel
+    namespace: default
+  spec: null
+  status:
+    conditions:
+    - lastTransitionTime: fake
+      message: 'failed to translate backend: backend sessionAffinity source is not
+        a valid CEL expression: not( valid cel'
+      reason: PartiallyValid
+      status: "True"
+      type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/static-secrets-not-found.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/static-secrets-not-found.yaml
@@ -13,7 +13,22 @@ spec:
         name: missing-secret
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - auth:
+          key: {}
+      key: default/static-backend
+      name:
+        name: static-backend
+        namespace: default
+      static:
+        host: example.com
+        port: 8888
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -25,6 +40,6 @@ status:
     conditions:
     - lastTransitionTime: fake
       message: 'failed to translate backend: secret default/missing-secret not found'
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/agentgateway/translator/testdata/backends/static-tls-ca-bundle-not-found.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/static-tls-ca-bundle-not-found.yaml
@@ -15,7 +15,22 @@ spec:
       - name: unknown-ca-bundle
 ---
 # Output
-output: []
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    backend:
+      inlinePolicies:
+      - backendTls:
+          root: ""
+      key: default/tls-backend
+      name:
+        name: tls-backend
+        namespace: default
+      static:
+        host: example.com
+        port: 8888
 status:
 - apiVersion: agentgateway.dev/v1alpha1
   kind: AgentgatewayBackend
@@ -29,6 +44,6 @@ status:
       message: |-
         failed to translate backend: secret default/unknown-mtls not found
         ConfigMap default/unknown-ca-bundle not found
-      reason: TranslationError
-      status: "False"
+      reason: PartiallyValid
+      status: "True"
       type: Accepted

--- a/controller/pkg/syncer/backend/backend_plugin.go
+++ b/controller/pkg/syncer/backend/backend_plugin.go
@@ -231,18 +231,27 @@ func TranslateAgwBackend(
 ) (*agentgateway.AgentgatewayBackendStatus, []agwir.AgwResource) {
 	var results []agwir.AgwResource
 	backends, err := BuildAgwBackend(ctx, backend)
+	condition := metav1.Condition{
+		Type:               "Accepted",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Accepted",
+		Message:            "Backend successfully accepted",
+		ObservedGeneration: backend.Generation,
+		LastTransitionTime: metav1.Now(),
+	}
 	if err != nil {
 		logger.Error("failed to translate backend", "backend", backend.Name, "namespace", backend.Namespace, "err", err)
-		return &agentgateway.AgentgatewayBackendStatus{
-			Conditions: kstatus.UpdateConditionIfChanged(backend.Status.Conditions, metav1.Condition{
-				Type:               "Accepted",
-				Status:             metav1.ConditionFalse,
-				Reason:             "TranslationError",
-				Message:            fmt.Sprintf("failed to translate backend: %v", err),
-				ObservedGeneration: backend.Generation,
-				LastTransitionTime: metav1.Now(),
-			}),
-		}, results
+		condition.Message = fmt.Sprintf("failed to translate backend: %v", err)
+		condition.Reason = "PartiallyValid"
+		// Policy translation can return usable output alongside diagnostics. Preserve
+		// that output, including policies that enforce failure in the data plane.
+		if len(backends) == 0 {
+			condition.Status = metav1.ConditionFalse
+			condition.Reason = "TranslationError"
+			return &agentgateway.AgentgatewayBackendStatus{
+				Conditions: kstatus.UpdateConditionIfChanged(backend.Status.Conditions, condition),
+			}, results
+		}
 	}
 
 	gtws := references.LookupGatewaysForBackend(ctx.Krt, utils.TypedNamespacedName{
@@ -263,14 +272,7 @@ func TranslateAgwBackend(
 	}
 
 	return &agentgateway.AgentgatewayBackendStatus{
-		Conditions: kstatus.UpdateConditionIfChanged(backend.Status.Conditions, metav1.Condition{
-			Type:               "Accepted",
-			Status:             metav1.ConditionTrue,
-			Reason:             "Accepted",
-			Message:            "Backend successfully accepted",
-			ObservedGeneration: backend.Generation,
-			LastTransitionTime: metav1.Now(),
-		}),
+		Conditions: kstatus.UpdateConditionIfChanged(backend.Status.Conditions, condition),
 	}, results
 }
 

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -4697,6 +4697,68 @@ mod tests {
 		Ok(())
 	}
 
+	#[tokio::test]
+	async fn mcp_empty_jwks_loads_and_rejects_authentication() -> Result<(), ProtoError> {
+		use proto::agent::traffic_policy_spec as tps;
+
+		use crate::http::jwt::TokenError;
+
+		let spec = proto::agent::TrafficPolicySpec {
+			kind: Some(tps::Kind::Jwt(tps::Jwt {
+				mode: tps::jwt::Mode::Strict as i32,
+				providers: vec![tps::JwtProvider {
+					issuer: "https://issuer.example.com".into(),
+					jwks_source: Some(tps::jwt_provider::JwksSource::Inline(
+						r#"{"keys":[]}"#.into(),
+					)),
+					..Default::default()
+				}],
+				mcp: Some(Default::default()),
+				..Default::default()
+			})),
+			..Default::default()
+		};
+		let mut diagnostics = Diagnostics::default();
+		let TrafficPolicy::JwtAuth(policy) = traffic_policy_from_proto(&spec, &mut diagnostics)? else {
+			panic!("expected JWT auth policy");
+		};
+		let jwt = &policy.iter().next().expect("expected JWT policy").pol;
+		let mcp = jwt.mcp.as_ref().expect("expected MCP extension");
+		let legacy = mcp_authentication_from_proto(
+			&proto::agent::backend_policy_spec::McpAuthentication {
+				issuer: "https://issuer.example.com".into(),
+				jwks_inline: r#"{"keys":[]}"#.into(),
+				mode: proto::agent::backend_policy_spec::mcp_authentication::Mode::Strict as i32,
+				..Default::default()
+			},
+			&mut diagnostics,
+		)?;
+		assert!(diagnostics.into_warnings().is_empty());
+
+		for validator in [
+			&jwt.jwt,
+			mcp.jwt_validator.as_ref(),
+			legacy.jwt_validator.as_ref(),
+		] {
+			let mut request = ::http::Request::new(crate::http::Body::empty());
+			assert!(matches!(
+				validator.apply(None, &mut request).await,
+				Err(TokenError::Missing)
+			));
+			request.headers_mut().insert(
+				::http::header::AUTHORIZATION,
+				format!("Bearer {}", build_unsigned_token("kid"))
+					.parse()
+					.unwrap(),
+			);
+			assert!(matches!(
+				validator.apply(None, &mut request).await,
+				Err(TokenError::UnknownKeyId(kid)) if kid == "kid"
+			));
+		}
+		Ok(())
+	}
+
 	#[test]
 	fn test_policy_spec_to_csrf_policy() -> Result<(), ProtoError> {
 		// Test CSRF policy conversion with deduplication


### PR DESCRIPTION
Before, when a backend inline policy was invalid we dropped the entire backend. Now we just emit a partially invalid one.

Followup commits are adjacent fixes:
* Webhook should partially degrade
* JWKS should partially degrade

related https://github.com/agentgateway/agentgateway/issues/1438