### PR TITLE
fix(podMonitor): populate gateway labels for the Grafana dashboard

### DIFF
--- a/controller/install/helm/agentgateway/templates/monitoring.yaml
+++ b/controller/install/helm/agentgateway/templates/monitoring.yaml
@@ -28,6 +28,10 @@ spec:
   - port: metrics
     path: /metrics
     interval: {{ .Values.monitoring.serviceMonitor.interval }}
+  {{- with .Values.monitoring.proxy.podMonitor.podTargetLabels }}
+  podTargetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- if .Values.monitoring.serviceMonitor.enabled }}
 ---

--- a/controller/install/helm/agentgateway/values.yaml
+++ b/controller/install/helm/agentgateway/values.yaml
@@ -305,6 +305,10 @@ monitoring:
       #    metrics port (15020) directly, without requiring a metrics port on the
       #    provisioned Service.
       enabled: true
+      # -- Pod labels copied onto scraped proxy metrics. The gateway name is required
+      #    by the bundled Grafana dashboard for gateway discovery and filtering.
+      podTargetLabels:
+        - gateway.networking.k8s.io/gateway-name
     # -- GatewayClass names whose proxy pods are selected by the proxy PodMonitor.
     gatewayClassNames:
       - agentgateway

--- a/controller/test/helm/testdata/agentgateway/monitoring-custom-gateway-class-names.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-custom-gateway-class-names.golden
@@ -24,4 +24,6 @@ spec:
   - port: metrics
     path: /metrics
     interval: 15s
+  podTargetLabels:
+    - gateway.networking.k8s.io/gateway-name
 

--- a/controller/test/helm/testdata/agentgateway/monitoring-custom-proxy-namespace-selector.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-custom-proxy-namespace-selector.golden
@@ -25,4 +25,6 @@ spec:
   - port: metrics
     path: /metrics
     interval: 15s
+  podTargetLabels:
+    - gateway.networking.k8s.io/gateway-name
 

--- a/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-dashboard.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-dashboard.golden
@@ -23,6 +23,8 @@ spec:
   - port: metrics
     path: /metrics
     interval: 15s
+  podTargetLabels:
+    - gateway.networking.k8s.io/gateway-name
 
 ---
 # Source: agentgateway/templates/monitoring.yaml

--- a/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-service-monitor.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-enabled-no-service-monitor.golden
@@ -23,3 +23,5 @@ spec:
   - port: metrics
     path: /metrics
     interval: 15s
+  podTargetLabels:
+    - gateway.networking.k8s.io/gateway-name

--- a/controller/test/helm/testdata/agentgateway/monitoring-enabled.golden
+++ b/controller/test/helm/testdata/agentgateway/monitoring-enabled.golden
@@ -27,6 +27,8 @@ spec:
   - port: metrics
     path: /metrics
     interval: 30s
+  podTargetLabels:
+    - gateway.networking.k8s.io/gateway-name
 
 ---
 # Source: agentgateway/templates/monitoring.yaml


### PR DESCRIPTION
The bundled Grafana dashboard discovers gateways through the
`gateway_networking_k8s_io_gateway_name` label on `agentgateway_build_info` metric.

The included PodMonitor selects the correct proxy pods, but does not copy
the `gateway.networking.k8s.io/gateway-name` pod label onto scraped metrics. As a
result, the dashboard cannot populate its gateway variables, and queries using
the hidden `$gateway` filter return no data even though proxy metrics are being
scraped.

Reported in: https://github.com/agentgateway/agentgateway/issues/3420