### PR TITLE
feat: configure gateway bind address

### DIFF
--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1115,11 +1115,15 @@ struct LocalGateway {
 	/// port is the port to listen on for this gateway.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	port: Option<u16>,
+	/// bindAddress is the IPv4 or IPv6 address to listen on. Use `127.0.0.1` or `::1` for loopback.
+	/// When omitted, listens on all interfaces (`::` on Unix with IPv6 enabled, otherwise `0.0.0.0`).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	bind_address: Option<IpAddr>,
 	/// protocol controls whether this gateway accepts HTTP/HTTPS routes or TCP/TLS routes. When omitted, gateways
 	/// default to HTTP, or HTTPS when tls is set.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	protocol: Option<LocalGatewayProtocol>,
-	/// listeners defines multiple named listeners under this gateway. When set, only `port` may be configured on the top level gateway.
+	/// listeners defines multiple named listeners under this gateway. When set, only `port` and `bindAddress` may be configured on the top level gateway.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	listeners: Vec<LocalGatewayListener>,
 
@@ -3650,15 +3654,16 @@ async fn convert_gateways(
 			}
 			refs.insert(gateway_name, listener_keys);
 		}
-		let sockaddr = if cfg!(target_family = "unix") && config.ipv6_enabled {
-			SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), port)
+		let default_address = if cfg!(target_family = "unix") && config.ipv6_enabled {
+			IpAddr::V6(Ipv6Addr::UNSPECIFIED)
 		} else {
-			SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), port)
+			IpAddr::V4(Ipv4Addr::UNSPECIFIED)
 		};
