### PR TITLE
llm: increase default buffer size to 32mb for LLM

### DIFF
--- a/crates/agentgateway/src/http/buffer.rs
+++ b/crates/agentgateway/src/http/buffer.rs
@@ -68,9 +68,12 @@ impl Buffer {
 			},
 		};
 		*req.body_mut() = buffered;
-		req
-			.extensions_mut()
-			.insert(crate::transport::BufferLimit::new(limit));
+		// Preserve an unset limit so LLM processing can apply its own default later.
+		if let Some(limit) = request.max_bytes {
+			req
+				.extensions_mut()
+				.insert(crate::transport::BufferLimit::new(limit));
+		}
 		Ok(())
 	}
 

--- a/crates/agentgateway/src/llm/mod.rs
+++ b/crates/agentgateway/src/llm/mod.rs
@@ -33,6 +33,9 @@ use crate::*;
 pub mod model_router;
 pub use agent_llm::{azure, bedrock, vertex};
 
+/// Default body buffer limit once a request enters LLM processing.
+pub const DEFAULT_BUFFER_LIMIT: usize = 32 * 1024 * 1024;
+
 pub mod catalog;
 pub mod policy;
 

--- a/crates/agentgateway/src/proxy/gateway.rs
+++ b/crates/agentgateway/src/proxy/gateway.rs
@@ -758,12 +758,7 @@ impl Gateway {
 	) -> anyhow::Result<()> {
 		let policies = Arc::new(policies);
 		let connection = Arc::new(raw_stream.get_ext());
-		let def = frontend::HTTP::default();
-		let buffer = policies
-			.http
-			.as_ref()
-			.map(|h| h.max_buffer_size)
-			.unwrap_or(def.max_buffer_size);
+		let buffer = policies.http.as_ref().and_then(|h| h.max_buffer_size);
 		let server = auto_server(policies.http.as_ref());
 		let substrate_egress_actor_resolution = policies.substrate_egress_actor_resolution.clone();
 
@@ -776,7 +771,9 @@ impl Gateway {
 				let substrate_egress_actor_resolution = substrate_egress_actor_resolution.clone();
 				async move {
 					let mut req = req.map(crate::http::Body::new);
-					req.extensions_mut().insert(BufferLimit::new(buffer));
+					if let Some(buffer) = buffer {
+						req.extensions_mut().insert(BufferLimit::new(buffer));
+					}
 					if req.method() != ::http::Method::CONNECT {
 						return Ok::<_, Infallible>(
 							ProxyError::MethodNotAllowed.into_response_with_grpc(false),
@@ -883,7 +880,9 @@ impl Gateway {
 							downstream.ext_mut().insert(identity);
 						}
 						downstream.ext_mut().insert(ConnectHeaders(connect_headers));
-						downstream.ext_mut().insert(BufferLimit::new(buffer));
+						if let Some(buffer) = buffer {
+							downstream.ext_mut().insert(BufferLimit::new(buffer));
+						}
 						Self::proxy_bind(bind.key.clone(), bind.protocol, downstream, inputs, drain).await;
 					});
 
@@ -990,14 +989,12 @@ impl Gateway {
 		let mut stream = stream;
 		stream.set_transport_metrics(transport_metrics, transport_labels);
 
-		let def = frontend::HTTP::default();
 		let tunneled_buffer = stream.ext::<BufferLimit>().map(|b| b.0);
 		let buffer = policies
 			.http
 			.as_ref()
-			.map(|h| h.max_buffer_size)
-			.or(tunneled_buffer)
-			.unwrap_or(def.max_buffer_size);
+			.and_then(|h| h.max_buffer_size)
+			.or(tunneled_buffer);
 
 		let max_connection_duration = policies
 			.http
@@ -1034,7 +1031,9 @@ impl Gateway {
 					)));
 				};
 
-				req.extensions_mut().insert(BufferLimit::new(buffer));
+				if let Some(buffer) = buffer {
+					req.extensions_mut().insert(BufferLimit::new(buffer));
+				}
 				let req = req.map(crate::http::Body::new);
 
 				Either::Right(async move {

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -2335,6 +2335,10 @@ async fn make_backend_call(
 ) -> Result<Response, ProxyResponse> {
 	let resolved_backend;
 	let backend = if let Backend::LLMRouter(_, router) = backend {
+		// Model routing parses the LLM body before provider request processing.
+		req
+			.extensions_mut()
+			.get_or_insert_with(|| crate::transport::BufferLimit::new(llm::DEFAULT_BUFFER_LIMIT));
 		let resolved = match router.resolve(&mut req).await {
 			model_router::ResolveResult::DirectResponse(resp) => return Ok(resp),
 			model_router::ResolveResult::Backend(resolved) => resolved,
@@ -2660,6 +2664,9 @@ async fn make_backend_call(
 
 	let (mut req, llm_response_policies, llm_request) =
 		if let Some(llm) = &backend_call.backend_policies.llm_provider {
+			req
+				.extensions_mut()
+				.get_or_insert_with(|| crate::transport::BufferLimit::new(llm::DEFAULT_BUFFER_LIMIT));
 			// LLM requires CEL execution after the snapshot so we do not clear extensions
 			let mut req = req.take_and_snapshot_without_clearing_extensions(log.as_mut())?;
 			let route_type = llm_request_policies

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -3341,10 +3341,7 @@ fn frontend_policy_from_proto(
 
 	Ok(match &spec.kind {
 		Some(fps::Kind::Http(h)) => FrontendPolicy::HTTP(frontend::HTTP {
-			max_buffer_size: h
-				.max_buffer_size
-				.map(|v| v as usize)
-				.unwrap_or_else(crate::defaults::max_buffer_size),
+			max_buffer_size: h.max_buffer_size.map(|v| v as usize),
 			http1_max_headers: h.http1_max_headers.map(|v| v as usize),
 			http1_idle_timeout: h
 				.http1_idle_timeout

--- a/crates/agentgateway/src/types/frontend.rs
+++ b/crates/agentgateway/src/types/frontend.rs
@@ -48,8 +48,9 @@ pub enum HTTPHeaderCase {
 #[cfg_attr(feature = "schema", schemars(rename = "FrontendHTTP"))]
 pub struct HTTP {
 	/// Maximum request or response body size buffered by the frontend.
-	#[serde(default = "defaults::max_buffer_size")]
-	pub max_buffer_size: usize,
+	/// Defaults to 2 MiB, or 32 MiB once the request enters LLM processing.
+	#[serde(default)]
+	pub max_buffer_size: Option<usize>,
 
 	/// Maximum number of headers allowed in an HTTP/1 request. Changing this value causes a
 	/// performance degradation, even when set lower than the default of 100.
@@ -104,7 +105,7 @@ pub struct HTTP {
 impl Default for HTTP {
 	fn default() -> Self {
 		Self {
-			max_buffer_size: defaults::max_buffer_size(),
+			max_buffer_size: None,
 
 			http1_max_headers: None,
 			http1_idle_timeout: defaults::http1_idle_timeout(),

--- a/schema/config.json
+++ b/schema/config.json
@@ -9942,11 +9942,14 @@
       "type": "object",
       "properties": {
         "maxBufferSize": {
-          "description": "Maximum request or response body size buffered by the frontend.",
-          "type": "integer",
+          "description": "Maximum request or response body size buffered by the frontend.\nDefaults to 2 MiB, or 32 MiB once the request enters LLM processing.",
+          "type": [
+            "integer",
+            "null"
+          ],
           "format": "uint",
           "minimum": 0,
-          "default": 2097152
+          "default": null
         },
         "http1MaxHeaders": {
           "description": "Maximum number of headers allowed in an HTTP/1 request. Changing this value causes a\nperformance degradation, even when set lower than the default of 100.",

--- a/schema/config.md
+++ b/schema/config.md
@@ -17800,7 +17800,7 @@
 |`binds[].mode`|enum|Whether the bind opens an OS listener socket. Defaults to `standard` (binds the port).<br>Set to `internal` to create a routing-only bind that does not bind a socket.<br>Possible values: `standard`, `internal`.|
 |`frontendPolicies`|object|frontendPolicies defines top level policies applying to all traffic.|
 |`frontendPolicies.http`|object|Settings for handling incoming HTTP requests.|
-|`frontendPolicies.http.maxBufferSize`|integer|Maximum request or response body size buffered by the frontend.|
+|`frontendPolicies.http.maxBufferSize`|integer|Maximum request or response body size buffered by the frontend.<br>Defaults to 2 MiB, or 32 MiB once the request enters LLM processing.|
 |`frontendPolicies.http.http1MaxHeaders`|integer|Maximum number of headers allowed in an HTTP/1 request. Changing this value causes a<br>performance degradation, even when set lower than the default of 100.|
 |`frontendPolicies.http.http1IdleTimeout`|string|How long an idle HTTP/1 connection may stay open.|
 |`frontendPolicies.http.http1HeaderCase`|enum|Header casing behavior for HTTP/1 responses.<br>Possible values: `lowercase`, `preserve`.|


### PR DESCRIPTION
2mb is a reasonable default for general traffic, but for LLM its a bit
small; increase it there. this allows large 1M context.

Note: this applies once we hit the LLM traffic path; a pre-route policy
buffering would still be 2mb

Signed-off-by: John Howard <john.howard@solo.io>
