### PR TITLE
docs: repoint stale documentation URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -560,7 +560,7 @@ jobs:
 
           ## Quick Start
 
-          Follow the [Kubernetes](https://agentgateway.dev/docs/kubernetes/latest/quickstart/) or [Standalone](https://agentgateway.dev/docs/standalone/latest/quickstart/) quick start guide to get started!
+          Follow the [Kubernetes](https://agentgateway.dev/docs/kubernetes/latest/documentation/quickstart/) or [Standalone](https://agentgateway.dev/docs/standalone/latest/documentation/quickstart/) quick start guide to get started!
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@
 
 ## Getting Started
 
-- [Standalone Quickstart](https://agentgateway.dev/docs/standalone/latest/quickstart) — Get started with agentgateway in minutes.
-- [Kubernetes Quickstart](https://agentgateway.dev/docs/kubernetes/latest/quickstart) — Deploy on Kubernetes using the built-in controller and Gateway API.
+- [Standalone Quickstart](https://agentgateway.dev/docs/standalone/latest/documentation/quickstart) — Get started with agentgateway in minutes.
+- [Kubernetes Quickstart](https://agentgateway.dev/docs/kubernetes/latest/documentation/quickstart) — Deploy on Kubernetes using the built-in controller and Gateway API.
 
 ## Documentation
 

--- a/controller/install/helm/agentgateway/values.yaml
+++ b/controller/install/helm/agentgateway/values.yaml
@@ -222,7 +222,7 @@ image:
   # -- Set the default image pull policy.
   pullPolicy: IfNotPresent
 
-# -- Configure the integration with the Gateway API Inference Extension project, which lets you use agentgateway to route to AI inference workloads like LLMs that run locally in your Kubernetes cluster. Documentation for Inference Extension can be found here: https://agentgateway.dev/docs/kubernetes/latest/inference/
+# -- Configure the integration with the Gateway API Inference Extension project, which lets you use agentgateway to route to AI inference workloads like LLMs that run locally in your Kubernetes cluster. Documentation for Inference Extension can be found here: https://agentgateway.dev/docs/kubernetes/latest/documentation/inference/
 inferenceExtension:
   # -- Enable Inference Extension support in the agentgateway controller.
   enabled: false
@@ -237,7 +237,7 @@ xBackend:
   # -- Enable XBackend support in the agentgateway controller.
   enabled: false
 
-# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Agentgateway includes the selected namespaces in config discovery. For more information, see the docs https://agentgateway.dev/docs/kubernetes/latest/install/advanced/#namespace-discovery.
+# -- List of namespace selectors (OR'ed): each entry can use 'matchLabels' or 'matchExpressions' (AND'ed within each entry if used together). Agentgateway includes the selected namespaces in config discovery. For more information, see the docs https://agentgateway.dev/docs/kubernetes/latest/documentation/install/advanced/#namespace-discovery.
 discoveryNamespaceSelectors: []
 
 # -- Map of GatewayClass names to GatewayParameters references that will be set on

--- a/controller/pkg/syncer/README.md
+++ b/controller/pkg/syncer/README.md
@@ -1105,7 +1105,7 @@ Port-forward, and send a request through the gateway:
 
 The agentgateway data plane supports comprehensive observability through OpenTelemetry (OTEL) tracing. You can configure tracing using the `rawConfig` field in AgentgatewayParameters to integrate with various observability platforms and add custom trace fields for enhanced monitoring of your AI/LLM traffic.
 
-For detailed information about tracing configuration and observability features, see the [agentgateway observability documentation](https://agentgateway.dev/docs/reference/observability/traces/).
+For detailed information about tracing configuration and observability features, see the [agentgateway observability documentation](https://agentgateway.dev/docs/kubernetes/latest/documentation/observability/traces/).
 
 #### Configuring Tracing with RawConfig
 

--- a/examples/llm-semantic-routing/README.md
+++ b/examples/llm-semantic-routing/README.md
@@ -77,7 +77,7 @@ vSR supports multiple cache backends, including a default in-memory store.
 Redis is used here as a production-oriented backend because it allows vSR
 replicas to share cache entries and persist them across process restarts. Redis
 also backs other agentgateway-related services, such as [global rate
-limiting](https://agentgateway.dev/docs/kubernetes/main/security/rate-limit-global/).
+limiting](https://agentgateway.dev/docs/kubernetes/main/documentation/security/rate-limit-global/).
 The example enables Redis persistence on a local persistent volume.
 
 See: `k8s/semantic-cache`

--- a/examples/llm-semantic-routing/k8s/cost-based/README.md
+++ b/examples/llm-semantic-routing/k8s/cost-based/README.md
@@ -20,11 +20,11 @@ following the [vLLM Semantic Router configuration guide](https://vllm-semantic-r
 This example assumes a working agentgateway LLM path with cost and
 observability data available:
 
-- [Install agentgateway with Helm](https://agentgateway.dev/docs/kubernetes/main/install/helm/).
-- [Set up an agentgateway proxy](https://agentgateway.dev/docs/kubernetes/main/setup/gateway/).
-- [Configure OpenAI as an LLM provider](https://agentgateway.dev/docs/kubernetes/main/llm/providers/openai/).
-- [Price LLM requests with a model cost catalog](https://agentgateway.dev/docs/kubernetes/main/llm/costs/).
-- [Install an OpenTelemetry stack](https://agentgateway.dev/docs/kubernetes/main/observability/otel-stack/).
+- [Install agentgateway with Helm](https://agentgateway.dev/docs/kubernetes/main/documentation/install/helm/).
+- [Set up an agentgateway proxy](https://agentgateway.dev/docs/kubernetes/main/documentation/setup/gateway/).
+- [Configure OpenAI as an LLM provider](https://agentgateway.dev/docs/kubernetes/main/integrations/llm/providers/openai/).
+- [Price LLM requests with a model cost catalog](https://agentgateway.dev/docs/kubernetes/main/documentation/llm/cost-controls/costs/).
+- [Install an OpenTelemetry stack](https://agentgateway.dev/docs/kubernetes/main/documentation/observability/otel-stack/).
 
 The `AgentgatewayBackend` in `agentgateway-routing.yaml` expects an
 `openai-secret` in `agentgateway-system`, matching the provider setup guide.
@@ -148,7 +148,7 @@ kubectl apply \
 ```
 
 The policy uses an [agentgateway request-body
-transformation](https://agentgateway.dev/docs/kubernetes/latest/traffic-management/transformations/validate/)
+transformation](https://agentgateway.dev/docs/kubernetes/latest/documentation/traffic-management/transformations/validate/)
 to rewrite the request's `model` field to `auto` before vSR selects a model.
 Remove it to restore direct model selection:
 
@@ -173,7 +173,7 @@ OpenAI Responses API and vSR translates streamed Responses events before the
 gateway forwards the request to the selected model.
 
 For Codex CLI and ChatGPT desktop app setup, see [Use Codex with
-agentgateway](https://agentgateway.dev/docs/kubernetes/latest/integrations/llm-clients/codex/).
+agentgateway](https://agentgateway.dev/docs/kubernetes/latest/integrations/llm/clients/codex/).
 
 ### Verify Codex Routing
 
@@ -191,9 +191,9 @@ successful `response_status`.
 The gateway authenticates to OpenAI with its configured provider credential and
 records the selected model and cost as it does for other OpenAI-compatible
 clients. Agentgateway can [rewrite client-facing model names with model
-aliases](https://agentgateway.dev/docs/kubernetes/latest/llm/alias/). An
+aliases](https://agentgateway.dev/docs/kubernetes/latest/documentation/llm/alias/). An
 organization can also use a [request-body
-transformation](https://agentgateway.dev/docs/kubernetes/latest/traffic-management/transformations/validate/)
+transformation](https://agentgateway.dev/docs/kubernetes/latest/documentation/traffic-management/transformations/validate/)
 to rewrite every request to `auto`. Treat `auto` as the supported client path
 when testing this policy.
 

--- a/examples/llm-semantic-routing/k8s/semantic-cache/README.md
+++ b/examples/llm-semantic-routing/k8s/semantic-cache/README.md
@@ -21,7 +21,7 @@ when that process restarts. This example chooses Redis as a production-oriented
 backend because it provides shared, persistent cache state and can fit an
 existing Redis operational model. Redis is also used by other agentgateway
 features; for example, the [agentgateway global rate-limiting
-guide](https://agentgateway.dev/docs/kubernetes/main/security/rate-limit-global/)
+guide](https://agentgateway.dev/docs/kubernetes/main/documentation/security/rate-limit-global/)
 deploys a Redis-backed rate-limit service.
 
 See the [vSR semantic-cache documentation](https://vllm-semantic-router.com/docs/tutorials/plugin/semantic-cache/),
@@ -77,7 +77,7 @@ Install these tools:
 
 The example uses Kubernetes 1.36, agentgateway 1.4.1, the current vSR chart and
 image, and Redis Open Source 8.10.0. See the [agentgateway version-support
-reference](https://agentgateway.dev/docs/kubernetes/main/reference/versions/)
+reference](https://agentgateway.dev/docs/kubernetes/main/release-notes/versions/)
 for the supported Kubernetes and Gateway API versions. vSR downloads an
 embedding model on its first startup. Allocate at least 6 CPUs, 10 GiB of
 memory, and 15 GiB of free disk space to Docker.
@@ -89,9 +89,9 @@ for both connections:
 - Serve the vSR ExtProc gRPC endpoint with TLS, either directly or through a
   TLS-terminating sidecar, and configure agentgateway to originate TLS to the
   `semantic-router` Service. See the agentgateway [ExtProc
-  guide](https://agentgateway.dev/docs/kubernetes/main/traffic-management/extproc/)
+  guide](https://agentgateway.dev/docs/kubernetes/main/documentation/traffic-management/extproc/)
   and [BackendTLS
-  guide](https://agentgateway.dev/docs/kubernetes/main/security/backendtls/).
+  guide](https://agentgateway.dev/docs/kubernetes/main/documentation/security/backendtls/).
 - Configure Redis with a server certificate, private key, and trusted CA as
   described in the [Redis Open Source TLS
   documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/security/encryption/).

--- a/examples/llm-semantic-routing/k8s/tier-aware/README.md
+++ b/examples/llm-semantic-routing/k8s/tier-aware/README.md
@@ -72,9 +72,9 @@ This example requires:
 - Helm and `kubectl`.
 
 Follow the agentgateway guides to
-[install agentgateway](https://agentgateway.dev/docs/kubernetes/main/install/helm/)
+[install agentgateway](https://agentgateway.dev/docs/kubernetes/main/documentation/install/helm/)
 and
-[set up a Gateway](https://agentgateway.dev/docs/kubernetes/main/setup/gateway/).
+[set up a Gateway](https://agentgateway.dev/docs/kubernetes/main/documentation/setup/gateway/).
 
 For example, enable model routing on an existing Helm installation while
 retaining its other values:
@@ -313,7 +313,7 @@ The request header is directly supplied by `curl` only to keep this example
 focused on routing. Do not trust a client-provided entitlement header in
 production.
 
-Use [agentgateway policies](https://agentgateway.dev/docs/kubernetes/latest/about/policies/)
+Use [agentgateway policies](https://agentgateway.dev/docs/kubernetes/latest/documentation/about/policies/)
 for JWT, API key, or external authorization to authenticate the caller. Derive
 or overwrite `x-entitlement-tier` from trusted identity context before the
 conditional ExtProc policy runs. Retain model authorization as defense in

--- a/examples/microsoft-intune/compliance/claude-desktop/compliance.json
+++ b/examples/microsoft-intune/compliance/claude-desktop/compliance.json
@@ -5,7 +5,7 @@
       "Operator": "IsEquals",
       "DataType": "Boolean",
       "Operand": true,
-      "MoreInfoUrl": "https://agentgateway.dev/docs/kubernetes/latest/integrations/llm-clients/microsoft-intune/#manage-claude-desktop",
+      "MoreInfoUrl": "https://agentgateway.dev/docs/kubernetes/latest/integrations/llm/clients/microsoft-intune/#manage-claude-desktop",
       "RemediationStrings": [
         {
           "Language": "en_US",

--- a/examples/microsoft-intune/compliance/codex/compliance.json
+++ b/examples/microsoft-intune/compliance/codex/compliance.json
@@ -5,7 +5,7 @@
       "Operator": "IsEquals",
       "DataType": "Boolean",
       "Operand": true,
-      "MoreInfoUrl": "https://agentgateway.dev/docs/kubernetes/latest/integrations/llm-clients/microsoft-intune/#manage-codex",
+      "MoreInfoUrl": "https://agentgateway.dev/docs/kubernetes/latest/integrations/llm/clients/microsoft-intune/#manage-codex",
       "RemediationStrings": [
         {
           "Language": "en_US",

--- a/examples/netbird-agent-network/kubernetes/README.md
+++ b/examples/netbird-agent-network/kubernetes/README.md
@@ -546,5 +546,5 @@ The `x-netbird-groups` value is stored as one CSV string. For example,
 `Engineering,Platform` appears as one combined group dimension rather than two
 separate groups.
 
-[agentgateway-cost-dashboard]: https://agentgateway.dev/docs/kubernetes/latest/llm/cost-controls/dashboard/
-[agentgateway-admin-ui]: https://agentgateway.dev/docs/kubernetes/latest/observability/ui/
+[agentgateway-cost-dashboard]: https://agentgateway.dev/docs/kubernetes/latest/documentation/llm/cost-controls/dashboard/
+[agentgateway-admin-ui]: https://agentgateway.dev/docs/kubernetes/latest/documentation/observability/ui/

--- a/examples/netbird-agent-network/standalone/README.md
+++ b/examples/netbird-agent-network/standalone/README.md
@@ -251,7 +251,7 @@ request-log storage and retention, monitor every component, and consider HTTPS
 or mTLS between the NetBird proxy and private AI agentgateway when the Docker
 bridge is not an adequate trust boundary.
 
-Agentgateway's [model catalog](https://agentgateway.dev/docs/standalone/latest/llm/cost-controls/costs/),
-[request logging](https://agentgateway.dev/docs/standalone/latest/observability/access-logs/database/),
-and [dashboard](https://agentgateway.dev/docs/standalone/latest/llm/cost-controls/dashboard/)
+Agentgateway's [model catalog](https://agentgateway.dev/docs/standalone/latest/documentation/llm/cost-controls/costs/),
+[request logging](https://agentgateway.dev/docs/standalone/latest/documentation/observability/access-logs/database/),
+and [dashboard](https://agentgateway.dev/docs/standalone/latest/documentation/llm/cost-controls/dashboard/)
 are useful next steps for model discovery, cost reporting, and usage analysis.

--- a/examples/render-deploy/Dockerfile
+++ b/examples/render-deploy/Dockerfile
@@ -7,7 +7,7 @@
 # UI-only config.yaml on first boot, then execs the gateway. Add models
 # and MCP in the UI after login.
 #
-# Pin: https://agentgateway.dev/docs/standalone/latest/setup/install/docker/
+# Pin: https://agentgateway.dev/docs/standalone/latest/documentation/setup/install/docker/
 #
 # The published image USER is 65532. Render disks are typically root-owned,
 # so this image starts as root to claim /config, then the entrypoint chowns

--- a/examples/render-deploy/render.yaml
+++ b/examples/render-deploy/render.yaml
@@ -10,7 +10,7 @@
 # Builds examples/render-deploy/Dockerfile (entrypoint + official image).
 # Do not use runtime: image — that skips the Dockerfile and leaves /ui/
 # unauthenticated on an empty disk.
-# https://agentgateway.dev/docs/standalone/latest/setup/install/docker/
+# https://agentgateway.dev/docs/standalone/latest/documentation/setup/install/docker/
 #
 # dockerfilePath / dockerContext are relative to the repo root (Render
 # Blueprint spec), even though this file lives under examples/render-deploy/.


### PR DESCRIPTION
The docs site partitioned each version root into sections (documentation, integrations, reference, release-notes). URLs written before that lost the segment they now need, so 28 distinct `agentgateway.dev/docs/` links in this repo no longer resolve: 32 references across 14 files, including the quickstart links in the README and in the release notes template.

Most needed only the missing `documentation/` segment. Seven had moved further: the LLM client guides are now under `integrations/llm/clients/`, provider guides under `integrations/llm/providers/`, the version table under `release-notes/`, cost docs under `documentation/llm/cost-controls/`, and one link in the syncer README carried no section or version at all.

Every replacement was resolved against a local build of the docs site, and the two `#manage-*` fragments were checked against the target page rather than assumed. No prose changed; these are URL substitutions only.

The two in the agentgateway chart's values.yaml matter beyond this repo: the docs site generates its Helm reference from these comments verbatim, so both shipped into the published tables for every version at once.

- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
