### PR TITLE
feat(controller): select the CA bundle key in AgentgatewayPolicy CA refs

### DIFF
--- a/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
+++ b/controller/api/tests/testdata/agentgateway_policy_invalid.yaml
@@ -1694,6 +1694,38 @@ spec:
         - name: ca-bundle
           kind: Invalid
 ---
+_err: 'should be at least 1 chars long'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: backend-tls-empty-ca-key
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: dummy
+  backend:
+    tls:
+      caCertificateRefs:
+        - name: ca-bundle
+          key: ""
+---
+_err: 'should match'
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: backend-tls-invalid-ca-key
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: dummy
+  backend:
+    tls:
+      caCertificateRefs:
+        - name: ca-bundle
+          key: "not/a/key"
+---
 _err: 'at most one of the fields in [clientId objectId resourceId] may be set'
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy

--- a/controller/api/tests/testdata/agentgateway_policy_valid.yaml
+++ b/controller/api/tests/testdata/agentgateway_policy_valid.yaml
@@ -44,6 +44,37 @@ spec:
 apiVersion: agentgateway.dev/v1alpha1
 kind: AgentgatewayPolicy
 metadata:
+  name: backend-tls-custom-ca-key
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: dummy
+  backend:
+    tls:
+      caCertificateRefs:
+        - name: corporate-trust
+          kind: Secret
+          key: corporate-roots.pem
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: backend-tls-explicit-default-ca-key
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: dummy
+  backend:
+    tls:
+      caCertificateRefs:
+        - name: ca-bundle
+          key: ca.crt
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
   name: backend-mtls
 spec:
   targetRefs:

--- a/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
+++ b/controller/api/v1alpha1/agentgateway/agentgateway_policy_types.go
@@ -534,7 +534,7 @@ const (
 )
 
 // LocalCACertificateRef references a same-namespace CA certificate source.
