### PR TITLE
fix(ext_proc): treat clean stream close as pass-through instead of error

### DIFF
--- a/crates/agentgateway/src/http/ext_proc.rs
+++ b/crates/agentgateway/src/http/ext_proc.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::anyhow;
 use bytes::Bytes;
@@ -396,6 +397,9 @@ impl ExtProcRequest {
 struct ExtProcInstance {
 	failure_mode: FailureMode,
 	skipped: bool,
+	// Set by the stream task when the server closes the gRPC stream cleanly (gRPC OK);
+	// the rest of the request/response continues without the server.
+	server_disengaged: Arc<AtomicBool>,
 	request_body_immediate_response: Arc<Mutex<Option<http::Response>>>,
 	protocol_config_sent: bool,
 	mode_state: ModeStateMachine,
@@ -427,6 +431,7 @@ impl ExtProcInstance {
 		let chan = target.grpc_channel(client.clone());
 		Self {
 			skipped: Default::default(),
+			server_disengaged: Arc::new(AtomicBool::new(false)),
 			request_body_immediate_response: Arc::new(Mutex::new(None)),
 			failure_mode,
 			protocol_config_sent: false,
@@ -460,6 +465,7 @@ impl ExtProcInstance {
 		let failure_mode = self.failure_mode;
 		let span_client = self.span_client.clone();
 		let span_target = self.span_target.clone();
+		let server_disengaged = self.server_disengaged.clone();
 		let (tx_req, rx_req) = tokio::sync::mpsc::channel(10);
 		let (tx_resp, mut rx_resp) = tokio::sync::mpsc::channel(10);
 		let req_stream = tokio_stream::wrappers::ReceiverStream::new(rx_req);
@@ -492,6 +498,7 @@ impl ExtProcInstance {
 						}
 					},
 					Ok(None) => {
+						server_disengaged.store(true, Ordering::SeqCst);
 						if let Some(span) = span.as_deref_mut() {
 							span.record_grpc_status(tonic::Code::Ok);
 						}
@@ -552,6 +559,10 @@ impl ExtProcInstance {
 
 	fn request_sender(&self) -> Result<Sender<ProcessingRequest>, Error> {
 		self.tx_req.clone().ok_or(Error::RequestSend)
+	}
+
+	fn disengaged(&self) -> bool {
+		self.server_disengaged.load(Ordering::SeqCst)
 	}
 
 	fn protocol_config_for_headers(
@@ -1438,7 +1449,7 @@ impl ExtProcInstance {
 		request: Option<&RequestSnapshot>,
 		resolved_destination_metadata: Option<SocketAddr>,
 	) -> Result<(http::Response, Option<PolicyResponse>), Error> {
-		if self.skipped {
+		if self.skipped || self.disengaged() {
 			return Ok((response, None));
 		}
 		let response_trailers = Arc::new(Mutex::new(None));
@@ -1495,9 +1506,12 @@ impl ExtProcInstance {
 		// Send the response headers to ext_proc.
 		// No response side fail_open handling.
 		if send_response_headers {
+			if self.disengaged() {
+				return Ok((http::Response::from_parts(parts, body), None));
+			}
 			let (header_protocol_config, sends_protocol_config) =
 				self.protocol_config_for_headers(protocol_config);
-			self
+			if let Err(e) = self
 				.send_request(ProcessingRequest {
 					request: Some(Request::ResponseHeaders(HttpHeaders {
 						headers,
@@ -1508,7 +1522,15 @@ impl ExtProcInstance {
 					protocol_config: header_protocol_config,
 					observability_mode: false,
 				})
-				.await?;
+				.await
+			{
+				// The server may have closed the stream cleanly after finishing the
+				// request phase; in that case pass the response through.
+				if self.disengaged() {
+					return Ok((http::Response::from_parts(parts, body), None));
+				}
+				return Err(e);
+			}
 			self.mark_protocol_config_sent_if(sends_protocol_config);
 		}
 
@@ -1585,7 +1607,23 @@ impl ExtProcInstance {
 			.take()
 			.expect("mutate_response called twice");
 		loop {
-			let msg = Self::recv_response_loop_message(&mut rx).await?;
+			let msg = match Self::recv_response_loop_message(&mut rx).await {
+				Ok(msg) => msg,
+				// The response headers were sent before the clean close was observed;
+				// no response will arrive. Pass the original body through when it has
+				// not already been forwarded to the ext_proc server.
+				Err(Error::NoMoreResponses) if self.disengaged() => {
+					if let Some(original) = pending_response_body
+						.take()
+						.or_else(|| BufferedBodyPhase::take_deferred_body(&mut pending_response_buffer))
+					{
+						let (parts, _) = resp.into_parts();
+						return Ok((http::Response::from_parts(parts, original), None));
+					}
+					return Ok((resp, None));
+				},
+				Err(e) => return Err(e),
+			};
 			let (transitioned, eos, streamed_body_mutation) = match msg {
 				ResponseLoopMessage::Immediate(dr) => return Ok((resp, Some(dr))),
 				ResponseLoopMessage::Processing(presp) => {

--- a/crates/agentgateway/src/http/ext_proc_tests.rs
+++ b/crates/agentgateway/src/http/ext_proc_tests.rs
@@ -1774,6 +1774,81 @@ mod immediate_and_failure {
 		let res = send_request(io, Method::POST, "http://lo").await;
 		assert_eq!(res.status(), 200);
 	}
+
+	// The ext_proc server answers the request phases and then closes the gRPC
+	// stream cleanly. The ext_proc protocol defines a clean close as "the data
+	// plane proceeds without the server", so the upstream response must pass
+	// through instead of failing with a 500.
+	#[tokio::test]
+	async fn clean_close_after_request_phase_passes_response_through() {
+		let mock = body_mock(b"upstream-response").await;
+		let processing_options = json!({
+			"requestBodyMode": "fullDuplexStreamed",
+			"responseBodyMode": "fullDuplexStreamed",
+			"requestHeaderMode": "send",
+			"responseHeaderMode": "send",
+			"requestTrailerMode": "send",
+			"responseTrailerMode": "send",
+		});
+		let (_mock, _ext_proc, _bind, io) = setup_ext_proc_mock_with_processing_options(
+			mock,
+			ext_proc::FailureMode::FailClosed,
+			ExtProcMock::new(CleanCloseAfterRequestExtProc::default),
+			"{}",
+			Some(processing_options),
+		)
+		.await;
+		let res = send_request_body(io, Method::POST, "http://lo", b"request").await;
+		assert_eq!(res.status(), 200);
+		let body = read_body_raw(res.into_body()).await;
+		assert_eq!(body.as_ref(), b"upstream-response");
+	}
+
+	// Same scenario driven directly against ExtProcRequest so the clean close is
+	// observed before the response phase starts.
+	#[tokio::test]
+	async fn clean_close_disengages_response_processing() {
+		let ext_proc = ExtProcMock::new(CleanCloseAfterRequestExtProc::default)
+			.spawn()
+			.await;
+		let processing_options = ext_proc::ProcessingOptions {
+			request_body_mode: ext_proc::BodySendMode::FullDuplexStreamed,
+			response_body_mode: ext_proc::BodySendMode::FullDuplexStreamed,
+			request_header_mode: ext_proc::HeaderSendMode::Send,
+			response_header_mode: ext_proc::HeaderSendMode::Send,
+			request_trailer_mode: ext_proc::TrailerSendMode::Send,
+			response_trailer_mode: ext_proc::TrailerSendMode::Send,
+			..Default::default()
+		};
+		let mut ext_proc_request =
+			build_ext_proc_request_for_test(ext_proc.address, processing_options);
+
+		let frames = tokio_stream::iter(vec![Ok::<Frame<bytes::Bytes>, Infallible>(Frame::data(
+			bytes::Bytes::from_static(b"request"),
+		))]);
+		let mut req = crate::proxy::request_builder::RequestBuilder::new(Method::POST, "http://lo")
+			.body(Body::new(http_body_util::StreamBody::new(frames)))
+			.build()
+			.unwrap();
+		let _ = ext_proc_request.mutate_request(&mut req).await.unwrap();
+
+		// Let the stream task observe the clean close before the response phase.
+		tokio::time::sleep(Duration::from_millis(50)).await;
+
+		let frames = tokio_stream::iter(vec![
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::data(bytes::Bytes::from_static(
+				b"upstream-response",
+			))),
+			Ok::<Frame<bytes::Bytes>, Infallible>(Frame::trailers(::http::HeaderMap::new())),
+		]);
+		let mut resp = http::Response::new(Body::new(http_body_util::StreamBody::new(frames)));
+		ext_proc_request
+			.mutate_response(&mut resp, None)
+			.await
+			.unwrap();
+		let collected = resp.into_body().collect().await.unwrap();
+		assert_eq!(collected.to_bytes().as_ref(), b"upstream-response");
+	}
 }
 
 // Dynamic metadata propagation through request/response extensions.
@@ -3764,6 +3839,40 @@ impl Handler for RequestBodyFailureExtProc {
 		_: &mpsc::Sender<Result<ProcessingResponse, Status>>,
 	) -> Result<(), Status> {
 		Err(Status::failed_precondition("injected request body error"))
+	}
+}
+
+/// Simulates an ext_proc server that answers the request phases and then closes
+/// the gRPC stream cleanly, as the llm-d endpoint picker does for requests whose
+/// response processing is skipped.
+#[derive(Debug, Default)]
+struct CleanCloseAfterRequestExtProc {
+	closed: bool,
+}
+
+#[async_trait::async_trait]
+impl Handler for CleanCloseAfterRequestExtProc {
+	async fn handle_request_headers(
+		&mut self,
+		_: &HttpHeaders,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender.send(request_header_response(None)).await;
+		Ok(())
+	}
+
+	async fn handle_request_body(
+		&mut self,
+		_: &proto::HttpBody,
+		sender: &mpsc::Sender<Result<ProcessingResponse, Status>>,
+	) -> Result<(), Status> {
+		let _ = sender.send(request_body_response(None)).await;
+		self.closed = true;
+		Ok(())
+	}
+
+	async fn close_stream_after_request(&mut self) -> bool {
+		self.closed
 	}
 }
 

--- a/crates/agentgateway/src/test_helpers/extprocmock.rs
+++ b/crates/agentgateway/src/test_helpers/extprocmock.rs
@@ -90,6 +90,12 @@ pub trait Handler {
 
 	async fn on_request(&mut self, _request: &ProcessingRequest) {}
 
+	// Return true after handling a request to end the response stream cleanly,
+	// simulating an ext_proc server that closes the gRPC stream when it is done.
+	async fn close_stream_after_request(&mut self) -> bool {
+		false
+	}
+
 	async fn handle_request_headers(
 		&mut self,
 		_headers: &HttpHeaders,
@@ -267,6 +273,10 @@ where
 						// Invalid request
 						continue;
 					},
+				}
+				if handler.close_stream_after_request().await {
+					// Dropping tx ends the response stream with a clean gRPC OK status.
+					break;
 				}
 			}
 			Ok::<(), Status>(())


### PR DESCRIPTION
fix: https://github.com/agentgateway/agentgateway/issues/3436
- [x] As required by the [Code of Conduct](https://github.com/agentgateway/agentgateway/blob/main/CODE_OF_CONDUCT.md#generative-ai-policy), the description, docs, and comments (words meant for humans) are written by a human, not by an LLM.
