### PR TITLE
ui: use playwright-managed chromium

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -115,6 +115,8 @@ jobs:
         corepack enable
         pnpm install --frozen-lockfile
         pnpm lint
+    - name: Install Playwright browser
+      run: pnpm exec playwright install --with-deps chromium
     - name: End-to-end tests
       run: pnpm test:e2e
     - name: Upload Playwright traces

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -11,7 +11,6 @@ export default defineConfig({
 	reporter: [['list']],
 	use: {
 		baseURL: 'http://127.0.0.1:19100',
-		channel: 'chrome',
 		trace: 'retain-on-failure'
 	},
 	webServer: {


### PR DESCRIPTION
Use Playwright-managed Chromium for UI E2E tests instead of a locally installed Chrome channel. This keeps local and CI browser versions aligned and avoids environment-specific browser failures.

- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