+		let address = gateway_config.bind_address.unwrap_or(default_address);
 		all_binds.push(BindSnapshot {
 			bind: Arc::new(Bind {
 				key: strng::format!("bind/{port}"),
-				address: sockaddr,
+				address: SocketAddr::new(address, port),
 				protocol: detect_bind_protocol(&listeners),
 				tunnel_protocol: TunnelProtocol::Direct,
 				mode: BindMode::Standard,

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -1218,40 +1218,6 @@ mcp:
 	);
 }
 
-#[rstest::rstest]
-#[case::default_ipv4(None, false, "0.0.0.0:3000")]
-#[case::default_ipv6(None, true, "[::]:3000")]
-#[case::loopback_ipv4(Some("127.0.0.1"), false, "127.0.0.1:3000")]
-#[case::loopback_ipv6(Some("::1"), true, "[::1]:3000")]
-#[tokio::test]
-async fn test_gateway_bind_address(
-	#[case] address: Option<&str>,
-	#[case] ipv6_enabled: bool,
-	#[case] expected: &str,
-) {
-	let mut config = test_config();
-	config.ipv6_enabled = ipv6_enabled;
-	let resources = crate::resource_manager::ResourceFetcher::direct(test_client());
-	let bind_address = address
-		.map(|address| format!("    bindAddress: '{address}'\n"))
-		.unwrap_or_default();
-	let yaml = format!("gateways:\n  private:\n    port: 3000\n{bind_address}");
-	let normalized = NormalizedLocalConfig::from(
-		&config,
-		&resources,
-		ListenerTarget {
-			gateway_name: "name".into(),
-			gateway_namespace: "ns".into(),
-			listener_name: None,
-			port: None,
-		},
-		&yaml,
-	)
-	.await
-	.expect("gateway bind address should normalize");
-	assert_eq!(normalized.binds.len(), 1);
-	assert_eq!(normalized.binds[0].address, expected.parse().unwrap());
-}
 
 #[tokio::test]
 async fn test_gateway_bind_address_is_per_gateway() {

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -1218,7 +1218,6 @@ mcp:
 	);
 }
 
-
 #[tokio::test]
 async fn test_gateway_bind_address_is_per_gateway() {
 	let normalized = normalize_test_yaml(

--- a/crates/agentgateway/src/types/local_tests.rs
+++ b/crates/agentgateway/src/types/local_tests.rs
@@ -1218,6 +1218,86 @@ mcp:
 	);
 }
 
+#[rstest::rstest]
+#[case::default_ipv4(None, false, "0.0.0.0:3000")]
+#[case::default_ipv6(None, true, "[::]:3000")]
+#[case::loopback_ipv4(Some("127.0.0.1"), false, "127.0.0.1:3000")]
+#[case::loopback_ipv6(Some("::1"), true, "[::1]:3000")]
+#[tokio::test]
+async fn test_gateway_bind_address(
+	#[case] address: Option<&str>,
+	#[case] ipv6_enabled: bool,
+	#[case] expected: &str,
+) {
+	let mut config = test_config();
+	config.ipv6_enabled = ipv6_enabled;
+	let resources = crate::resource_manager::ResourceFetcher::direct(test_client());
+	let bind_address = address
+		.map(|address| format!("    bindAddress: '{address}'\n"))
+		.unwrap_or_default();
+	let yaml = format!("gateways:\n  private:\n    port: 3000\n{bind_address}");
+	let normalized = NormalizedLocalConfig::from(
+		&config,
+		&resources,
+		ListenerTarget {
+			gateway_name: "name".into(),
+			gateway_namespace: "ns".into(),
+			listener_name: None,
+			port: None,
+		},
+		&yaml,
+	)
+	.await
+	.expect("gateway bind address should normalize");
+	assert_eq!(normalized.binds.len(), 1);
+	assert_eq!(normalized.binds[0].address, expected.parse().unwrap());
+}
+
+#[tokio::test]
+async fn test_gateway_bind_address_is_per_gateway() {
+	let normalized = normalize_test_yaml(
+		r#"
+gateways:
+  private:
+    port: 3000
+    bindAddress: 127.0.0.1
+  shared:
+    port: 4000
+    bindAddress: 0.0.0.0
+    listeners:
+    - name: first
+      hostname: first.example.com
+    - name: second
+      hostname: second.example.com
+"#,
+	)
+	.await
+	.expect("gateways with different bind addresses should normalize");
+	assert_eq!(normalized.binds.len(), 2);
+	let private = normalized
+		.binds
+		.iter()
+		.find(|b| b.address.port() == 3000)
+		.unwrap();
+	let shared = normalized
+		.binds
+		.iter()
+		.find(|b| b.address.port() == 4000)
+		.unwrap();
+	assert_eq!(private.address, "127.0.0.1:3000".parse().unwrap());
+	assert_eq!(shared.address, "0.0.0.0:4000".parse().unwrap());
+	assert_eq!(shared.listeners.iter().count(), 2);
+}
+
+#[tokio::test]
+async fn test_gateway_bind_address_rejects_invalid_ip() {
+	let err =
+		normalize_test_yaml("gateways:\n  private:\n    port: 3000\n    bindAddress: localhost\n")
+			.await
+			.expect_err("bindAddress must be an IP address");
+	assert!(err.to_string().contains("IP address"), "{err:?}");
+}
+
 #[tokio::test]
 async fn test_gateways_attach_llm_mcp_and_ui_to_one_listener() {
 	let normalized = normalize_test_yaml(&format!(

--- a/examples/traffic-unified-gateway/README.md
+++ b/examples/traffic-unified-gateway/README.md
@@ -8,6 +8,31 @@ The `default` gateway listens on port 3000. Because the gateway is named
 `default`, the top-level `llm`, `mcp`, and `ui` sections attach to it without
 setting explicit `gateways` fields.
 
+### Choosing a listen address
+
+Set `bindAddress` on a gateway to choose its IPv4 or IPv6 listen address:
+
+```yaml
+gateways:
+  default:
+    port: 3000
+    bindAddress: 127.0.0.1
+  shared:
+    port: 4000
+    bindAddress: 0.0.0.0
+```
+
+Here, the `default` gateway accepts connections only through IPv4 loopback.
+In a Kubernetes pod without `hostNetwork`, all containers in that pod can
+connect to it, but other pods cannot connect directly. Use `::1` for IPv6 loopback.
+The `shared` gateway listens on all IPv4 interfaces; attach routes to it using
+`gateways: shared`.
+
+When `bindAddress` is omitted, the existing default remains: `::` on Unix with
+IPv6 enabled, otherwise `0.0.0.0`. All named listeners within a gateway share
+its address and port. Gateways must still use different ports, even when their
+addresses differ.
+
 ### Running the example
 
 Set the provider API key:

--- a/examples/traffic-unified-gateway/README.md
+++ b/examples/traffic-unified-gateway/README.md
@@ -8,31 +8,6 @@ The `default` gateway listens on port 3000. Because the gateway is named
 `default`, the top-level `llm`, `mcp`, and `ui` sections attach to it without
 setting explicit `gateways` fields.
 
-### Choosing a listen address
-
-Set `bindAddress` on a gateway to choose its IPv4 or IPv6 listen address:
-
-```yaml
-gateways:
-  default:
-    port: 3000
-    bindAddress: 127.0.0.1
-  shared:
-    port: 4000
-    bindAddress: 0.0.0.0
-```
-
-Here, the `default` gateway accepts connections only through IPv4 loopback.
-In a Kubernetes pod without `hostNetwork`, all containers in that pod can
-connect to it, but other pods cannot connect directly. Use `::1` for IPv6 loopback.
-The `shared` gateway listens on all IPv4 interfaces; attach routes to it using
-`gateways: shared`.
-
-When `bindAddress` is omitted, the existing default remains: `::` on Unix with
-IPv6 enabled, otherwise `0.0.0.0`. All named listeners within a gateway share
-its address and port. Gateways must still use different ports, even when their
-addresses differ.
-
 ### Running the example
 
 Set the provider API key:

--- a/schema/config.json
+++ b/schema/config.json
@@ -11042,6 +11042,14 @@
           "minimum": 0,
           "maximum": 65535
         },
+        "bindAddress": {
+          "description": "bindAddress is the IPv4 or IPv6 address to listen on. Use `127.0.0.1` or `::1` for loopback.\nWhen omitted, listens on all interfaces (`::` on Unix with IPv6 enabled, otherwise `0.0.0.0`).",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "ip"
+        },
         "protocol": {
           "description": "protocol controls whether this gateway accepts HTTP/HTTPS routes or TCP/TLS routes. When omitted, gateways\ndefault to HTTP, or HTTPS when tls is set.",
           "anyOf": [
@@ -11054,7 +11062,7 @@
           ]
         },
         "listeners": {
-          "description": "listeners defines multiple named listeners under this gateway. When set, only `port` may be configured on the top level gateway.",
+          "description": "listeners defines multiple named listeners under this gateway. When set, only `port` and `bindAddress` may be configured on the top level gateway.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/LocalGatewayListener"

--- a/schema/config.md
+++ b/schema/config.md
@@ -50552,8 +50552,9 @@
 |`routeGroups[].routes[].backends[].policies.ai.routes`|object|Route type overrides selected by request path suffix.|
 |`gateways`|object|gateways defines the entrypoint to the proxy, setting up ports and listeners that features (LLM, MCP, and UI) and routes can attach to.<br>Each gateway defines a port that proxy will listen on, and optionally TLS settings for that port.|
 |`gateways.*.port`|integer|port is the port to listen on for this gateway.|
+|`gateways.*.bindAddress`|string|bindAddress is the IPv4 or IPv6 address to listen on. Use `127.0.0.1` or `::1` for loopback.<br>When omitted, listens on all interfaces (`::` on Unix with IPv6 enabled, otherwise `0.0.0.0`).|
 |`gateways.*.protocol`|enum|protocol controls whether this gateway accepts HTTP/HTTPS routes or TCP/TLS routes. When omitted, gateways<br>default to HTTP, or HTTPS when tls is set.<br>Possible values: `HTTP`, `HTTPS`, `TCP`, `TLS`, `null`.|
-|`gateways.*.listeners`|[]object|listeners defines multiple named listeners under this gateway. When set, only `port` may be configured on the top level gateway.|
+|`gateways.*.listeners`|[]object|listeners defines multiple named listeners under this gateway. When set, only `port` and `bindAddress` may be configured on the top level gateway.|
 |`gateways.*.listeners[].name`|string|name identifies this listener for gateway references like `gateways: gateway-name/listener-name`.|
 |`gateways.*.listeners[].hostname`|string|Hostname defines what hostnames are served under this listener. Can be a wildcard.<br>This allows serving multiple domains with different TLS configurations.<br>If unset, all domains will be served (implicit wildcard).|
 |`gateways.*.listeners[].protocol`|enum|protocol controls whether this listener accepts HTTP/HTTPS routes or TCP/TLS routes. When omitted, listeners<br>default to HTTP, or HTTPS when tls is set.<br>Possible values: `HTTP`, `HTTPS`, `TCP`, `TLS`, `null`.|


### PR DESCRIPTION
Closes #3378

- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.

Adds an optional `bindAddress` to each configured gateway, allowing it to listen on a specific IPv4 or IPv6 address. This supports binding to loopback when agentgateway runs as a sidecar and should only accept connections from within the pod.

Leaving `bindAddress` unset preserves the current behaviour. All listeners within a gateway share its address and port. 

Added tests covering default behaviour, IPv4/IPv6 loopback, separate gateway addresses, named listeners, and invalid input.

Updated `schema/config.json` and `schema/config.md` so the configuration schema and reference documentation include `bindAddress`. 

Added an example showing loopback and shared gateway addresses in `examples/traffic-unified-gateway/README.md`
