### PR TITLE
fix(3384): stable sorting and inclusion of parent CreationTimestamp on ListenerSets

### DIFF
--- a/controller/pkg/agentgateway/translator/gateway_collection.go
+++ b/controller/pkg/agentgateway/translator/gateway_collection.go
@@ -358,7 +358,7 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 		// Ref: https://gateway-api.sigs.k8s.io/geps/gep-1713/#listener-precedence
 		// - ListenerSet ordered by creation time (oldest first)
 		// - ListenerSet ordered alphabetically by “{namespace}/{name}”
-		slices.SortFunc(listenersFromSets, func(a, b ListenerSet) int {
+		slices.SortStableFunc(listenersFromSets, func(a, b ListenerSet) int {
 			// primary sort: creation timestamp (oldest first)
 			if r := a.ParentInfo.CreationTimestamp.Compare(b.ParentInfo.CreationTimestamp.Time); r != 0 {
 				return r
@@ -367,7 +367,10 @@ func GatewayTransformationFunc(cfg GatewayCollectionConfig) func(ctx krt.Handler
 			if r := cmp.Compare(a.Parent.Namespace, b.Parent.Namespace); r != 0 {
 				return r
 			}
-			return cmp.Compare(a.Parent.Name, b.Parent.Name)
+			if r := cmp.Compare(a.Parent.Name, b.Parent.Name); r != 0 {
+				return r
+			}
+			return cmp.Compare(a.ListenerIndex, b.ListenerIndex)
 		})
 
 		for _, ls := range listenersFromSets {
@@ -445,6 +448,7 @@ func validateListenerConflicts(listeners []*GatewayListener) {
 type ListenerSet struct {
 	Name          string               `json:"name"`
 	Parent        types.NamespacedName `json:"parent"`
+	ListenerIndex int                  `json:"listenerIndex"`
 	ParentInfo    ParentInfo           `json:"parentInfo"`
 	TLSInfo       *TLSInfo             `json:"tlsInfo"`
 	GatewayParent types.NamespacedName `json:"gatewayParent"`
@@ -475,6 +479,7 @@ func (g ListenerSet) Equals(other ListenerSet) bool {
 		g.Name == other.Name &&
 		g.GatewayParent == other.GatewayParent &&
 		g.Parent == other.Parent &&
+		g.ListenerIndex == other.ListenerIndex &&
 		g.ParentInfo.Equals(other.ParentInfo)
 }
 
@@ -553,16 +558,17 @@ func ListenerSetBuilder(
 
 		allowed, _ := GenerateSupportedKinds(standardListener, enableAgentgatewayModels)
 		pri := ParentInfo{
-			ParentGateway:    config.NamespacedName(parentGwObj),
-			ListenerKey:      name,
-			AllowedKinds:     allowed,
-			Hostnames:        hostnames,
-			OriginalHostname: string(ptr.OrEmpty(l.Hostname)),
-			SectionName:      l.Name,
-			Port:             l.Port,
-			Protocol:         l.Protocol,
-			TLSPassthrough:   l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gwv1.TLSModePassthrough,
-			Internal:         internalPorts.Has(l.Port),
+			ParentGateway:     config.NamespacedName(parentGwObj),
+			ListenerKey:       name,
+			AllowedKinds:      allowed,
+			Hostnames:         hostnames,
+			OriginalHostname:  string(ptr.OrEmpty(l.Hostname)),
+			SectionName:       l.Name,
+			Port:              l.Port,
+			Protocol:          l.Protocol,
+			TLSPassthrough:    l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gwv1.TLSModePassthrough,
+			Internal:          internalPorts.Has(l.Port),
+			CreationTimestamp: obj.CreationTimestamp,
 		}
 
 		res := ListenerSet{
@@ -571,6 +577,7 @@ func ListenerSetBuilder(
 			TLSInfo:       tlsInfo,
 			Parent:        config.NamespacedName(obj),
 			GatewayParent: config.NamespacedName(parentGwObj),
+			ListenerIndex: i,
 			ParentInfo:    pri,
 		}
 		result = append(result, res)

--- a/controller/pkg/agentgateway/translator/testdata/gateways/listenerset-precedence.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/gateways/listenerset-precedence.yaml
@@ -1,0 +1,363 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example
+  namespace: default
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: gw-8080
+      protocol: HTTP
+      port: 8080
+      hostname: gateway.example.com
+  allowedListeners:
+    namespaces:
+      from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: aaa-newer
+  namespace: default
+  creationTimestamp: "2026-01-02T00:00:00Z"
+spec:
+  parentRef:
+    name: example
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: shared
+      protocol: HTTP
+      port: 8080
+      hostname: shared.example.com
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: ListenerSet
+metadata:
+  name: zzz-older
+  namespace: default
+  creationTimestamp: "2026-01-01T00:00:00Z"
+spec:
+  parentRef:
+    name: example
+    kind: Gateway
+    group: gateway.networking.k8s.io
+  listeners:
+    - name: shared
+      protocol: HTTP
+      port: 8080
+      hostname: shared.example.com
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: first-on-8081
+      protocol: HTTP
+      port: 8081
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: second-on-8081
+      protocol: TCP
+      port: 8081
+      allowedRoutes:
+        namespaces:
+          from: All
+
+---
+# Output
+output:
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    bind:
+      key: 8080/default/example
+      port: 8080
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    bind:
+      key: 8081/default/example
+      port: 8081
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 8080/default/example
+      hostname: shared.example.com
+      key: default/aaa-newer.shared
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: shared
+        listenerSet:
+          name: aaa-newer
+          namespace: default
+      protocol: HTTP
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 8080/default/example
+      hostname: gateway.example.com
+      key: default/example.gw-8080
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: gw-8080
+      protocol: HTTP
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 8081/default/example
+      key: default/zzz-older.first-on-8081
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: first-on-8081
+        listenerSet:
+          name: zzz-older
+          namespace: default
+      protocol: HTTP
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 8081/default/example
+      key: default/zzz-older.second-on-8081
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: second-on-8081
+        listenerSet:
+          name: zzz-older
+          namespace: default
+      protocol: TCP
+- gateway:
+    Name: example
+    Namespace: default
+  resource:
+    listener:
+      bindKey: 8080/default/example
+      hostname: shared.example.com
+      key: default/zzz-older.shared
+      name:
+        gatewayName: example
+        gatewayNamespace: default
+        listenerName: shared
+        listenerSet:
+          name: zzz-older
+          namespace: default
+      protocol: HTTP
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    name: aaa-newer
+    namespace: default
+  spec: null
+  status:
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: ListenersNotValid
+      status: "False"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: ""
+      reason: ListenersNotValid
+      status: "False"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: Found conflicting hostnames on listeners, all listeners on a single
+          port must have unique hostnames
+        reason: HostnameConflict
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Found conflicting hostnames on listeners, all listeners on a single
+          port must have unique hostnames
+        reason: HostnameConflict
+        status: "True"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: Found conflicting hostnames on listeners, all listeners on a single
+          port must have unique hostnames
+        reason: HostnameConflict
+        status: "False"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: shared
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: ListenerSet
+  metadata:
+    name: zzz-older
+    namespace: default
+  spec: null
+  status:
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: ListenersNotValid
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: ""
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: shared
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: first-on-8081
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: Found conflicting protocols on listeners, a single port can only
+          contain listeners with compatible protocols
+        reason: ProtocolConflict
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Found conflicting protocols on listeners, a single port can only
+          contain listeners with compatible protocols
+        reason: ProtocolConflict
+        status: "True"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: Found conflicting protocols on listeners, a single port can only
+          contain listeners with compatible protocols
+        reason: ProtocolConflict
+        status: "False"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: second-on-8081
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: TCPRoute
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: example
+    namespace: default
+  spec: null
+  status:
+    attachedListenerSets: 1
+    conditions:
+    - lastTransitionTime: fake
+      message: ""
+      reason: Accepted
+      status: "True"
+      type: Accepted
+    - lastTransitionTime: fake
+      message: Successfully programmed Gateway
+      reason: Programmed
+      status: "True"
+      type: Programmed
+    listeners:
+    - attachedRoutes: 0
+      conditions:
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: NoConflicts
+        status: "False"
+        type: Conflicted
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: Programmed
+        status: "True"
+        type: Programmed
+      - lastTransitionTime: fake
+        message: No errors found
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      name: gw-8080
+      supportedKinds:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+      - group: gateway.networking.k8s.io
+        kind: GRPCRoute


### PR DESCRIPTION
- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.

Fixes #3384 