### PR TITLE
llm: always treat baseURL as the full base URL

### DIFF
--- a/controller/api/tests/testdata/agentgateway_model_valid.yaml
+++ b/controller/api/tests/testdata/agentgateway_model_valid.yaml
@@ -25,7 +25,7 @@ spec:
   match:
     model: gpt-5-mini
   provider: OpenAI
-  baseURL: https://api.openai.com
+  baseURL: https://api.openai.com/v1
   policies:
     authorization:
       policy:

--- a/controller/api/v1alpha1/agentgateway/agentgateway_model_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_model_types.go
@@ -104,6 +104,10 @@ type AgentgatewayModelSpec struct {
 	// BaseURL overrides the provider address and base path prefix. It must use the
 	// http or https scheme. Backend policies may override the default TLS
 	// configuration. Query parameters, fragments, and user info are not supported.
+	// The URL path is the upstream base path and defaults to / when omitted.
+	// Provider-specific endpoint paths are appended to this base path.
+	// For example, https://api.openai.com/v1 sends completions to /v1/chat/completions,
+	// while https://api.openai.com sends them to /chat/completions.
 	// +kubebuilder:validation:Format=uri
 	// +optional
 	BaseURL *LongString `json:"baseURL,omitempty"`

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -101,6 +101,10 @@ spec:
                   BaseURL overrides the provider address and base path prefix. It must use the
                   http or https scheme. Backend policies may override the default TLS
                   configuration. Query parameters, fragments, and user info are not supported.
+                  The URL path is the upstream base path and defaults to / when omitted.
+                  Provider-specific endpoint paths are appended to this base path.
+                  For example, https://api.openai.com/v1 sends completions to /v1/chat/completions,
+                  while https://api.openai.com sends them to /chat/completions.
                 format: uri
                 maxLength: 1024
                 minLength: 1

--- a/controller/test/e2e/testdata/modelrouting/setup.yaml
+++ b/controller/test/e2e/testdata/modelrouting/setup.yaml
@@ -61,7 +61,7 @@ spec:
     name: model-routing
     sectionName: llm
   provider: OpenAI
-  baseURL: http://ai-testbox.default.svc.cluster.local:9234
+  baseURL: http://ai-testbox.default.svc.cluster.local:9234/v1
   policies:
     transformations:
     - field: model
@@ -80,7 +80,7 @@ spec:
     sectionName: llm
   visibility: Internal
   provider: OpenAI
-  baseURL: http://ai-testbox.default.svc.cluster.local:9234
+  baseURL: http://ai-testbox.default.svc.cluster.local:9234/v1
   policies:
     transformations:
     - field: model
@@ -99,7 +99,7 @@ spec:
     sectionName: llm
   visibility: Internal
   provider: OpenAI
-  baseURL: http://ai-testbox.default.svc.cluster.local:9234
+  baseURL: http://ai-testbox.default.svc.cluster.local:9234/v1
   policies:
     transformations:
     - field: model
@@ -120,7 +120,7 @@ spec:
     model: internal/*
   visibility: Internal
   provider: OpenAI
-  baseURL: http://ai-testbox.default.svc.cluster.local:9234
+  baseURL: http://ai-testbox.default.svc.cluster.local:9234/v1
   policies:
     transformations:
     - field: model
@@ -139,7 +139,7 @@ spec:
     sectionName: llm
   visibility: Internal
   provider: OpenAI
-  baseURL: http://model-routing-primary.default.svc.cluster.local:9235
+  baseURL: http://model-routing-primary.default.svc.cluster.local:9235/v1
   policies:
     health:
       eviction:
@@ -239,7 +239,7 @@ spec:
     sectionName: llm
   visibility: Internal
   provider: OpenAI
-  baseURL: http://model-routing-primary.default.svc.cluster.local:9235
+  baseURL: http://model-routing-primary.default.svc.cluster.local:9235/v1
   policies:
     authorization:
       policy:
@@ -265,7 +265,7 @@ spec:
     sectionName: llm
   visibility: Internal
   provider: OpenAI
-  baseURL: http://ai-testbox.default.svc.cluster.local:9234
+  baseURL: http://ai-testbox.default.svc.cluster.local:9234/v1
   policies:
     authorization:
       policy:
@@ -348,7 +348,7 @@ spec:
     name: scoped-models
     sectionName: models
   provider: OpenAI
-  baseURL: http://ai-testbox.default.svc.cluster.local:9234
+  baseURL: http://ai-testbox.default.svc.cluster.local:9234/v1
   policies:
     transformations:
     - field: model
@@ -425,7 +425,7 @@ spec:
     name: tenant-a-models
     sectionName: models
   provider: OpenAI
-  baseURL: http://ai-testbox.default.svc.cluster.local:9234
+  baseURL: http://ai-testbox.default.svc.cluster.local:9234/v1
   policies:
     transformations:
     - field: model
@@ -443,7 +443,7 @@ spec:
     name: tenant-b-models
     sectionName: models
   provider: OpenAI
-  baseURL: http://ai-testbox.default.svc.cluster.local:9234
+  baseURL: http://ai-testbox.default.svc.cluster.local:9234/v1
   policies:
     transformations:
     - field: model

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -226,7 +226,7 @@ fn provider_connection_from_url(
 		host_override: Some(Target::from((host, port))),
 		path_prefix: {
 			let path = url.path().trim_end_matches('/');
-			(!path.is_empty()).then(|| strng::new(path))
+			Some(strng::new(if path.is_empty() { "/" } else { path }))
 		},
 		use_tls: url.scheme() == "https",
 	})
@@ -5756,6 +5756,11 @@ mod tests {
 
 	#[test]
 	fn test_provider_connection_precedence() -> Result<(), ProtoError> {
+		for base_url in ["http://override.example", "http://override.example/"] {
+			let connection = provider_connection_from_url(base_url, 0)?;
+			assert_eq!(connection.path_prefix.as_deref(), Some("/"));
+		}
+
 		let explicit = resolve_provider_connection(
 			Some(llm::custom::ProviderPreset::Ollama),
 			Some("https://override.example/v2/"),

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -937,6 +937,10 @@ pub struct LocalLLMParams {
 	/// For Azure: the Foundry project name (required for foundry resource type)
 	azure_project_name: Option<Strng>,
 	/// Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs.
+	/// The URL path is the upstream base path and defaults to / when omitted.
+	/// Provider-specific endpoint paths are appended to this base path.
+	/// For example, https://api.openai.com/v1 sends completions to /v1/chat/completions,
+	/// while https://api.openai.com sends them to /chat/completions.
 	#[serde(default)]
 	base_url: Option<Strng>,
 	/// Override the upstream host for this provider.
@@ -1063,11 +1067,11 @@ impl LocalLLMModels {
 			.host_override
 			.get_or_insert_with(|| (host, port).into());
 		let path = url.path().trim_end_matches('/');
-		if !path.is_empty() && self.params.path_override.is_none() {
+		if self.params.path_override.is_none() {
 			self
 				.params
 				.path_prefix
-				.get_or_insert_with(|| strng::new(path));
+				.get_or_insert_with(|| strng::new(if path.is_empty() { "/" } else { path }));
 		}
 		if url.scheme() == "https" && self.backend_tls.is_none() {
 			self.backend_tls = Some(http::backendtls::LocalBackendTLS::default());

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -1038,6 +1038,7 @@ llm:
 		panic!("expected custom provider");
 	};
 	assert_eq!(custom_provider.model.as_deref(), Some("upstream-custom"));
+	assert_eq!(provider.path_prefix.as_deref(), Some("/"));
 	assert!(custom_provider.formats.iter().any(|format| format.format
 		== crate::llm::custom::ProviderFormat::Messages
 		&& format.path.as_deref() == Some("/api/messages")));

--- a/crates/agentgateway/tests/tests/llm.rs
+++ b/crates/agentgateway/tests/tests/llm.rs
@@ -346,11 +346,11 @@ llm:
   - name: openai/*
     provider: openAI
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
   - name: direct-model
     provider: openAI
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
 "#,
 		mock.address(),
 		mock.address(),
@@ -389,7 +389,7 @@ llm:
       rules:
       - 'request.headers["x-model-auth"] == "yes"'
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
     health:
       eviction: {{}}
       unhealthyExpression: 'response.code == 403'
@@ -397,7 +397,7 @@ llm:
     visibility: internal
     provider: openai
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
     transformation:
       model: llmRequest.model.stripPrefix("prefix/")
   - name: direct-model
@@ -406,7 +406,7 @@ llm:
       rules:
       - 'request.headers["x-model-auth"] == "yes"'
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
   virtualModels:
   - name: virtual-model
     routing:
@@ -539,7 +539,7 @@ llm:
     visibility: internal
     provider: openAI
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
   virtualModels:
   - name: public-model
     routing:
@@ -580,7 +580,7 @@ llm:
   - name: real-model
     provider: openAI
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
     passthrough: detect
 "#,
 		mock.address()
@@ -631,7 +631,7 @@ llm:
     visibility: internal
     provider: openAI
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
     passthrough: detect
   virtualModels:
   - name: public-model
@@ -671,7 +671,7 @@ llm:
   - name: public-model
     provider: openAI
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
       model: upstream-model
     passthrough: opaque
 "#,
@@ -707,7 +707,7 @@ llm:
     visibility: internal
     provider: openAI
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
       model: upstream-model
     passthrough: detect
   virtualModels:
@@ -749,7 +749,7 @@ llm:
     visibility: internal
     provider: openAI
     params:
-      baseUrl: http://{}
+      baseUrl: http://{}/v1
     passthrough: opaque
   virtualModels:
   - name: public-model

--- a/schema/config.json
+++ b/schema/config.json
@@ -11736,7 +11736,7 @@
           ]
         },
         "baseUrl": {
-          "description": "Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs.",
+          "description": "Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs. The URL path is the upstream base path and defaults to / when omitted. Provider-specific endpoint paths are appended to this base path. For example, https://api.openai.com/v1 sends completions to /v1/chat/completions, while https://api.openai.com sends them to /chat/completions.",
           "type": [
             "string",
             "null"

--- a/schema/config.json
+++ b/schema/config.json
@@ -11736,7 +11736,7 @@
           ]
         },
         "baseUrl": {
-          "description": "Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs. The URL path is the upstream base path and defaults to / when omitted. Provider-specific endpoint paths are appended to this base path. For example, https://api.openai.com/v1 sends completions to /v1/chat/completions, while https://api.openai.com sends them to /chat/completions.",
+          "description": "Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs.\nThe URL path is the upstream base path and defaults to / when omitted.\nProvider-specific endpoint paths are appended to this base path.\nFor example, https://api.openai.com/v1 sends completions to /v1/chat/completions,\nwhile https://api.openai.com sends them to /chat/completions.",
           "type": [
             "string",
             "null"

--- a/schema/config.md
+++ b/schema/config.md
@@ -70420,7 +70420,7 @@
 |`llm.providers[].params.azureResourceType`|enum|For Azure: the type of Azure endpoint (openAI or foundry)<br>Possible values: `openAI`, `foundry`, `aiServices`.|
 |`llm.providers[].params.azureApiVersion`|string|For Azure: the API version to use|
 |`llm.providers[].params.azureProjectName`|string|For Azure: the Foundry project name (required for foundry resource type)|
-|`llm.providers[].params.baseUrl`|string|Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs. The URL path is the upstream base path and defaults to / when omitted. Provider-specific endpoint paths are appended to this base path. For example, https://api.openai.com/v1 sends completions to /v1/chat/completions, while https://api.openai.com sends them to /chat/completions.|
+|`llm.providers[].params.baseUrl`|string|Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs.<br>The URL path is the upstream base path and defaults to / when omitted.<br>Provider-specific endpoint paths are appended to this base path.<br>For example, https://api.openai.com/v1 sends completions to /v1/chat/completions,<br>while https://api.openai.com sends them to /chat/completions.|
 |`llm.providers[].params.hostOverride`|string|Override the upstream host for this provider.|
 |`llm.providers[].params.pathOverride`|string|Override the upstream path for this provider.|
 |`llm.providers[].params.pathPrefix`|string|Override the default base path prefix for this provider.|
@@ -71145,7 +71145,7 @@
 |`llm.models[].params.azureResourceType`|enum|For Azure: the type of Azure endpoint (openAI or foundry)<br>Possible values: `openAI`, `foundry`, `aiServices`.|
 |`llm.models[].params.azureApiVersion`|string|For Azure: the API version to use|
 |`llm.models[].params.azureProjectName`|string|For Azure: the Foundry project name (required for foundry resource type)|
-|`llm.models[].params.baseUrl`|string|Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs. The URL path is the upstream base path and defaults to / when omitted. Provider-specific endpoint paths are appended to this base path. For example, https://api.openai.com/v1 sends completions to /v1/chat/completions, while https://api.openai.com sends them to /chat/completions.|
+|`llm.models[].params.baseUrl`|string|Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs.<br>The URL path is the upstream base path and defaults to / when omitted.<br>Provider-specific endpoint paths are appended to this base path.<br>For example, https://api.openai.com/v1 sends completions to /v1/chat/completions,<br>while https://api.openai.com sends them to /chat/completions.|
 |`llm.models[].params.hostOverride`|string|Override the upstream host for this provider.|
 |`llm.models[].params.pathOverride`|string|Override the upstream path for this provider.|
 |`llm.models[].params.pathPrefix`|string|Override the default base path prefix for this provider.|

--- a/schema/config.md
+++ b/schema/config.md
@@ -70420,7 +70420,7 @@
 |`llm.providers[].params.azureResourceType`|enum|For Azure: the type of Azure endpoint (openAI or foundry)<br>Possible values: `openAI`, `foundry`, `aiServices`.|
 |`llm.providers[].params.azureApiVersion`|string|For Azure: the API version to use|
 |`llm.providers[].params.azureProjectName`|string|For Azure: the Foundry project name (required for foundry resource type)|
-|`llm.providers[].params.baseUrl`|string|Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs.|
+|`llm.providers[].params.baseUrl`|string|Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs. The URL path is the upstream base path and defaults to / when omitted. Provider-specific endpoint paths are appended to this base path. For example, https://api.openai.com/v1 sends completions to /v1/chat/completions, while https://api.openai.com sends them to /chat/completions.|
 |`llm.providers[].params.hostOverride`|string|Override the upstream host for this provider.|
 |`llm.providers[].params.pathOverride`|string|Override the upstream path for this provider.|
 |`llm.providers[].params.pathPrefix`|string|Override the default base path prefix for this provider.|
@@ -71145,7 +71145,7 @@
 |`llm.models[].params.azureResourceType`|enum|For Azure: the type of Azure endpoint (openAI or foundry)<br>Possible values: `openAI`, `foundry`, `aiServices`.|
 |`llm.models[].params.azureApiVersion`|string|For Azure: the API version to use|
 |`llm.models[].params.azureProjectName`|string|For Azure: the Foundry project name (required for foundry resource type)|
-|`llm.models[].params.baseUrl`|string|Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs.|
+|`llm.models[].params.baseUrl`|string|Base URL for the upstream provider. Expands to hostOverride, pathPrefix, and tls for https URLs. The URL path is the upstream base path and defaults to / when omitted. Provider-specific endpoint paths are appended to this base path. For example, https://api.openai.com/v1 sends completions to /v1/chat/completions, while https://api.openai.com sends them to /chat/completions.|
 |`llm.models[].params.hostOverride`|string|Override the upstream host for this provider.|
 |`llm.models[].params.pathOverride`|string|Override the upstream path for this provider.|
 |`llm.models[].params.pathPrefix`|string|Override the default base path prefix for this provider.|


### PR DESCRIPTION
"baseURL", in all contexts other than these APIs, means "The url we add
/chat/completions" to. But due to a bug in the original impleemntation,
if the baseURL had no path like `https://example.com` we treat it
differently than if it had a path, and would unconditionally not rewrite
the path breaking translation.

This could be a breaking change in theory but any user with this config
should be broken currently.

Signed-off-by: John Howard <john.howard@solo.io>
