### PR TITLE
Misc UI improvements

### DIFF
--- a/crates/agentgateway/src/config_store.rs
+++ b/crates/agentgateway/src/config_store.rs
@@ -65,6 +65,8 @@ pub enum ConfigResourceKind {
 	McpTarget,
 	#[serde(rename = "mcp.policy")]
 	McpPolicy,
+	#[serde(rename = "llm.settings")]
+	LlmSettings,
 	#[serde(rename = "mcp.settings")]
 	McpSettings,
 	#[serde(rename = "traffic.gateway")]
@@ -78,6 +80,14 @@ pub enum ConfigResourceKind {
 }
 
 impl ConfigResourceKind {
+	pub(crate) fn settings_fields(self) -> Option<(&'static str, &'static [&'static str])> {
+		match self {
+			Self::LlmSettings => Some(("llm", &["gateways", "port", "tls"])),
+			Self::McpSettings => Some(("mcp", &MCP_SETTINGS_FIELDS)),
+			_ => None,
+		}
+	}
+
 	pub const fn as_str(self) -> &'static str {
 		match self {
 			Self::ModelCatalog => "modelCatalog",
@@ -89,6 +99,7 @@ impl ConfigResourceKind {
 			Self::McpTarget => "mcp.target",
 			Self::McpPolicy => "mcp.policy",
 			Self::McpSettings => "mcp.settings",
+			Self::LlmSettings => "llm.settings",
 			Self::TrafficGateway => "traffic.gateway",
 			Self::TrafficRoute => "traffic.route",
 			Self::TrafficTcpRoute => "traffic.tcpRoute",
@@ -117,6 +128,7 @@ impl FromStr for ConfigResourceKind {
 			"mcp.target" => Ok(Self::McpTarget),
 			"mcp.policy" => Ok(Self::McpPolicy),
 			"mcp.settings" => Ok(Self::McpSettings),
+			"llm.settings" => Ok(Self::LlmSettings),
 			"traffic.gateway" => Ok(Self::TrafficGateway),
 			"traffic.route" => Ok(Self::TrafficRoute),
 			"traffic.tcpRoute" => Ok(Self::TrafficTcpRoute),
@@ -380,7 +392,8 @@ fn file_resource_collection(kind: ConfigResourceKind) -> Option<FileResourceColl
 		ConfigResourceKind::TrafficTcpRoute => Some(FileResourceCollection::List(&["tcpRoutes"])),
 		ConfigResourceKind::ModelCatalog
 		| ConfigResourceKind::LlmApiKey
-		| ConfigResourceKind::McpSettings => None,
+		| ConfigResourceKind::McpSettings
+		| ConfigResourceKind::LlmSettings => None,
 	}
 }
 
@@ -402,7 +415,9 @@ pub(crate) fn upsert_file_config_resource(
 	match prepared.kind {
 		ConfigResourceKind::ModelCatalog => upsert_file_model_catalog(config, &prepared.value),
 		ConfigResourceKind::LlmApiKey => upsert_file_api_key(config, prepared, previous_id),
-		ConfigResourceKind::McpSettings => upsert_file_mcp_settings(config, &prepared.value),
+		ConfigResourceKind::McpSettings | ConfigResourceKind::LlmSettings => {
+			upsert_file_settings(config, prepared.kind, &prepared.value)
+		},
 		ConfigResourceKind::LlmProvider
 		| ConfigResourceKind::LlmModel
 		| ConfigResourceKind::LlmVirtualModel
@@ -430,7 +445,9 @@ pub(crate) fn delete_file_config_resource(
 	match kind {
 		ConfigResourceKind::ModelCatalog => delete_file_model_catalog(config),
 		ConfigResourceKind::LlmApiKey => delete_file_api_key(config, id),
-		ConfigResourceKind::McpSettings => delete_file_mcp_settings(config),
+		ConfigResourceKind::McpSettings | ConfigResourceKind::LlmSettings => {
+			delete_file_settings(config, kind)
+		},
 		ConfigResourceKind::LlmProvider
 		| ConfigResourceKind::LlmModel
 		| ConfigResourceKind::LlmVirtualModel
@@ -660,29 +677,36 @@ fn delete_file_api_key(config: &mut Value, id: &str) -> anyhow::Result<bool> {
 	Ok(false)
 }
 
-/// Projects the singleton MCP settings resource onto its top-level `mcp` fields.
-fn upsert_file_mcp_settings(config: &mut Value, value: &Value) -> anyhow::Result<()> {
+/// Projects the singleton surface settings resource onto its top-level fields.
+fn upsert_file_settings(
+	config: &mut Value,
+	kind: ConfigResourceKind,
+	value: &Value,
+) -> anyhow::Result<()> {
+	let (section, fields) = kind.settings_fields().expect("settings resource");
 	let value = value
 		.as_object()
-		.ok_or_else(|| anyhow::anyhow!("mcp.settings/default must be an object"))?;
-	let mcp = ensure_file_object(config, &["mcp"])?;
-	for field in MCP_SETTINGS_FIELDS {
+		.ok_or_else(|| anyhow::anyhow!("{kind}/default must be an object"))?;
+	let settings = ensure_file_object(config, &[section])?;
+	for &field in fields {
 		if let Some(value) = value.get(field) {
-			mcp.insert(field.to_string(), value.clone());
+			settings.insert(field.to_string(), value.clone());
 		} else {
-			mcp.remove(field);
+			settings.remove(field);
 		}
 	}
 	Ok(())
 }
 
-fn delete_file_mcp_settings(config: &mut Value) -> anyhow::Result<bool> {
-	let Some(mcp) = crate::json::traverse_mut(config, &["mcp"]).and_then(Value::as_object_mut) else {
+fn delete_file_settings(config: &mut Value, kind: ConfigResourceKind) -> anyhow::Result<bool> {
+	let (section, fields) = kind.settings_fields().expect("settings resource");
+	let Some(settings) = crate::json::traverse_mut(config, &[section]).and_then(Value::as_object_mut)
+	else {
 		return Ok(false);
 	};
 	let mut deleted = false;
-	for field in MCP_SETTINGS_FIELDS {
-		deleted |= mcp.remove(field).is_some();
+	for &field in fields {
+		deleted |= settings.remove(field).is_some();
 	}
 	Ok(deleted)
 }
@@ -876,7 +900,8 @@ fn overlay_config_resources(
 	let has_llm_resources = resources.iter().any(|resource| {
 		matches!(
 			resource.kind,
-			ConfigResourceKind::LlmProvider
+			ConfigResourceKind::LlmSettings
+				| ConfigResourceKind::LlmProvider
 				| ConfigResourceKind::LlmModel
 				| ConfigResourceKind::LlmVirtualModel
 				| ConfigResourceKind::LlmApiKey
@@ -935,10 +960,16 @@ fn overlay_config_resources(
 		anyhow::bail!("local config root must be a JSON object");
 	};
 	if has_llm_resources {
-		if has_llm_policies && !root.contains_key("llm") {
+		if has_llm_policies
+			&& !root.contains_key("llm")
+			&& !resources
+				.iter()
+				.any(|r| r.kind == ConfigResourceKind::LlmSettings)
+		{
 			return Err(
 				ConfigResourceError::Conflict(
-					"DB-backed LLM policies require llm in the file config".to_string(),
+					"DB-backed LLM policies require llm in the file config or a llm.settings resource"
+						.to_string(),
 				)
 				.into(),
 			);
@@ -958,6 +989,7 @@ fn overlay_config_resources(
 			anyhow::bail!("local config llm must be a JSON object");
 		};
 
+		append_settings(llm, resources, ConfigResourceKind::LlmSettings)?;
 		append_policy_kind(llm, resources, ConfigResourceKind::LlmPolicy, "llm")?;
 		append_llm_kind(llm, resources, ConfigResourceKind::LlmProvider, "providers")?;
 		append_llm_kind(llm, resources, ConfigResourceKind::LlmModel, "models")?;
@@ -980,7 +1012,7 @@ fn overlay_config_resources(
 			.entry("targets")
 			.or_insert_with(|| Value::Array(Vec::new()));
 
-		append_mcp_settings(mcp, resources)?;
+		append_settings(mcp, resources, ConfigResourceKind::McpSettings)?;
 		append_policy_kind(mcp, resources, ConfigResourceKind::McpPolicy, "mcp")?;
 		append_list_kind(
 			mcp,
@@ -1155,37 +1187,36 @@ fn append_llm_kind(
 	append_list_kind(llm, resources, kind, field, "llm")
 }
 
-fn append_mcp_settings(
-	mcp: &mut serde_json::Map<String, Value>,
+fn append_settings(
+	settings: &mut serde_json::Map<String, Value>,
 	resources: &[ConfigResource],
+	kind: ConfigResourceKind,
 ) -> anyhow::Result<()> {
-	let Some(settings) = resources
-		.iter()
-		.find(|resource| resource.kind == ConfigResourceKind::McpSettings)
-	else {
+	let (_, fields) = kind.settings_fields().expect("settings resource");
+	let Some(resource) = resources.iter().find(|resource| resource.kind == kind) else {
 		return Ok(());
 	};
-	let value = settings.value.as_object().ok_or_else(|| {
-		ConfigResourceError::InvalidRequest("mcp.settings/default must be an object".to_string())
+	let value = resource.value.as_object().ok_or_else(|| {
+		ConfigResourceError::InvalidRequest(format!("{kind}/default must be an object"))
 	})?;
 	for (field, value) in value {
-		if !MCP_SETTINGS_FIELDS.contains(&field.as_str()) {
+		if !fields.contains(&field.as_str()) {
 			return Err(
 				ConfigResourceError::InvalidRequest(format!(
-					"mcp.settings/default contains unsupported field: {field}"
+					"{kind}/default contains unsupported field: {field}"
 				))
 				.into(),
 			);
 		}
-		if mcp.contains_key(field) {
+		if settings.contains_key(field) {
 			return Err(
 				ConfigResourceError::Conflict(format!(
-					"config resource mcp.settings/default field {field} conflicts with file-owned configuration"
+					"config resource {kind}/default field {field} conflicts with file-owned configuration"
 				))
 				.into(),
 			);
 		}
-		mcp.insert(field.clone(), value.clone());
+		settings.insert(field.clone(), value.clone());
 	}
 	Ok(())
 }
@@ -1302,7 +1333,7 @@ pub(crate) fn prepare_resource(
 fn resource_id(kind: ConfigResourceKind, value: &Value) -> anyhow::Result<String> {
 	match kind {
 		ConfigResourceKind::ModelCatalog => Ok("default".to_string()),
-		ConfigResourceKind::McpSettings => Ok("default".to_string()),
+		ConfigResourceKind::McpSettings | ConfigResourceKind::LlmSettings => Ok("default".to_string()),
 		ConfigResourceKind::LlmProvider
 		| ConfigResourceKind::LlmVirtualModel
 		| ConfigResourceKind::McpTarget

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -438,6 +438,7 @@ pub struct LocalLLMConfig {
 	/// models defines the set of models that can be served by this gateway. The model name refers to the
 	/// model in the users request that is matched; the model sent to the actual LLM can be overridden
 	/// on a per-model basis.
+	#[serde(default)]
 	models: Vec<LocalLLMModels>,
 	/// virtualModels defines a set of models that can be served from the gateway. The model name refers to the
 	/// model in the users request that is matched. However, unlike the `models` field, virtual models will
@@ -1850,6 +1851,7 @@ pub enum McpStatefulMode {
 #[apply(schema_de!)]
 pub struct LocalMcpBackend {
 	/// MCP server targets to multiplex together.
+	#[serde(default)]
 	pub targets: Vec<Arc<LocalMcpTarget>>,
 	#[serde(default)]
 	pub stateful_mode: McpStatefulMode,

--- a/crates/agentgateway/src/ui.rs
+++ b/crates/agentgateway/src/ui.rs
@@ -397,10 +397,10 @@ async fn upsert_config_resources(
 	kind: ConfigResourceKind,
 	mut request: ConfigResourceUpsertRequest,
 ) -> Result<UiConfigResourcesResponse, ErrorResponse> {
-	if app.state.storage.mode == ConfigStoreMode::Hybrid && kind == ConfigResourceKind::McpSettings {
+	if app.state.storage.mode == ConfigStoreMode::Hybrid && kind.settings_fields().is_some() {
 		let file_config = read_file_config(app).await?;
 		for resource in &mut request.resources {
-			remove_file_owned_mcp_settings(&file_config, &mut resource.value)?;
+			remove_file_owned_settings(kind, &file_config, &mut resource.value)?;
 		}
 	}
 	let prepared =
@@ -443,8 +443,8 @@ async fn update_config_resource(
 	} else {
 		None
 	};
-	if app.state.storage.mode == ConfigStoreMode::Hybrid && kind == ConfigResourceKind::McpSettings {
-		remove_file_owned_mcp_settings(&read_file_config(&app).await?, &mut resource.value)?;
+	if app.state.storage.mode == ConfigStoreMode::Hybrid && kind.settings_fields().is_some() {
+		remove_file_owned_settings(kind, &read_file_config(&app).await?, &mut resource.value)?;
 	}
 	let stored_resources = if app.state.storage.mode == ConfigStoreMode::Hybrid {
 		Some(
@@ -558,23 +558,25 @@ async fn update_config_resource(
 	Ok(Json(response.into()))
 }
 
-fn remove_file_owned_mcp_settings(
+fn remove_file_owned_settings(
+	kind: ConfigResourceKind,
 	file_config: &Value,
 	value: &mut Value,
 ) -> Result<(), ErrorResponse> {
+	let (section, fields) = kind.settings_fields().expect("settings resource");
 	let value = value.as_object_mut().ok_or_else(|| {
-		resource_api_error(ConfigResourceError::InvalidRequest(
-			"mcp.settings/default must be an object".to_string(),
-		))
+		resource_api_error(ConfigResourceError::InvalidRequest(format!(
+			"{kind}/default must be an object"
+		)))
 	})?;
-	let file_mcp = file_config.get("mcp").and_then(Value::as_object);
-	for field in crate::config_store::MCP_SETTINGS_FIELDS {
-		let Some(file_value) = file_mcp.and_then(|mcp| mcp.get(field)) else {
+	let file_settings = file_config.get(section).and_then(Value::as_object);
+	for &field in fields {
+		let Some(file_value) = file_settings.and_then(|settings| settings.get(field)) else {
 			continue;
 		};
 		if value.get(field).is_some_and(|value| value != file_value) {
 			return Err(resource_api_error(ConfigResourceError::Conflict(format!(
-				"file-owned mcp.settings/default field cannot be updated in hybrid mode: {field}"
+				"file-owned {kind}/default field cannot be updated in hybrid mode: {field}"
 			))));
 		}
 		value.remove(field);

--- a/schema/config.json
+++ b/schema/config.json
@@ -8236,10 +8236,7 @@
           "type": "boolean"
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "targets"
-      ]
+      "additionalProperties": false
     },
     "LocalMcpTarget": {
       "type": "object",
@@ -11622,10 +11619,7 @@
           ]
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "models"
-      ]
+      "additionalProperties": false
     },
     "LocalLLMProvider": {
       "type": "object",
@@ -12621,10 +12615,7 @@
           ]
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "targets"
-      ]
+      "additionalProperties": false
     },
     "LocalUIConfig": {
       "type": "object",

--- a/ui/src/api/configResourcesApi.ts
+++ b/ui/src/api/configResourcesApi.ts
@@ -1,6 +1,7 @@
 import { requestJson } from '@/api/base';
 import type { LocalAttachedRoute, LocalAttachedTCPRoute } from '@/gateway-config';
 import type {
+	LlmConfig,
 	LlmModel,
 	LlmProvider,
 	LlmVirtualModel,
@@ -19,6 +20,7 @@ export type ConfigResourceKind =
 	| 'llm.policy'
 	| 'mcp.target'
 	| 'mcp.policy'
+	| 'llm.settings'
 	| 'mcp.settings'
 	| 'traffic.gateway'
 	| 'traffic.route'
@@ -27,6 +29,7 @@ export type ConfigResourceKind =
 
 export type PolicyResourceKind = Extract<ConfigResourceKind, `${string}.policy`>;
 
+export type LlmSettingsResource = Pick<LlmConfig, 'gateways' | 'port' | 'tls'>;
 export type McpSettingsResource = Partial<Omit<McpConfig, 'targets' | 'policies'>>;
 export type TrafficGatewayResource = TrafficGateway & { name: string };
 export type TrafficRouteResource = LocalAttachedRoute & { name: string };
@@ -34,27 +37,29 @@ export type TrafficTcpRouteResource = LocalAttachedTCPRoute & { name: string };
 
 export type ConfigResourceValue<K extends ConfigResourceKind> = K extends 'modelCatalog'
 	? { base?: unknown; custom?: unknown }
-	: K extends 'llm.provider'
-		? LlmProvider
-		: K extends 'llm.model'
-			? LlmModel
-			: K extends 'llm.virtualModel'
-				? LlmVirtualModel
-				: K extends 'llm.apiKey'
-					? VirtualApiKey
-					: K extends 'mcp.target'
-						? McpTarget
-						: K extends 'mcp.settings'
-							? McpSettingsResource
-							: K extends 'traffic.gateway'
-								? TrafficGatewayResource
-								: K extends 'traffic.route'
-									? TrafficRouteResource
-									: K extends 'traffic.tcpRoute'
-										? TrafficTcpRouteResource
-										: K extends 'llm.policy' | 'mcp.policy' | 'ui.policy'
-											? unknown
-											: never;
+	: K extends 'llm.settings'
+		? LlmSettingsResource
+		: K extends 'llm.provider'
+			? LlmProvider
+			: K extends 'llm.model'
+				? LlmModel
+				: K extends 'llm.virtualModel'
+					? LlmVirtualModel
+					: K extends 'llm.apiKey'
+						? VirtualApiKey
+						: K extends 'mcp.target'
+							? McpTarget
+							: K extends 'mcp.settings'
+								? McpSettingsResource
+								: K extends 'traffic.gateway'
+									? TrafficGatewayResource
+									: K extends 'traffic.route'
+										? TrafficRouteResource
+										: K extends 'traffic.tcpRoute'
+											? TrafficTcpRouteResource
+											: K extends 'llm.policy' | 'mcp.policy' | 'ui.policy'
+												? unknown
+												: never;
 
 export interface ConfigResource<K extends ConfigResourceKind = ConfigResourceKind> {
 	kind: K;

--- a/ui/src/components/GatewayBindingEditor.tsx
+++ b/ui/src/components/GatewayBindingEditor.tsx
@@ -114,7 +114,7 @@ function PortField(props: {
 	);
 }
 
-function gatewayOptions(config: GatewayConfig | null | undefined) {
+export function gatewayOptions(config: GatewayConfig | null | undefined) {
 	return Object.entries(config?.gateways ?? {}).flatMap(([name, gateway]) => {
 		const listeners = gateway.listeners ?? [];
 		if (!listeners.length) {

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -195,12 +195,7 @@ export function startupLlmConfig(
 	gateways = startupGatewayRefs(config)
 ): LlmConfig {
 	ensureStartupGateway(config, gateways);
-	return {
-		gateways,
-		models: [],
-		providers: [],
-		virtualModels: []
-	};
+	return { gateways };
 }
 
 export function startupMcpConfig(
@@ -208,7 +203,7 @@ export function startupMcpConfig(
 	gateways = startupGatewayRefs(config)
 ): McpConfig {
 	ensureStartupGateway(config, gateways);
-	return { gateways, targets: [] };
+	return { gateways };
 }
 
 export function upsertModel(config: GatewayConfig, model: LlmModel, previousId?: string) {
@@ -295,6 +290,7 @@ export function setLlmGuardrails(config: GatewayConfig, guardrails: LlmGuardrail
 
 export function upsertMcpTarget(config: GatewayConfig, target: McpTarget, previousName?: string) {
 	const mcp = ensureMcp(config);
+	mcp.targets ??= [];
 	const index = mcp.targets.findIndex(item => item.name === (previousName ?? target.name));
 	if (index >= 0) {
 		mcp.targets[index] = target;

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -170,38 +170,45 @@ export function ensureMcp(config: GatewayConfig): McpConfig {
 	return config.mcp;
 }
 
-export function startupLlmConfig(config: GatewayConfig, port: number): LlmConfig {
-	const gateways = config.ui?.gateways;
-	if (gateways) {
-		return {
-			gateways,
-			models: [],
-			providers: [],
-			virtualModels: []
-		};
-	}
+export function startupGatewayRefs(config: GatewayConfig | undefined): string | string[] {
+	const gateways = config?.ui?.gateways;
+	if (gateways && (!Array.isArray(gateways) || gateways.length > 0)) return gateways;
+	if (config?.gateways?.default) return 'default';
+	return Object.keys(config?.gateways ?? {})[0] ?? 'default';
+}
+
+function ensureStartupGateway(config: GatewayConfig, gateways: string | string[]) {
+	if (Object.keys(config.gateways ?? {}).length) return;
+	const occupiedPorts = new Set([
+		...(config.binds ?? []).map(bind => bind.port),
+		config.llm ? (config.llm.port ?? 4000) : undefined,
+		config.mcp ? (config.mcp.port ?? 3000) : undefined
+	]);
+	let port = 4000;
+	while (occupiedPorts.has(port)) port++;
+	const name = (Array.isArray(gateways) ? gateways[0] : gateways).split('/')[0];
+	config.gateways = { [name]: { port } };
+}
+
+export function startupLlmConfig(
+	config: GatewayConfig,
+	gateways = startupGatewayRefs(config)
+): LlmConfig {
+	ensureStartupGateway(config, gateways);
 	return {
-		port,
+		gateways,
 		models: [],
 		providers: [],
 		virtualModels: []
 	};
 }
 
-export function startupMcpConfig(config: GatewayConfig, port: number): McpConfig {
-	const gateways = config.ui?.gateways;
-	if (gateways) {
-		return {
-			gateways,
-			targets: []
-		};
-	}
-	return { port, targets: [] };
-}
-
-export function usesUiGateways(config: GatewayConfig | undefined) {
-	const gateways = config?.ui?.gateways;
-	return Array.isArray(gateways) ? gateways.length > 0 : Boolean(gateways);
+export function startupMcpConfig(
+	config: GatewayConfig,
+	gateways = startupGatewayRefs(config)
+): McpConfig {
+	ensureStartupGateway(config, gateways);
+	return { gateways, targets: [] };
 }
 
 export function upsertModel(config: GatewayConfig, model: LlmModel, previousId?: string) {

--- a/ui/src/hooks.ts
+++ b/ui/src/hooks.ts
@@ -14,7 +14,14 @@ import {
 	updateConfigResource
 } from '@/api/configResourcesApi';
 import { getRuntimeInfo } from '@/api/runtimeApi';
-import { cloneConfig, configWarnings } from '@/config';
+import {
+	cloneConfig,
+	configWarnings,
+	enableTrafficConfig,
+	ensureLlmFrontendDefaults,
+	startupLlmConfig,
+	startupMcpConfig
+} from '@/config';
 import { validateGatewayConfig } from '@/configValidation';
 import type { GatewayConfig, LlmApiKeyPolicy, LlmConfig } from '@/types';
 
@@ -240,6 +247,54 @@ export function useUpdateConfig() {
 			queryClient.setQueryData(['config'], next);
 			invalidateConfigViews(queryClient);
 		}
+	});
+}
+
+export function useEnableSurface() {
+	const queryClient = useQueryClient();
+	const update = useUpdateConfig();
+	return useMutation({
+		mutationFn: async ({
+			surface,
+			gateway
+		}: {
+			surface: 'llm' | 'mcp' | 'traffic';
+			gateway?: string;
+		}) => {
+			const runtime = await requireWritableRuntime(queryClient);
+			const hybrid = runtime.ui.configStoreMode === 'hybrid';
+			function apply(next: GatewayConfig) {
+				if (surface === 'llm') {
+					next.llm ??= startupLlmConfig(next, gateway);
+					ensureLlmFrontendDefaults(next);
+				} else if (surface === 'mcp') {
+					next.mcp ??= startupMcpConfig(next, gateway);
+				} else {
+					enableTrafficConfig(next);
+				}
+			}
+			if (!hybrid) {
+				await update.mutateAsync(next => {
+					apply(next);
+				});
+				return { hybrid };
+			}
+			const current = await getEffectiveConfig();
+			if (surface !== 'traffic' && current[surface]) return { hybrid };
+			const next = cloneConfig(current);
+			apply(next);
+			const gateways = Object.entries(next.gateways ?? {})
+				.filter(([name]) => !current.gateways?.[name])
+				.map(([name, value]) => ({ ...value, name }));
+			if (gateways.length) await putConfigResources('traffic.gateway', gateways);
+			if (surface === 'llm') {
+				await putConfigResources('llm.settings', [{ gateways: next.llm?.gateways }]);
+			} else if (surface === 'mcp') {
+				await putConfigResources('mcp.settings', [{ gateways: next.mcp?.gateways }]);
+			}
+			return { hybrid };
+		},
+		onSettled: () => invalidateConfigViews(queryClient)
 	});
 }
 

--- a/ui/src/pages/GetStarted.tsx
+++ b/ui/src/pages/GetStarted.tsx
@@ -2,13 +2,14 @@ import { Link, useNavigate } from '@tanstack/react-router';
 import { Bot, Network, Server } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
-import { Field, PageHeader, Panel, StatusBanner } from '@/components/Primitives';
+import { gatewayOptions } from '@/components/GatewayBindingEditor';
+import { Dropdown, FieldGroup, PageHeader, Panel, StatusBanner } from '@/components/Primitives';
 import {
 	enableTrafficConfig,
 	ensureLlmFrontendDefaults,
+	startupGatewayRefs,
 	startupLlmConfig,
-	startupMcpConfig,
-	usesUiGateways
+	startupMcpConfig
 } from '@/config';
 import { refreshBaseCostsAndConfigure } from '@/costs';
 import {
@@ -100,8 +101,9 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
 				? trafficData.error
 				: null);
 	const enabled = surface.enabled(effectiveConfig);
-	const useGateways = usesUiGateways(trafficData.data ?? config.data);
-	const [port, setPort] = useState(() => String(defaultSurfacePort(props.surface)));
+	const [gateway, setGateway] = useState('');
+	const options = gatewayOptions(trafficData.data ?? config.data);
+	const defaultGateways = startupGatewayRefs(trafficData.data ?? config.data);
 
 	useEffect(() => {
 		if (!loading && !configError && enabled) {
@@ -117,13 +119,12 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
 		try {
 			await update.mutateAsync(next => {
 				if (props.surface === 'llm') {
-					next.llm = next.llm ?? startupLlmConfig(next, parsePort(port, 4000));
+					next.llm = next.llm ?? startupLlmConfig(next, gateway || undefined);
 					ensureLlmFrontendDefaults(next);
 				} else if (props.surface === 'mcp') {
-					next.mcp =
-						next.mcp ?? startupMcpConfig(next, parsePort(port, defaultSurfacePort(props.surface)));
+					next.mcp = next.mcp ?? startupMcpConfig(next, gateway || undefined);
 				} else {
-					enableTrafficConfig(next, parsePort(port, defaultSurfacePort(props.surface)));
+					enableTrafficConfig(next);
 				}
 			});
 			void navigate({ to: surface.destination });
@@ -176,17 +177,26 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
 					</div>
 				</div>
 
-				{!enabled && !useGateways && (props.surface === 'llm' || props.surface === 'mcp') ? (
+				{!enabled && (props.surface === 'llm' || props.surface === 'mcp') ? (
 					<details className="schema-details">
 						<summary>Advanced</summary>
-						<Field label="Port">
-							<input
-								value={port}
-								inputMode="numeric"
-								onChange={event => setPort(event.target.value)}
-								placeholder={String(defaultSurfacePort(props.surface))}
+						<FieldGroup label="Gateway">
+							<Dropdown
+								ariaLabel="Gateway"
+								value={gateway}
+								onChange={setGateway}
+								options={[
+									{
+										value: '',
+										label: `Automatic (${Array.isArray(defaultGateways) ? defaultGateways.join(', ') : defaultGateways})`,
+										description: options.length
+											? 'Use the configured gateway.'
+											: 'Create a default gateway.'
+									},
+									...options
+								]}
 							/>
-						</Field>
+						</FieldGroup>
 					</details>
 				) : null}
 
@@ -212,15 +222,4 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
 			</Panel>
 		</div>
 	);
-}
-
-function parsePort(value: string, fallback: number) {
-	const parsed = Number.parseInt(value, 10);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function defaultSurfacePort(surface: SurfaceKind) {
-	if (surface === 'llm') return 4000;
-	if (surface === 'traffic') return 8080;
-	return 3000;
 }

--- a/ui/src/pages/GetStarted.tsx
+++ b/ui/src/pages/GetStarted.tsx
@@ -2,18 +2,14 @@ import { Link, useNavigate } from '@tanstack/react-router';
 import { Bot, Network, Server } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
+import { refreshBaseCosts } from '@/api/costsApi';
 import { gatewayOptions } from '@/components/GatewayBindingEditor';
 import { Dropdown, FieldGroup, PageHeader, Panel, StatusBanner } from '@/components/Primitives';
-import {
-	enableTrafficConfig,
-	ensureLlmFrontendDefaults,
-	startupGatewayRefs,
-	startupLlmConfig,
-	startupMcpConfig
-} from '@/config';
+import { startupGatewayRefs } from '@/config';
 import { refreshBaseCostsAndConfigure } from '@/costs';
 import {
 	useEffectiveGatewayConfig,
+	useEnableSurface,
 	useMcpConfigData,
 	useTrafficConfigData,
 	useUpdateConfig
@@ -80,6 +76,7 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
 	const mcpData = useMcpConfigData();
 	const trafficData = useTrafficConfigData();
 	const update = useUpdateConfig();
+	const enableSurface = useEnableSurface();
 	const navigate = useNavigate();
 	const surface = surfaceConfig[props.surface];
 	const Icon = surface.icon;
@@ -117,22 +114,18 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
 			return;
 		}
 		try {
-			await update.mutateAsync(next => {
-				if (props.surface === 'llm') {
-					next.llm = next.llm ?? startupLlmConfig(next, gateway || undefined);
-					ensureLlmFrontendDefaults(next);
-				} else if (props.surface === 'mcp') {
-					next.mcp = next.mcp ?? startupMcpConfig(next, gateway || undefined);
-				} else {
-					enableTrafficConfig(next);
-				}
+			const { hybrid } = await enableSurface.mutateAsync({
+				surface: props.surface,
+				gateway: gateway || undefined
 			});
 			void navigate({ to: surface.destination });
 			if (props.surface === 'llm') {
-				void refreshBaseCostsAndConfigure(update).catch(() => undefined);
+				void (hybrid ? refreshBaseCosts() : refreshBaseCostsAndConfigure(update)).catch(
+					() => undefined
+				);
 			}
 		} catch {
-			// useUpdateConfig exposes the save error through update.isError.
+			// The enable mutation exposes the save error.
 		}
 	}
 
@@ -154,9 +147,9 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
 					{configError.message}
 				</StatusBanner>
 			) : null}
-			{update.isError ? (
+			{enableSurface.isError || update.isError ? (
 				<StatusBanner state="bad" title="Save failed">
-					{update.error.message}
+					{enableSurface.error?.message ?? update.error?.message}
 				</StatusBanner>
 			) : null}
 
@@ -209,7 +202,7 @@ function GetStartedPage(props: { surface: SurfaceKind }) {
 						<button
 							className="button primary"
 							type="button"
-							disabled={loading || update.isPending}
+							disabled={loading || enableSurface.isPending || update.isPending}
 							onClick={() => void enable()}
 						>
 							Enable

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -229,6 +229,12 @@ export function HomePage() {
 		<div className="page-stack">
 			<PageHeader title="Gateway Overview" />
 
+			{update.isError ? (
+				<StatusBanner state="bad" title="Save failed">
+					{update.error.message}
+				</StatusBanner>
+			) : null}
+
 			{pageDataLoading ? (
 				<StatusBanner state="loading" title="Loading gateway configuration" />
 			) : pageDataError ? (

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -100,10 +100,10 @@ export function HomePage() {
 		try {
 			await update.mutateAsync(next => {
 				if (surface === 'llm') {
-					next.llm = startupLlmConfig(next, 4000);
+					next.llm = startupLlmConfig(next);
 					ensureLlmFrontendDefaults(next);
 				} else if (surface === 'mcp') {
-					next.mcp = startupMcpConfig(next, 3000);
+					next.mcp = startupMcpConfig(next);
 				} else {
 					enableTrafficConfig(next);
 				}

--- a/ui/src/pages/Home.tsx
+++ b/ui/src/pages/Home.tsx
@@ -4,18 +4,13 @@ import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
 
 import type { McpSettingsResource } from '@/api/configResourcesApi';
+import { refreshBaseCosts } from '@/api/costsApi';
 import { PageHeader, StatusBanner } from '@/components/Primitives';
-import {
-	enableTrafficConfig,
-	ensureLlm,
-	ensureLlmFrontendDefaults,
-	fileOwnedMcpSettingFields,
-	startupLlmConfig,
-	startupMcpConfig
-} from '@/config';
+import { ensureLlm, fileOwnedMcpSettingFields } from '@/config';
 import { refreshBaseCostsAndConfigure } from '@/costs';
 import {
 	useConfigDumpMode,
+	useEnableSurface,
 	useLlmConfigData,
 	useMcpConfigData,
 	useTrafficConfigData,
@@ -55,6 +50,7 @@ export function HomePage() {
 		enabled: Boolean(mode.data && mode.data.mode !== 'dump')
 	});
 	const update = useUpdateConfig();
+	const enable = useEnableSurface();
 	const upsertResource = useUpsertConfigResource();
 	const help = useSchemaHelp();
 	const [locallyEnabled, setLocallyEnabled] = useState<Set<StartupSurface>>(() => new Set());
@@ -98,20 +94,14 @@ export function HomePage() {
 	async function enableSurface(surface: StartupSurface) {
 		setCostRefreshError(null);
 		try {
-			await update.mutateAsync(next => {
-				if (surface === 'llm') {
-					next.llm = startupLlmConfig(next);
-					ensureLlmFrontendDefaults(next);
-				} else if (surface === 'mcp') {
-					next.mcp = startupMcpConfig(next);
-				} else {
-					enableTrafficConfig(next);
-				}
+			const { hybrid } = await enable.mutateAsync({
+				surface: surface === 'apis' ? 'traffic' : surface
 			});
 			setLocallyEnabled(current => new Set(current).add(surface));
 			if (surface === 'llm') {
 				try {
-					await refreshBaseCostsAndConfigure(update);
+					if (hybrid) await refreshBaseCosts();
+					else await refreshBaseCostsAndConfigure(update);
 				} catch (err) {
 					setCostRefreshError(
 						err instanceof Error ? err.message : 'Failed to refresh base cost catalog'
@@ -119,7 +109,7 @@ export function HomePage() {
 				}
 			}
 		} catch {
-			// useUpdateConfig exposes the save error through update.isError.
+			// The enable mutation exposes the save error.
 		}
 	}
 
@@ -164,9 +154,9 @@ export function HomePage() {
 							{pageDataError.message}
 						</StatusBanner>
 					) : null}
-					{update.isError ? (
+					{enable.isError || update.isError ? (
 						<StatusBanner state="bad" title="Save failed">
-							{update.error.message}
+							{enable.error?.message ?? update.error?.message}
 						</StatusBanner>
 					) : null}
 					{costRefreshError ? (
@@ -180,7 +170,7 @@ export function HomePage() {
 							label="LLM"
 							description="Models, keys, policies, and chat testing."
 							enabled={hasLlm || locallyEnabled.has('llm')}
-							disabled={update.isPending}
+							disabled={enable.isPending || update.isPending}
 							icon={<Bot size={24} />}
 							onClick={() => void enableSurface('llm')}
 						/>
@@ -188,7 +178,7 @@ export function HomePage() {
 							label="MCP"
 							description="Servers, tools, and MCP playground flows."
 							enabled={hasMcp || locallyEnabled.has('mcp')}
-							disabled={update.isPending}
+							disabled={enable.isPending || update.isPending}
 							icon={<Server size={24} />}
 							onClick={() => void enableSurface('mcp')}
 						/>
@@ -196,7 +186,7 @@ export function HomePage() {
 							label="APIs"
 							description="HTTP and TCP listeners, routes, and policy controls."
 							enabled={hasTraffic || locallyEnabled.has('apis')}
-							disabled={update.isPending}
+							disabled={enable.isPending || update.isPending}
 							icon={<Network size={24} />}
 							onClick={() => void enableSurface('apis')}
 						/>
@@ -229,9 +219,9 @@ export function HomePage() {
 		<div className="page-stack">
 			<PageHeader title="Gateway Overview" />
 
-			{update.isError ? (
+			{enable.isError || update.isError ? (
 				<StatusBanner state="bad" title="Save failed">
-					{update.error.message}
+					{enable.error?.message ?? update.error?.message}
 				</StatusBanner>
 			) : null}
 
@@ -281,7 +271,7 @@ export function HomePage() {
 					title="LLM"
 					icon={<Bot size={18} />}
 					enabled={hasLlm}
-					disabled={update.isPending}
+					disabled={enable.isPending || update.isPending}
 					onEnable={() => void enableSurface('llm')}
 					setupNeeded={callableModels === 0}
 					setupText="Add a model before LLM traffic can be served."
@@ -298,7 +288,7 @@ export function HomePage() {
 						<button
 							className="button"
 							type="button"
-							disabled={update.isPending}
+							disabled={enable.isPending || update.isPending}
 							onClick={() => setLlmSettingsOpen(true)}
 						>
 							<Settings size={16} />
@@ -310,7 +300,7 @@ export function HomePage() {
 					title="MCP"
 					icon={<Server size={18} />}
 					enabled={hasMcp}
-					disabled={update.isPending}
+					disabled={enable.isPending || update.isPending}
 					onEnable={() => void enableSurface('mcp')}
 					setupNeeded={mcpServers.length === 0}
 					setupText="Add an MCP target before tools are available."
@@ -324,7 +314,7 @@ export function HomePage() {
 						<button
 							className="button"
 							type="button"
-							disabled={update.isPending}
+							disabled={enable.isPending || update.isPending}
 							onClick={() => setMcpSettingsOpen(true)}
 						>
 							<Settings size={16} />
@@ -336,7 +326,7 @@ export function HomePage() {
 					title="Traffic"
 					icon={<Network size={18} />}
 					enabled={hasTraffic}
-					disabled={update.isPending}
+					disabled={enable.isPending || update.isPending}
 					onEnable={() => void enableSurface('apis')}
 					setupNeeded={hasBinds ? traffic.listeners === 0 : traffic.gateways === 0}
 					setupText={

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -109,7 +109,7 @@ export type McpTarget =
 			openapi: McpNetworkTarget & { schema: unknown };
 	  });
 export type McpConfig = Omit<LocalSimpleMcpConfig, 'targets'> & {
-	targets: McpTarget[];
+	targets?: McpTarget[];
 };
 export type GatewayConfig = Omit<LocalConfig, 'llm' | 'mcp'> & {
 	llm?: LlmConfig | null;

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -170,18 +170,14 @@ test('onboards all surfaces from a completely empty config', async ({ page }) =>
 	await page.getByRole('button', { name: /LLM/ }).click();
 	await expect.poll(() => gateway.postedConfigs.length).toBe(2);
 	expect(gateway.postedConfigs[1].llm).toEqual({
-		gateways: 'public',
-		models: [],
-		providers: [],
-		virtualModels: []
+		gateways: 'public'
 	});
 	await expect(page.getByRole('heading', { name: 'Welcome to Agentgateway' })).toBeVisible();
 
 	await page.getByRole('button', { name: /MCP/ }).click();
 	await expect.poll(() => gateway.postedConfigs.length).toBe(3);
 	expect(gateway.postedConfigs[2].mcp).toEqual({
-		gateways: 'public',
-		targets: []
+		gateways: 'public'
 	});
 	await expect(page.getByRole('heading', { name: 'Welcome to Agentgateway' })).toBeVisible();
 	await expect(page.getByText('3 of 3 enabled')).toBeVisible();
@@ -342,18 +338,14 @@ test('onboards LLM and MCP onto the UI gateway when present', async ({ page }) =
 	await page.getByRole('button', { name: /LLM/ }).click();
 	await expect.poll(() => gateway.postedConfigs.length).toBe(1);
 	expect(gateway.postedConfigs[0].llm).toMatchObject({
-		gateways: 'default',
-		models: [],
-		providers: [],
-		virtualModels: []
+		gateways: 'default'
 	});
 	expect(gateway.postedConfigs[0].llm).not.toHaveProperty('port');
 
 	await page.getByRole('button', { name: /MCP/ }).click();
 	await expect.poll(() => gateway.postedConfigs.length).toBe(2);
 	expect(gateway.postedConfigs[1].mcp).toMatchObject({
-		gateways: 'default',
-		targets: []
+		gateways: 'default'
 	});
 	expect(gateway.postedConfigs[1].mcp).not.toHaveProperty('port');
 

--- a/ui/tests/e2e/ui.spec.ts
+++ b/ui/tests/e2e/ui.spec.ts
@@ -169,8 +169,8 @@ test('onboards all surfaces from a completely empty config', async ({ page }) =>
 
 	await page.getByRole('button', { name: /LLM/ }).click();
 	await expect.poll(() => gateway.postedConfigs.length).toBe(2);
-	expect(gateway.postedConfigs[1].llm).toMatchObject({
-		port: 4000,
+	expect(gateway.postedConfigs[1].llm).toEqual({
+		gateways: 'public',
 		models: [],
 		providers: [],
 		virtualModels: []
@@ -179,8 +179,8 @@ test('onboards all surfaces from a completely empty config', async ({ page }) =>
 
 	await page.getByRole('button', { name: /MCP/ }).click();
 	await expect.poll(() => gateway.postedConfigs.length).toBe(3);
-	expect(gateway.postedConfigs[2].mcp).toMatchObject({
-		port: 3000,
+	expect(gateway.postedConfigs[2].mcp).toEqual({
+		gateways: 'public',
 		targets: []
 	});
 	await expect(page.getByRole('heading', { name: 'Welcome to Agentgateway' })).toBeVisible();


### PR DESCRIPTION
Split into commits:

1. UI should use modern `gateways` config, not `port`
2. Allow `llm: {}` and `mcp: {}` in config (so you don't need `models: []` as well, etc)
3. If we fail to enable LLM/MCP, properly show an error
4. In hybrid mode, allow enabling LLM and MCP
