### PR TITLE
Use default 80 for non-CONNECT ingress

### DIFF
--- a/crates/agentgateway/src/client/connect_tunnel.rs
+++ b/crates/agentgateway/src/client/connect_tunnel.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use http::HeaderValue;
+use http::{HeaderName, HeaderValue};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::http::substrate::STALE_ASSIGNMENT_HEADER;
@@ -47,6 +47,7 @@ pub async fn handshake_h1(
 	conn: Socket,
 	dest: &str,
 	auth: Option<HeaderValue>,
+	headers: &[(HeaderName, HeaderValue)],
 ) -> Result<Socket, anyhow::Error> {
 	let (mut ext, metrics, inner) = conn.into_parts();
 	let mut conn = Socket::new_rewind(inner);
@@ -65,6 +66,12 @@ pub async fn handshake_h1(
 		buf.extend_from_slice(PROXY_AUTHORIZATION_HEADER.as_bytes());
 		buf.extend_from_slice(b": ");
 		buf.extend_from_slice(auth.as_bytes());
+		buf.extend_from_slice(b"\r\n");
+	}
+	for (name, value) in headers {
+		buf.extend_from_slice(name.as_str().as_bytes());
+		buf.extend_from_slice(b": ");
+		buf.extend_from_slice(value.as_bytes());
 		buf.extend_from_slice(b"\r\n");
 	}
 	// headers end
@@ -124,6 +131,7 @@ pub(crate) async fn handshake(
 	conn: Socket,
 	dest: &str,
 	auth: Option<HeaderValue>,
+	headers: &[(HeaderName, HeaderValue)],
 	h2_config: Arc<agent_hbone::H2Config>,
 ) -> Result<Socket, Error> {
 	// `TunnelConfig::token` has always authenticated configured HTTP proxies
@@ -133,9 +141,9 @@ pub(crate) async fn handshake(
 		.ext::<TLSConnectionInfo>()
 		.and_then(|info| info.negotiated_alpn)
 	{
-		Some(stream::Alpn::H2) => handshake_h2(conn, dest, auth, h2_config).await,
-		Some(stream::Alpn::Http11) => handshake_h1(conn, dest, auth).await,
-		None => handshake_h1(conn, dest, auth).await,
+		Some(stream::Alpn::H2) => handshake_h2(conn, dest, auth, headers, h2_config).await,
+		Some(stream::Alpn::Http11) => handshake_h1(conn, dest, auth, headers).await,
+		None => handshake_h1(conn, dest, auth, headers).await,
 		Some(alpn) => Err(anyhow::anyhow!(
 			"CONNECT negotiated unsupported ALPN: {alpn:?}"
 		)),
@@ -147,6 +155,7 @@ async fn handshake_h2(
 	conn: Socket,
 	dest: &str,
 	auth: Option<HeaderValue>,
+	headers: &[(HeaderName, HeaderValue)],
 	h2_config: Arc<agent_hbone::H2Config>,
 ) -> Result<Socket, anyhow::Error> {
 	let target = conn.target_address();
@@ -171,6 +180,9 @@ async fn handshake_h2(
 		request
 			.headers_mut()
 			.insert(PROXY_AUTHORIZATION_HEADER, auth);
+	}
+	for (name, value) in headers {
+		request.headers_mut().insert(name, value.clone());
 	}
 	let stream = sender.send_request(request).await?;
 	Ok(Socket::from_hbone(
@@ -230,7 +242,7 @@ mod tests {
 				.expect("write response");
 		});
 
-		let mut tunneled = handshake_h1(memory_socket(client), "dest:443", None)
+		let mut tunneled = handshake_h1(memory_socket(client), "dest:443", None, &[])
 			.await
 			.expect("handshake should succeed");
 		let mut first_bytes = [0; 5];
@@ -256,7 +268,7 @@ mod tests {
 				.expect("write response");
 		});
 
-		let error = match handshake_h1(memory_socket(client), "dest:443", None).await {
+		let error = match handshake_h1(memory_socket(client), "dest:443", None, &[]).await {
 			Ok(_) => panic!("stale assignment must fail the tunnel handshake"),
 			Err(error) => error,
 		};

--- a/crates/agentgateway/src/client/mod.rs
+++ b/crates/agentgateway/src/client/mod.rs
@@ -7,8 +7,8 @@ mod tls;
 use std::str::FromStr;
 use std::task;
 
-use ::http::HeaderValue;
 use ::http::uri::{Authority, Scheme};
+use ::http::{HeaderName, HeaderValue};
 use agent_pool::pool::ExpectedCapacity;
 use agent_pool::rt::TokioIo;
 use tracing::event;
@@ -76,6 +76,7 @@ pub struct TunnelConfig {
 	pub target: Target,
 	pub connection: Box<ConnectionConfig>,
 	pub token: Option<HeaderValue>,
+	pub connect_headers: Vec<(HeaderName, HeaderValue)>,
 	pub connect: bool,
 }
 
@@ -357,9 +358,15 @@ impl Connector {
 				// This is recursive but bounded: we cannot even tunnel to a tunnel
 				let con = Box::pin(self.connect(tcfg.target, proxy_dst, *tcfg.connection, false)).await?;
 
-				let con = connect_tunnel::handshake(con, &dest, tcfg.token, self.h2_config.clone())
-					.await
-					.map_err(crate::http::Error::new)?;
+				let con = connect_tunnel::handshake(
+					con,
+					&dest,
+					tcfg.token,
+					&tcfg.connect_headers,
+					self.h2_config.clone(),
+				)
+				.await
+				.map_err(crate::http::Error::new)?;
 				debug!(%dest, "connected to tunnel proxy (CONNECT)");
 				con
 			},

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -188,6 +188,16 @@ fn default_connect_target_port() -> NonZeroU16 {
 	DEFAULT_CONNECT_TARGET_PORT
 }
 
+// Regular HTTP requests have no actor-port contract, so their frontend
+// authority must not leak a proxy or port-forward port into actor selection.
+fn actor_port(authority: &::http::uri::Authority, method: &::http::Method) -> u16 {
+	if *method == ::http::Method::CONNECT {
+		authority.port_u16().unwrap_or(DEFAULT_ACTOR_PORT)
+	} else {
+		DEFAULT_ACTOR_PORT
+	}
+}
+
 /// Bounds requests held while an actor is waiting for capacity to resume.
 #[apply(schema!)]
 pub struct RequestParking {
@@ -633,8 +643,8 @@ impl RequestPolicyTrait for SubstrateIngress {
 				let authority = values.next()?.to_str().ok()?;
 				(values.next().is_none()).then_some(authority)
 			});
-		// N.B: we only use the authority to determine the target port.
-		// We forward it unchanged to the actor.
+		// The application request authority is forwarded unchanged. Its port only
+		// selects an actor port for raw CONNECT; regular HTTP addresses port 80.
 		let authority = connect_authority
 			.map(ToOwned::to_owned)
 			.or_else(|| {
@@ -652,8 +662,8 @@ impl RequestPolicyTrait for SubstrateIngress {
 					format!("invalid actor authority {authority:?}: {error}"),
 				)
 			})?;
-		let connect_authority = authority.to_string();
-		let actor_port = authority.port_u16().unwrap_or(DEFAULT_ACTOR_PORT);
+		let actor_port = actor_port(&authority, req.method());
+		let connect_authority = format!("{}:{actor_port}", authority.host());
 		let target_actor = if let Some(source) = req
 			.extensions()
 			.get::<crate::cel::SourceContext>()
@@ -733,6 +743,16 @@ mod tests {
 	#[test]
 	fn default_connect_target_port_matches_atunnel_connect_ingress() {
 		assert_eq!(super::default_connect_target_port().get(), 8443);
+	}
+
+	#[test]
+	fn actor_port_uses_default_port_for_http_and_connect_port_for_tunnels() {
+		let authority = "application.example:43123"
+			.parse::<::http::uri::Authority>()
+			.unwrap();
+
+		assert_eq!(super::actor_port(&authority, &Method::GET), 80);
+		assert_eq!(super::actor_port(&authority, &Method::CONNECT), 43123);
 	}
 
 	#[derive(Clone)]

--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -505,6 +505,11 @@ impl SubstrateRequestState {
 		self.connect_authority.clone()
 	}
 
+	pub(crate) fn target_actor_header(&self) -> ::http::HeaderValue {
+		::http::HeaderValue::try_from(format!("{}/{}", self.actor.atespace, self.actor.name))
+			.expect("validated actor reference is a valid header value")
+	}
+
 	pub(crate) fn actor_uid(&self) -> Option<String> {
 		self
 			.current

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -1895,6 +1895,7 @@ pub async fn build_transport(
 			}),
 			target: call.target.clone(),
 			token,
+			connect_headers: backend_call.connect_headers.clone(),
 			connect: tun.mode == backend::TunnelMode::Connect,
 		};
 		return Ok(Transport::Tunnel(app_transport, tc));
@@ -2179,6 +2180,15 @@ fn configure_tunnel_backend_call(
 			Target::try_from(state.connect_authority().as_str()).map_err(|error| {
 				ProxyError::ProcessingString(format!("invalid Substrate CONNECT authority: {error}"))
 			})?;
+	}
+	if let Some(state) = req
+		.extensions()
+		.get::<http::substrate::SubstrateRequestState>()
+	{
+		backend_call.connect_headers = vec![(
+			HeaderName::from_static("ate-target-actor"),
+			state.target_actor_header(),
+		)];
 	}
 	backend_call.set_tunnel_proxy(resolve_tunnel_backend_call(inputs, &tunnel, req)?);
 	Ok(())
@@ -3260,6 +3270,7 @@ pub fn build_service_call(
 			http_version_override,
 			transport_override: None,
 			hbone_port: agent_hbone::DEFAULT_HBONE_PORT,
+			connect_headers: vec![],
 			advanced_routing: None,
 			backend_policies,
 			tunnel_proxy: None,
@@ -3432,6 +3443,7 @@ pub fn build_service_call(
 		http_version_override,
 		transport_override,
 		hbone_port,
+		connect_headers: vec![],
 		advanced_routing: BackendCallAdvancedRouting::new(network_gateway, waypoint),
 		backend_policies,
 		tunnel_proxy: None,
@@ -4543,6 +4555,7 @@ pub struct BackendCall {
 	pub http_version_override: Option<::http::Version>,
 	pub transport_override: Option<(InboundProtocol, Vec<Identity>)>,
 	pub hbone_port: u16,
+	connect_headers: Vec<(HeaderName, HeaderValue)>,
 	advanced_routing: Option<Box<BackendCallAdvancedRouting>>,
 	pub backend_policies: Arc<BackendPolicies>,
 	tunnel_proxy: Option<Box<BackendCall>>,
@@ -4564,6 +4577,7 @@ impl BackendCall {
 			http_version_override: None,
 			transport_override: None,
 			hbone_port: agent_hbone::DEFAULT_HBONE_PORT,
+			connect_headers: vec![],
 			advanced_routing: None,
 			backend_policies,
 			tunnel_proxy: None,

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -1131,7 +1131,7 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 		}
 		let request = String::from_utf8(request).unwrap();
 		assert!(
-			request.starts_with("CONNECT application.example:9090 HTTP/1.1\r\n"),
+			request.starts_with("CONNECT application.example:80 HTTP/1.1\r\n"),
 			"unexpected tunnel request: {request:?}"
 		);
 		downstream
@@ -1210,7 +1210,12 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 		.unwrap();
 	assert!(String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK\r\n"));
 	assert_eq!(calls.load(Ordering::Relaxed), 1);
-	assert_eq!(actor.received_requests().await.unwrap().len(), 1);
+	let actor_requests = actor.received_requests().await.unwrap();
+	assert_eq!(actor_requests.len(), 1);
+	assert_eq!(
+		actor_requests[0].headers.get("x-ate-target-port").unwrap(),
+		"80"
+	);
 	drop(io);
 	atunnel.abort();
 }

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -1107,7 +1107,7 @@ async fn actor_ingress_uses_the_original_connect_target_actor() {
 	let actor_requests = actor.received_requests().await.unwrap();
 	assert_eq!(
 		actor_requests[0].headers.get("x-ate-target-port").unwrap(),
-		"9090"
+		"80"
 	);
 }
 

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -1134,6 +1134,10 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 			request.starts_with("CONNECT application.example:80 HTTP/1.1\r\n"),
 			"unexpected tunnel request: {request:?}"
 		);
+		assert!(
+			request.contains("ate-target-actor: demo/my-actor\r\n"),
+			"tunnel request is missing the actor header: {request:?}"
+		);
 		downstream
 			.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
 			.await


### PR DESCRIPTION
#3409 was overbroad; I forgot that non-CONNECT ingress exists and that we should use port 80 for that since non-CONNECT authority tells us nothing about the actor port

- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
