### PR TITLE
Move to the new substrate ingress header

### DIFF
--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -22,7 +22,7 @@ use crate::telemetry::metrics::{OutboundCallKind, OutboundCallSubtype};
 use crate::types::agent::{SimpleBackendReferenceWithPolicies, Target};
 use crate::*;
 
-const ACTOR_DNS_SUFFIX: &str = ".actors.resources.substrate.ate.dev";
+const TARGET_ACTOR_HEADER: &str = "ate-target-actor";
 const RESUME_TIMEOUT: Duration = Duration::from_secs(15);
 const DEFAULT_PARKING_BUDGET: Duration = Duration::from_secs(5);
 const DEFAULT_PARKING_MAX: usize = 1024;
@@ -148,7 +148,7 @@ impl AssignmentCache {
 #[derive(Clone)]
 pub(crate) struct SubstrateRequestState {
 	actor: ActorRef,
-	actor_port: u16,
+	connect_authority: String,
 	ingress: SubstrateIngress,
 	client: PolicyClient,
 	current: Option<CachedAssignment>,
@@ -246,7 +246,7 @@ impl Default for RequestParking {
 	}
 }
 
-/// Resolves Substrate actor hostnames through the ate-api for dynamic route backends.
+/// Resolves Substrate actors through the ate-api for dynamic route backends.
 #[apply(schema!)]
 pub struct SubstrateIngress {
 	/// Backend that receives ResumeActor calls and policies used when connecting to it.
@@ -488,14 +488,11 @@ impl SubstrateRequestState {
 		self.route_outcome
 	}
 
-	/// The authority sent to atunnel when proxying a raw CONNECT tunnel. atunnel
-	/// authenticates the router connection and uses this stable actor DNS name
-	/// plus port to select the currently active actor process.
+	/// The authority sent to atunnel when proxying a raw CONNECT tunnel. Actor
+	/// selection is carried separately in `ate-target-actor`, so this preserves
+	/// the caller's target host and port as application metadata.
 	pub(crate) fn connect_authority(&self) -> String {
-		format!(
-			"{}.{}{}:{}",
-			self.actor.name, self.actor.atespace, ACTOR_DNS_SUFFIX, self.actor_port
-		)
+		self.connect_authority.clone()
 	}
 
 	pub(crate) fn actor_uid(&self) -> Option<String> {
@@ -638,7 +635,9 @@ impl RequestPolicyTrait for SubstrateIngress {
 			});
 		// CONNECT re-entry retains the outer authority in SourceContext. A direct
 		// CONNECT routed by AgentGateway has no such re-entry, so its request URI
-		// is the authoritative source (and preserves its non-default port).
+		// is the authoritative source (and preserves its non-default port). The
+		// authority identifies only the target port; actor selection comes from
+		// `ate-target-actor` below.
 		let authority = connect_authority
 			.map(ToOwned::to_owned)
 			.or_else(|| {
@@ -656,20 +655,27 @@ impl RequestPolicyTrait for SubstrateIngress {
 					format!("invalid actor authority {authority:?}: {error}"),
 				)
 			})?;
-		let host = authority.host();
+		let connect_authority = authority.to_string();
 		let actor_port = authority.port_u16().unwrap_or(DEFAULT_ACTOR_PORT);
-		let host = host.strip_suffix('.').unwrap_or(host);
-		let parsed = host
-			.strip_suffix(ACTOR_DNS_SUFFIX)
-			.and_then(|prefix| prefix.split_once('.'))
-			.filter(|(_, atespace)| !atespace.contains('.'));
-		let Some((name, atespace)) =
-			parsed.filter(|(name, atespace)| valid_resource_name(name) && valid_resource_name(atespace))
+		let target_actor = if let Some(source) = req
+			.extensions()
+			.get::<crate::cel::SourceContext>()
+			.filter(|source| source.connect_headers.contains_key(TARGET_ACTOR_HEADER))
+		{
+			source.connect_headers.get(TARGET_ACTOR_HEADER)
+		} else {
+			req.headers().get(TARGET_ACTOR_HEADER)
+		}
+		.and_then(|value| value.to_str().ok());
+		let Some((atespace, name)) = target_actor
+			.and_then(|target| target.split_once('/'))
+			.filter(|(_, name)| !name.contains('/'))
+			.filter(|(atespace, name)| valid_resource_name(atespace) && valid_resource_name(name))
 		else {
 			return Err(
 				ProxyError::SubstrateIngressFailed(
 					StatusCode::NOT_FOUND,
-					format!("invalid host {host:?}: expected <actor>.<atespace>{ACTOR_DNS_SUFFIX}"),
+					format!("invalid {TARGET_ACTOR_HEADER:?}: expected <atespace>/<actor>"),
 				)
 				.into(),
 			);
@@ -692,7 +698,7 @@ impl RequestPolicyTrait for SubstrateIngress {
 		}
 		req.extensions_mut().insert(SubstrateRequestState {
 			actor,
-			actor_port,
+			connect_authority,
 			ingress: self.clone(),
 			client: client.clone(),
 			current: None,
@@ -720,10 +726,10 @@ mod tests {
 	use wiremock::matchers::{header, method};
 	use wiremock::{Mock, MockServer, ResponseTemplate};
 
-	use super::STALE_ASSIGNMENT_HEADER;
+	use super::{STALE_ASSIGNMENT_HEADER, TARGET_ACTOR_HEADER};
 	use crate::strng;
 	use crate::test_helpers::proxymock::{
-		basic_named_route, send_request, setup_proxy_test, simple_bind,
+		basic_named_route, send_request_headers, setup_proxy_test, simple_bind,
 	};
 	use crate::types::agent::{Backend, ResourceName};
 
@@ -785,10 +791,7 @@ mod tests {
 		let actor_calls = Arc::new(AtomicUsize::new(0));
 		let responder_calls = actor_calls.clone();
 		Mock::given(method("GET"))
-			.and(header(
-				"host",
-				"my-actor.my-space.actors.resources.substrate.ate.dev",
-			))
+			.and(header("host", "application.example"))
 			.respond_with(move |_: &wiremock::Request| {
 				if responder_calls.fetch_add(1, Ordering::Relaxed) < 2 {
 					ResponseTemplate::new(421).insert_header(STALE_ASSIGNMENT_HEADER, "true")
@@ -825,10 +828,11 @@ mod tests {
 
 		let started = Instant::now();
 		for _ in 0..2 {
-			let response = send_request(
+			let response = send_request_headers(
 				client.clone(),
 				Method::GET,
-				"http://my-actor.my-space.actors.resources.substrate.ate.dev/",
+				"http://application.example/",
+				&[(TARGET_ACTOR_HEADER, "my-space/my-actor")],
 			)
 			.await;
 			assert_eq!(response.status(), ::http::StatusCode::OK);
@@ -870,10 +874,11 @@ mod tests {
 				}
 			}))
 			.await;
-		let response = send_request(
+		let response = send_request_headers(
 			proxy.serve_http("bind".into()),
 			Method::GET,
 			"http://my-actor.my-space.actors.resources.substrate.ate.dev/",
+			&[(TARGET_ACTOR_HEADER, "my-space/my-actor")],
 		)
 		.await;
 

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -633,11 +633,8 @@ impl RequestPolicyTrait for SubstrateIngress {
 				let authority = values.next()?.to_str().ok()?;
 				(values.next().is_none()).then_some(authority)
 			});
-		// CONNECT re-entry retains the outer authority in SourceContext. A direct
-		// CONNECT routed by AgentGateway has no such re-entry, so its request URI
-		// is the authoritative source (and preserves its non-default port). The
-		// authority identifies only the target port; actor selection comes from
-		// `ate-target-actor` below.
+		// N.B: we only use the authority to determine the target port.
+		// We forward it unchanged to the actor.
 		let authority = connect_authority
 			.map(ToOwned::to_owned)
 			.or_else(|| {

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -9,6 +9,28 @@ use crate::common::prelude::*;
 
 const ACTOR_UID: &str = "6f1c2d3e-4a5b-6c7d-8e9f-0a1b2c3d4e5f";
 
+async fn send_request(io: MemoryClient, method: Method, url: &str) -> Response {
+	let authority = url
+		.strip_prefix("http://")
+		.and_then(|url| url.split('/').next())
+		.expect("Substrate ingress test URL has an HTTP authority");
+	let mut labels = authority.split('.');
+	let actor = labels
+		.next()
+		.expect("Substrate ingress test URL has an actor");
+	let atespace = labels
+		.next()
+		.expect("Substrate ingress test URL has an atespace");
+	let target_actor = format!("{atespace}/{actor}");
+	send_request_headers(
+		io,
+		method,
+		url,
+		&[("ate-target-actor", target_actor.as_str())],
+	)
+	.await
+}
+
 #[derive(Clone)]
 struct IngressHandler {
 	pod_ip: String,
@@ -1001,7 +1023,7 @@ async fn actor_ingress_reports_no_resume_when_the_resume_fails() {
 }
 
 #[tokio::test]
-async fn actor_ingress_uses_the_original_connect_authority() {
+async fn actor_ingress_uses_the_original_connect_target_actor() {
 	let actor = simple_mock().await;
 	let calls = Arc::new(AtomicUsize::new(0));
 	let api = ateapimock::AteApiMock::new({
@@ -1041,9 +1063,12 @@ async fn actor_ingress_uses_the_original_connect_authority() {
 		.await;
 
 	let mut io = gateway.serve_tunnel(strng::literal!("outer"));
-	let connect_target = "my-actor.demo.actors.resources.substrate.ate.dev:9090";
+	let connect_target = "application.example:9090";
 	io.write_all(
-		format!("CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\n\r\n").as_bytes(),
+	format!(
+		"CONNECT {connect_target} HTTP/1.1\r\nHost: {connect_target}\r\nate-target-actor: demo/my-actor\r\n\r\n"
+	)
+	.as_bytes(),
 	)
 	.await
 	.unwrap();
@@ -1064,7 +1089,7 @@ async fn actor_ingress_uses_the_original_connect_authority() {
 	);
 
 	// The re-entered request's Host is unrelated to the actor. Native ingress
-	// must use the original CONNECT authority retained in SourceContext.
+	// must use the original CONNECT routing header retained in SourceContext.
 	io.write_all(b"GET / HTTP/1.1\r\nHost: irrelevant.example\r\nConnection: close\r\n\r\n")
 		.await
 		.unwrap();
@@ -1106,8 +1131,7 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 		}
 		let request = String::from_utf8(request).unwrap();
 		assert!(
-			request
-				.starts_with("CONNECT my-actor.demo.actors.resources.substrate.ate.dev:9090 HTTP/1.1\r\n"),
+			request.starts_with("CONNECT application.example:9090 HTTP/1.1\r\n"),
 			"unexpected tunnel request: {request:?}"
 		);
 		downstream
@@ -1163,10 +1187,15 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 		}))
 		.await;
 	let mut io = gateway.serve_tunnel(strng::literal!("outer"));
-	let authority = "my-actor.demo.actors.resources.substrate.ate.dev:9090";
-	io.write_all(format!("CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\n\r\n").as_bytes())
-		.await
-		.unwrap();
+	let authority = "application.example:9090";
+	io.write_all(
+		format!(
+			"CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\nate-target-actor: demo/my-actor\r\n\r\n"
+		)
+		.as_bytes(),
+	)
+	.await
+	.unwrap();
 	let mut response = [0; 128];
 	let response_len = io.read(&mut response).await.unwrap();
 	assert!(String::from_utf8_lossy(&response[..response_len]).starts_with("HTTP/1.1 200 OK\r\n"));

--- a/schema/config.json
+++ b/schema/config.json
@@ -7578,7 +7578,7 @@
       ]
     },
     "SubstrateIngress": {
-      "description": "Resolves Substrate actor hostnames through the ate-api for dynamic route backends.",
+      "description": "Resolves Substrate actors through the ate-api for dynamic route backends.",
       "type": "object",
       "properties": {
         "policies": {


### PR DESCRIPTION
- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.

agent-substrate/substrate#1333 removed the Host header parsing from substrate, so this PR moves agentgateway to respect the new `ate-target-actor` header.