### PR TITLE
AgentgatewayModel: avoid overrwriting default routes

### DIFF
--- a/controller/test/e2e/modelrouting_test.go
+++ b/controller/test/e2e/modelrouting_test.go
@@ -115,6 +115,25 @@ func testGatewayBoundModelsUseDefaultRoute(t base.Test, gw base.Gateway) {
 		modelRoutingExpectModel("agw-public-direct"),
 		modelRoutingCompletion("public-direct")...,
 	)
+
+	// This model has transformations; they must preserve the Messages route format.
+	expected := modelRoutingExpectModel("agw-public-direct")
+	expected.Body = gomega.And(
+		gomega.ContainSubstring(`"type":"message"`),
+		gomega.ContainSubstring(`"content":[{"type":"text","text":"The name of this project is agentgateway"}]`),
+		gomega.ContainSubstring(`"stop_reason":"end_turn"`),
+		gomega.ContainSubstring(`"input_tokens":10`),
+		gomega.ContainSubstring(`"output_tokens":10`),
+		gomega.Not(gomega.ContainSubstring(`"choices"`)),
+	)
+	gw.Send(
+		t,
+		expected,
+		curl.WithPath("/v1/messages"),
+		curl.WithPostBody(`{"model":"public-direct","max_tokens":128,"messages":[{"role":"user","content":[{"type":"text","text":"What is the name of this project?"}]}]}`),
+		curl.WithHeader("Content-Type", "application/json"),
+		curl.WithHeader("anthropic-version", "2023-06-01"),
+	)
 }
 
 func testAgentgatewayModelWeightedRouting(t base.Test, gw base.Gateway) {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -1646,7 +1646,14 @@ impl ModelRoute {
 		let llm_policy = s
 			.ai_policy
 			.as_ref()
-			.map(|policy| convert_backend_ai_policy(policy, diagnostics).map(Arc::new))
+			.map(|policy| {
+				let mut policy = convert_backend_ai_policy(policy, diagnostics)?;
+				// Preserve default model endpoint formats when the policy does not specify routes.
+				if policy.routes.is_empty() {
+					policy.routes = llm::model_router::default_route_types().routes.clone();
+				}
+				Ok::<_, ProtoError>(Arc::new(policy))
+			})
 			.transpose()?
 			.unwrap_or_else(llm::model_router::default_route_types);
 		let authorization = s
@@ -5245,7 +5252,10 @@ mod tests {
 				}),
 				backend_policies: vec![],
 			})),
-			ai_policy: None,
+			ai_policy: Some(proto::agent::backend_policy_spec::Ai {
+				transformations: [("model".to_string(), "\"gpt-5-mini\"".to_string())].into(),
+				..Default::default()
+			}),
 			authorization: Some(proto::agent::traffic_policy_spec::Rbac {
 				allow: vec!["request.headers['x-model-access'] == 'allowed'".to_string()],
 				deny: vec![],
@@ -5274,6 +5284,11 @@ mod tests {
 				.contains_key("/v1/chat/completions")
 		);
 		assert!(model.policies.authorization.is_some());
+		assert!(model.policies.llm.transformations.is_some());
+		assert_eq!(
+			model.policies.llm.resolve_route("/v1/messages"),
+			llm::RouteType::Messages
+		);
 		assert_eq!(model.backend.weight, 1);
 		match model.backend.target {
 			RouteBackendTarget::Backend(key) => {


### PR DESCRIPTION
Signed-off-by: John Howard <john.howard@solo.io>
