### PR TITLE
substrate: Fix custom port

### DIFF
--- a/crates/agentgateway/src/http/substrate/ingress.rs
+++ b/crates/agentgateway/src/http/substrate/ingress.rs
@@ -190,8 +190,8 @@ fn default_connect_target_port() -> NonZeroU16 {
 
 // Regular HTTP requests have no actor-port contract, so their frontend
 // authority must not leak a proxy or port-forward port into actor selection.
-fn actor_port(authority: &::http::uri::Authority, method: &::http::Method) -> u16 {
-	if *method == ::http::Method::CONNECT {
+fn actor_port(authority: &::http::uri::Authority, from_connect_tunnel: bool) -> u16 {
+	if from_connect_tunnel {
 		authority.port_u16().unwrap_or(DEFAULT_ACTOR_PORT)
 	} else {
 		DEFAULT_ACTOR_PORT
@@ -648,8 +648,11 @@ impl RequestPolicyTrait for SubstrateIngress {
 				let authority = values.next()?.to_str().ok()?;
 				(values.next().is_none()).then_some(authority)
 			});
+		// We detect whether this was from the connect tunnel based on whether there's
+		// a CONNECT authority in source context.
+		let from_connect_tunnel = connect_authority.is_some();
 		// The application request authority is forwarded unchanged. Its port only
-		// selects an actor port for raw CONNECT; regular HTTP addresses port 80.
+		// selects an actor port for CONNECT traffic; regular HTTP addresses port 80.
 		let authority = connect_authority
 			.map(ToOwned::to_owned)
 			.or_else(|| {
@@ -667,7 +670,7 @@ impl RequestPolicyTrait for SubstrateIngress {
 					format!("invalid actor authority {authority:?}: {error}"),
 				)
 			})?;
-		let actor_port = actor_port(&authority, req.method());
+		let actor_port = actor_port(&authority, from_connect_tunnel);
 		let connect_authority = format!("{}:{actor_port}", authority.host());
 		let target_actor = if let Some(source) = req
 			.extensions()
@@ -756,8 +759,8 @@ mod tests {
 			.parse::<::http::uri::Authority>()
 			.unwrap();
 
-		assert_eq!(super::actor_port(&authority, &Method::GET), 80);
-		assert_eq!(super::actor_port(&authority, &Method::CONNECT), 43123);
+		assert_eq!(super::actor_port(&authority, false), 80);
+		assert_eq!(super::actor_port(&authority, true), 43123);
 	}
 
 	#[derive(Clone)]

--- a/crates/agentgateway/tests/tests/substrate.rs
+++ b/crates/agentgateway/tests/tests/substrate.rs
@@ -1107,7 +1107,7 @@ async fn actor_ingress_uses_the_original_connect_target_actor() {
 	let actor_requests = actor.received_requests().await.unwrap();
 	assert_eq!(
 		actor_requests[0].headers.get("x-ate-target-port").unwrap(),
-		"80"
+		"9090"
 	);
 }
 
@@ -1131,7 +1131,7 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 		}
 		let request = String::from_utf8(request).unwrap();
 		assert!(
-			request.starts_with("CONNECT application.example:80 HTTP/1.1\r\n"),
+			request.starts_with("CONNECT application.example:9090 HTTP/1.1\r\n"),
 			"unexpected tunnel request: {request:?}"
 		);
 		assert!(
@@ -1218,7 +1218,7 @@ async fn actor_ingress_uses_backend_tunnel_for_connect() {
 	assert_eq!(actor_requests.len(), 1);
 	assert_eq!(
 		actor_requests[0].headers.get("x-ate-target-port").unwrap(),
-		"80"
+		"9090"
 	);
 	drop(io);
 	atunnel.abort();


### PR DESCRIPTION
Method was the wrong conditional to use 🤦🏾 This was CONNECT with HTTP so the inner method was not connect. Instead of method, we check for the presence of CONNECT authority  

- [X] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