-// An omitted kind defaults to ConfigMap.
+// An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
 //
 // +structType=atomic
 type LocalCACertificateRef struct {
@@ -547,6 +547,15 @@ type LocalCACertificateRef struct {
 	// +kubebuilder:validation:Enum=ConfigMap;Secret
 	// +optional
 	Kind string `json:"kind,omitempty"`
+
+	// Key within the referenced source holding the PEM-encoded CA bundle.
+	// Omitted defaults to `ca.crt`.
+	// +kubebuilder:default="ca.crt"
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$`
+	// +optional
+	Key string `json:"key,omitempty"`
 }
 
 // BackendTLSCertificateSource selects where the gateway's client identity and trust roots come
@@ -585,8 +594,9 @@ type BackendTLS struct {
 	// +optional
 	MtlsCertificateRef []LocalSecretObjectRef `json:"mtlsCertificateRef,omitempty"`
 	// CA certificate source to use to verify the server certificate. Omitted kind
-	// and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-	// key is required. If unset, the system's trusted certificates are used.
+	// and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+	// read from the `ca.crt` key unless `key` names a different one. If unset, the
+	// system's trusted certificates are used.
 	//
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=1

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaybackends.yaml
@@ -1145,13 +1145,23 @@ spec:
                                                             caCertificateRefs:
                                                               description: |-
                                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                                key is required. If unset, the system's trusted certificates are used.
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                                system's trusted certificates are used.
                                                               items:
                                                                 description: |-
                                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                                  An omitted kind defaults to ConfigMap.
+                                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                                 properties:
+                                                                  key:
+                                                                    default: ca.crt
+                                                                    description: |-
+                                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                                      Omitted defaults to `ca.crt`.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                                    type: string
                                                                   kind:
                                                                     default: ConfigMap
                                                                     description: Kind
@@ -1692,13 +1702,23 @@ spec:
                                                             caCertificateRefs:
                                                               description: |-
                                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                                key is required. If unset, the system's trusted certificates are used.
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                                system's trusted certificates are used.
                                                               items:
                                                                 description: |-
                                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                                  An omitted kind defaults to ConfigMap.
+                                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                                 properties:
+                                                                  key:
+                                                                    default: ca.crt
+                                                                    description: |-
+                                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                                      Omitted defaults to `ca.crt`.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                                    type: string
                                                                   kind:
                                                                     default: ConfigMap
                                                                     description: Kind
@@ -2258,13 +2278,23 @@ spec:
                                                             caCertificateRefs:
                                                               description: |-
                                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                                key is required. If unset, the system's trusted certificates are used.
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                                system's trusted certificates are used.
                                                               items:
                                                                 description: |-
                                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                                  An omitted kind defaults to ConfigMap.
+                                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                                 properties:
+                                                                  key:
+                                                                    default: ca.crt
+                                                                    description: |-
+                                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                                      Omitted defaults to `ca.crt`.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                                    type: string
                                                                   kind:
                                                                     default: ConfigMap
                                                                     description: Kind
@@ -3248,13 +3278,23 @@ spec:
                                                             caCertificateRefs:
                                                               description: |-
                                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                                key is required. If unset, the system's trusted certificates are used.
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                                system's trusted certificates are used.
                                                               items:
                                                                 description: |-
                                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                                  An omitted kind defaults to ConfigMap.
+                                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                                 properties:
+                                                                  key:
+                                                                    default: ca.crt
+                                                                    description: |-
+                                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                                      Omitted defaults to `ca.crt`.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                                    type: string
                                                                   kind:
                                                                     default: ConfigMap
                                                                     description: Kind
@@ -3795,13 +3835,23 @@ spec:
                                                             caCertificateRefs:
                                                               description: |-
                                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                                key is required. If unset, the system's trusted certificates are used.
+                                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                                system's trusted certificates are used.
                                                               items:
                                                                 description: |-
                                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                                  An omitted kind defaults to ConfigMap.
+                                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                                 properties:
+                                                                  key:
+                                                                    default: ca.crt
+                                                                    description: |-
+                                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                                      Omitted defaults to `ca.crt`.
+                                                                    maxLength: 253
+                                                                    minLength: 1
+                                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                                    type: string
                                                                   kind:
                                                                     default: ConfigMap
                                                                     description: Kind
@@ -6533,13 +6583,23 @@ spec:
                                       caCertificateRefs:
                                         description: |-
                                           CA certificate source to use to verify the server certificate. Omitted kind
-                                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                          key is required. If unset, the system's trusted certificates are used.
+                                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                          read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                          system's trusted certificates are used.
                                         items:
                                           description: |-
                                             LocalCACertificateRef references a same-namespace CA certificate source.
-                                            An omitted kind defaults to ConfigMap.
+                                            An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                           properties:
+                                            key:
+                                              default: ca.crt
+                                              description: |-
+                                                Key within the referenced source holding the PEM-encoded CA bundle.
+                                                Omitted defaults to `ca.crt`.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                              type: string
                                             kind:
                                               default: ConfigMap
                                               description: Kind of the referenced
@@ -9751,13 +9811,23 @@ spec:
                                     caCertificateRefs:
                                       description: |-
                                         CA certificate source to use to verify the server certificate. Omitted kind
-                                        and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                        key is required. If unset, the system's trusted certificates are used.
+                                        and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                        read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                        system's trusted certificates are used.
                                       items:
                                         description: |-
                                           LocalCACertificateRef references a same-namespace CA certificate source.
-                                          An omitted kind defaults to ConfigMap.
+                                          An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                         properties:
+                                          key:
+                                            default: ca.crt
+                                            description: |-
+                                              Key within the referenced source holding the PEM-encoded CA bundle.
+                                              Omitted defaults to `ca.crt`.
+                                            maxLength: 253
+                                            minLength: 1
+                                            pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                            type: string
                                           kind:
                                             default: ConfigMap
                                             description: Kind of the referenced CA
@@ -10629,13 +10699,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -11096,13 +11176,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -11586,13 +11676,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -12450,13 +12550,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -12917,13 +13027,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -16119,13 +16239,23 @@ spec:
                       caCertificateRefs:
                         description: |-
                           CA certificate source to use to verify the server certificate. Omitted kind
-                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                          key is required. If unset, the system's trusted certificates are used.
+                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                          read from the `ca.crt` key unless `key` names a different one. If unset, the
+                          system's trusted certificates are used.
                         items:
                           description: |-
                             LocalCACertificateRef references a same-namespace CA certificate source.
-                            An omitted kind defaults to ConfigMap.
+                            An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                           properties:
+                            key:
+                              default: ca.crt
+                              description: |-
+                                Key within the referenced source holding the PEM-encoded CA bundle.
+                                Omitted defaults to `ca.crt`.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                              type: string
                             kind:
                               default: ConfigMap
                               description: Kind of the referenced CA certificate source.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaymodels.yaml
@@ -2109,13 +2109,23 @@ spec:
                                         caCertificateRefs:
                                           description: |-
                                             CA certificate source to use to verify the server certificate. Omitted kind
-                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                            key is required. If unset, the system's trusted certificates are used.
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                            read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                            system's trusted certificates are used.
                                           items:
                                             description: |-
                                               LocalCACertificateRef references a same-namespace CA certificate source.
-                                              An omitted kind defaults to ConfigMap.
+                                              An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                             properties:
+                                              key:
+                                                default: ca.crt
+                                                description: |-
+                                                  Key within the referenced source holding the PEM-encoded CA bundle.
+                                                  Omitted defaults to `ca.crt`.
+                                                maxLength: 253
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                type: string
                                               kind:
                                                 default: ConfigMap
                                                 description: Kind of the referenced
@@ -2568,13 +2578,23 @@ spec:
                                         caCertificateRefs:
                                           description: |-
                                             CA certificate source to use to verify the server certificate. Omitted kind
-                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                            key is required. If unset, the system's trusted certificates are used.
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                            read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                            system's trusted certificates are used.
                                           items:
                                             description: |-
                                               LocalCACertificateRef references a same-namespace CA certificate source.
-                                              An omitted kind defaults to ConfigMap.
+                                              An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                             properties:
+                                              key:
+                                                default: ca.crt
+                                                description: |-
+                                                  Key within the referenced source holding the PEM-encoded CA bundle.
+                                                  Omitted defaults to `ca.crt`.
+                                                maxLength: 253
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                type: string
                                               kind:
                                                 default: ConfigMap
                                                 description: Kind of the referenced
@@ -3047,13 +3067,23 @@ spec:
                                         caCertificateRefs:
                                           description: |-
                                             CA certificate source to use to verify the server certificate. Omitted kind
-                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                            key is required. If unset, the system's trusted certificates are used.
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                            read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                            system's trusted certificates are used.
                                           items:
                                             description: |-
                                               LocalCACertificateRef references a same-namespace CA certificate source.
-                                              An omitted kind defaults to ConfigMap.
+                                              An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                             properties:
+                                              key:
+                                                default: ca.crt
+                                                description: |-
+                                                  Key within the referenced source holding the PEM-encoded CA bundle.
+                                                  Omitted defaults to `ca.crt`.
+                                                maxLength: 253
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                type: string
                                               kind:
                                                 default: ConfigMap
                                                 description: Kind of the referenced
@@ -3895,13 +3925,23 @@ spec:
                                         caCertificateRefs:
                                           description: |-
                                             CA certificate source to use to verify the server certificate. Omitted kind
-                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                            key is required. If unset, the system's trusted certificates are used.
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                            read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                            system's trusted certificates are used.
                                           items:
                                             description: |-
                                               LocalCACertificateRef references a same-namespace CA certificate source.
-                                              An omitted kind defaults to ConfigMap.
+                                              An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                             properties:
+                                              key:
+                                                default: ca.crt
+                                                description: |-
+                                                  Key within the referenced source holding the PEM-encoded CA bundle.
+                                                  Omitted defaults to `ca.crt`.
+                                                maxLength: 253
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                type: string
                                               kind:
                                                 default: ConfigMap
                                                 description: Kind of the referenced
@@ -4354,13 +4394,23 @@ spec:
                                         caCertificateRefs:
                                           description: |-
                                             CA certificate source to use to verify the server certificate. Omitted kind
-                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                            key is required. If unset, the system's trusted certificates are used.
+                                            and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                            read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                            system's trusted certificates are used.
                                           items:
                                             description: |-
                                               LocalCACertificateRef references a same-namespace CA certificate source.
-                                              An omitted kind defaults to ConfigMap.
+                                              An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                             properties:
+                                              key:
+                                                default: ca.crt
+                                                description: |-
+                                                  Key within the referenced source holding the PEM-encoded CA bundle.
+                                                  Omitted defaults to `ca.crt`.
+                                                maxLength: 253
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                type: string
                                               kind:
                                                 default: ConfigMap
                                                 description: Kind of the referenced
@@ -4843,13 +4893,23 @@ spec:
                       caCertificateRefs:
                         description: |-
                           CA certificate source to use to verify the server certificate. Omitted kind
-                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                          key is required. If unset, the system's trusted certificates are used.
+                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                          read from the `ca.crt` key unless `key` names a different one. If unset, the
+                          system's trusted certificates are used.
                         items:
                           description: |-
                             LocalCACertificateRef references a same-namespace CA certificate source.
-                            An omitted kind defaults to ConfigMap.
+                            An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                           properties:
+                            key:
+                              default: ca.crt
+                              description: |-
+                                Key within the referenced source holding the PEM-encoded CA bundle.
+                                Omitted defaults to `ca.crt`.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                              type: string
                             kind:
                               default: ConfigMap
                               description: Kind of the referenced CA certificate source.

--- a/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
+++ b/controller/install/helm/agentgateway-crds/templates/agentgateway.dev_agentgatewaypolicies.yaml
@@ -682,13 +682,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -1149,13 +1159,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -1639,13 +1659,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -2503,13 +2533,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -2970,13 +3010,23 @@ spec:
                                             caCertificateRefs:
                                               description: |-
                                                 CA certificate source to use to verify the server certificate. Omitted kind
-                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                                                key is required. If unset, the system's trusted certificates are used.
+                                                and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                                                read from the `ca.crt` key unless `key` names a different one. If unset, the
+                                                system's trusted certificates are used.
                                               items:
                                                 description: |-
                                                   LocalCACertificateRef references a same-namespace CA certificate source.
-                                                  An omitted kind defaults to ConfigMap.
+                                                  An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                                                 properties:
+                                                  key:
+                                                    default: ca.crt
+                                                    description: |-
+                                                      Key within the referenced source holding the PEM-encoded CA bundle.
+                                                      Omitted defaults to `ca.crt`.
+                                                    maxLength: 253
+                                                    minLength: 1
+                                                    pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                                                    type: string
                                                   kind:
                                                     default: ConfigMap
                                                     description: Kind of the referenced
@@ -6172,13 +6222,23 @@ spec:
                       caCertificateRefs:
                         description: |-
                           CA certificate source to use to verify the server certificate. Omitted kind
-                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The `ca.crt`
-                          key is required. If unset, the system's trusted certificates are used.
+                          and `ConfigMap` select a ConfigMap; `Secret` selects a Secret. The bundle is
+                          read from the `ca.crt` key unless `key` names a different one. If unset, the
+                          system's trusted certificates are used.
                         items:
                           description: |-
                             LocalCACertificateRef references a same-namespace CA certificate source.
-                            An omitted kind defaults to ConfigMap.
+                            An omitted kind defaults to ConfigMap, and an omitted key to `ca.crt`.
                           properties:
+                            key:
+                              default: ca.crt
+                              description: |-
+                                Key within the referenced source holding the PEM-encoded CA bundle.
+                                Omitted defaults to `ca.crt`.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+                              type: string
                             kind:
                               default: ConfigMap
                               description: Kind of the referenced CA certificate source.

--- a/controller/pkg/agentgateway/cacert/ca.go
+++ b/controller/pkg/agentgateway/cacert/ca.go
@@ -12,6 +12,9 @@ import (
 	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
 )
 
+// DefaultKey is the data key a CA bundle is read from when a reference does not name one.
+const DefaultKey = corev1.ServiceAccountRootCAKey
+
 // Kind returns the selected Kubernetes source kind for a CA reference.
 func Kind(kind string) string {
 	if kind == "" {
@@ -20,7 +23,16 @@ func Kind(kind string) string {
 	return kind
 }
 
-// Resolve validates and normalizes the CA certificate selected by ref.
+// Key returns the data key ref reads its CA bundle from, defaulting to ca.crt.
+func Key(ref agentgateway.LocalCACertificateRef) string {
+	if ref.Key == "" {
+		return DefaultKey
+	}
+	return ref.Key
+}
+
+// Resolve validates and normalizes the CA certificate selected by ref. The bundle is read from the
+// key named by ref.Key, or ca.crt when it is unset.
 func Resolve(
 	krtctx krt.HandlerContext,
 	configMaps krt.Collection[*corev1.ConfigMap],
@@ -30,6 +42,7 @@ func Resolve(
 ) (string, error) {
 	nn := types.NamespacedName{Namespace: namespace, Name: string(ref.Name)}
 	kind := Kind(ref.Kind)
+	key := Key(ref)
 	var caCRT []byte
 
 	switch kind {
@@ -38,9 +51,9 @@ func Resolve(
 		if configMap == nil {
 			return "", fmt.Errorf("ConfigMap %s not found", nn)
 		}
-		value, ok := configMap.Data[corev1.ServiceAccountRootCAKey]
+		value, ok := configMap.Data[key]
 		if !ok || value == "" {
-			return "", fmt.Errorf("error extracting CA cert from ConfigMap %s: missing ca.crt", nn)
+			return "", fmt.Errorf("error extracting CA cert from ConfigMap %s: missing key %q", nn, key)
 		}
 		caCRT = []byte(value)
 	case "Secret":
@@ -49,9 +62,9 @@ func Resolve(
 			return "", fmt.Errorf("Secret %s not found", nn)
 		}
 		var ok bool
-		caCRT, ok = secret.Data[corev1.ServiceAccountRootCAKey]
+		caCRT, ok = secret.Data[key]
 		if !ok || len(caCRT) == 0 {
-			return "", fmt.Errorf("error extracting CA cert from Secret %s: missing ca.crt", nn)
+			return "", fmt.Errorf("error extracting CA cert from Secret %s: missing key %q", nn, key)
 		}
 	default:
 		return "", fmt.Errorf("unsupported CA certificate reference kind %q", ref.Kind)
@@ -59,11 +72,11 @@ func Resolve(
 
 	certificates, err := cert.ParseCertsPEM(caCRT)
 	if err != nil {
-		return "", fmt.Errorf("invalid ca.crt in %s %s: %w", kind, nn, err)
+		return "", fmt.Errorf("invalid CA certificate in %s %s key %q: %w", kind, nn, key, err)
 	}
 	normalized, err := cert.EncodeCertificates(certificates...)
 	if err != nil {
-		return "", fmt.Errorf("invalid ca.crt in %s %s: %w", kind, nn, err)
+		return "", fmt.Errorf("invalid CA certificate in %s %s key %q: %w", kind, nn, key, err)
 	}
 	return string(normalized), nil
 }

--- a/controller/pkg/agentgateway/cacert/ca_test.go
+++ b/controller/pkg/agentgateway/cacert/ca_test.go
@@ -1,0 +1,227 @@
+package cacert_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/kube/krt"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/agentgateway/agentgateway/controller/api/v1alpha1/agentgateway"
+	"github.com/agentgateway/agentgateway/controller/pkg/agentgateway/cacert"
+)
+
+// TestResolveKinds covers selecting the ConfigMap or Secret a CA bundle is read from.
+func TestResolveKinds(t *testing.T) {
+	const namespace = "default"
+	configMapCA := testCAPEM(t, 1)
+	secretCA := testCAPEM(t, 2)
+
+	tests := []struct {
+		name      string
+		ref       agentgateway.LocalCACertificateRef
+		configMap *corev1.ConfigMap
+		secret    *corev1.Secret
+		want      []byte
+		wantErr   string
+	}{
+		{
+			name:      "ConfigMap",
+			ref:       agentgateway.LocalCACertificateRef{Kind: "ConfigMap", Name: "ca"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: namespace, Data: map[string]string{"ca.crt": string(configMapCA)}},
+			want:      configMapCA,
+		},
+		{
+			name:   "Secret",
+			ref:    agentgateway.LocalCACertificateRef{Kind: "Secret", Name: "ca"},
+			secret: &corev1.Secret{Name: "ca", Namespace: namespace, Data: map[string][]byte{"ca.crt": secretCA}},
+			want:   secretCA,
+		},
+		{
+			name:      "omitted kind defaults to ConfigMap",
+			ref:       agentgateway.LocalCACertificateRef{Name: "ca"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: namespace, Data: map[string]string{"ca.crt": string(configMapCA)}},
+			want:      configMapCA,
+		},
+		{
+			name:      "Secret ref does not fall back to a same-name ConfigMap",
+			ref:       agentgateway.LocalCACertificateRef{Kind: "Secret", Name: "ca"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: namespace, Data: map[string]string{"ca.crt": string(configMapCA)}},
+			wantErr:   "Secret default/ca not found",
+		},
+		{
+			name:    "missing ConfigMap",
+			ref:     agentgateway.LocalCACertificateRef{Kind: "ConfigMap", Name: "ca"},
+			wantErr: "ConfigMap default/ca not found",
+		},
+		{
+			name:    "Secret missing ca.crt",
+			ref:     agentgateway.LocalCACertificateRef{Kind: "Secret", Name: "ca"},
+			secret:  &corev1.Secret{Name: "ca", Namespace: namespace},
+			wantErr: `missing key "ca.crt"`,
+		},
+		{
+			name:    "Secret with invalid PEM",
+			ref:     agentgateway.LocalCACertificateRef{Kind: "Secret", Name: "ca"},
+			secret:  &corev1.Secret{Name: "ca", Namespace: namespace, Data: map[string][]byte{"ca.crt": []byte("not pem")}},
+			wantErr: `invalid CA certificate in Secret default/ca key "ca.crt"`,
+		},
+		{
+			name:    "unsupported kind",
+			ref:     agentgateway.LocalCACertificateRef{Kind: "Service", Name: "ca"},
+			wantErr: `unsupported CA certificate reference kind "Service"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolve(t, namespace, tt.ref, tt.configMap, tt.secret)
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != string(tt.want) {
+				t.Fatalf("CA = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveKey covers selecting the data key the CA bundle is read from.
+func TestResolveKey(t *testing.T) {
+	const namespace = "default"
+	defaultCA := testCAPEM(t, 1)
+	customCA := testCAPEM(t, 2)
+
+	// One object carrying two distinct bundles: only a key selector can reach the second.
+	configMap := &corev1.ConfigMap{Name: "ca", Namespace: namespace, Data: map[string]string{
+		"ca.crt":              string(defaultCA),
+		"corporate-roots.pem": string(customCA),
+	}}
+	secret := &corev1.Secret{Name: "ca", Namespace: namespace, Data: map[string][]byte{
+		"ca.crt":              defaultCA,
+		"corporate-roots.pem": customCA,
+	}}
+
+	tests := []struct {
+		name    string
+		ref     agentgateway.LocalCACertificateRef
+		want    []byte
+		wantErr string
+	}{
+		{
+			name: "ConfigMap omitted key defaults to ca.crt",
+			ref:  agentgateway.LocalCACertificateRef{Kind: "ConfigMap", Name: "ca"},
+			want: defaultCA,
+		},
+		{
+			name: "ConfigMap explicit ca.crt matches the default",
+			ref:  agentgateway.LocalCACertificateRef{Kind: "ConfigMap", Name: "ca", Key: "ca.crt"},
+			want: defaultCA,
+		},
+		{
+			name: "ConfigMap custom key",
+			ref:  agentgateway.LocalCACertificateRef{Kind: "ConfigMap", Name: "ca", Key: "corporate-roots.pem"},
+			want: customCA,
+		},
+		{
+			name: "Secret omitted key defaults to ca.crt",
+			ref:  agentgateway.LocalCACertificateRef{Kind: "Secret", Name: "ca"},
+			want: defaultCA,
+		},
+		{
+			name: "Secret custom key",
+			ref:  agentgateway.LocalCACertificateRef{Kind: "Secret", Name: "ca", Key: "corporate-roots.pem"},
+			want: customCA,
+		},
+		{
+			name:    "ConfigMap missing custom key names the key",
+			ref:     agentgateway.LocalCACertificateRef{Kind: "ConfigMap", Name: "ca", Key: "absent.pem"},
+			wantErr: `error extracting CA cert from ConfigMap default/ca: missing key "absent.pem"`,
+		},
+		{
+			name:    "Secret missing custom key names the key",
+			ref:     agentgateway.LocalCACertificateRef{Kind: "Secret", Name: "ca", Key: "absent.pem"},
+			wantErr: `error extracting CA cert from Secret default/ca: missing key "absent.pem"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolve(t, namespace, tt.ref, configMap, secret)
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != string(tt.want) {
+				t.Fatalf("CA = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func resolve(
+	t *testing.T,
+	namespace string,
+	ref agentgateway.LocalCACertificateRef,
+	configMap *corev1.ConfigMap,
+	secret *corev1.Secret,
+) (string, error) {
+	t.Helper()
+	var configMaps []*corev1.ConfigMap
+	if configMap != nil {
+		configMaps = []*corev1.ConfigMap{configMap}
+	}
+	var secrets []*corev1.Secret
+	if secret != nil {
+		secrets = []*corev1.Secret{secret}
+	}
+	return cacert.Resolve(
+		krt.TestingDummyContext{},
+		krt.NewStaticCollection(nil, configMaps, krt.WithName("cacert/ConfigMaps")),
+		krt.NewStaticCollection(nil, secrets, krt.WithName("cacert/Secrets")),
+		namespace,
+		ref,
+	)
+}
+
+func testCAPEM(t *testing.T, serial int64) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		NotBefore:             now,
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	certificate, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate})
+}

--- a/controller/pkg/agentgateway/plugins/backend_tls_policy_test.go
+++ b/controller/pkg/agentgateway/plugins/backend_tls_policy_test.go
@@ -87,7 +87,7 @@ func TestTranslateBackendTLSCAReference(t *testing.T) {
 			name:    "secret missing ca key",
 			ref:     agentgateway.LocalCACertificateRef{Name: "ca", Kind: "Secret"},
 			secret:  &corev1.Secret{Name: "ca", Namespace: "default"},
-			wantErr: "missing ca.crt",
+			wantErr: `missing key "ca.crt"`,
 		},
 		{
 			name: "secret has invalid pem",
@@ -95,7 +95,7 @@ func TestTranslateBackendTLSCAReference(t *testing.T) {
 			secret: &corev1.Secret{Name: "ca", Namespace: "default", Data: map[string][]byte{
 				"ca.crt": []byte("not pem"),
 			}},
-			wantErr: "invalid ca.crt in Secret default/ca",
+			wantErr: `invalid CA certificate in Secret default/ca key "ca.crt"`,
 		},
 		{
 			name: "configmap has invalid pem",
@@ -103,7 +103,41 @@ func TestTranslateBackendTLSCAReference(t *testing.T) {
 			configMap: &corev1.ConfigMap{Name: "ca", Namespace: "default", Data: map[string]string{
 				"ca.crt": "not pem",
 			}},
-			wantErr: "invalid ca.crt in ConfigMap default/ca",
+			wantErr: `invalid CA certificate in ConfigMap default/ca key "ca.crt"`,
+		},
+		{
+			name: "custom key in ConfigMap",
+			ref:  agentgateway.LocalCACertificateRef{Name: "ca", Kind: "ConfigMap", Key: "corporate-roots.pem"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: "default", Data: map[string]string{
+				"ca.crt":              "not pem",
+				"corporate-roots.pem": string(configMapCA),
+			}},
+			wantRoot: configMapCA,
+		},
+		{
+			name: "custom key in Secret",
+			ref:  agentgateway.LocalCACertificateRef{Name: "ca", Kind: "Secret", Key: "corporate-roots.pem"},
+			secret: &corev1.Secret{Name: "ca", Namespace: "default", Data: map[string][]byte{
+				"ca.crt":              []byte("not pem"),
+				"corporate-roots.pem": secretCA,
+			}},
+			wantRoot: secretCA,
+		},
+		{
+			name: "explicit ca.crt key matches the default",
+			ref:  agentgateway.LocalCACertificateRef{Name: "ca", Kind: "ConfigMap", Key: "ca.crt"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: "default", Data: map[string]string{
+				"ca.crt": string(configMapCA),
+			}},
+			wantRoot: configMapCA,
+		},
+		{
+			name: "missing custom key",
+			ref:  agentgateway.LocalCACertificateRef{Name: "ca", Kind: "ConfigMap", Key: "absent.pem"},
+			configMap: &corev1.ConfigMap{Name: "ca", Namespace: "default", Data: map[string]string{
+				"ca.crt": string(configMapCA),
+			}},
+			wantErr: `missing key "absent.pem"`,
 		},
 		{
 			name:    "unsupported kind",

--- a/controller/pkg/agentgateway/remotehttp/ca_bundle.go
+++ b/controller/pkg/agentgateway/remotehttp/ca_bundle.go
@@ -39,6 +39,8 @@ func caBundleFromBackendTLSRefs(
 		_, _ = h.Write([]byte{0})
 		_, _ = h.Write([]byte(nn.String()))
 		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(cacert.Key(ref)))
+		_, _ = h.Write([]byte{0})
 		_, _ = h.Write([]byte(caCRT))
 		_, _ = h.Write([]byte{0})
 	}

--- a/controller/pkg/agentgateway/remotehttp/secret_ca_test.go
+++ b/controller/pkg/agentgateway/remotehttp/secret_ca_test.go
@@ -153,13 +153,13 @@ func TestResolveCAReferenceKindsAndErrors(t *testing.T) {
 			name:    "Secret missing ca.crt",
 			ref:     agentgateway.LocalCACertificateRef{Name: "ca", Kind: "Secret"},
 			source:  &corev1.Secret{Name: "ca", Namespace: namespace},
-			wantErr: "missing ca.crt",
+			wantErr: `missing key "ca.crt"`,
 		},
 		{
 			name:    "Secret with invalid PEM",
 			ref:     agentgateway.LocalCACertificateRef{Name: "ca", Kind: "Secret"},
 			source:  &corev1.Secret{Name: "ca", Namespace: namespace, Data: map[string][]byte{"ca.crt": []byte("invalid")}},
-			wantErr: "invalid ca.crt in Secret default/ca",
+			wantErr: `invalid CA certificate in Secret default/ca key "ca.crt"`,
 		},
 		{
 			name:    "Secret does not fall back to ConfigMap",

--- a/controller/test/e2e/secret_ca_test.go
+++ b/controller/test/e2e/secret_ca_test.go
@@ -16,3 +16,15 @@ func TestBackendTLSSecretCA(tt *testing.T) {
 	)
 	t.Send("secret-ca.example.com", base.ExpectOK())
 }
+
+// TestBackendTLSCustomCAKey covers reading the CA bundle from a key other than ca.crt. Both
+// sources in the manifest hold garbage under ca.crt, so the handshake only succeeds if the
+// `key` selector is honoured.
+func TestBackendTLSCustomCAKey(tt *testing.T) {
+	t := New(tt)
+	t.Apply(
+		manifest("secret-ca", "custom-key.yaml"),
+		manifest("secret-ca", "custom-key-route.yaml"),
+	)
+	t.Send("custom-key-ca.example.com", base.ExpectOK())
+}

--- a/controller/test/e2e/testdata/secret-ca/custom-key-route.yaml
+++ b/controller/test/e2e/testdata/secret-ca/custom-key-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: custom-key-ca-route
+  namespace: agentgateway-base
+spec:
+  parentRefs:
+  - name: gateway
+  hostnames:
+  - custom-key-ca.example.com
+  rules:
+  - backendRefs:
+    - name: backend
+      port: 443

--- a/controller/test/e2e/testdata/secret-ca/custom-key.yaml
+++ b/controller/test/e2e/testdata/secret-ca/custom-key.yaml
@@ -1,0 +1,29 @@
+# The bundle lives under a key other than ca.crt, and ca.crt deliberately holds garbage so the
+# test fails if the custom key is ignored.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom-key-ca
+  namespace: agentgateway-base
+type: Opaque
+data:
+  ca.crt: aW52YWxpZA==
+  corporate-roots.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJlekNDQVNDZ0F3SUJBZ0lSQU9ubW9jOWFWU1preUo1OVU5cis2S0F3Q2dZSUtvWkl6ajBFQXdJd0d6RVoKTUJjR0ExVUVBeE1RWVdkbGJuUm5ZWFJsZDJGNUxtUmxkakFlRncweU5URXdNVFV4T1RRek16WmFGdzB6TlRFdwpNVE14T1RRek16WmFNQnN4R1RBWEJnTlZCQU1URUdGblpXNTBaMkYwWlhkaGVTNWtaWFl3V1RBVEJnY3Foa2pPClBRSUJCZ2dxaGtqT1BRTUJCd05DQUFTY1B1QWc2NSs5RDJZdU9yRmw0eEFZT0I2aDI0NjBRaFpUSVN0RTFQSFAKTUlPVUpBQXFCZEFXQUg1Skc0VWlWVUgvdEtZRWQ3M0NmYUJzSFNOck9KbExvMFV3UXpBT0JnTlZIUThCQWY4RQpCQU1DQVFZd0VnWURWUjBUQVFIL0JBZ3dCZ0VCL3dJQkFUQWRCZ05WSFE0RUZnUVVjd3RNaC85RmZKdmNSOUpVCmJJU091czdZRE1vd0NnWUlLb1pJemowRUF3SURTUUF3UmdJaEFMMmFnZkVJOVRCbDA2MFkwYUdRN1NYNjlhTEMKNy9pZmpMbUgzOFNHT1dDSkFpRUE2M05SeWY1b3o2cnp2dklIcEs4T00yaFNIcVdRRlFuaEJUQ2J5ek5BZTVVPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: custom-key-ca
+  namespace: agentgateway-base
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: backend
+  backend:
+    tls:
+      sni: localhost
+      caCertificateRefs:
+      - name: custom-key-ca
+        kind: Secret
+        key: corporate-roots.pem


### PR DESCRIPTION
### Description

This PR adds the support of ca bundle key configuration in certificate references. Up to now, it always (and only) resolved `ca.crt` key in the configured Secret / ConfigMap. This is now a configurable key, with default value of `ca.crt` if omitted for backward compatibility.

Closes #3418 

### Context

Every CA source was read from a hardcoded `ca.crt`, so a bundle stored under any other key could not be consumed at all. trust-manager Bundles, external-secrets and Vault sync routinely use a descriptive key name, and a single object holding several bundles could only ever expose one.

More context available in the corresponding issue: #3418 

> [!WARNING]
> This does not extend to `BackendTLSPolicy`, `XBackend` or the Gateway listener's `frontendValidation`: those use the upstream `gwv1.LocalObjectReference`, which has only group/kind/name and no field to carry a key, and upstream pins Core support to `ca.crt`. Those refs stay on the default key, documented on `cacert.GatewayRefSource`.

### What changed

Add an optional `key` to `LocalCACertificateRef`, defaulting to `ca.crt`:

```yaml
    caCertificateRefs:
        - name: corporate-trust
        kind: Secret
        key: corporate-roots.pem
```

`cacert` now resolves a `Source{Kind, Name, Key}`, so the key threads through both the ConfigMap and Secret branches and through the `remotehttp` control-plane client. Omitting `key`, or setting it to `ca.crt`, is identical to previous behaviour. Resolution errors now name the key that was looked for instead of always saying `ca.crt`.

**This is a non-breaking, retro-compatible PR**

### How was it tested

Ran the e2e tests against a live cluster, worked with no problems.

---

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
