### PR TITLE
proxy: add default timeouts for missing policy calls

### DIFF
--- a/crates/agentgateway/src/http/ext_authz.rs
+++ b/crates/agentgateway/src/http/ext_authz.rs
@@ -561,6 +561,10 @@ impl ExtAuthz {
 			}),
 		};
 		let mut authz_req = tonic::Request::new(authz_req);
+		// Set the default request timeout. This can be overridden by a timeout on the Backend object itself.
+		authz_req
+			.extensions_mut()
+			.insert(BackendRequestTimeout(Duration::from_secs(2)));
 		copy_span_writer(req.extensions(), authz_req.extensions_mut());
 		let mut span = policy_client.start_grpc_span(
 			&mut authz_req,

--- a/crates/agentgateway/src/proxy/httpproxy.rs
+++ b/crates/agentgateway/src/proxy/httpproxy.rs
@@ -5069,10 +5069,14 @@ impl PolicyClient {
 
 	fn internal_call_with_policies<'a>(
 		&'a self,
-		req: Request,
+		mut req: Request,
 		backend: Backend,
 		pols: BackendPolicies,
 	) -> Pin<Box<dyn Future<Output = Result<Response, ProxyError>> + Send + '_>> {
+		// Preserve caller timeouts; backend policies can override this fallback.
+		req
+			.extensions_mut()
+			.get_or_insert(BackendRequestTimeout(Duration::from_secs(10)));
 		let mut req = Some(req);
 		Box::pin(async move {
 			let mut response_policies = Default::default();
@@ -5102,6 +5106,9 @@ impl PolicyClient {
 		&self,
 		mut req: Request,
 	) -> Pin<Box<dyn Future<Output = Result<Response, ProxyError>> + Send + '_>> {
+		req
+			.extensions_mut()
+			.get_or_insert(BackendRequestTimeout(Duration::from_secs(10)));
 		Box::pin(async move {
 			let start = std::time::Instant::now();
 			let mut span = self.start_outbound_span(&mut req);


### PR DESCRIPTION
ext auth http is 2s, so match it in grpc

For others, have 10s fallback

Signed-off-by: John Howard <john.howard@solo.io>
