### PR TITLE
feat(mcp): allow overriding gateway serverInfo and instructions

### DIFF
--- a/crates/agentgateway/src/mcp/handler.rs
+++ b/crates/agentgateway/src/mcp/handler.rs
@@ -820,6 +820,9 @@ impl Relay {
 					resource_subscribe,
 					upstream_instructions,
 					upstreams.merged_extensions(&HashMap::new()),
+					upstreams.server_name_override(),
+					upstreams.server_version_override(),
+					upstreams.instructions_override(),
 				)
 				.into(),
 			)
@@ -873,6 +876,9 @@ impl Relay {
 				resource_subscribe,
 				upstream_instructions,
 				upstreams.merged_extensions(&upstream_extensions),
+				upstreams.server_name_override(),
+				upstreams.server_version_override(),
+				upstreams.instructions_override(),
 			);
 			discover.supported_versions = supported_versions;
 			Ok(discover.into())
@@ -1569,11 +1575,16 @@ impl Relay {
 		Ok(accepted_response())
 	}
 
+	pub(crate) const DEFAULT_GATEWAY_PREAMBLE: &str = "This server is a gateway to a set of mcp servers. It is responsible for routing requests to the correct server and aggregating the results.";
+
 	fn get_info(
 		pv: ProtocolVersion,
 		resource_subscribe: bool,
 		upstream_instructions: Vec<(String, String)>,
 		extensions: Option<ExtensionCapabilities>,
+		server_name_override: Option<Strng>,
+		server_version_override: Option<Strng>,
+		instructions_override: Option<Strng>,
 	) -> ServerInfo {
 		let capabilities = {
 			// Prompts are supported with multiplexing using proxy-prefixed names.
@@ -1592,7 +1603,9 @@ impl Relay {
 			capabilities.extensions = extensions;
 			capabilities
 		};
-		let gateway_preamble = "This server is a gateway to a set of mcp servers. It is responsible for routing requests to the correct server and aggregating the results.";
+		let gateway_preamble = instructions_override
+			.as_deref()
+			.unwrap_or(Self::DEFAULT_GATEWAY_PREAMBLE);
 		let instructions = if upstream_instructions.is_empty() {
 			Some(gateway_preamble.to_string())
 		} else {
@@ -1605,8 +1618,12 @@ impl Relay {
 		ServerInfo::new(capabilities)
 			.with_protocol_version(pv)
 			.with_server_info(Implementation::new(
-				"agentgateway",
-				BuildInfo::new().version.to_string(),
+				server_name_override
+					.map(|s| s.to_string())
+					.unwrap_or_else(|| "agentgateway".to_string()),
+				server_version_override
+					.map(|s| s.to_string())
+					.unwrap_or_else(|| BuildInfo::new().version.to_string()),
 			))
 			.with_instructions(instructions.unwrap_or_default())
 	}
@@ -1615,12 +1632,18 @@ impl Relay {
 		resource_subscribe: bool,
 		upstream_instructions: Vec<(String, String)>,
 		extensions: Option<ExtensionCapabilities>,
+		server_name_override: Option<Strng>,
+		server_version_override: Option<Strng>,
+		instructions_override: Option<Strng>,
 	) -> DiscoverResult {
 		let info = Self::get_info(
 			ProtocolVersion::default(),
 			resource_subscribe,
 			upstream_instructions,
 			extensions,
+			server_name_override,
+			server_version_override,
+			instructions_override,
 		);
 		let mut result =
 			DiscoverResult::new(ProtocolVersion::KNOWN_VERSIONS.to_vec(), info.capabilities)

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -6065,6 +6065,168 @@ fn test_merge_initialize_no_instructions_when_multiplexing() {
 }
 
 #[test]
+fn test_merge_initialize_uses_server_name_override_when_multiplexing() {
+	use agent_core::version::BuildInfo;
+	use rmcp::model::{
+		Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerResult,
+	};
+
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![fake_streamable_target(
+				"alpha",
+				SocketAddr::from(([127, 0, 0, 1], 30117)),
+			)],
+			server_name: Some("custom-gateway".into()),
+			..Default::default()
+		},
+		empty_mcp_policies(),
+		PolicyClient::new(setup_proxy_test("{}").unwrap().pi),
+	)
+	.unwrap();
+
+	let merge_fn = relay.merge_initialize(ProtocolVersion::V_2025_06_18, true);
+
+	let results: Vec<(Strng, ServerResult)> = vec![(
+		"alpha".into(),
+		ServerResult::InitializeResult(
+			InitializeResult::new(ServerCapabilities::default())
+				.with_protocol_version(ProtocolVersion::V_2025_06_18)
+				.with_server_info(Implementation::new("alpha-server", "1.0")),
+		),
+	)];
+
+	let result = merge_fn(results, &empty_cel()).unwrap();
+	let info = match result {
+		ServerResult::InitializeResult(ir) => ir,
+		other => panic!("expected InitializeResult, got: {:?}", other),
+	};
+
+	// Name is overridden; version and instructions preamble keep their defaults.
+	assert_eq!(info.server_info.name, "custom-gateway");
+	assert_eq!(info.server_info.version, BuildInfo::new().version.to_string());
+	let instructions = info.instructions.expect("instructions should be present");
+	assert_eq!(
+		instructions,
+		Relay::DEFAULT_GATEWAY_PREAMBLE,
+		"unset instructions override should keep the default preamble, got: {instructions}"
+	);
+}
+
+#[test]
+fn test_merge_initialize_uses_full_override_when_multiplexing() {
+	use rmcp::model::{
+		Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerResult,
+	};
+
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![fake_streamable_target(
+				"alpha",
+				SocketAddr::from(([127, 0, 0, 1], 30118)),
+			)],
+			server_name: Some("custom-gateway".into()),
+			server_version: Some("9.9.9".into()),
+			instructions: Some("Custom gateway preamble.".into()),
+			..Default::default()
+		},
+		empty_mcp_policies(),
+		PolicyClient::new(setup_proxy_test("{}").unwrap().pi),
+	)
+	.unwrap();
+
+	let merge_fn = relay.merge_initialize(ProtocolVersion::V_2025_06_18, true);
+
+	let results: Vec<(Strng, ServerResult)> = vec![(
+		"alpha".into(),
+		ServerResult::InitializeResult(
+			InitializeResult::new(ServerCapabilities::default())
+				.with_protocol_version(ProtocolVersion::V_2025_06_18)
+				.with_server_info(Implementation::new("alpha-server", "1.0"))
+				.with_instructions("Alpha server instructions."),
+		),
+	)];
+
+	let result = merge_fn(results, &empty_cel()).unwrap();
+	let info = match result {
+		ServerResult::InitializeResult(ir) => ir,
+		other => panic!("expected InitializeResult, got: {:?}", other),
+	};
+
+	assert_eq!(info.server_info.name, "custom-gateway");
+	assert_eq!(info.server_info.version, "9.9.9");
+	let instructions = info.instructions.expect("instructions should be present");
+	assert!(instructions.starts_with("Custom gateway preamble."));
+	assert!(instructions.contains("Alpha server instructions."));
+	assert!(
+		!instructions.contains(Relay::DEFAULT_GATEWAY_PREAMBLE),
+		"default preamble text must not leak through when overridden, got: {instructions}"
+	);
+}
+
+#[test]
+fn test_merge_discover_uses_full_override_when_multiplexing() {
+	use rmcp::model::{DiscoverResult, Implementation, ProtocolVersion, ServerCapabilities, ServerResult};
+
+	let relay = Relay::new(
+		McpBackendGroup {
+			targets: vec![
+				fake_streamable_target("alpha", SocketAddr::from(([127, 0, 0, 1], 30119))),
+				fake_streamable_target("beta", SocketAddr::from(([127, 0, 0, 1], 30120))),
+			],
+			server_name: Some("custom-gateway".into()),
+			server_version: Some("9.9.9".into()),
+			instructions: Some("Custom gateway preamble.".into()),
+			..Default::default()
+		},
+		empty_mcp_policies(),
+		PolicyClient::new(setup_proxy_test("{}").unwrap().pi),
+	)
+	.unwrap();
+
+	let discover_merge = relay.merge_discover(true);
+	let results: Vec<(Strng, ServerResult)> = vec![
+		(
+			"alpha".into(),
+			ServerResult::DiscoverResult(
+				DiscoverResult::new(
+					ProtocolVersion::KNOWN_VERSIONS.to_vec(),
+					ServerCapabilities::default(),
+				)
+				.with_server_info(Implementation::new("alpha-server", "1.0"))
+				.with_instructions("Alpha guidance."),
+			),
+		),
+		(
+			"beta".into(),
+			ServerResult::DiscoverResult(
+				DiscoverResult::new(
+					ProtocolVersion::KNOWN_VERSIONS.to_vec(),
+					ServerCapabilities::default(),
+				)
+				.with_server_info(Implementation::new("beta-server", "1.0")),
+			),
+		),
+	];
+
+	let result = discover_merge(results, &empty_cel()).unwrap();
+	let discover = match result {
+		ServerResult::DiscoverResult(dr) => dr,
+		other => panic!("expected DiscoverResult, got: {:?}", other),
+	};
+
+	assert_eq!(discover.server_info.name, "custom-gateway");
+	assert_eq!(discover.server_info.version, "9.9.9");
+	let instructions = discover.instructions.expect("instructions should be present");
+	assert!(instructions.starts_with("Custom gateway preamble."));
+	assert!(instructions.contains("[alpha]\nAlpha guidance."));
+	assert!(
+		!instructions.contains(Relay::DEFAULT_GATEWAY_PREAMBLE),
+		"default preamble text must not leak through when overridden, got: {instructions}"
+	);
+}
+
+#[test]
 fn test_merge_initialize_forwards_single_backend_without_multiplexing() {
 	use rmcp::model::{
 		Implementation, InitializeResult, ProtocolVersion, ServerCapabilities, ServerResult,

--- a/crates/agentgateway/src/mcp/mcp_tests.rs
+++ b/crates/agentgateway/src/mcp/mcp_tests.rs
@@ -6104,7 +6104,10 @@ fn test_merge_initialize_uses_server_name_override_when_multiplexing() {
 
 	// Name is overridden; version and instructions preamble keep their defaults.
 	assert_eq!(info.server_info.name, "custom-gateway");
-	assert_eq!(info.server_info.version, BuildInfo::new().version.to_string());
+	assert_eq!(
+		info.server_info.version,
+		BuildInfo::new().version.to_string()
+	);
 	let instructions = info.instructions.expect("instructions should be present");
 	assert_eq!(
 		instructions,
@@ -6166,7 +6169,9 @@ fn test_merge_initialize_uses_full_override_when_multiplexing() {
 
 #[test]
 fn test_merge_discover_uses_full_override_when_multiplexing() {
-	use rmcp::model::{DiscoverResult, Implementation, ProtocolVersion, ServerCapabilities, ServerResult};
+	use rmcp::model::{
+		DiscoverResult, Implementation, ProtocolVersion, ServerCapabilities, ServerResult,
+	};
 
 	let relay = Relay::new(
 		McpBackendGroup {
@@ -6188,14 +6193,15 @@ fn test_merge_discover_uses_full_override_when_multiplexing() {
 	let results: Vec<(Strng, ServerResult)> = vec![
 		(
 			"alpha".into(),
-			ServerResult::DiscoverResult(
-				DiscoverResult::new(
+			ServerResult::DiscoverResult({
+				let mut dr = DiscoverResult::new(
 					ProtocolVersion::KNOWN_VERSIONS.to_vec(),
 					ServerCapabilities::default(),
 				)
-				.with_server_info(Implementation::new("alpha-server", "1.0"))
-				.with_instructions("Alpha guidance."),
-			),
+				.with_server_info(Implementation::new("alpha-server", "1.0"));
+				dr.instructions = Some("Alpha guidance.".to_string());
+				dr
+			}),
 		),
 		(
 			"beta".into(),
@@ -6215,9 +6221,14 @@ fn test_merge_discover_uses_full_override_when_multiplexing() {
 		other => panic!("expected DiscoverResult, got: {:?}", other),
 	};
 
-	assert_eq!(discover.server_info.name, "custom-gateway");
-	assert_eq!(discover.server_info.version, "9.9.9");
-	let instructions = discover.instructions.expect("instructions should be present");
+	let server_info = discover
+		.server_info()
+		.expect("server_info should be present");
+	assert_eq!(server_info.name, "custom-gateway");
+	assert_eq!(server_info.version, "9.9.9");
+	let instructions = discover
+		.instructions
+		.expect("instructions should be present");
 	assert!(instructions.starts_with("Custom gateway preamble."));
 	assert!(instructions.contains("[alpha]\nAlpha guidance."));
 	assert!(

--- a/crates/agentgateway/src/mcp/router.rs
+++ b/crates/agentgateway/src/mcp/router.rs
@@ -113,6 +113,9 @@ impl App {
 				failure_mode: backend.failure_mode,
 				session_idle_ttl: backend.session_idle_ttl,
 				sse_keep_alive: backend.sse_keep_alive,
+				server_name: backend.server_name.clone(),
+				server_version: backend.server_version.clone(),
+				instructions: backend.instructions.clone(),
 			}
 		};
 		let sessions = self.session.clone();
@@ -240,6 +243,9 @@ pub struct McpBackendGroup {
 	pub failure_mode: FailureMode,
 	pub session_idle_ttl: Duration,
 	pub sse_keep_alive: Option<Duration>,
+	pub server_name: Option<Strng>,
+	pub server_version: Option<Strng>,
+	pub instructions: Option<Strng>,
 }
 
 impl Default for McpBackendGroup {
@@ -251,6 +257,9 @@ impl Default for McpBackendGroup {
 			failure_mode: crate::mcp::FailureMode::default(),
 			session_idle_ttl: mcp::DEFAULT_SESSION_IDLE_TTL,
 			sse_keep_alive: None,
+			server_name: None,
+			server_version: None,
+			instructions: None,
 		}
 	}
 }

--- a/crates/agentgateway/src/mcp/upstream/mod.rs
+++ b/crates/agentgateway/src/mcp/upstream/mod.rs
@@ -541,6 +541,18 @@ impl UpstreamGroup {
 		self.backend.stateful
 	}
 
+	pub(crate) fn server_name_override(&self) -> Option<Strng> {
+		self.backend.server_name.clone()
+	}
+
+	pub(crate) fn server_version_override(&self) -> Option<Strng> {
+		self.backend.server_version.clone()
+	}
+
+	pub(crate) fn instructions_override(&self) -> Option<Strng> {
+		self.backend.instructions.clone()
+	}
+
 	/// True when some target's `delete` does teardown work even without an upstream
 	/// session id: stdio processes and SSE streams hold per-connection state.
 	pub(crate) fn has_connection_teardown(&self) -> bool {

--- a/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
+++ b/crates/agentgateway/src/mcp/upstream/openapi/tests.rs
@@ -1672,6 +1672,9 @@ async fn test_openapi_from_url() {
 		failure_mode: None,
 		sse_keep_alive: None,
 		dns_rebinding_protection: false,
+		server_name: None,
+		server_version: None,
+		instructions: None,
 	});
 
 	// Convert to runtime backends

--- a/crates/agentgateway/src/test_helpers/proxymock.rs
+++ b/crates/agentgateway/src/test_helpers/proxymock.rs
@@ -771,6 +771,9 @@ impl TestBind {
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
 				sse_keep_alive: None,
 				dns_rebinding_protection,
+				server_name: None,
+				server_version: None,
+				instructions: None,
 			},
 		);
 		{
@@ -891,6 +894,9 @@ impl TestBind {
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
 				sse_keep_alive: None,
 				dns_rebinding_protection: false,
+				server_name: None,
+				server_version: None,
+				instructions: None,
 			},
 		);
 		{

--- a/crates/agentgateway/src/types/agent.rs
+++ b/crates/agentgateway/src/types/agent.rs
@@ -1849,6 +1849,18 @@ pub struct McpBackend {
 	/// agentgateway is typically not a browser-facing localhost MCP server.
 	#[serde(default, skip_serializing_if = "crate::serdes::is_default")]
 	pub dns_rebinding_protection: bool,
+	/// Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`
+	/// when multiplexing multiple targets. Defaults to `agentgateway` when unset.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub server_name: Option<Strng>,
+	/// Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`
+	/// when multiplexing multiple targets. Defaults to the build version when unset.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub server_version: Option<Strng>,
+	/// Overrides the gateway preamble prepended to merged upstream instructions when
+	/// multiplexing multiple targets. Defaults to a generic gateway description when unset.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub instructions: Option<Strng>,
 }
 
 impl McpBackend {

--- a/crates/agentgateway/src/types/agent_xds.rs
+++ b/crates/agentgateway/src/types/agent_xds.rs
@@ -2068,6 +2068,11 @@ pub(crate) fn backend_with_policies_from_proto(
 				session_idle_ttl: crate::mcp::DEFAULT_SESSION_IDLE_TTL,
 				sse_keep_alive: m.sse_keep_alive.map(convert_duration),
 				dns_rebinding_protection: false,
+				// Not yet exposed over xDS; only the local/static config surface
+				// (`LocalMcpBackend`) supports these overrides today.
+				server_name: None,
+				server_version: None,
+				instructions: None,
 			},
 		),
 		Some(backend::Kind::Guardrail(_)) => {

--- a/crates/agentgateway/src/types/local.rs
+++ b/crates/agentgateway/src/types/local.rs
@@ -1800,6 +1800,9 @@ impl LocalBackend {
 					session_idle_ttl: mcp_session_ttl,
 					sse_keep_alive: tgt.sse_keep_alive,
 					dns_rebinding_protection: tgt.dns_rebinding_protection,
+					server_name: tgt.server_name.clone(),
+					server_version: tgt.server_version.clone(),
+					instructions: tgt.instructions.clone(),
 				};
 				backends.push(Backend::MCP(name, m).into());
 				backends
@@ -1881,6 +1884,18 @@ pub struct LocalMcpBackend {
 	/// Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.
 	#[serde(default, skip_serializing_if = "crate::serdes::is_default")]
 	pub dns_rebinding_protection: bool,
+	/// Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`
+	/// when multiplexing multiple targets. Defaults to `agentgateway` when unset.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub server_name: Option<Strng>,
+	/// Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`
+	/// when multiplexing multiple targets. Defaults to the build version when unset.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub server_version: Option<Strng>,
+	/// Overrides the gateway preamble prepended to merged upstream instructions when
+	/// multiplexing multiple targets. Defaults to a generic gateway description when unset.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub instructions: Option<Strng>,
 }
 
 #[apply(schema_de!)]

--- a/schema/config.json
+++ b/schema/config.json
@@ -8241,6 +8241,27 @@
         "dnsRebindingProtection": {
           "description": "Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).\nOff by default; see https://github.com/agentgateway/agentgateway/issues/1855.",
           "type": "boolean"
+        },
+        "serverName": {
+          "description": "Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`\nwhen multiplexing multiple targets. Defaults to `agentgateway` when unset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "serverVersion": {
+          "description": "Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`\nwhen multiplexing multiple targets. Defaults to the build version when unset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "instructions": {
+          "description": "Overrides the gateway preamble prepended to merged upstream instructions when\nmultiplexing multiple targets. Defaults to a generic gateway description when unset.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -12627,6 +12648,27 @@
         "dnsRebindingProtection": {
           "description": "Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).\nOff by default; see https://github.com/agentgateway/agentgateway/issues/1855.",
           "type": "boolean"
+        },
+        "serverName": {
+          "description": "Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`\nwhen multiplexing multiple targets. Defaults to `agentgateway` when unset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "serverVersion": {
+          "description": "Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`\nwhen multiplexing multiple targets. Defaults to the build version when unset.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "instructions": {
+          "description": "Overrides the gateway preamble prepended to merged upstream instructions when\nmultiplexing multiple targets. Defaults to a generic gateway description when unset.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "policies": {
           "description": "Policies applied to MCP requests.",

--- a/schema/config.md
+++ b/schema/config.md
@@ -6017,6 +6017,9 @@
 |`binds[].listeners[].routes[].backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
 |`binds[].listeners[].routes[].backends[].mcp.sseKeepAlive`|string|Interval at which SSE keep-alive comments are sent on long-lived MCP streams.<br>Disabled when unset. Set this when a load balancer or API gateway sits in front<br>of agentgateway and reaps connections that carry no traffic.|
 |`binds[].listeners[].routes[].backends[].mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
+|`binds[].listeners[].routes[].backends[].mcp.serverName`|string|Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to `agentgateway` when unset.|
+|`binds[].listeners[].routes[].backends[].mcp.serverVersion`|string|Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to the build version when unset.|
+|`binds[].listeners[].routes[].backends[].mcp.instructions`|string|Overrides the gateway preamble prepended to merged upstream instructions when<br>multiplexing multiple targets. Defaults to a generic gateway description when unset.|
 |`binds[].listeners[].routes[].backends[].ai`|object||
 |`binds[].listeners[].routes[].backends[].ai.name`|string|Name identifying this provider, referenced by `llm.models[].provider`.|
 |`binds[].listeners[].routes[].backends[].ai.provider`|object|The upstream LLM provider type and its configuration.<br>Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -25187,6 +25190,9 @@
 |`backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
 |`backends[].mcp.sseKeepAlive`|string|Interval at which SSE keep-alive comments are sent on long-lived MCP streams.<br>Disabled when unset. Set this when a load balancer or API gateway sits in front<br>of agentgateway and reaps connections that carry no traffic.|
 |`backends[].mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
+|`backends[].mcp.serverName`|string|Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to `agentgateway` when unset.|
+|`backends[].mcp.serverVersion`|string|Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to the build version when unset.|
+|`backends[].mcp.instructions`|string|Overrides the gateway preamble prepended to merged upstream instructions when<br>multiplexing multiple targets. Defaults to a generic gateway description when unset.|
 |`backends[].ai`|object||
 |`backends[].ai.name`|string|Name identifying this provider, referenced by `llm.models[].provider`.|
 |`backends[].ai.provider`|object|The upstream LLM provider type and its configuration.<br>Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -41231,6 +41237,9 @@
 |`routeGroups[].routes[].backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
 |`routeGroups[].routes[].backends[].mcp.sseKeepAlive`|string|Interval at which SSE keep-alive comments are sent on long-lived MCP streams.<br>Disabled when unset. Set this when a load balancer or API gateway sits in front<br>of agentgateway and reaps connections that carry no traffic.|
 |`routeGroups[].routes[].backends[].mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
+|`routeGroups[].routes[].backends[].mcp.serverName`|string|Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to `agentgateway` when unset.|
+|`routeGroups[].routes[].backends[].mcp.serverVersion`|string|Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to the build version when unset.|
+|`routeGroups[].routes[].backends[].mcp.instructions`|string|Overrides the gateway preamble prepended to merged upstream instructions when<br>multiplexing multiple targets. Defaults to a generic gateway description when unset.|
 |`routeGroups[].routes[].backends[].ai`|object||
 |`routeGroups[].routes[].backends[].ai.name`|string|Name identifying this provider, referenced by `llm.models[].provider`.|
 |`routeGroups[].routes[].backends[].ai.provider`|object|The upstream LLM provider type and its configuration.<br>Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -59926,6 +59935,9 @@
 |`routes[].backends[].mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
 |`routes[].backends[].mcp.sseKeepAlive`|string|Interval at which SSE keep-alive comments are sent on long-lived MCP streams.<br>Disabled when unset. Set this when a load balancer or API gateway sits in front<br>of agentgateway and reaps connections that carry no traffic.|
 |`routes[].backends[].mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
+|`routes[].backends[].mcp.serverName`|string|Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to `agentgateway` when unset.|
+|`routes[].backends[].mcp.serverVersion`|string|Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to the build version when unset.|
+|`routes[].backends[].mcp.instructions`|string|Overrides the gateway preamble prepended to merged upstream instructions when<br>multiplexing multiple targets. Defaults to a generic gateway description when unset.|
 |`routes[].backends[].ai`|object||
 |`routes[].backends[].ai.name`|string|Name identifying this provider, referenced by `llm.models[].provider`.|
 |`routes[].backends[].ai.provider`|object|The upstream LLM provider type and its configuration.<br>Exactly one of openAI, gemini, vertex, anthropic, bedrock, azure, copilot, or custom may be set.|
@@ -77832,6 +77844,9 @@
 |`mcp.failureMode`|enum|Behavior when one or more MCP targets fail to initialize or fail during fanout.<br>Defaults to `failClosed`.<br>Possible values: `failClosed`, `failOpen`.|
 |`mcp.sseKeepAlive`|string|Interval at which SSE keep-alive comments are sent on long-lived MCP streams.<br>Disabled when unset. Set this when a load balancer or API gateway sits in front<br>of agentgateway and reaps connections that carry no traffic.|
 |`mcp.dnsRebindingProtection`|boolean|Opt-in MCP DNS rebinding protection (Host/Origin must be localhost).<br>Off by default; see https://github.com/agentgateway/agentgateway/issues/1855.|
+|`mcp.serverName`|string|Overrides the `serverInfo.name` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to `agentgateway` when unset.|
+|`mcp.serverVersion`|string|Overrides the `serverInfo.version` reported to clients on `initialize`/`server/discover`<br>when multiplexing multiple targets. Defaults to the build version when unset.|
+|`mcp.instructions`|string|Overrides the gateway preamble prepended to merged upstream instructions when<br>multiplexing multiple targets. Defaults to a generic gateway description when unset.|
 |`mcp.policies`|object|Policies applied to MCP requests.|
 |`mcp.policies.requestHeaderModifier`|object|Modify request headers before forwarding.|
 |`mcp.policies.requestHeaderModifier.add`|object|Headers to append without replacing existing values.|


### PR DESCRIPTION
## Summary
- Adds optional overrides for the following fields:
    - `serverName`
    - `serverVersion`
    - `instructions`
- Only affects multiplexing, single targets remain the same
- Doesn't change current behaviour, if you don't see them, they default to the norm
- xDS/proto control-plane has NOT been set up   

## Why
- Allowing the `serverName` and `serverVersion` to be changed supports hiding the software being used, and the version to avoid fingerprinting the exact software and version being used.
- Allowing `instructions` to be changed gives more customisation options around them. 

## Testing
- Unit tests added covering the new overrides 

---

First time contributing, new to Rust, etc. so please let me know if i've missed anything, any changes required, etc.!

---

- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.