### PR TITLE
feat(controller): support Secret CA refs in BackendTLSPolicy and XBackend

### DIFF
--- a/controller/pkg/agentgateway/cacert/ca.go
+++ b/controller/pkg/agentgateway/cacert/ca.go
@@ -1,6 +1,7 @@
 package cacert
 
 import (
+	"errors"
 	"fmt"
 
 	"istio.io/istio/pkg/kube/krt"
@@ -8,14 +9,29 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/cert"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+)
+
+const (
+	// KindConfigMap is the ConfigMap CA source kind, and the default when a reference omits its kind.
+	KindConfigMap = "ConfigMap"
+	// KindSecret is the Secret CA source kind.
+	KindSecret = "Secret"
+)
+
+var (
+	// ErrUnsupportedKind reports a CA reference naming something other than a core ConfigMap or Secret.
+	ErrUnsupportedKind = errors.New("unsupported CA certificate reference kind")
+	// ErrNotFound reports a CA reference whose target object does not exist.
+	ErrNotFound = errors.New("not found")
 )
 
 // Kind returns the selected Kubernetes source kind for a CA reference.
 func Kind(kind string) string {
 	if kind == "" {
-		return "ConfigMap"
+		return KindConfigMap
 	}
 	return kind
 }
@@ -28,25 +44,68 @@ func Resolve(
 	namespace string,
 	ref agentgateway.LocalCACertificateRef,
 ) (string, error) {
-	nn := types.NamespacedName{Namespace: namespace, Name: string(ref.Name)}
-	kind := Kind(ref.Kind)
+	return ResolveSource(krtctx, configMaps, secrets, namespace, Kind(ref.Kind), string(ref.Name))
+}
+
+// GatewayRefKind returns the source kind selected by an upstream Gateway API reference, as used by
+// BackendTLSPolicy and XBackend. A ConfigMap has "Core" support upstream; a Secret is an
+// implementation-specific extension that upstream explicitly permits. Anything else, including any
+// non-core group, is ErrUnsupportedKind.
+func GatewayRefKind(ref gwv1.LocalObjectReference) (string, error) {
+	if ref.Group != "" {
+		return "", fmt.Errorf("%w %q: only the core API group is supported", ErrUnsupportedKind, string(ref.Group)+"/"+string(ref.Kind))
+	}
+	kind := Kind(string(ref.Kind))
+	if kind != KindConfigMap && kind != KindSecret {
+		return "", fmt.Errorf("%w %q", ErrUnsupportedKind, kind)
+	}
+	return kind, nil
+}
+
+// ResolveGatewayRef validates and normalizes the CA certificate selected by an upstream Gateway API
+// reference.
+func ResolveGatewayRef(
+	krtctx krt.HandlerContext,
+	configMaps krt.Collection[*corev1.ConfigMap],
+	secrets krt.Collection[*corev1.Secret],
+	namespace string,
+	ref gwv1.LocalObjectReference,
+) (string, error) {
+	kind, err := GatewayRefKind(ref)
+	if err != nil {
+		return "", err
+	}
+	return ResolveSource(krtctx, configMaps, secrets, namespace, kind, string(ref.Name))
+}
+
+// ResolveSource validates and normalizes the CA certificate held under the ca.crt key of the named
+// ConfigMap or Secret.
+func ResolveSource(
+	krtctx krt.HandlerContext,
+	configMaps krt.Collection[*corev1.ConfigMap],
+	secrets krt.Collection[*corev1.Secret],
+	namespace string,
+	kind string,
+	name string,
+) (string, error) {
+	nn := types.NamespacedName{Namespace: namespace, Name: name}
 	var caCRT []byte
 
 	switch kind {
-	case "ConfigMap":
+	case KindConfigMap:
 		configMap := ptr.Flatten(krt.FetchOne(krtctx, configMaps, krt.FilterObjectName(nn)))
 		if configMap == nil {
-			return "", fmt.Errorf("ConfigMap %s not found", nn)
+			return "", fmt.Errorf("ConfigMap %s %w", nn, ErrNotFound)
 		}
 		value, ok := configMap.Data[corev1.ServiceAccountRootCAKey]
 		if !ok || value == "" {
 			return "", fmt.Errorf("error extracting CA cert from ConfigMap %s: missing ca.crt", nn)
 		}
 		caCRT = []byte(value)
-	case "Secret":
+	case KindSecret:
 		secret := ptr.Flatten(krt.FetchOne(krtctx, secrets, krt.FilterObjectName(nn)))
 		if secret == nil {
-			return "", fmt.Errorf("Secret %s not found", nn)
+			return "", fmt.Errorf("Secret %s %w", nn, ErrNotFound)
 		}
 		var ok bool
 		caCRT, ok = secret.Data[corev1.ServiceAccountRootCAKey]
@@ -54,7 +113,7 @@ func Resolve(
 			return "", fmt.Errorf("error extracting CA cert from Secret %s: missing ca.crt", nn)
 		}
 	default:
-		return "", fmt.Errorf("unsupported CA certificate reference kind %q", ref.Kind)
+		return "", fmt.Errorf("%w %q", ErrUnsupportedKind, kind)
 	}
 
 	certificates, err := cert.ParseCertsPEM(caCRT)

--- a/controller/pkg/agentgateway/cacert/ca_test.go
+++ b/controller/pkg/agentgateway/cacert/ca_test.go
@@ -1,0 +1,154 @@
+package cacert_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/cacert"
+)
+
+// TestResolveGatewayRef covers the upstream Gateway API entry point used by BackendTLSPolicy and
+// XBackend. A ConfigMap has "Core" support upstream; a Secret is an implementation-specific
+// extension upstream explicitly permits.
+func TestResolveGatewayRef(t *testing.T) {
+	const namespace = "default"
+	configMapCA := testCAPEM(t, 1)
+	secretCA := testCAPEM(t, 2)
+
+	tests := []struct {
+		name      string
+		ref       gwv1.LocalObjectReference
+		configMap *corev1.ConfigMap
+		secret    *corev1.Secret
+		want      []byte
+		wantErr   string
+		wantIs    error
+	}{
+		{
+			name:      "ConfigMap",
+			ref:       gwv1.LocalObjectReference{Group: "", Kind: "ConfigMap", Name: "ca"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: namespace, Data: map[string]string{"ca.crt": string(configMapCA)}},
+			want:      configMapCA,
+		},
+		{
+			name:   "Secret",
+			ref:    gwv1.LocalObjectReference{Group: "", Kind: "Secret", Name: "ca"},
+			secret: &corev1.Secret{Name: "ca", Namespace: namespace, Data: map[string][]byte{"ca.crt": secretCA}},
+			want:   secretCA,
+		},
+		{
+			// Kind is required by the CRD, but an empty one must not be treated as unsupported.
+			name:      "omitted kind defaults to ConfigMap",
+			ref:       gwv1.LocalObjectReference{Group: "", Name: "ca"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: namespace, Data: map[string]string{"ca.crt": string(configMapCA)}},
+			want:      configMapCA,
+		},
+		{
+			name:      "Secret ref does not fall back to a same-name ConfigMap",
+			ref:       gwv1.LocalObjectReference{Group: "", Kind: "Secret", Name: "ca"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: namespace, Data: map[string]string{"ca.crt": string(configMapCA)}},
+			wantErr:   "Secret default/ca not found",
+			wantIs:    cacert.ErrNotFound,
+		},
+		{
+			name:    "missing ConfigMap",
+			ref:     gwv1.LocalObjectReference{Group: "", Kind: "ConfigMap", Name: "ca"},
+			wantErr: "ConfigMap default/ca not found",
+			wantIs:  cacert.ErrNotFound,
+		},
+		{
+			name:    "Secret missing ca.crt",
+			ref:     gwv1.LocalObjectReference{Group: "", Kind: "Secret", Name: "ca"},
+			secret:  &corev1.Secret{Name: "ca", Namespace: namespace},
+			wantErr: "missing ca.crt",
+		},
+		{
+			name:    "Secret with invalid PEM",
+			ref:     gwv1.LocalObjectReference{Group: "", Kind: "Secret", Name: "ca"},
+			secret:  &corev1.Secret{Name: "ca", Namespace: namespace, Data: map[string][]byte{"ca.crt": []byte("not pem")}},
+			wantErr: "invalid ca.crt in Secret default/ca",
+		},
+		{
+			name:    "unsupported kind",
+			ref:     gwv1.LocalObjectReference{Group: "", Kind: "Service", Name: "ca"},
+			wantErr: `unsupported CA certificate reference kind "Service"`,
+			wantIs:  cacert.ErrUnsupportedKind,
+		},
+		{
+			name:    "non-core group",
+			ref:     gwv1.LocalObjectReference{Group: "example.com", Kind: "ConfigMap", Name: "ca"},
+			wantErr: "only the core API group is supported",
+			wantIs:  cacert.ErrUnsupportedKind,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var configMaps []*corev1.ConfigMap
+			if tt.configMap != nil {
+				configMaps = []*corev1.ConfigMap{tt.configMap}
+			}
+			var secrets []*corev1.Secret
+			if tt.secret != nil {
+				secrets = []*corev1.Secret{tt.secret}
+			}
+			got, err := cacert.ResolveGatewayRef(
+				krt.TestingDummyContext{},
+				krt.NewStaticCollection(nil, configMaps, krt.WithName("cacert/ConfigMaps")),
+				krt.NewStaticCollection(nil, secrets, krt.WithName("cacert/Secrets")),
+				namespace,
+				tt.ref,
+			)
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+				}
+				if tt.wantIs != nil && !errors.Is(err, tt.wantIs) {
+					t.Fatalf("error = %v, want errors.Is %v", err, tt.wantIs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != string(tt.want) {
+				t.Fatalf("CA = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func testCAPEM(t *testing.T, serial int64) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		NotBefore:             now,
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	certificate, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate})
+}

--- a/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
+++ b/controller/pkg/agentgateway/plugins/backend_tls_plugin.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -18,6 +19,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/agentgateway/agentgateway/api"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/cacert"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/policyselection"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/utils"
 	"github.com/agentgateway/agentgateway/controller/pkg/pluginsdk/krtutil"
@@ -91,7 +93,7 @@ func translatePoliciesForBackendTLS(
 		},
 	}
 
-	caCert, err := getBackendTLSCACert(krtctx, cfgmaps, btls, conds)
+	caCert, err := getBackendTLSCACert(krtctx, cfgmaps, secrets, btls, conds)
 	if err != nil {
 		conds[string(gwv1.PolicyConditionAccepted)].Error = &ConfigError{
 			Reason:  string(gwv1.BackendTLSPolicyReasonNoValidCACertificate),
@@ -348,6 +350,7 @@ func applyGatewayBackendClientCert(
 func getBackendTLSCACert(
 	krtctx krt.HandlerContext,
 	cfgmaps krt.Collection[*corev1.ConfigMap],
+	secrets krt.Collection[*corev1.Secret],
 	btls *gwv1.BackendTLSPolicy,
 	conds map[string]*Condition,
 ) ([]byte, error) {
@@ -374,32 +377,11 @@ func getBackendTLSCACert(
 
 	var sb strings.Builder
 	for _, ref := range validation.CACertificateRefs {
-		if ref.Group != gwv1.Group(wellknown.ConfigMapGVK.Group) || ref.Kind != gwv1.Kind(wellknown.ConfigMapGVK.Kind) {
-			conds[string(gwv1.BackendTLSPolicyReasonResolvedRefs)].Error = &ConfigError{
-				Reason:  string(gwv1.BackendTLSPolicyReasonInvalidKind),
-				Message: "Certificate reference invalid: " + string(ref.Kind),
-			}
-			return nil, fmt.Errorf("invalid certificate reference: %v", ref)
-		}
-		nn := types.NamespacedName{
-			Name:      string(ref.Name),
-			Namespace: btls.Namespace,
-		}
-		cfgmap := krt.FetchOne(krtctx, cfgmaps, krt.FilterObjectName(nn))
-		if cfgmap == nil {
-			conds[string(gwv1.BackendTLSPolicyReasonResolvedRefs)].Error = &ConfigError{
-				Reason:  string(gwv1.BackendTLSPolicyReasonInvalidCACertificateRef),
-				Message: "Certificate reference not found",
-			}
-			return nil, fmt.Errorf("certificate reference not found: %v", ref)
-		}
-		caCert, err := GetCACertFromConfigMap(ptr.Flatten(cfgmap))
+		caCert, err := cacert.ResolveGatewayRef(krtctx, cfgmaps, secrets, btls.Namespace, ref)
 		if err != nil {
-			conds[string(gwv1.BackendTLSPolicyReasonResolvedRefs)].Error = &ConfigError{
-				Reason:  string(gwv1.BackendTLSPolicyReasonInvalidCACertificateRef),
-				Message: "Certificate invalid: " + err.Error(),
-			}
-			return nil, fmt.Errorf("certificate invalid: %v", err)
+			configErr, accepted := caCertificateRefError(ref, err)
+			conds[string(gwv1.BackendTLSPolicyConditionResolvedRefs)].Error = configErr
+			return nil, accepted
 		}
 		if sb.Len() > 0 {
 			sb.WriteString("\n")
@@ -407,4 +389,26 @@ func getBackendTLSCACert(
 		sb.WriteString(caCert)
 	}
 	return []byte(sb.String()), nil
+}
+
+// caCertificateRefError maps a CA resolution failure onto the ResolvedRefs reason Gateway API
+// requires for it, along with the error carried by the Accepted condition.
+func caCertificateRefError(ref gwv1.LocalObjectReference, err error) (*ConfigError, error) {
+	switch {
+	case errors.Is(err, cacert.ErrUnsupportedKind):
+		return &ConfigError{
+			Reason:  string(gwv1.BackendTLSPolicyReasonInvalidKind),
+			Message: "Certificate reference invalid: " + string(ref.Kind),
+		}, fmt.Errorf("invalid certificate reference: %v", ref)
+	case errors.Is(err, cacert.ErrNotFound):
+		return &ConfigError{
+			Reason:  string(gwv1.BackendTLSPolicyReasonInvalidCACertificateRef),
+			Message: "Certificate reference not found",
+		}, fmt.Errorf("certificate reference not found: %v", ref)
+	default:
+		return &ConfigError{
+			Reason:  string(gwv1.BackendTLSPolicyReasonInvalidCACertificateRef),
+			Message: "Certificate invalid: " + err.Error(),
+		}, fmt.Errorf("certificate invalid: %v", err)
+	}
 }

--- a/controller/pkg/agentgateway/plugins/tls.go
+++ b/controller/pkg/agentgateway/plugins/tls.go
@@ -15,12 +15,6 @@ var (
 	InvalidTlsSecretError = func(n, ns string, err error) error {
 		return fmt.Errorf("%w %s/%s: %v", ErrInvalidTlsSecret, ns, n, err)
 	}
-
-	ErrMissingCACertKey = errors.New("ca.crt key missing")
-
-	ErrInvalidCACertificate = func(n, ns string, err error) error {
-		return fmt.Errorf("invalid ca.crt in ConfigMap %s/%s: %v", ns, n, err)
-	}
 )
 
 func ValidateTlsSecretData(n, ns string, sslSecretData map[string][]byte) (cleanedCertChain string, err error) {
@@ -60,34 +54,4 @@ func cleanedSslKeyPair(certChain, privateKey, rootCa string) (cleanedChain strin
 	cleanedChain = string(cleanedChainBytes)
 
 	return cleanedChain, err
-}
-
-// GetCACertFromConfigMap validates and extracts the ca.crt string from a ConfigMap
-func GetCACertFromConfigMap(cm *corev1.ConfigMap) (string, error) {
-	caCrt, ok := cm.Data["ca.crt"]
-	if !ok {
-		return "", ErrMissingCACertKey
-	}
-	return getCACertFromBytes([]byte(caCrt), cm.Name, cm.Namespace)
-}
-
-// getCACertFromBytes validates and extracts the ca.crt string from certificate bytes
-func getCACertFromBytes(caCrtBytes []byte, name, namespace string) (string, error) {
-	if len(caCrtBytes) == 0 {
-		return "", ErrMissingCACertKey
-	}
-
-	// Validate CA certificate by trying to parse it
-	candidateCert, err := cert.ParseCertsPEM(caCrtBytes)
-	if err != nil {
-		return "", ErrInvalidCACertificate(name, namespace, err)
-	}
-
-	// Clean and encode the certificate to ensure proper formatting
-	cleanedChainBytes, err := cert.EncodeCertificates(candidateCert...)
-	if err != nil {
-		return "", ErrInvalidCACertificate(name, namespace, err)
-	}
-
-	return string(cleanedChainBytes), nil
 }

--- a/controller/pkg/agentgateway/remotehttp/ca_bundle.go
+++ b/controller/pkg/agentgateway/remotehttp/ca_bundle.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"istio.io/istio/pkg/kube/krt"
-	"istio.io/istio/pkg/ptr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -16,6 +15,12 @@ import (
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/cacert"
 )
 
+// caSource identifies one CA certificate source to resolve.
+type caSource struct {
+	kind string
+	name string
+}
+
 func caBundleFromBackendTLSRefs(
 	krtctx krt.HandlerContext,
 	cfgmaps krt.Collection[*corev1.ConfigMap],
@@ -23,64 +28,52 @@ func caBundleFromBackendTLSRefs(
 	namespace string,
 	refs []agentgateway.LocalCACertificateRef,
 ) (*x509.CertPool, string, error) {
-	certPool := x509.NewCertPool()
-	h := sha256.New()
-
+	sources := make([]caSource, 0, len(refs))
 	for _, ref := range refs {
-		caCRT, err := cacert.Resolve(krtctx, cfgmaps, secrets, namespace, ref)
-		if err != nil {
-			return nil, "", err
-		}
-		nn := types.NamespacedName{Name: string(ref.Name), Namespace: namespace}
-		if !certPool.AppendCertsFromPEM([]byte(caCRT)) {
-			return nil, "", fmt.Errorf("error appending CA cert from %s %s", cacert.Kind(ref.Kind), nn)
-		}
-		_, _ = h.Write([]byte(cacert.Kind(ref.Kind)))
-		_, _ = h.Write([]byte{0})
-		_, _ = h.Write([]byte(nn.String()))
-		_, _ = h.Write([]byte{0})
-		_, _ = h.Write([]byte(caCRT))
-		_, _ = h.Write([]byte{0})
+		sources = append(sources, caSource{kind: cacert.Kind(ref.Kind), name: string(ref.Name)})
 	}
-
-	return certPool, hex.EncodeToString(h.Sum(nil)), nil
+	return caBundleFromSources(krtctx, cfgmaps, secrets, namespace, sources)
 }
 
 func caBundleFromGatewayRefs(
 	krtctx krt.HandlerContext,
 	cfgmaps krt.Collection[*corev1.ConfigMap],
+	secrets krt.Collection[*corev1.Secret],
 	namespace string,
 	refs []gwv1.LocalObjectReference,
 ) (*x509.CertPool, string, error) {
-	names := make([]string, 0, len(refs))
+	sources := make([]caSource, 0, len(refs))
 	for _, ref := range refs {
-		names = append(names, string(ref.Name))
+		kind, err := cacert.GatewayRefKind(ref)
+		if err != nil {
+			return nil, "", err
+		}
+		sources = append(sources, caSource{kind: kind, name: string(ref.Name)})
 	}
-	return caBundleFromConfigMapNames(krtctx, cfgmaps, namespace, names)
+	return caBundleFromSources(krtctx, cfgmaps, secrets, namespace, sources)
 }
 
-func caBundleFromConfigMapNames(
+func caBundleFromSources(
 	krtctx krt.HandlerContext,
 	cfgmaps krt.Collection[*corev1.ConfigMap],
+	secrets krt.Collection[*corev1.Secret],
 	namespace string,
-	names []string,
+	sources []caSource,
 ) (*x509.CertPool, string, error) {
 	certPool := x509.NewCertPool()
 	h := sha256.New()
 
-	for _, name := range names {
-		nn := types.NamespacedName{Name: name, Namespace: namespace}
-		cfgmap := ptr.Flatten(krt.FetchOne(krtctx, cfgmaps, krt.FilterObjectName(nn)))
-		if cfgmap == nil {
-			return nil, "", fmt.Errorf("ConfigMap %s not found", nn)
+	for _, src := range sources {
+		caCRT, err := cacert.ResolveSource(krtctx, cfgmaps, secrets, namespace, src.kind, src.name)
+		if err != nil {
+			return nil, "", err
 		}
-		caCRT, ok := cfgmap.Data["ca.crt"]
-		if !ok {
-			return nil, "", fmt.Errorf("error extracting CA cert from ConfigMap %s: missing ca.crt", nn)
-		}
+		nn := types.NamespacedName{Name: src.name, Namespace: namespace}
 		if !certPool.AppendCertsFromPEM([]byte(caCRT)) {
-			return nil, "", fmt.Errorf("error appending CA cert from ConfigMap %s", nn)
+			return nil, "", fmt.Errorf("error appending CA cert from %s %s", src.kind, nn)
 		}
+		_, _ = h.Write([]byte(src.kind))
+		_, _ = h.Write([]byte{0})
 		_, _ = h.Write([]byte(nn.String()))
 		_, _ = h.Write([]byte{0})
 		_, _ = h.Write([]byte(caCRT))

--- a/controller/pkg/agentgateway/remotehttp/tls_resolver.go
+++ b/controller/pkg/agentgateway/remotehttp/tls_resolver.go
@@ -38,7 +38,7 @@ func (r *defaultResolver) resolveTLS(
 		return resolvedTLSFromBackendTLS(krtctx, r.cfgmaps, r.secrets, namespace, agwPolicy.Spec.Backend.TLS)
 	}
 	if backendTLSPolicy := r.policySelector.BestMatchingBackendTLSPolicy(krtctx, namespace, group, kind, name, backendTLSSections); backendTLSPolicy != nil {
-		return resolvedTLSFromBackendTLSPolicy(krtctx, r.cfgmaps, namespace, backendTLSPolicy)
+		return resolvedTLSFromBackendTLSPolicy(krtctx, r.cfgmaps, r.secrets, namespace, backendTLSPolicy)
 	}
 	return nil, nil
 }
@@ -46,6 +46,7 @@ func (r *defaultResolver) resolveTLS(
 func resolvedTLSFromBackendTLSPolicy(
 	krtctx krt.HandlerContext,
 	cfgmaps krt.Collection[*corev1.ConfigMap],
+	secrets krt.Collection[*corev1.Secret],
 	namespace string,
 	policy *gwv1.BackendTLSPolicy,
 ) (*resolvedTLS, error) {
@@ -64,7 +65,7 @@ func resolvedTLSFromBackendTLSPolicy(
 		return resolved, nil
 	}
 
-	rootCAs, caBundleHash, err := caBundleFromGatewayRefs(krtctx, cfgmaps, namespace, policy.Spec.Validation.CACertificateRefs)
+	rootCAs, caBundleHash, err := caBundleFromGatewayRefs(krtctx, cfgmaps, secrets, namespace, policy.Spec.Validation.CACertificateRefs)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/pkg/agentgateway/translator/testdata/backends/backendtlspolicy-secret-ca.yaml
+++ b/controller/pkg/agentgateway/translator/testdata/backends/backendtlspolicy-secret-ca.yaml
@@ -1,0 +1,245 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: infra-backend-v1
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: infra-backend-v2
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: infra-backend-v3
+  namespace: default
+spec:
+  ports:
+    - name: https
+      port: 443
+---
+# A Secret CA ref resolves the same way a ConfigMap one does.
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: test-tls-secret-ca
+  namespace: default
+spec:
+  targetRefs:
+    - name: infra-backend-v1
+      kind: Service
+      group: ""
+      sectionName: https
+  validation:
+    hostname: example.com
+    caCertificateRefs:
+      - name: ca-cert-secret
+        group: ""
+        kind: Secret
+---
+# A Secret that does not exist is InvalidCACertificateRef, not InvalidKind.
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: test-tls-secret-missing
+  namespace: default
+spec:
+  targetRefs:
+    - name: infra-backend-v2
+      kind: Service
+      group: ""
+  validation:
+    hostname: example.com
+    caCertificateRefs:
+      - name: ca-cert-absent
+        group: ""
+        kind: Secret
+---
+# Anything other than a core ConfigMap or Secret is still InvalidKind.
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: test-tls-unsupported-kind
+  namespace: default
+spec:
+  targetRefs:
+    - name: infra-backend-v3
+      kind: Service
+      group: ""
+  validation:
+    hostname: example.com
+    caCertificateRefs:
+      - name: infra-backend-v3
+        group: ""
+        kind: Service
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: default
+  name: ca-cert-secret
+data:
+  ca.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJpVENDQVMrZ0F3SUJBZ0lVTTI4V01BTit6VllDSXAraHNFUnZHbUhoMmNrd0NnWUlLb1pJemowRUF3SXcKR1RFWE1CVUdBMVVFQXd3T1oyOXNaR1Z1TFhSbGMzUXRZMkV3SUJjTk1qWXdPVEV3TURBeE1UUTRXaGdQTWpFeQpOakE0TVRjd01ERXhORGhhTUJreEZ6QVZCZ05WQkFNTURtZHZiR1JsYmkxMFpYTjBMV05oTUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRURYZzhudmc4TjRoTUNZT2NHaHQ1VHQxSnExWjJnaUZ0MnBCbVhXd1kKMHBCZWVjckp4UXZXR3EwYUlldkhVcHVraUJreHZpUHRoNHJpRVljUE1QYmN4Nk5UTUZFd0hRWURWUjBPQkJZRQpGSmZ2NEJCYWlNcVkvZ3pZcENHMTFBN0c1RXhUTUI4R0ExVWRJd1FZTUJhQUZKZnY0QkJhaU1xWS9nellwQ0cxCjFBN0c1RXhUTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3Q2dZSUtvWkl6ajBFQXdJRFNBQXdSUUlnZkVJV2o0SWEKcS9qbWJiSG9zM1FLZEY5YTR3SjdLNGUyMGNlRTNJYWtGMjhDSVFDUFAwOUgwYTVqbHVWdEMyanBNa1hkY3pWagpwSi8wQk0yZkNKMlpCZEgzc2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+
+---
+# Output
+output:
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          hostname: example.com
+          root: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJpVENDQVMrZ0F3SUJBZ0lVTTI4V01BTit6VllDSXAraHNFUnZHbUhoMmNrd0NnWUlLb1pJemowRUF3SXcKR1RFWE1CVUdBMVVFQXd3T1oyOXNaR1Z1TFhSbGMzUXRZMkV3SUJjTk1qWXdPVEV3TURBeE1UUTRXaGdQTWpFeQpOakE0TVRjd01ERXhORGhhTUJreEZ6QVZCZ05WQkFNTURtZHZiR1JsYmkxMFpYTjBMV05oTUZrd0V3WUhLb1pJCnpqMENBUVlJS29aSXpqMERBUWNEUWdBRURYZzhudmc4TjRoTUNZT2NHaHQ1VHQxSnExWjJnaUZ0MnBCbVhXd1kKMHBCZWVjckp4UXZXR3EwYUlldkhVcHVraUJreHZpUHRoNHJpRVljUE1QYmN4Nk5UTUZFd0hRWURWUjBPQkJZRQpGSmZ2NEJCYWlNcVkvZ3pZcENHMTFBN0c1RXhUTUI4R0ExVWRJd1FZTUJhQUZKZnY0QkJhaU1xWS9nellwQ0cxCjFBN0c1RXhUTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3Q2dZSUtvWkl6ajBFQXdJRFNBQXdSUUlnZkVJV2o0SWEKcS9qbWJiSG9zM1FLZEY5YTR3SjdLNGUyMGNlRTNJYWtGMjhDSVFDUFAwOUgwYTVqbHVWdEMyanBNa1hkY3pWagpwSi8wQk0yZkNKMlpCZEgzc2c9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      key: default/test-tls-secret-ca:backend-tls:default/infra-backend-v1.default.svc.cluster.local/443
+      name:
+        kind: BackendTLSPolicy
+        name: test-tls-secret-ca
+        namespace: default
+      target:
+        service:
+          hostname: infra-backend-v1.default.svc.cluster.local
+          namespace: default
+          port: 443
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          hostname: example.com
+          root: aW52YWxpZA==
+      key: default/test-tls-secret-missing:backend-tls:default/infra-backend-v2.default.svc.cluster.local
+      name:
+        kind: BackendTLSPolicy
+        name: test-tls-secret-missing
+        namespace: default
+      target:
+        service:
+          hostname: infra-backend-v2.default.svc.cluster.local
+          namespace: default
+- gateway:
+    Name: basic
+    Namespace: default
+  resource:
+    policy:
+      backend:
+        backendTls:
+          hostname: example.com
+          root: aW52YWxpZA==
+      key: default/test-tls-unsupported-kind:backend-tls:default/infra-backend-v3.default.svc.cluster.local
+      name:
+        kind: BackendTLSPolicy
+        name: test-tls-unsupported-kind
+        namespace: default
+      target:
+        service:
+          hostname: infra-backend-v3.default.svc.cluster.local
+          namespace: default
+- canonical: true
+  hostname: infra-backend-v1.default.svc.cluster.local
+  name: infra-backend-v1
+  namespace: default
+  ports:
+  - appProtocol: TLS
+    servicePort: 443
+- canonical: true
+  hostname: infra-backend-v2.default.svc.cluster.local
+  name: infra-backend-v2
+  namespace: default
+  ports:
+  - appProtocol: TLS
+    servicePort: 443
+- canonical: true
+  hostname: infra-backend-v3.default.svc.cluster.local
+  name: infra-backend-v3
+  namespace: default
+  ports:
+  - appProtocol: TLS
+    servicePort: 443
+status:
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: BackendTLSPolicy
+  metadata:
+    name: test-tls-secret-ca
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: basic
+      conditions:
+      - lastTransitionTime: fake
+        message: Configuration is valid
+        reason: Accepted
+        status: "True"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Configuration is valid
+        reason: ResolvedRefs
+        status: "True"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: BackendTLSPolicy
+  metadata:
+    name: test-tls-secret-missing
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: basic
+      conditions:
+      - lastTransitionTime: fake
+        message: 'certificate reference not found: { Secret ca-cert-absent}'
+        reason: NoValidCACertificate
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: Certificate reference not found
+        reason: InvalidCACertificateRef
+        status: "False"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway
+- apiVersion: gateway.networking.k8s.io/v1
+  kind: BackendTLSPolicy
+  metadata:
+    name: test-tls-unsupported-kind
+    namespace: default
+  spec: null
+  status:
+    ancestors:
+    - ancestorRef:
+        group: gateway.networking.k8s.io
+        kind: Gateway
+        name: basic
+      conditions:
+      - lastTransitionTime: fake
+        message: 'invalid certificate reference: { Service infra-backend-v3}'
+        reason: NoValidCACertificate
+        status: "False"
+        type: Accepted
+      - lastTransitionTime: fake
+        message: 'Certificate reference invalid: Service'
+        reason: InvalidKind
+        status: "False"
+        type: ResolvedRefs
+      controllerName: agentgateway.dev/agentgateway

--- a/controller/pkg/syncer/backend/xbackend.go
+++ b/controller/pkg/syncer/backend/xbackend.go
@@ -16,6 +16,7 @@ import (
 	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 
 	"github.com/agentgateway/agentgateway/api"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/cacert"
 	agwir "github.com/agentgateway/agentgateway/controller/pkg/agentgateway/ir"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/plugins"
 	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/translator"
@@ -159,19 +160,9 @@ func translateXBackendTLS(
 	} else {
 		var roots strings.Builder
 		for _, ref := range tls.Validation.CACertificateRefs {
-			if ref.Group != gwv1.Group(wellknown.ConfigMapGVK.Group) || ref.Kind != gwv1.Kind(wellknown.ConfigMapKind) {
-				return nil, fmt.Errorf("CA certificate reference %s must refer to a core ConfigMap", ref.Name)
-			}
-			configMap := ptr.Flatten(krt.FetchOne(krtctx, agw.ConfigMaps, krt.FilterObjectName(types.NamespacedName{
-				Namespace: backend.Namespace,
-				Name:      string(ref.Name),
-			})))
-			if configMap == nil {
-				return nil, fmt.Errorf("CA certificate ConfigMap %s/%s not found", backend.Namespace, ref.Name)
-			}
-			root, err := plugins.GetCACertFromConfigMap(configMap)
+			root, err := cacert.ResolveGatewayRef(krtctx, agw.ConfigMaps, agw.Secrets, backend.Namespace, ref)
 			if err != nil {
-				return nil, fmt.Errorf("invalid CA certificate ConfigMap %s/%s: %w", backend.Namespace, ref.Name, err)
+				return nil, fmt.Errorf("CA certificate reference %s is invalid: %w", ref.Name, err)
 			}
 			if roots.Len() > 0 {
 				roots.WriteByte('\n')

--- a/controller/test/e2e/backendtls_test.go
+++ b/controller/test/e2e/backendtls_test.go
@@ -54,6 +54,43 @@ func TestBackendTLSPolicyAndStatus(tt *testing.T) {
 	})
 }
 
+// TestBackendTLSPolicySecretCA covers the implementation-specific `kind: Secret` CA reference.
+// Upstream grants Core support only to ConfigMap, but explicitly permits other kinds.
+func TestBackendTLSPolicySecretCA(tt *testing.T) {
+	t := New(tt, base.WithMinGwApiVersion(base.GwApiRequireBackendTLSPolicy))
+	t.Apply(
+		manifest("backendtls", "secret.yaml"),
+		manifest("backendtls", "secret-base.yaml"),
+	)
+
+	backendTLSPolicy := &gwv1.BackendTLSPolicy{
+		Name:      "tls-policy-secret",
+		Namespace: base.Namespace,
+	}
+	err := t.TestInstallation.ClusterContext.ControllerClient.Get(t.Ctx, client.ObjectKeyFromObject(backendTLSPolicy), backendTLSPolicy)
+	assert.NoError(t, err)
+
+	t.Send("secret.example.com", base.ExpectOK())
+
+	assertBackendTLSPolicyStatus(t, backendTLSPolicy, metav1.Condition{
+		Type:               agentgateway.PolicyConditionAccepted,
+		Status:             metav1.ConditionTrue,
+		Reason:             string(gwv1.PolicyReasonAccepted),
+		ObservedGeneration: backendTLSPolicy.Generation,
+	})
+
+	// Deleting the Secret must invalidate the policy, proving the controller watches Secrets the
+	// same way it watches ConfigMaps.
+	t.Delete(manifest("backendtls", "secret.yaml"))
+
+	assertBackendTLSPolicyStatus(t, backendTLSPolicy, metav1.Condition{
+		Type:               string(gwv1.PolicyConditionAccepted),
+		Status:             metav1.ConditionFalse,
+		Reason:             string(gwv1.BackendTLSPolicyReasonNoValidCACertificate),
+		ObservedGeneration: backendTLSPolicy.Generation,
+	})
+}
+
 func assertBackendTLSPolicyStatus(t base.Test, policy *gwv1.BackendTLSPolicy, inCondition metav1.Condition) {
 	t.Helper()
 	retry.UntilSuccessOrFail(t, func() error {

--- a/controller/test/e2e/testdata/backendtls/secret-base.yaml
+++ b/controller/test/e2e/testdata/backendtls/secret-base.yaml
@@ -1,0 +1,31 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: backend-secret-route
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+  - name: gateway
+  hostnames:
+  - "secret.example.com"
+  rules:
+  - backendRefs:
+    - name: backend
+      port: 443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: tls-policy-secret
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backend
+  validation:
+    hostname: "localhost"
+    caCertificateRefs:
+    - group: ""
+      kind: Secret
+      name: ca-secret

--- a/controller/test/e2e/testdata/backendtls/secret.yaml
+++ b/controller/test/e2e/testdata/backendtls/secret.yaml
@@ -1,0 +1,19 @@
+# Same cert as configmap.yaml, but in a Secret. Exercises the implementation-specific
+# `kind: Secret` CA reference that Gateway API permits for BackendTLSPolicy.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ca-secret
+  namespace: agentgateway-base
+stringData:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIBezCCASCgAwIBAgIRAOnmoc9aVSZkyJ59U9r+6KAwCgYIKoZIzj0EAwIwGzEZ
+    MBcGA1UEAxMQYWdlbnRnYXRld2F5LmRldjAeFw0yNTEwMTUxOTQzMzZaFw0zNTEw
+    MTMxOTQzMzZaMBsxGTAXBgNVBAMTEGFnZW50Z2F0ZXdheS5kZXYwWTATBgcqhkjO
+    PQIBBggqhkjOPQMBBwNCAAScPuAg65+9D2YuOrFl4xAYOB6h2460QhZTIStE1PHP
+    MIOUJAAqBdAWAH5JG4UiVUH/tKYEd73CfaBsHSNrOJlLo0UwQzAOBgNVHQ8BAf8E
+    BAMCAQYwEgYDVR0TAQH/BAgwBgEB/wIBATAdBgNVHQ4EFgQUcwtMh/9FfJvcR9JU
+    bISOus7YDMowCgYIKoZIzj0EAwIDSQAwRgIhAL2agfEI9TBl060Y0aGQ7SX69aLC
+    7/ifjLmH38SGOWCJAiEA63NRyf5oz6rzvvIHpK8OM2hSHqWQFQnhBTCbyzNAe5U=
+    -----END CERTIFICATE-----


### PR DESCRIPTION
### Description

This PR adds the support of a Secret based `BackendTLSPolicy` `caCertificateRefs`. This is essential for infrastructures using cert-manager (among other things) that generate certificates in Secrets instead of ConfigMaps.
 
### Context

`BackendTLSPolicy.validation.caCertificateRefs` and the identical `XBackend.spec.tls.validation` only accepted a core ConfigMap, rejecting `kind: Secret` with `ResolvedRefs=False`/`InvalidKind`.

For more information, read #3414 which details the "history" of this field.

### What this changes

Users can now use without error:

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: BackendTLSPolicy
metadata:
  name: my-backend-tls
  namespace: my-app
spec:
  ...
  validation:
    ...
    caCertificateRefs:
      - group: ""
        kind: Secret
        name: my-app-tls
```

**This is a non-breaking, retro-compatible PR which only adds new capabilities, without changing default behaviour**:
- Generalize the `cacert` package so it also resolves upstream `gwv1.LocalObjectReference` CA refs, and add `ErrUnsupportedKind` / `ErrNotFound` sentinels so callers can map failures onto the right Gateway API condition reason.
- Route all three ConfigMap-only call sites through it: the BackendTLSPolicy dataplane path, the `remotehttp` control-plane client, and XBackend.
- ConfigMap refs, an omitted kind, and every existing status reason are unchanged. A Secret ref never falls back to a same-name ConfigMap.
- Drop `plugins.GetCACertFromConfigMap` and friends, now unused.

Secret rotation propagates for free: `krt.FetchOne` registers the dependency the same way it does for ConfigMaps, and the Helm chart already grants read access to Secrets.

Closes #3414 

### How was it tested

Ran the e2e tests against a live cluster, worked with no problems.

---

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
