### PR TITLE
fix: preserve trailing slash in ReplaceFullPath rewrite and redirect

### DIFF
--- a/controller/pkg/agentgateway/translator/agw.go
+++ b/controller/pkg/agentgateway/translator/agw.go
@@ -196,7 +196,7 @@ func CreateAgwRewriteFilter(filter *gwv1.HTTPURLRewriteFilter) *api.TrafficPolic
 		case gwv1.PrefixMatchHTTPPathModifier:
 			ff.Path = &api.UrlRewrite_Prefix{Prefix: strings.TrimSuffix(*filter.Path.ReplacePrefixMatch, "/")}
 		case gwv1.FullPathHTTPPathModifier:
-			ff.Path = &api.UrlRewrite_Full{Full: strings.TrimSuffix(*filter.Path.ReplaceFullPath, "/")}
+			ff.Path = &api.UrlRewrite_Full{Full: *filter.Path.ReplaceFullPath}
 		}
 	}
 	return &api.TrafficPolicySpec{
@@ -357,7 +357,7 @@ func CreateAgwRedirectFilter(filter *gwv1.HTTPRequestRedirectFilter) *api.Reques
 		case gwv1.PrefixMatchHTTPPathModifier:
 			ff.Path = &api.RequestRedirect_Prefix{Prefix: strings.TrimSuffix(*filter.Path.ReplacePrefixMatch, "/")}
 		case gwv1.FullPathHTTPPathModifier:
-			ff.Path = &api.RequestRedirect_Full{Full: strings.TrimSuffix(*filter.Path.ReplaceFullPath, "/")}
+			ff.Path = &api.RequestRedirect_Full{Full: *filter.Path.ReplaceFullPath}
 		}
 	}
 	return ff

--- a/controller/pkg/agentgateway/translator/agw_test.go
+++ b/controller/pkg/agentgateway/translator/agw_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"istio.io/istio/pkg/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -23,7 +22,7 @@ func TestCreateAgwRewriteFilterFullPath(t *testing.T) {
 			spec := CreateAgwRewriteFilter(&gwv1.HTTPURLRewriteFilter{
 				Path: &gwv1.HTTPPathModifier{
 					Type:            gwv1.FullPathHTTPPathModifier,
-					ReplaceFullPath: ptr.Of(tc.path),
+					ReplaceFullPath: new(tc.path),
 				},
 			})
 			rewrite := spec.GetUrlRewrite()
@@ -37,7 +36,7 @@ func TestCreateAgwRewriteFilterPrefix(t *testing.T) {
 	spec := CreateAgwRewriteFilter(&gwv1.HTTPURLRewriteFilter{
 		Path: &gwv1.HTTPPathModifier{
 			Type:               gwv1.PrefixMatchHTTPPathModifier,
-			ReplacePrefixMatch: ptr.Of("/app/"),
+			ReplacePrefixMatch: new("/app/"),
 		},
 	})
 	rewrite := spec.GetUrlRewrite()
@@ -60,7 +59,7 @@ func TestCreateAgwRedirectFilterFullPath(t *testing.T) {
 			redirect := CreateAgwRedirectFilter(&gwv1.HTTPRequestRedirectFilter{
 				Path: &gwv1.HTTPPathModifier{
 					Type:            gwv1.FullPathHTTPPathModifier,
-					ReplaceFullPath: ptr.Of(tc.path),
+					ReplaceFullPath: new(tc.path),
 				},
 			})
 			assert.Equal(t, tc.want, redirect.GetFull())

--- a/controller/pkg/agentgateway/translator/agw_test.go
+++ b/controller/pkg/agentgateway/translator/agw_test.go
@@ -1,0 +1,69 @@
+package translator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"istio.io/istio/pkg/ptr"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestCreateAgwRewriteFilterFullPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"trailing slash preserved", "/app/", "/app/"},
+		{"no trailing slash", "/app", "/app"},
+		{"root", "/", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := CreateAgwRewriteFilter(&gwv1.HTTPURLRewriteFilter{
+				Path: &gwv1.HTTPPathModifier{
+					Type:            gwv1.FullPathHTTPPathModifier,
+					ReplaceFullPath: ptr.Of(tc.path),
+				},
+			})
+			rewrite := spec.GetUrlRewrite()
+			assert.NotNil(t, rewrite)
+			assert.Equal(t, tc.want, rewrite.GetFull())
+		})
+	}
+}
+
+func TestCreateAgwRewriteFilterPrefix(t *testing.T) {
+	spec := CreateAgwRewriteFilter(&gwv1.HTTPURLRewriteFilter{
+		Path: &gwv1.HTTPPathModifier{
+			Type:               gwv1.PrefixMatchHTTPPathModifier,
+			ReplacePrefixMatch: ptr.Of("/app/"),
+		},
+	})
+	rewrite := spec.GetUrlRewrite()
+	assert.NotNil(t, rewrite)
+	assert.Equal(t, "/app", rewrite.GetPrefix())
+}
+
+func TestCreateAgwRedirectFilterFullPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"trailing slash preserved", "/app/", "/app/"},
+		{"no trailing slash", "/app", "/app"},
+		{"root", "/", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			redirect := CreateAgwRedirectFilter(&gwv1.HTTPRequestRedirectFilter{
+				Path: &gwv1.HTTPPathModifier{
+					Type:            gwv1.FullPathHTTPPathModifier,
+					ReplaceFullPath: ptr.Of(tc.path),
+				},
+			})
+			assert.Equal(t, tc.want, redirect.GetFull())
+		})
+	}
+}


### PR DESCRIPTION
The URLRewrite filter's ReplaceFullPath value had its trailing slash trimmed during translation, so a route configured with replaceFullPath: `/app/` forwarded `/app` to the backend.
Backends that require the trailing slash answer that with a 307 redirect.
RequestRedirect shared the same code path, so its Location header lost the slash too.

Prefix rewrites were unaffected, since the data plane re-joins the remaining path with a separator.

The fix passes the configured full path through verbatim instead of trimming it, in both the rewrite and redirect translators, and keeps the trim for prefix rewrites.

- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
